### PR TITLE
Fix/change nullabe graphql schema

### DIFF
--- a/src/application/domain/account/membership/controller/dataloader.ts
+++ b/src/application/domain/account/membership/controller/dataloader.ts
@@ -44,10 +44,7 @@ export function createMembershipsByUserLoader(issuer: PrismaClientIssuer) {
           where: {
             userId: { in: [...userIds] },
           },
-          include: {
-            participationGeoViews: true,
-            participationCountViews: true,
-          },
+          select: membershipSelectDetail,
         }),
       );
     },
@@ -62,10 +59,7 @@ export function createMembershipsByCommunityLoader(issuer: PrismaClientIssuer) {
       return issuer.internal((tx) =>
         tx.membership.findMany({
           where: { communityId: { in: [...communityIds] } },
-          include: {
-            participationGeoViews: true,
-            participationCountViews: true,
-          },
+          select: membershipSelectDetail,
         }),
       );
     },

--- a/src/application/domain/account/membership/controller/resolver.ts
+++ b/src/application/domain/account/membership/controller/resolver.ts
@@ -24,7 +24,7 @@ export default class MembershipResolver {
     memberships: (_: unknown, args: GqlQueryMembershipsArgs, ctx: IContext) =>
       this.useCase.visitorBrowseMemberships(args, ctx),
     membership: (_: unknown, args: GqlQueryMembershipArgs, ctx: IContext) => {
-      this.useCase.visitorViewMembership(args, ctx);
+      return this.useCase.visitorViewMembership(args, ctx);
     },
   };
 

--- a/src/application/domain/account/membership/data/interface.ts
+++ b/src/application/domain/account/membership/data/interface.ts
@@ -16,6 +16,11 @@ export interface IMembershipRepository {
 
   find(ctx: IContext, where: Prisma.MembershipWhereUniqueInput): Promise<PrismaMembership | null>;
 
+  findDetail(
+    ctx: IContext,
+    where: Prisma.MembershipWhereUniqueInput,
+  ): Promise<PrismaMembershipDetail | null>;
+
   create(
     ctx: IContext,
     data: Prisma.MembershipCreateInput,

--- a/src/application/domain/account/membership/data/repository.ts
+++ b/src/application/domain/account/membership/data/repository.ts
@@ -34,6 +34,15 @@ export default class MembershipRepository implements IMembershipRepository {
     });
   }
 
