### PR TITLE
FIX: fix find member wallet for give reward

### DIFF
--- a/src/app/membership/wallet/service.ts
+++ b/src/app/membership/wallet/service.ts
@@ -55,7 +55,7 @@ export default class WalletService {
     ctx: IContext,
     tx: Prisma.TransactionClient,
     communityId: string,
-    participantId: string,
+    userId: string,
     transferPoints: number,
   ) {
     const communityWallet = await WalletRepository.findCommunityWallet(ctx, communityId, tx);
@@ -66,11 +66,11 @@ export default class WalletService {
     const participantWallet = await WalletRepository.checkIfExistingMemberWallet(
       ctx,
       communityId,
-      participantId,
+      userId,
       tx,
     );
     if (!participantWallet) {
-      throw new NotFoundError("Participant wallet", { participantId });
+      throw new NotFoundError("Participant wallet", { userId });
     }
 
     await WalletUtils.validateTransfer(transferPoints, communityWallet, participantWallet);

--- a/src/app/opportunity/participation/usecase.ts
+++ b/src/app/opportunity/participation/usecase.ts
@@ -311,7 +311,7 @@ export default class ParticipationUseCase {
           ctx,
           tx,
           communityId,
-          participation.id,
+          userId,
           fromPointChange,
         );
 


### PR DESCRIPTION
`WalletService.findWalletsForGiveReward`内で呼び出している`WalletRepository.checkIfExistingMemberWallet`は、
引数にuserIdを取る必要があるが、
participation.idを渡す実装になっていたため、結果が取得できていなかった。
そのため、userIdを使うよう修正した。