### PR TITLE
Add GraphQL queries for TicketIssuer with pagination

### DIFF
--- a/src/application/domain/experience/evaluation/usecase.ts
+++ b/src/application/domain/experience/evaluation/usecase.ts
@@ -39,7 +39,6 @@ export default class EvaluationUseCase {
 
     const hasNextPage = evaluations.length > take;
     const data = evaluations.slice(0, take).map(EvaluationPresenter.get);
-    console.log(data);
     return EvaluationPresenter.query(data, hasNextPage);
   }
 

--- a/src/application/domain/reward/ticketIssuer/controller/resolver.ts
+++ b/src/application/domain/reward/ticketIssuer/controller/resolver.ts
@@ -1,14 +1,28 @@
 import { IContext } from "@/types/server";
-import { injectable } from "tsyringe";
+import { inject, injectable } from "tsyringe";
 import { PrismaTicketIssuerDetail } from "@/application/domain/reward/ticketIssuer/data/type";
+import { GqlQueryTicketIssuerArgs, GqlQueryTicketIssuersArgs } from "@/types/graphql";
+import { TicketIssuerUseCase } from "@/application/domain/reward/ticketIssuer/usecase";
 
 @injectable()
 export default class TicketIssuerResolver {
+  constructor(
+    @inject("TicketIssuerUseCase") private readonly ticketIssuerUseCase: TicketIssuerUseCase,
+  ) {}
+
+  Query = {
+    ticketIssuers: (_: unknown, args: GqlQueryTicketIssuersArgs, ctx: IContext) => {
+      return this.ticketIssuerUseCase.visitorBrowseTicketIssuers(ctx, args);
+    },
+
+    ticketIssuer: (_: unknown, args: GqlQueryTicketIssuerArgs, ctx: IContext) => {
+      return ctx.loaders.ticketIssuer.load(args.id); // ← N+1 回避の DataLoader 利用
+    },
+  };
+
   TicketIssuer = {
     utility: (parent: PrismaTicketIssuerDetail, _: unknown, ctx: IContext) => {
-      return parent.utilityId
-        ? ctx.loaders.utility.load(parent.utilityId)
-        : null;
+      return parent.utilityId ? ctx.loaders.utility.load(parent.utilityId) : null;
     },
 
     owner: (parent: PrismaTicketIssuerDetail, _: unknown, ctx: IContext) => {
@@ -16,9 +30,7 @@ export default class TicketIssuerResolver {
     },
 
     claimLink: (parent: PrismaTicketIssuerDetail, _: unknown, ctx: IContext) => {
-      return parent.claimLinkId
-        ? ctx.loaders.ticketClaimLink.load(parent.claimLinkId)
-        : null;
+      return parent.claimLinkId ? ctx.loaders.ticketClaimLink.load(parent.claimLinkId) : null;
     },
   };
 }

--- a/src/application/domain/reward/ticketIssuer/data/converter.ts
+++ b/src/application/domain/reward/ticketIssuer/data/converter.ts
@@ -1,8 +1,25 @@
 import { Prisma } from "@prisma/client";
 import { injectable } from "tsyringe";
+import { GqlTicketIssuerFilterInput, GqlTicketIssuerSortInput } from "@/types/graphql";
 
 @injectable()
 export default class TicketIssuerConverter {
+  filter(filter?: GqlTicketIssuerFilterInput): Prisma.TicketIssuerWhereInput {
+    const conditions: Prisma.TicketIssuerWhereInput[] = [];
+
+    if (!filter) return {};
+
+    if (filter.ownerId) {
+      conditions.push({ ownerId: filter.ownerId });
+    }
+
+    return conditions.length ? { AND: conditions } : {};
+  }
+
+  sort(sort?: GqlTicketIssuerSortInput): Prisma.TicketIssuerOrderByWithRelationInput[] {
+    return [{ createdAt: sort?.createdAt ?? Prisma.SortOrder.desc }];
+  }
+
   issue(userId: string, utilityId: string, qty: number): Prisma.TicketIssuerCreateInput {
     return {
       qtyToBeIssued: qty,

--- a/src/application/domain/reward/ticketIssuer/data/interface.ts
+++ b/src/application/domain/reward/ticketIssuer/data/interface.ts
@@ -3,6 +3,13 @@ import { Prisma } from "@prisma/client";
 import { PrismaTicketIssuerDetail } from "./type";
 
 export interface ITicketIssuerRepository {
+  query(
+    ctx: IContext,
+    where: Prisma.TicketIssuerWhereInput,
+    orderBy: Prisma.TicketIssuerOrderByWithRelationInput[],
+    take: number,
+    cursor?: string,
+  ): Promise<PrismaTicketIssuerDetail[]>;
   find(ctx: IContext, id: string): Promise<PrismaTicketIssuerDetail | null>;
   create(
     ctx: IContext,

--- a/src/application/domain/reward/ticketIssuer/data/repository.ts
+++ b/src/application/domain/reward/ticketIssuer/data/repository.ts
@@ -9,7 +9,7 @@ export default class TicketIssuerRepository implements ITicketIssuerRepository {
   async query(
     ctx: IContext,
     where: Prisma.TicketIssuerWhereInput,
-    orderBy: Prisma.TicketIssuerOrderByWithRelationInput,
+    orderBy: Prisma.TicketIssuerOrderByWithRelationInput[],
     take: number,
     cursor?: string,
   ) {

--- a/src/application/domain/reward/ticketIssuer/presenter.ts
+++ b/src/application/domain/reward/ticketIssuer/presenter.ts
@@ -1,7 +1,27 @@
-import { GqlTicketIssuePayload, GqlTicketIssuer } from "@/types/graphql";
+import {
+  GqlTicketIssuePayload,
+  GqlTicketIssuer,
+  GqlTicketIssuersConnection,
+} from "@/types/graphql";
 import { PrismaTicketIssuerDetail } from "@/application/domain/reward/ticketIssuer/data/type";
 
 export default class TicketIssuerPresenter {
+  static query(records: GqlTicketIssuer[], hasNextPage: boolean): GqlTicketIssuersConnection {
+    return {
+      totalCount: records.length,
+      pageInfo: {
+        hasNextPage,
+        hasPreviousPage: true,
+        startCursor: records[0]?.id,
+        endCursor: records.length ? records[records.length - 1].id : undefined,
+      },
+      edges: records.map((record) => ({
+        cursor: record.id,
+        node: record,
+      })),
+    };
+  }
+
   static get(r: PrismaTicketIssuerDetail): GqlTicketIssuer {
     return r;
   }

--- a/src/application/domain/reward/ticketIssuer/schema/query.graphql
+++ b/src/application/domain/reward/ticketIssuer/schema/query.graphql
@@ -1,0 +1,37 @@
+# ------------------------------
+# TicketIssuer Query Definitions
+# ------------------------------
+extend type Query {
+    ticketIssuers(
+        filter: TicketIssuerFilterInput
+        sort: TicketIssuerSortInput
+        cursor: String
+        first: Int
+    ): TicketIssuersConnection!
+    ticketIssuer(id: ID!): TicketIssuer
+}
+
+# ------------------------------
+# TicketIssuer Connection Type Definitions
+# ------------------------------
+type TicketIssuersConnection {
+    edges: [TicketIssuerEdge]
+    pageInfo: PageInfo!
+    totalCount: Int!
+}
+
+type TicketIssuerEdge implements Edge {
+    cursor: String!
+    node: TicketIssuer
+}
+
+# ------------------------------
+# TicketIssuer Query Input Definitions
+# ------------------------------
+input TicketIssuerFilterInput {
+    ownerId: ID
+}
+
+input TicketIssuerSortInput {
+    createdAt: SortDirection
+}

--- a/src/application/domain/reward/ticketIssuer/service.ts
+++ b/src/application/domain/reward/ticketIssuer/service.ts
@@ -3,6 +3,7 @@ import { IContext } from "@/types/server";
 import { ITicketIssuerRepository, ITicketIssuerService } from "./data/interface";
 import { NotFoundError } from "@/errors/graphql";
 import TicketIssuerConverter from "@/application/domain/reward/ticketIssuer/data/converter";
+import { GqlQueryTicketIssuersArgs } from "@/types/graphql";
 
 @injectable()
 export default class TicketIssuerService implements ITicketIssuerService {
@@ -10,6 +11,17 @@ export default class TicketIssuerService implements ITicketIssuerService {
     @inject("TicketIssuerRepository") private readonly repository: ITicketIssuerRepository,
     @inject("TicketIssuerConverter") private readonly converter: TicketIssuerConverter,
   ) {}
+
+  async fetchTicketIssuers(
+    ctx: IContext,
+    { cursor, filter, sort }: GqlQueryTicketIssuersArgs,
+    take: number,
+  ) {
+    const where = this.converter.filter(filter ?? {});
+    const orderBy = this.converter.sort(sort ?? {});
+
+    return await this.repository.query(ctx, where, orderBy, take, cursor);
+  }
 
   async findTicketIssuer(ctx: IContext, id: string) {
     return await this.repository.find(ctx, id);

--- a/src/application/domain/reward/ticketIssuer/usecase.ts
+++ b/src/application/domain/reward/ticketIssuer/usecase.ts
@@ -1,4 +1,4 @@
-import { injectable } from "tsyringe";
+import { inject, injectable } from "tsyringe";
 import type {
   GqlQueryTicketIssuerArgs,
   GqlQueryTicketIssuersArgs,
@@ -12,7 +12,9 @@ import { clampFirst } from "@/application/domain/utils";
 
 @injectable()
 export class TicketIssuerUseCase {
-  constructor(private readonly ticketIssuerService: TicketIssuerService) {}
+  constructor(
+    @inject("TicketIssuerService") private readonly ticketIssuerService: TicketIssuerService,
+  ) {}
 
   async visitorBrowseTicketIssuers(
     ctx: IContext,

--- a/src/application/domain/reward/ticketIssuer/usecase.ts
+++ b/src/application/domain/reward/ticketIssuer/usecase.ts
@@ -1,0 +1,43 @@
+import { injectable } from "tsyringe";
+import type {
+  GqlQueryTicketIssuerArgs,
+  GqlQueryTicketIssuersArgs,
+  GqlTicketIssuer,
+  GqlTicketIssuersConnection,
+} from "@/types/graphql";
+import TicketIssuerService from "@/application/domain/reward/ticketIssuer/service";
+import { IContext } from "@/types/server";
+import TicketIssuerPresenter from "@/application/domain/reward/ticketIssuer/presenter";
+import { clampFirst } from "@/application/domain/utils";
+
+@injectable()
+export class TicketIssuerUseCase {
+  constructor(private readonly ticketIssuerService: TicketIssuerService) {}
+
+  async visitorBrowseTicketIssuers(
+    ctx: IContext,
+    { cursor, filter, sort, first }: GqlQueryTicketIssuersArgs,
+  ): Promise<GqlTicketIssuersConnection> {
+    const take = clampFirst(first);
+    const ticketIssuers = await this.ticketIssuerService.fetchTicketIssuers(
+      ctx,
+      { cursor, filter, sort },
+      take,
+    );
+
+    const hasNextPage = ticketIssuers.length > take;
+    const data = ticketIssuers.slice(0, take).map(TicketIssuerPresenter.get);
+    return TicketIssuerPresenter.query(data, hasNextPage);
+  }
+
+  async visitorViewTicketIssuer(
+    ctx: IContext,
+    { id }: GqlQueryTicketIssuerArgs,
+  ): Promise<GqlTicketIssuer | null> {
+    const ticketIssuer = await this.ticketIssuerService.findTicketIssuer(ctx, id);
+    if (!ticketIssuer) {
+      return null;
+    }
+    return TicketIssuerPresenter.get(ticketIssuer);
+  }
+}

--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -75,6 +75,7 @@ import MembershipRepository from "@/application/domain/account/membership/data/r
 import ReservationValidator from "@/application/domain/experience/reservation/validator";
 import WalletUseCase from "@/application/domain/account/wallet/usecase";
 import TicketClaimLinkUseCase from "@/application/domain/reward/ticketClaimLink/usecase";
+import { TicketIssuerUseCase } from "@/application/domain/reward/ticketIssuer/usecase";
 
 export function registerProductionDependencies() {
   // ------------------------------
@@ -204,6 +205,7 @@ export function registerProductionDependencies() {
   container.register("TicketClaimLinkRepository", { useClass: TicketClaimLinkRepository });
 
   // 🧾 TicketIssuer
+  container.register("TicketIssuerUseCase", { useClass: TicketIssuerUseCase });
   container.register("TicketIssuerService", { useClass: TicketIssuerService });
   container.register("TicketIssuerConverter", { useClass: TicketIssuerConverter });
   container.register("TicketIssuerRepository", { useClass: TicketIssuerRepository });

--- a/src/presentation/graphql/resolver.ts
+++ b/src/presentation/graphql/resolver.ts
@@ -16,6 +16,7 @@ import TicketResolver from "@/application/domain/reward/ticket/controller/resolv
 import UtilityResolver from "@/application/domain/reward/utility/controller/resolver";
 import TransactionResolver from "@/application/domain/transaction/controller/resolver";
 import TicketClaimLinkResolver from "@/application/domain/reward/ticketClaimLink/controller/resolver";
+import TicketIssuerResolver from "@/application/domain/reward/ticketIssuer/controller/resolver";
 
 const identity = container.resolve(IdentityResolver);
 const user = container.resolve(UserResolver);
@@ -34,7 +35,7 @@ const evaluation = container.resolve(EvaluationResolver);
 const place = container.resolve(PlaceResolver);
 
 const ticket = container.resolve(TicketResolver);
-const ticketIssuer = container.resolve(TicketResolver);
+const ticketIssuer = container.resolve(TicketIssuerResolver);
 const ticketClaimLink = container.resolve(TicketClaimLinkResolver);
 const utility = container.resolve(UtilityResolver);
 
@@ -92,7 +93,7 @@ const resolvers = {
   Place: place.Place,
 
   Ticket: ticket.Ticket,
-  TicketIssuer: ticketIssuer.Ticket,
+  TicketIssuer: ticketIssuer.TicketIssuer,
   TicketClaimLink: ticketClaimLink.TicketClaimLink,
   Utility: utility.Utility,
 

--- a/src/presentation/graphql/resolver.ts
+++ b/src/presentation/graphql/resolver.ts
@@ -34,6 +34,7 @@ const evaluation = container.resolve(EvaluationResolver);
 const place = container.resolve(PlaceResolver);
 
 const ticket = container.resolve(TicketResolver);
+const ticketIssuer = container.resolve(TicketResolver);
 const ticketClaimLink = container.resolve(TicketClaimLinkResolver);
 const utility = container.resolve(UtilityResolver);
 
@@ -55,6 +56,7 @@ const resolvers = {
     ...place.Query,
     ...utility.Query,
     ...ticket.Query,
+    ...ticketIssuer.Query,
     ...ticketClaimLink.Query,
     ...transaction.Query,
   },
@@ -78,15 +80,22 @@ const resolvers = {
   Wallet: wallet.Wallet,
   Membership: membership.Membership,
   Community: community.Community,
+
   Article: article.Article,
+
   Opportunity: opportunity.Opportunity,
   OpportunitySlot: opportunitySlot.OpportunitySlot,
   Reservation: reservation.Reservation,
   Participation: participation.Participation,
   Evaluation: evaluation.Evaluation,
+
   Place: place.Place,
+
   Ticket: ticket.Ticket,
+  TicketIssuer: ticketIssuer.Ticket,
+  TicketClaimLink: ticketClaimLink.TicketClaimLink,
   Utility: utility.Utility,
+
   Transaction: transaction.Transaction,
 };
 

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1421,6 +1421,8 @@ export type GqlQuery = {
   states: Array<GqlState>;
   ticket?: Maybe<GqlTicket>;
   ticketClaimLink?: Maybe<GqlTicketClaimLink>;
+  ticketIssuer?: Maybe<GqlTicketIssuer>;
+  ticketIssuers: GqlTicketIssuersConnection;
   ticketStatusHistories: GqlTicketStatusHistoriesConnection;
   ticketStatusHistory?: Maybe<GqlTicketStatusHistory>;
   tickets: GqlTicketsConnection;
@@ -1611,6 +1613,19 @@ export type GqlQueryTicketArgs = {
 
 export type GqlQueryTicketClaimLinkArgs = {
   id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryTicketIssuerArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryTicketIssuersArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlTicketIssuerFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlTicketIssuerSortInput>;
 };
 
 
@@ -1912,6 +1927,27 @@ export type GqlTicketIssuer = {
   qtyToBeIssued: Scalars['Int']['output'];
   updatedAt?: Maybe<Scalars['Datetime']['output']>;
   utility?: Maybe<GqlUtility>;
+};
+
+export type GqlTicketIssuerEdge = GqlEdge & {
+  __typename?: 'TicketIssuerEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlTicketIssuer>;
+};
+
+export type GqlTicketIssuerFilterInput = {
+  ownerId?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type GqlTicketIssuerSortInput = {
+  createdAt?: InputMaybe<GqlSortDirection>;
+};
+
+export type GqlTicketIssuersConnection = {
+  __typename?: 'TicketIssuersConnection';
+  edges?: Maybe<Array<Maybe<GqlTicketIssuerEdge>>>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
 };
 
 export type GqlTicketPurchaseInput = {
@@ -2443,7 +2479,7 @@ export type GqlResolversUnionTypes<_RefType extends Record<string, unknown>> = R
 
 /** Mapping of interface types */
 export type GqlResolversInterfaceTypes<_RefType extends Record<string, unknown>> = ResolversObject<{
-  Edge: ( Omit<GqlArticleEdge, 'node'> & { node?: Maybe<_RefType['Article']> } ) | ( Omit<GqlCommunityEdge, 'node'> & { node?: Maybe<_RefType['Community']> } ) | ( Omit<GqlEvaluationEdge, 'node'> & { node?: Maybe<_RefType['Evaluation']> } ) | ( Omit<GqlEvaluationHistoryEdge, 'node'> & { node?: Maybe<_RefType['EvaluationHistory']> } ) | ( Omit<GqlMembershipEdge, 'node'> & { node?: Maybe<_RefType['Membership']> } ) | ( Omit<GqlOpportunityEdge, 'node'> & { node?: Maybe<_RefType['Opportunity']> } ) | ( Omit<GqlOpportunitySlotEdge, 'node'> & { node?: Maybe<_RefType['OpportunitySlot']> } ) | ( Omit<GqlParticipationEdge, 'node'> & { node?: Maybe<_RefType['Participation']> } ) | ( Omit<GqlParticipationStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['ParticipationStatusHistory']> } ) | ( Omit<GqlPlaceEdge, 'node'> & { node?: Maybe<_RefType['Place']> } ) | ( Omit<GqlReservationEdge, 'node'> & { node?: Maybe<_RefType['Reservation']> } ) | ( Omit<GqlReservationHistoryEdge, 'node'> & { node?: Maybe<_RefType['ReservationHistory']> } ) | ( Omit<GqlTicketEdge, 'node'> & { node?: Maybe<_RefType['Ticket']> } ) | ( Omit<GqlTicketStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['TicketStatusHistory']> } ) | ( Omit<GqlTransactionEdge, 'node'> & { node?: Maybe<_RefType['Transaction']> } ) | ( Omit<GqlUserEdge, 'node'> & { node?: Maybe<_RefType['User']> } ) | ( Omit<GqlUtilityEdge, 'node'> & { node?: Maybe<_RefType['Utility']> } ) | ( Omit<GqlWalletEdge, 'node'> & { node?: Maybe<_RefType['Wallet']> } );
+  Edge: ( Omit<GqlArticleEdge, 'node'> & { node?: Maybe<_RefType['Article']> } ) | ( Omit<GqlCommunityEdge, 'node'> & { node?: Maybe<_RefType['Community']> } ) | ( Omit<GqlEvaluationEdge, 'node'> & { node?: Maybe<_RefType['Evaluation']> } ) | ( Omit<GqlEvaluationHistoryEdge, 'node'> & { node?: Maybe<_RefType['EvaluationHistory']> } ) | ( Omit<GqlMembershipEdge, 'node'> & { node?: Maybe<_RefType['Membership']> } ) | ( Omit<GqlOpportunityEdge, 'node'> & { node?: Maybe<_RefType['Opportunity']> } ) | ( Omit<GqlOpportunitySlotEdge, 'node'> & { node?: Maybe<_RefType['OpportunitySlot']> } ) | ( Omit<GqlParticipationEdge, 'node'> & { node?: Maybe<_RefType['Participation']> } ) | ( Omit<GqlParticipationStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['ParticipationStatusHistory']> } ) | ( Omit<GqlPlaceEdge, 'node'> & { node?: Maybe<_RefType['Place']> } ) | ( Omit<GqlReservationEdge, 'node'> & { node?: Maybe<_RefType['Reservation']> } ) | ( Omit<GqlReservationHistoryEdge, 'node'> & { node?: Maybe<_RefType['ReservationHistory']> } ) | ( Omit<GqlTicketEdge, 'node'> & { node?: Maybe<_RefType['Ticket']> } ) | ( Omit<GqlTicketIssuerEdge, 'node'> & { node?: Maybe<_RefType['TicketIssuer']> } ) | ( Omit<GqlTicketStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['TicketStatusHistory']> } ) | ( Omit<GqlTransactionEdge, 'node'> & { node?: Maybe<_RefType['Transaction']> } ) | ( Omit<GqlUserEdge, 'node'> & { node?: Maybe<_RefType['User']> } ) | ( Omit<GqlUtilityEdge, 'node'> & { node?: Maybe<_RefType['Utility']> } ) | ( Omit<GqlWalletEdge, 'node'> & { node?: Maybe<_RefType['Wallet']> } );
 }>;
 
 /** Mapping between all available schema types and the resolvers types */
@@ -2644,6 +2680,10 @@ export type GqlResolversTypes = ResolversObject<{
   TicketIssuePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['TicketIssuePayload']>;
   TicketIssueSuccess: ResolverTypeWrapper<Omit<GqlTicketIssueSuccess, 'issue'> & { issue: GqlResolversTypes['TicketIssuer'] }>;
   TicketIssuer: ResolverTypeWrapper<TicketIssuer>;
+  TicketIssuerEdge: ResolverTypeWrapper<Omit<GqlTicketIssuerEdge, 'node'> & { node?: Maybe<GqlResolversTypes['TicketIssuer']> }>;
+  TicketIssuerFilterInput: GqlTicketIssuerFilterInput;
+  TicketIssuerSortInput: GqlTicketIssuerSortInput;
+  TicketIssuersConnection: ResolverTypeWrapper<Omit<GqlTicketIssuersConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['TicketIssuerEdge']>>> }>;
   TicketPurchaseInput: GqlTicketPurchaseInput;
   TicketPurchasePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['TicketPurchasePayload']>;
   TicketPurchaseSuccess: ResolverTypeWrapper<Omit<GqlTicketPurchaseSuccess, 'ticket'> & { ticket: GqlResolversTypes['Ticket'] }>;
@@ -2888,6 +2928,10 @@ export type GqlResolversParentTypes = ResolversObject<{
   TicketIssuePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['TicketIssuePayload'];
   TicketIssueSuccess: Omit<GqlTicketIssueSuccess, 'issue'> & { issue: GqlResolversParentTypes['TicketIssuer'] };
   TicketIssuer: TicketIssuer;
+  TicketIssuerEdge: Omit<GqlTicketIssuerEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['TicketIssuer']> };
+  TicketIssuerFilterInput: GqlTicketIssuerFilterInput;
+  TicketIssuerSortInput: GqlTicketIssuerSortInput;
+  TicketIssuersConnection: Omit<GqlTicketIssuersConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['TicketIssuerEdge']>>> };
   TicketPurchaseInput: GqlTicketPurchaseInput;
   TicketPurchasePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['TicketPurchasePayload'];
   TicketPurchaseSuccess: Omit<GqlTicketPurchaseSuccess, 'ticket'> & { ticket: GqlResolversParentTypes['Ticket'] };
@@ -3089,7 +3133,7 @@ export interface GqlDecimalScalarConfig extends GraphQLScalarTypeConfig<GqlResol
 }
 
 export type GqlEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Edge'] = GqlResolversParentTypes['Edge']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'ArticleEdge' | 'CommunityEdge' | 'EvaluationEdge' | 'EvaluationHistoryEdge' | 'MembershipEdge' | 'OpportunityEdge' | 'OpportunitySlotEdge' | 'ParticipationEdge' | 'ParticipationStatusHistoryEdge' | 'PlaceEdge' | 'ReservationEdge' | 'ReservationHistoryEdge' | 'TicketEdge' | 'TicketStatusHistoryEdge' | 'TransactionEdge' | 'UserEdge' | 'UtilityEdge' | 'WalletEdge', ParentType, ContextType>;
+  __resolveType: TypeResolveFn<'ArticleEdge' | 'CommunityEdge' | 'EvaluationEdge' | 'EvaluationHistoryEdge' | 'MembershipEdge' | 'OpportunityEdge' | 'OpportunitySlotEdge' | 'ParticipationEdge' | 'ParticipationStatusHistoryEdge' | 'PlaceEdge' | 'ReservationEdge' | 'ReservationHistoryEdge' | 'TicketEdge' | 'TicketIssuerEdge' | 'TicketStatusHistoryEdge' | 'TransactionEdge' | 'UserEdge' | 'UtilityEdge' | 'WalletEdge', ParentType, ContextType>;
   cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
 }>;
 
@@ -3647,6 +3691,8 @@ export type GqlQueryResolvers<ContextType = any, ParentType extends GqlResolvers
   states?: Resolver<Array<GqlResolversTypes['State']>, ParentType, ContextType, Partial<GqlQueryStatesArgs>>;
   ticket?: Resolver<Maybe<GqlResolversTypes['Ticket']>, ParentType, ContextType, RequireFields<GqlQueryTicketArgs, 'id'>>;
   ticketClaimLink?: Resolver<Maybe<GqlResolversTypes['TicketClaimLink']>, ParentType, ContextType, RequireFields<GqlQueryTicketClaimLinkArgs, 'id'>>;
+  ticketIssuer?: Resolver<Maybe<GqlResolversTypes['TicketIssuer']>, ParentType, ContextType, RequireFields<GqlQueryTicketIssuerArgs, 'id'>>;
+  ticketIssuers?: Resolver<GqlResolversTypes['TicketIssuersConnection'], ParentType, ContextType, Partial<GqlQueryTicketIssuersArgs>>;
   ticketStatusHistories?: Resolver<GqlResolversTypes['TicketStatusHistoriesConnection'], ParentType, ContextType, Partial<GqlQueryTicketStatusHistoriesArgs>>;
   ticketStatusHistory?: Resolver<Maybe<GqlResolversTypes['TicketStatusHistory']>, ParentType, ContextType, RequireFields<GqlQueryTicketStatusHistoryArgs, 'id'>>;
   tickets?: Resolver<GqlResolversTypes['TicketsConnection'], ParentType, ContextType, Partial<GqlQueryTicketsArgs>>;
@@ -3794,6 +3840,19 @@ export type GqlTicketIssuerResolvers<ContextType = any, ParentType extends GqlRe
   qtyToBeIssued?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
   utility?: Resolver<Maybe<GqlResolversTypes['Utility']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTicketIssuerEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TicketIssuerEdge'] = GqlResolversParentTypes['TicketIssuerEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['TicketIssuer']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTicketIssuersConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TicketIssuersConnection'] = GqlResolversParentTypes['TicketIssuersConnection']> = ResolversObject<{
+  edges?: Resolver<Maybe<Array<Maybe<GqlResolversTypes['TicketIssuerEdge']>>>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -4179,6 +4238,8 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   TicketIssuePayload?: GqlTicketIssuePayloadResolvers<ContextType>;
   TicketIssueSuccess?: GqlTicketIssueSuccessResolvers<ContextType>;
   TicketIssuer?: GqlTicketIssuerResolvers<ContextType>;
+  TicketIssuerEdge?: GqlTicketIssuerEdgeResolvers<ContextType>;
+  TicketIssuersConnection?: GqlTicketIssuersConnectionResolvers<ContextType>;
   TicketPurchasePayload?: GqlTicketPurchasePayloadResolvers<ContextType>;
   TicketPurchaseSuccess?: GqlTicketPurchaseSuccessResolvers<ContextType>;
   TicketRefundPayload?: GqlTicketRefundPayloadResolvers<ContextType>;


### PR DESCRIPTION
### Description

This pull request introduces GraphQL queries for `TicketIssuer`, including support for pagination, filtering, and sorting. Key changes include:

- Added query resolvers for `ticketIssuers` and `ticketIssuer`.
- Implemented input types `GqlTicketIssuerFilterInput` and `GqlTicketIssuerSortInput`.
- Created connections and edges for `TicketIssuer` in the GraphQL schema.
- Updated service and use case layers for the new query functionality.
- Integrated the updates into the GraphQL resolver registry.

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have included documentation updates (if applicable)