+  async findDetail(ctx: IContext, where: Prisma.MembershipWhereUniqueInput) {
+    return ctx.issuer.public(ctx, (tx) => {
+      return tx.membership.findUnique({
+        where,
+        select: membershipSelectDetail,
+      });
+    });
+  }
+
   async find(ctx: IContext, where: Prisma.MembershipWhereUniqueInput) {
     return ctx.issuer.public(ctx, (tx) => {
       return tx.membership.findUnique({

--- a/src/application/domain/account/membership/data/type.ts
+++ b/src/application/domain/account/membership/data/type.ts
@@ -11,6 +11,7 @@ export const membershipSelectDetail = Prisma.validator<Prisma.MembershipSelect>(
   reason: true,
   role: true,
 
+  opportunityHostedCountView: true,
   participationGeoViews: true,
   participationCountViews: true,
 

--- a/src/application/domain/account/membership/history/schema/type.graphql
+++ b/src/application/domain/account/membership/history/schema/type.graphql
@@ -12,6 +12,6 @@ type MembershipHistory {
 
     createdByUser: User
 
-    createdAt: Datetime!
+    createdAt: Datetime
     updatedAt: Datetime
 }

--- a/src/application/domain/account/membership/presenter.ts
+++ b/src/application/domain/account/membership/presenter.ts
@@ -33,7 +33,7 @@ export default class MembershipPresenter {
     };
   }
 
-  static getWithGeo(r: PrismaMembershipDetail): GqlMembership {
+  static get(r: PrismaMembershipDetail): GqlMembership {
     const { participationGeoViews, participationCountViews, opportunityHostedCountView, ...prop } =
       r;
 
@@ -69,10 +69,6 @@ export default class MembershipPresenter {
       },
       hostOpportunityCount: opportunityHostedCountView?.totalCount,
     };
-  }
-
-  static get(r: Omit<PrismaMembership, "user">): GqlMembership {
-    return r;
   }
 
   static invite(r: Omit<PrismaMembership, "user">): GqlMembershipInviteSuccess {

--- a/src/application/domain/account/membership/presenter.ts
+++ b/src/application/domain/account/membership/presenter.ts
@@ -6,8 +6,13 @@ import {
   GqlMembershipWithdrawSuccess,
   GqlMembershipSetRoleSuccess,
   GqlMembershipRemoveSuccess,
+  GqlMembershipParticipationLocation,
 } from "@/types/graphql";
-import { PrismaMembership } from "@/application/domain/account/membership/data/type";
+import {
+  PrismaMembership,
+  PrismaMembershipDetail,
+} from "@/application/domain/account/membership/data/type";
+import { ParticipationType } from "@prisma/client";
 
 export default class MembershipPresenter {
   static query(r: GqlMembership[], hasNextPage: boolean): GqlMembershipsConnection {
@@ -25,6 +30,44 @@ export default class MembershipPresenter {
         cursor: edge.user?.id + "_" + edge.community?.id,
         node: edge,
       })),
+    };
+  }
+
+  static getWithGeo(r: PrismaMembershipDetail): GqlMembership {
+    const { participationGeoViews, participationCountViews, opportunityHostedCountView, ...prop } =
+      r;
+
+    const hostedGeoMap = new Map<string, GqlMembershipParticipationLocation>();
+
+    participationGeoViews
+      .filter((v) => v.type === ParticipationType.HOSTED)
+      .forEach((v) => {
+        if (!hostedGeoMap.has(v.placeId)) {
+          hostedGeoMap.set(v.placeId, {
+            placeId: v.placeId,
+            placeName: v.placeName,
+            placeImage: v.placeImage,
+            address: v.address,
+            latitude: v.latitude.toString(),
+            longitude: v.longitude.toString(),
+          });
+        }
+      });
+
+    const hostedGeo = Array.from(hostedGeoMap.values());
+
+    const hostedCount =
+      participationCountViews.find((v) => v.type === ParticipationType.HOSTED)?.totalCount ?? 0;
+
+    return {
+      ...prop,
+      participationView: {
+        hosted: {
+          totalParticipantCount: hostedCount,
+          geo: hostedGeo,
+        },
+      },
+      hostOpportunityCount: opportunityHostedCountView?.totalCount,
     };
   }
 

--- a/src/application/domain/account/membership/schema/type.graphql
+++ b/src/application/domain/account/membership/schema/type.graphql
@@ -13,6 +13,7 @@ type Membership {
     role: Role!
 
     participationView: MembershipParticipationView
+    hostOpportunityCount: Int
 
     histories: [MembershipHistory!]
 

--- a/src/application/domain/account/membership/schema/type.graphql
+++ b/src/application/domain/account/membership/schema/type.graphql
@@ -16,13 +16,13 @@ type Membership {
 
     histories: [MembershipHistory!]
 
-    createdAt: Datetime!
+    createdAt: Datetime
     updatedAt: Datetime
 }
 
 type MembershipParticipationView {
     hosted: MembershipHostedMetrics!
-    participated: MembershipParticipatedMetrics!
+    participated: MembershipParticipatedMetrics
 }
 
 type MembershipHostedMetrics {
@@ -31,7 +31,7 @@ type MembershipHostedMetrics {
 }
 
 type MembershipParticipatedMetrics {
-    geo: [MembershipParticipationLocation!]!
+    geo: [MembershipParticipationLocation!]
     totalParticipatedCount: Int! # ← 自分が参加した回数
 }
 

--- a/src/application/domain/account/membership/service.ts
+++ b/src/application/domain/account/membership/service.ts
@@ -31,6 +31,10 @@ export default class MembershipService {
     return this.repository.query(ctx, where, orderBy, take, cursor);
   }
 
+  async findMembershipDetail(ctx: IContext, userId: string, communityId: string) {
+    return this.repository.findDetail(ctx, { userId_communityId: { userId, communityId } });
+  }
+
   async findMembership(ctx: IContext, userId: string, communityId: string) {
     return this.repository.find(ctx, { userId_communityId: { userId, communityId } });
   }

--- a/src/application/domain/account/membership/usecase.ts
+++ b/src/application/domain/account/membership/usecase.ts
@@ -39,7 +39,7 @@ export default class MembershipUseCase {
     const records = await this.membershipService.fetchMemberships(ctx, args, take);
 
     const hasNextPage = records.length > take;
-    const data = records.slice(0, take).map(MembershipPresenter.get);
+    const data = records.slice(0, take).map(MembershipPresenter.getWithGeo);
     return MembershipPresenter.query(data, hasNextPage);
   }
 

--- a/src/application/domain/account/membership/usecase.ts
+++ b/src/application/domain/account/membership/usecase.ts
@@ -39,7 +39,7 @@ export default class MembershipUseCase {
     const records = await this.membershipService.fetchMemberships(ctx, args, take);
 
     const hasNextPage = records.length > take;
-    const data = records.slice(0, take).map(MembershipPresenter.getWithGeo);
+    const data = records.slice(0, take).map(MembershipPresenter.get);
     return MembershipPresenter.query(data, hasNextPage);
   }
 
@@ -47,7 +47,7 @@ export default class MembershipUseCase {
     args: GqlQueryMembershipArgs,
     ctx: IContext,
   ): Promise<GqlMembership | null> {
-    const membership = await this.membershipService.findMembership(
+    const membership = await this.membershipService.findMembershipDetail(
       ctx,
       args.userId,
       args.communityId,

--- a/src/application/domain/experience/evaluation/evaluationHistory/schema/schema.graphql
+++ b/src/application/domain/experience/evaluation/evaluationHistory/schema/schema.graphql
@@ -9,5 +9,5 @@ type EvaluationHistory {
     evaluation: Evaluation
     createdByUser: User
 
-    createdAt: Datetime!
+    createdAt: Datetime
 }

--- a/src/application/domain/experience/evaluation/schema/schema.graphql
+++ b/src/application/domain/experience/evaluation/schema/schema.graphql
@@ -14,7 +14,7 @@ type Evaluation {
 
     histories: [EvaluationHistory!]
 
-    createdAt: Datetime!
+    createdAt: Datetime
     updatedAt: Datetime
 }
 

--- a/src/application/domain/experience/participation/schema/type.graphql
+++ b/src/application/domain/experience/participation/schema/type.graphql
@@ -5,7 +5,7 @@ type Participation {
     id: ID!
     status: ParticipationStatus!
     reason: ParticipationStatusReason!
-    source: Source!
+    source: Source
     description: String
 
     images: [String!]
@@ -19,7 +19,7 @@ type Participation {
     statusHistories: [ParticipationStatusHistory!]
     transactions: [Transaction!]
 
-    createdAt: Datetime!
+    createdAt: Datetime
     updatedAt: Datetime
 }
 

--- a/src/application/domain/experience/reservation/statusHistory/type.graphql
+++ b/src/application/domain/experience/reservation/statusHistory/type.graphql
@@ -8,5 +8,5 @@ type ReservationHistory {
     reservation: Reservation!
     createdByUser: User
 
-    createdAt: Datetime!
+    createdAt: Datetime
 }

--- a/src/application/domain/transaction/schema/type.graphql
+++ b/src/application/domain/transaction/schema/type.graphql
@@ -14,7 +14,7 @@ type Transaction {
 
     ticketStatusHistories: [TicketStatusHistory!]
 
-    createdAt: Datetime!
+    createdAt: Datetime
     updatedAt: Datetime
 }
 

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -251,7 +251,7 @@ export type GqlEdge = {
 export type GqlEvaluation = {
   __typename?: 'Evaluation';
   comment?: Maybe<Scalars['String']['output']>;
-  createdAt: Scalars['Datetime']['output'];
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
   credentialUrl?: Maybe<Scalars['String']['output']>;
   evaluator?: Maybe<GqlUser>;
   histories?: Maybe<Array<GqlEvaluationHistory>>;
@@ -296,7 +296,7 @@ export type GqlEvaluationHistoriesConnection = {
 export type GqlEvaluationHistory = {
   __typename?: 'EvaluationHistory';
   comment?: Maybe<Scalars['String']['output']>;
-  createdAt: Scalars['Datetime']['output'];
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
   createdByUser?: Maybe<GqlUser>;
   evaluation?: Maybe<GqlEvaluation>;
   id: Scalars['ID']['output'];
@@ -363,7 +363,7 @@ export type GqlMembership = {
   __typename?: 'Membership';
   bio?: Maybe<Scalars['String']['output']>;
   community?: Maybe<GqlCommunity>;
-  createdAt: Scalars['Datetime']['output'];
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
   headline?: Maybe<Scalars['String']['output']>;
   histories?: Maybe<Array<GqlMembershipHistory>>;
   participationView?: Maybe<GqlMembershipParticipationView>;
@@ -394,7 +394,7 @@ export type GqlMembershipFilterInput = {
 
 export type GqlMembershipHistory = {
   __typename?: 'MembershipHistory';
-  createdAt: Scalars['Datetime']['output'];
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
   createdByUser?: Maybe<GqlUser>;
   id: Scalars['ID']['output'];
   membership: GqlMembership;
@@ -425,7 +425,7 @@ export type GqlMembershipInviteSuccess = {
 
 export type GqlMembershipParticipatedMetrics = {
   __typename?: 'MembershipParticipatedMetrics';
-  geo: Array<GqlMembershipParticipationLocation>;
+  geo?: Maybe<Array<GqlMembershipParticipationLocation>>;
   totalParticipatedCount: Scalars['Int']['output'];
 };
 
@@ -442,7 +442,7 @@ export type GqlMembershipParticipationLocation = {
 export type GqlMembershipParticipationView = {
   __typename?: 'MembershipParticipationView';
   hosted: GqlMembershipHostedMetrics;
-  participated: GqlMembershipParticipatedMetrics;
+  participated?: Maybe<GqlMembershipParticipatedMetrics>;
 };
 
 export type GqlMembershipRemoveInput = {
@@ -1112,14 +1112,14 @@ export type GqlPaging = {
 export type GqlParticipation = {
   __typename?: 'Participation';
   community?: Maybe<GqlCommunity>;
-  createdAt: Scalars['Datetime']['output'];
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
   description?: Maybe<Scalars['String']['output']>;
   evaluation?: Maybe<GqlEvaluation>;
   id: Scalars['ID']['output'];
   images?: Maybe<Array<Scalars['String']['output']>>;
   reason: GqlParticipationStatusReason;
   reservation?: Maybe<GqlReservation>;
-  source: GqlSource;
+  source?: Maybe<GqlSource>;
   status: GqlParticipationStatus;
   statusHistories?: Maybe<Array<GqlParticipationStatusHistory>>;
   ticketStatusHistories?: Maybe<Array<GqlTicketStatusHistory>>;
@@ -1713,7 +1713,7 @@ export type GqlReservationHistoriesConnection = {
 
 export type GqlReservationHistory = {
   __typename?: 'ReservationHistory';
-  createdAt: Scalars['Datetime']['output'];
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
   createdByUser?: Maybe<GqlUser>;
   id: Scalars['ID']['output'];
   reservation: GqlReservation;
@@ -1974,7 +1974,7 @@ export type GqlTicketsConnection = {
 
 export type GqlTransaction = {
   __typename?: 'Transaction';
-  createdAt: Scalars['Datetime']['output'];
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
   fromPointChange?: Maybe<Scalars['Int']['output']>;
   fromWallet?: Maybe<GqlWallet>;
   id: Scalars['ID']['output'];
@@ -3042,7 +3042,7 @@ export type GqlEdgeResolvers<ContextType = any, ParentType extends GqlResolversP
 
 export type GqlEvaluationResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Evaluation'] = GqlResolversParentTypes['Evaluation']> = ResolversObject<{
   comment?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
-  createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
   credentialUrl?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   evaluator?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
   histories?: Resolver<Maybe<Array<GqlResolversTypes['EvaluationHistory']>>, ParentType, ContextType>;
@@ -3078,7 +3078,7 @@ export type GqlEvaluationHistoriesConnectionResolvers<ContextType = any, ParentT
 
 export type GqlEvaluationHistoryResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['EvaluationHistory'] = GqlResolversParentTypes['EvaluationHistory']> = ResolversObject<{
   comment?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
-  createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
   createdByUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
   evaluation?: Resolver<Maybe<GqlResolversTypes['Evaluation']>, ParentType, ContextType>;
   id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
@@ -3115,7 +3115,7 @@ export interface GqlJsonScalarConfig extends GraphQLScalarTypeConfig<GqlResolver
 export type GqlMembershipResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Membership'] = GqlResolversParentTypes['Membership']> = ResolversObject<{
   bio?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   community?: Resolver<Maybe<GqlResolversTypes['Community']>, ParentType, ContextType>;
-  createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
   headline?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   histories?: Resolver<Maybe<Array<GqlResolversTypes['MembershipHistory']>>, ParentType, ContextType>;
   participationView?: Resolver<Maybe<GqlResolversTypes['MembershipParticipationView']>, ParentType, ContextType>;
@@ -3134,7 +3134,7 @@ export type GqlMembershipEdgeResolvers<ContextType = any, ParentType extends Gql
 }>;
 
 export type GqlMembershipHistoryResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['MembershipHistory'] = GqlResolversParentTypes['MembershipHistory']> = ResolversObject<{
-  createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
   createdByUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
   id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
   membership?: Resolver<GqlResolversTypes['Membership'], ParentType, ContextType>;
@@ -3161,7 +3161,7 @@ export type GqlMembershipInviteSuccessResolvers<ContextType = any, ParentType ex
 }>;
 
 export type GqlMembershipParticipatedMetricsResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['MembershipParticipatedMetrics'] = GqlResolversParentTypes['MembershipParticipatedMetrics']> = ResolversObject<{
-  geo?: Resolver<Array<GqlResolversTypes['MembershipParticipationLocation']>, ParentType, ContextType>;
+  geo?: Resolver<Maybe<Array<GqlResolversTypes['MembershipParticipationLocation']>>, ParentType, ContextType>;
   totalParticipatedCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
@@ -3178,7 +3178,7 @@ export type GqlMembershipParticipationLocationResolvers<ContextType = any, Paren
 
 export type GqlMembershipParticipationViewResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['MembershipParticipationView'] = GqlResolversParentTypes['MembershipParticipationView']> = ResolversObject<{
   hosted?: Resolver<GqlResolversTypes['MembershipHostedMetrics'], ParentType, ContextType>;
-  participated?: Resolver<GqlResolversTypes['MembershipParticipatedMetrics'], ParentType, ContextType>;
+  participated?: Resolver<Maybe<GqlResolversTypes['MembershipParticipatedMetrics']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -3411,14 +3411,14 @@ export type GqlPagingResolvers<ContextType = any, ParentType extends GqlResolver
 
 export type GqlParticipationResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Participation'] = GqlResolversParentTypes['Participation']> = ResolversObject<{
   community?: Resolver<Maybe<GqlResolversTypes['Community']>, ParentType, ContextType>;
-  createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
   description?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   evaluation?: Resolver<Maybe<GqlResolversTypes['Evaluation']>, ParentType, ContextType>;
   id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
   images?: Resolver<Maybe<Array<GqlResolversTypes['String']>>, ParentType, ContextType>;
   reason?: Resolver<GqlResolversTypes['ParticipationStatusReason'], ParentType, ContextType>;
   reservation?: Resolver<Maybe<GqlResolversTypes['Reservation']>, ParentType, ContextType>;
-  source?: Resolver<GqlResolversTypes['Source'], ParentType, ContextType>;
+  source?: Resolver<Maybe<GqlResolversTypes['Source']>, ParentType, ContextType>;
   status?: Resolver<GqlResolversTypes['ParticipationStatus'], ParentType, ContextType>;
   statusHistories?: Resolver<Maybe<Array<GqlResolversTypes['ParticipationStatusHistory']>>, ParentType, ContextType>;
   ticketStatusHistories?: Resolver<Maybe<Array<GqlResolversTypes['TicketStatusHistory']>>, ParentType, ContextType>;
@@ -3633,7 +3633,7 @@ export type GqlReservationHistoriesConnectionResolvers<ContextType = any, Parent
 }>;
 
 export type GqlReservationHistoryResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReservationHistory'] = GqlResolversParentTypes['ReservationHistory']> = ResolversObject<{
-  createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
   createdByUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
   id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
   reservation?: Resolver<GqlResolversTypes['Reservation'], ParentType, ContextType>;
@@ -3789,7 +3789,7 @@ export type GqlTicketsConnectionResolvers<ContextType = any, ParentType extends 
 }>;
 
 export type GqlTransactionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Transaction'] = GqlResolversParentTypes['Transaction']> = ResolversObject<{
-  createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
   fromPointChange?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
   fromWallet?: Resolver<Maybe<GqlResolversTypes['Wallet']>, ParentType, ContextType>;
   id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -366,6 +366,7 @@ export type GqlMembership = {
   createdAt?: Maybe<Scalars['Datetime']['output']>;
   headline?: Maybe<Scalars['String']['output']>;
   histories?: Maybe<Array<GqlMembershipHistory>>;
+  hostOpportunityCount?: Maybe<Scalars['Int']['output']>;
   participationView?: Maybe<GqlMembershipParticipationView>;
   reason: GqlMembershipStatusReason;
   role: GqlRole;
@@ -3118,6 +3119,7 @@ export type GqlMembershipResolvers<ContextType = any, ParentType extends GqlReso
   createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
   headline?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   histories?: Resolver<Maybe<Array<GqlResolversTypes['MembershipHistory']>>, ParentType, ContextType>;
+  hostOpportunityCount?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
   participationView?: Resolver<Maybe<GqlResolversTypes['MembershipParticipationView']>, ParentType, ContextType>;
   reason?: Resolver<GqlResolversTypes['MembershipStatusReason'], ParentType, ContextType>;
   role?: Resolver<GqlResolversTypes['Role'], ParentType, ContextType>;


### PR DESCRIPTION
## 概要
- GraphQLスキーマおよび関連リゾルバ・DataLoader・Presenterの大規模リファクタリングを実施しました。
- N+1回避・型安全性向上・責務分離の徹底を目的としています。
- 一部バグ修正（visitor view membership, presenter geoviews）も含みます。

## 主な変更点
- DataLoaderのパターン統一・拡張（IDベースLoaderのユーティリティ化、ドメインごとの登録整理）
- membership history関連の型・Loader・リゾルバの整理・リネーム
- GraphQLスキーマ・型・リゾルバの責務分離・型安全性強化
- N+1回避のためのLoader/Resolver/Presenterパターンの統一
- visitor view membership, presenter geoviewsのバグ修正
- release tag追加、GraphQL DBインタラクションのリファクタ

## 補足・レビューポイント
- 各ドメインのDataLoader登録・利用パターンが統一されているかご確認ください
- membership history関連の型・リゾルバの命名・責務分離に問題がないかご確認ください
- 既存のGraphQL型・スキーマとの互換性、N+1回避の実装に問題がないかご確認ください
- その他、影響範囲が広いため、各種ユースケースの動作確認をお願いします