### PR TITLE
FIX: Fix path alias resolution for imports from graphql

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "skipLibCheck": true,
     "types": ["node", "@types/jest", "@quramy/jest-prisma"],
     "paths": {
+      "graphql/*": ["node_modules/graphql/*"],
       "@/*": ["./src/*"]
     },
     "plugins": [


### PR DESCRIPTION
```
import { GraphQLError } from "graphql/error";
```
The intention here is to import from the graphql library, but tsc-alias was mistakenly treating it as an import from src/graphql/.
To address this, the configuration has been updated so that imports like import { hoge } from "graphql/*" will correctly resolve to node_modules/graphql/*.


上記でimportしたいのは、ライブラリとしてのgraphqlだが、
tsc-aliasが誤って、`src/graphql/`からimportするよう振る舞っていた。
そこで、`import { hoge }from "graphql/*"`と指定した際は、`node_modules/graphql/*`からimportするよう、設定を追記した。