### PR TITLE
FEAT: set process.env.NODE_ENV

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,9 @@ import { applyMiddleware } from "graphql-middleware";
 import errorMiddleware from "@/middleware/error";
 import logger from "./libs/logger";
 
+const isLocal = process.env.ENV === "LOCAL"
+process.env.NODE_ENV = isLocal ? "development" : "production"
+
 const app = express();
 const httpServer = http.createServer(app);
 


### PR DESCRIPTION
## Description
Set the process.env.NODE_ENV variable to improve performance and security in the production environment.

本番環境でのパフォーマンスとセキュリティの向上を狙って、process.env.NODE_ENV変数を設定する。

## References

[Apollo Server
](https://www.apollographql.com/docs/apollo-server/api/plugin/landing-pages#:~:text=landing%20page.-,Default%20behavior,-If%20you%20don%27t)

For example, when NODE_ENV is set to production, the Playground can be disabled, reducing security risks.

```
If you don't manually install any plugin that implements renderLandingPage, Apollo Server does the following by default:

In non-production environments (NODE_ENV is not production), Apollo Server installs ApolloServerPluginLandingPageLocalDefault.

In production environments (NODE_ENV is production), Apollo Server installs ApolloServerPluginLandingPageProductionDefault.
```

[Express](https://expressjs.com/ja/advanced/best-practice-performance.html#:~:text=%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%99%E3%82%8B-,NODE_ENV%20%E3%82%92%E3%80%8Cproduction%E3%80%8D%E3%81%AB%E8%A8%AD%E5%AE%9A%E3%81%99%E3%82%8B,-NODE_ENV%20%E7%92%B0%E5%A2%83%E5%A4%89%E6%95%B0)

The application's performance is improved through the use of caching and other optimizations.
```
NODE_ENV を「production」に設定する
NODE_ENV 環境変数は、アプリケーションが実行される環境 (通常は開発または実稼働) を指定します。パフォーマンスを向上させるために実行できる最も単純な処理の 1 つは、NODE_ENV を「production」に設定することです。

NODE_ENV を「production」に設定すると、Express は次のようになります。

ビュー・テンプレートをキャッシュに入れる。
CSS 拡張から生成された CSS ファイルをキャッシュに入れる。
詳細度の低いエラー・メッセージを生成する。
[テスト](http://apmblog.dynatrace.com/2015/07/22/the-drastic-effects-of-omitting-node_env-in-your-express-js-applications/)により、こうすると、アプリケーション・パフォーマンスが 3 倍も高くなることが示されています。
```

[Node.js](https://nodejs.org/en/learn/getting-started/nodejs-the-difference-between-development-and-production)