### PR TITLE
CHORE: Refactor GitHub Workflow to Use Environment Variable for GCP Region

### DIFF
--- a/.github/workflows/deploy-to-cloud-run-dev.yml
+++ b/.github/workflows/deploy-to-cloud-run-dev.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Configure Docker for GCP Artifact Registry
       run: |
         gcloud auth configure-docker ${{ env.ARTIFACT_REGISTRY }}
-        gcloud auth configure-docker asia-northeast1-docker.pkg.dev
+        gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev
 
 
     - name: Build Docker image


### PR DESCRIPTION
`GCP_REGION` was hardcoded in GitHub workflow, so I have updated it to refer the environment variable instead.