### PR TITLE
chore: auto-format on save with VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "editor.formatOnSave": true,
+    "[typescript]": {
+        "editor.defaultFormatter": "vscode.typescript-language-features"
+    }
+}


### PR DESCRIPTION
VSCodeで保存すると、フォーマッタが自動で走る設定を追加。
利用するフォーマッタはカスタマイズできるが（例：Prettier）、暫定でVSCode内蔵のフォーマッタを設定した