### PR TITLE
Make foreign keys nullable and enhance evaluation logic

### DIFF
--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -343,7 +343,7 @@ TICKET_REFUNDED TICKET_REFUNDED
     Int fee_required "❓"
     String community_id "❓"
     String place_id "❓"
-    String created_by 
+    String created_by "❓"
     DateTime created_at 
     DateTime updated_at "❓"
     }
@@ -412,7 +412,7 @@ TICKET_REFUNDED TICKET_REFUNDED
     String credential_url "❓"
     DateTime issued_at "❓"
     String participation_id 
-    String evaluator_id 
+    String evaluator_id "❓"
     DateTime created_at 
     DateTime updated_at "❓"
     }
@@ -637,7 +637,7 @@ TICKET_REFUNDED TICKET_REFUNDED
     "t_opportunities" o|--|o "t_communities" : "community"
     "t_opportunities" o|--|o "t_places" : "place"
     "t_opportunities" o{--}o "t_articles" : "articles"
-    "t_opportunities" o|--|| "t_users" : "createdByUser"
+    "t_opportunities" o|--|o "t_users" : "createdByUser"
     "t_opportunity_slots" o|--|| "OpportunitySlotHostingStatus" : "enum:hosting_status"
     "t_opportunity_slots" o{--}o "v_slot_remaining_capacity" : "remainingCapacityView"
     "t_opportunity_slots" o{--}o "v_slot_evaluation_progress" : "slotEvaluationProgress"
@@ -668,7 +668,7 @@ TICKET_REFUNDED TICKET_REFUNDED
     "t_participation_status_histories" o|--|o "t_users" : "createdByUser"
     "t_evaluations" o|--|| "EvaluationStatus" : "enum:status"
     "t_evaluations" o|--|| "t_participations" : "participation"
-    "t_evaluations" o|--|| "t_users" : "evaluator"
+    "t_evaluations" o|--|o "t_users" : "evaluator"
     "t_evaluations" o{--}o "t_evaluation_histories" : "histories"
     "t_evaluation_histories" o|--|| "EvaluationStatus" : "enum:status"
     "t_evaluation_histories" o|--|| "t_evaluations" : "evaluation"

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -550,6 +550,13 @@ TICKET_REFUNDED TICKET_REFUNDED
     Int remainingCapacity "❓"
     }
   
+
+  "v_slot_evaluation_progress" {
+    String slotId "🗝️"
+    Int totalEvaluated 
+    Int validParticipations 
+    }
+  
     "t_images" o{--}o "t_users" : "users"
     "t_images" o{--}o "t_communities" : "communities"
     "t_images" o{--}o "t_articles" : "articles"
@@ -633,6 +640,7 @@ TICKET_REFUNDED TICKET_REFUNDED
     "t_opportunities" o|--|| "t_users" : "createdByUser"
     "t_opportunity_slots" o|--|| "OpportunitySlotHostingStatus" : "enum:hosting_status"
     "t_opportunity_slots" o{--}o "v_slot_remaining_capacity" : "remainingCapacityView"
+    "t_opportunity_slots" o{--}o "v_slot_evaluation_progress" : "slotEvaluationProgress"
     "t_opportunity_slots" o|--|| "t_opportunities" : "opportunity"
     "t_opportunity_slots" o{--}o "t_reservations" : "reservations"
     "t_reservations" o|--|| "t_opportunity_slots" : "opportunitySlot"
@@ -703,4 +711,5 @@ TICKET_REFUNDED TICKET_REFUNDED
     "mv_accumulated_points" o|--|| "t_wallets" : "wallet"
     "v_earliest_reservable_slot" o|--|| "t_opportunities" : "opportunity"
     "v_slot_remaining_capacity" o|--|| "t_opportunity_slots" : "slot"
+    "v_slot_evaluation_progress" o|--|| "t_opportunity_slots" : "slot"
 ```

--- a/docs/schema.dbml
+++ b/docs/schema.dbml
@@ -238,6 +238,7 @@ Table t_opportunity_slots {
   endsAt DateTime [not null]
   capacity Int
   remainingCapacityView v_slot_remaining_capacity
+  slotEvaluationProgress v_slot_evaluation_progress
   opportunityId String [not null]
   opportunity t_opportunities [not null]
   reservations t_reservations [not null]
@@ -476,6 +477,13 @@ Table v_slot_remaining_capacity {
   slotId String [pk]
   slot t_opportunity_slots [not null]
   remainingCapacity Int
+}
+
+Table v_slot_evaluation_progress {
+  slotId String [pk]
+  slot t_opportunity_slots [not null]
+  totalEvaluated Int [not null]
+  validParticipations Int [not null]
 }
 
 Table t_images_on_opportunities {
@@ -760,3 +768,5 @@ Ref: mv_accumulated_points.walletId - t_wallets.id
 Ref: v_earliest_reservable_slot.opportunityId - t_opportunities.id
 
 Ref: v_slot_remaining_capacity.slotId - t_opportunity_slots.id
+
+Ref: v_slot_evaluation_progress.slotId - t_opportunity_slots.id

--- a/docs/schema.dbml
+++ b/docs/schema.dbml
@@ -225,8 +225,8 @@ Table t_opportunities {
   placeId String
   place t_places
   articles t_articles [not null]
-  createdBy String [not null]
-  createdByUser t_users [not null]
+  createdBy String
+  createdByUser t_users
   createdAt DateTime [default: `now()`, not null]
   updatedAt DateTime
 }
@@ -310,8 +310,8 @@ Table t_evaluations {
   issuedAt DateTime
   participationId String [unique, not null]
   participation t_participations [not null]
-  evaluatorId String [not null]
-  evaluator t_users [not null]
+  evaluatorId String
+  evaluator t_users
   histories t_evaluation_histories [not null]
   createdAt DateTime [default: `now()`, not null]
   updatedAt DateTime

--- a/src/application/domain/experience/evaluation/controller/resolver.ts
+++ b/src/application/domain/experience/evaluation/controller/resolver.ts
@@ -19,7 +19,7 @@ export default class EvaluationResolver {
     },
 
     evaluation: (_: unknown, args: GqlQueryEvaluationArgs, ctx: IContext) => {
-      return ctx.loaders.evaluation.load(args.id);
+      return this.evaluationUseCase.visitorViewEvaluation(ctx, args);
     },
   };
 

--- a/src/application/domain/experience/evaluation/data/interface.ts
+++ b/src/application/domain/experience/evaluation/data/interface.ts
@@ -3,6 +3,7 @@ import { IContext } from "@/types/server";
 import {
   PrismaEvaluation,
   PrismaEvaluationDetail,
+  PrismaEvaluationSelectSlotStartsAt,
 } from "@/application/domain/experience/evaluation/data/type";
 
 export interface IEvaluationRepository {
@@ -13,6 +14,11 @@ export interface IEvaluationRepository {
     take: number,
     cursor?: string,
   ): Promise<PrismaEvaluationDetail[]>;
+
+  queryByParticipation(
+    ctx: IContext,
+    participationId: string,
+  ): Promise<PrismaEvaluationSelectSlotStartsAt[]>;
 
   find(ctx: IContext, id: string): Promise<PrismaEvaluationDetail | null>;
 

--- a/src/application/domain/experience/evaluation/data/repository.ts
+++ b/src/application/domain/experience/evaluation/data/repository.ts
@@ -4,6 +4,7 @@ import { IContext } from "@/types/server";
 import {
   evaluationInclude,
   evaluationSelectDetail,
+  evaluationSelectSlotStartsAt,
 } from "@/application/domain/experience/evaluation/data/type";
 import { IEvaluationRepository } from "@/application/domain/experience/evaluation/data/interface";
 
@@ -24,6 +25,16 @@ export default class EvaluationRepository implements IEvaluationRepository {
         skip: cursor ? 1 : 0,
         cursor: cursor ? { id: cursor } : undefined,
         select: evaluationSelectDetail,
+      });
+    });
+  }
+
+  async queryByParticipation(ctx: IContext, participationId: string) {
+    return ctx.issuer.public(ctx, (tx) => {
+      return tx.evaluation.findMany({
+        where: { participationId },
+        take: 1,
+        select: evaluationSelectSlotStartsAt,
       });
     });
   }

--- a/src/application/domain/experience/evaluation/data/type.ts
+++ b/src/application/domain/experience/evaluation/data/type.ts
@@ -28,10 +28,20 @@ export const evaluationSelectDetail = Prisma.validator<Prisma.EvaluationSelect>(
   updatedAt: true,
 });
 
+export const evaluationSelectSlotStartsAt = Prisma.validator<Prisma.EvaluationSelect>()({
+  participation: {
+    select: { reservation: { select: { opportunitySlot: { select: { startsAt: true } } } } },
+  },
+});
+
 export type PrismaEvaluation = Prisma.EvaluationGetPayload<{
   include: typeof evaluationInclude;
 }>;
 
 export type PrismaEvaluationDetail = Prisma.EvaluationGetPayload<{
   select: typeof evaluationSelectDetail;
+}>;
+
+export type PrismaEvaluationSelectSlotStartsAt = Prisma.EvaluationGetPayload<{
+  select: typeof evaluationSelectSlotStartsAt;
 }>;

--- a/src/application/domain/experience/evaluation/service.ts
+++ b/src/application/domain/experience/evaluation/service.ts
@@ -4,7 +4,7 @@ import { IEvaluationRepository } from "@/application/domain/experience/evaluatio
 import EvaluationConverter from "@/application/domain/experience/evaluation/data/converter";
 import { IContext } from "@/types/server";
 import { EvaluationStatus, Prisma } from "@prisma/client";
-import { NotFoundError } from "@/errors/graphql";
+import { NotFoundError, ValidationError } from "@/errors/graphql";
 import { PrismaEvaluation } from "@/application/domain/experience/evaluation/data/type";
 
 @injectable()
@@ -40,7 +40,7 @@ export default class EvaluationService {
       status === EvaluationStatus.PASSED || status === EvaluationStatus.FAILED;
 
     if (!isValidFinalStatus) {
-      throw new InvalidEvaluationStatusError(status);
+      throw new ValidationError("create evaluation allowed PASSED or FAILED status only.");
     }
 
     const data = this.converter.create(input.participationId, currentUserId, status, input.comment);

--- a/src/application/domain/experience/evaluation/service.ts
+++ b/src/application/domain/experience/evaluation/service.ts
@@ -4,7 +4,12 @@ import { IEvaluationRepository } from "@/application/domain/experience/evaluatio
 import EvaluationConverter from "@/application/domain/experience/evaluation/data/converter";
 import { IContext } from "@/types/server";
 import { EvaluationStatus, Prisma } from "@prisma/client";
-import { NotFoundError, ValidationError } from "@/errors/graphql";
+import {
+  AlreadyEvaluatedError,
+  CannotEvaluateBeforeOpportunityStartError,
+  NotFoundError,
+  ValidationError,
+} from "@/errors/graphql";
 import { PrismaEvaluation } from "@/application/domain/experience/evaluation/data/type";
 
 @injectable()
@@ -27,6 +32,20 @@ export default class EvaluationService {
 
   async findEvaluation(ctx: IContext, id: string) {
     return await this.repository.find(ctx, id);
+  }
+
+  async validateEvaluatable(ctx: IContext, participationId: string) {
+    const exist = await this.repository.queryByParticipation(ctx, participationId);
+    if (exist.length > 0) throw new AlreadyEvaluatedError();
+
+    const startsAt = exist[0].participation?.reservation?.opportunitySlot.startsAt;
+    if (!startsAt) throw new ValidationError("OpportunitySlot startsAt is undefined.");
+
+    const jstStartsAt = new Date(startsAt).toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" });
+    const nowJST = new Date().toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" });
+
+    if (new Date(nowJST) < new Date(jstStartsAt))
+      throw new CannotEvaluateBeforeOpportunityStartError();
   }
 
   async createEvaluation(

--- a/src/application/domain/experience/evaluation/usecase.ts
+++ b/src/application/domain/experience/evaluation/usecase.ts
@@ -109,6 +109,10 @@ export default class EvaluationUseCase {
     ctx: IContext,
   ): Promise<GqlEvaluationCreatePayload> {
     const currentUserId = getCurrentUserId(ctx);
+    await Promise.all([
+      this.participationService.findParticipationOrThrow(ctx, input.participationId),
+      this.evaluationService.validateEvaluatable(ctx, input.participationId),
+    ]);
 
     const evaluation = await this.evaluationService.createEvaluation(
       ctx,

--- a/src/application/domain/experience/evaluation/usecase.ts
+++ b/src/application/domain/experience/evaluation/usecase.ts
@@ -57,7 +57,10 @@ export default class EvaluationUseCase {
     ctx: IContext,
   ): Promise<GqlEvaluationCreatePayload> {
     const currentUserId = getCurrentUserId(ctx);
-    await this.participationService.findParticipationOrThrow(ctx, input.participationId);
+    await Promise.all([
+      this.participationService.findParticipationOrThrow(ctx, input.participationId),
+      this.evaluationService.validateEvaluatable(ctx, input.participationId),
+    ]);
 
     const evaluation = await ctx.issuer.public(ctx, async (tx) => {
       const evaluation = await this.evaluationService.createEvaluation(

--- a/src/application/domain/experience/opportunitySlot/controller/dataloader.ts
+++ b/src/application/domain/experience/opportunitySlot/controller/dataloader.ts
@@ -26,7 +26,9 @@ export function createSlotsByOpportunityLoader(issuer: PrismaClientIssuer) {
     const opportunities = await issuer.internal((tx) =>
       tx.opportunity.findMany({
         where: { id: { in: [...opportunityIds] } },
-        include: { slots: { include: { remainingCapacityView: true } } },
+        include: {
+          slots: { include: { remainingCapacityView: true, slotEvaluationProgress: true } },
+        },
       }),
     );
 

--- a/src/application/domain/experience/opportunitySlot/controller/resolver.ts
+++ b/src/application/domain/experience/opportunitySlot/controller/resolver.ts
@@ -20,7 +20,7 @@ export default class OpportunitySlotResolver {
       return this.slotUseCase.visitorBrowseOpportunitySlots(args, ctx);
     },
     opportunitySlot: (_: unknown, args: GqlQueryOpportunitySlotArgs, ctx: IContext) => {
-      return ctx.loaders.opportunitySlot.load(args.id);
+      return this.slotUseCase.visitorViewOpportunitySlot(args, ctx);
     },
   };
 

--- a/src/application/domain/experience/opportunitySlot/data/type.ts
+++ b/src/application/domain/experience/opportunitySlot/data/type.ts
@@ -20,6 +20,7 @@ export const opportunitySlotSelectDetail = Prisma.validator<Prisma.OpportunitySl
   capacity: true,
 
   remainingCapacityView: { select: { remainingCapacity: true } },
+  slotEvaluationProgress: { select: { totalEvaluated: true, validParticipations: true } },
   opportunityId: true,
 
   createdAt: true,

--- a/src/application/domain/experience/opportunitySlot/data/type.ts
+++ b/src/application/domain/experience/opportunitySlot/data/type.ts
@@ -10,6 +10,7 @@ export const opportunitySlotReserveInclude = Prisma.validator<Prisma.Opportunity
   opportunity: { include: { requiredUtilities: true } },
   reservations: { include: { participations: true } },
   remainingCapacityView: true,
+  slotEvaluationProgress: true,
 });
 
 export const opportunitySlotSelectDetail = Prisma.validator<Prisma.OpportunitySlotSelect>()({

--- a/src/application/domain/experience/opportunitySlot/presenter.ts
+++ b/src/application/domain/experience/opportunitySlot/presenter.ts
@@ -28,11 +28,17 @@ export default class OpportunitySlotPresenter {
   }
 
   static get(r: PrismaOpportunitySlotDetail): GqlOpportunitySlot {
-    const { remainingCapacityView, ...prop } = r;
+    const { remainingCapacityView, slotEvaluationProgress, ...prop } = r;
     return {
       __typename: "OpportunitySlot",
       ...prop,
       remainingCapacity: remainingCapacityView ? remainingCapacityView.remainingCapacity : null,
+      evaluationProgress: {
+        totalEvaluated: slotEvaluationProgress ? slotEvaluationProgress.totalEvaluated : null,
+        validParticipations: slotEvaluationProgress
+          ? slotEvaluationProgress.validParticipations
+          : null,
+      },
     };
   }
 

--- a/src/application/domain/experience/opportunitySlot/schema/type.graphql
+++ b/src/application/domain/experience/opportunitySlot/schema/type.graphql
@@ -7,6 +7,7 @@ type OpportunitySlot {
     hostingStatus: OpportunitySlotHostingStatus!
     capacity: Int
     remainingCapacity: Int
+    evaluationProgress: SlotEvaluationProgress
 
     startsAt: Datetime!
     endsAt: Datetime!
@@ -17,6 +18,11 @@ type OpportunitySlot {
 
     createdAt: Datetime
     updatedAt: Datetime
+}
+
+type SlotEvaluationProgress {
+    totalEvaluated: Int
+    validParticipations: Int
 }
 
 enum OpportunitySlotHostingStatus {

--- a/src/application/domain/experience/opportunitySlot/service.ts
+++ b/src/application/domain/experience/opportunitySlot/service.ts
@@ -40,6 +40,10 @@ export default class OpportunitySlotService {
     return this.repository.queryByOpportunityId(ctx, where, orderBy);
   }
 
+  async findOpportunitySlot(ctx: IContext, id: string) {
+    return await this.repository.find(ctx, id);
+  }
+
   async findOpportunitySlotOrThrow(ctx: IContext, id: string) {
     const record = await this.repository.find(ctx, id);
 

--- a/src/application/domain/experience/opportunitySlot/usecase.ts
+++ b/src/application/domain/experience/opportunitySlot/usecase.ts
@@ -5,6 +5,8 @@ import {
   GqlOpportunitySlotsBulkUpdatePayload,
   GqlMutationOpportunitySlotSetHostingStatusArgs,
   GqlOpportunitySlotSetHostingStatusPayload,
+  GqlQueryOpportunitySlotArgs,
+  GqlOpportunitySlot,
 } from "@/types/graphql";
 import { IContext } from "@/types/server";
 import OpportunitySlotService from "@/application/domain/experience/opportunitySlot/service";
@@ -40,14 +42,14 @@ export default class OpportunitySlotUseCase {
     return OpportunitySlotPresenter.query(data, hasNextPage);
   }
 
-  // async visitorViewOpportunitySlot(
-  //   { id }: GqlQueryOpportunitySlotArgs,
-  //   ctx: IContext,
-  // ): Promise<GqlOpportunitySlot | null> {
-  //   const slot = await this.service.findOpportunitySlot(ctx, id);
-  //   if (!slot) return null;
-  //   return OpportunitySlotPresenter.get(slot);
-  // }
+  async visitorViewOpportunitySlot(
+    { id }: GqlQueryOpportunitySlotArgs,
+    ctx: IContext,
+  ): Promise<GqlOpportunitySlot | null> {
+    const slot = await this.service.findOpportunitySlot(ctx, id);
+    if (!slot) return null;
+    return OpportunitySlotPresenter.get(slot);
+  }
 
   async managerSetOpportunitySlotHostingStatus(
     { id, input }: GqlMutationOpportunitySlotSetHostingStatusArgs,

--- a/src/application/domain/experience/participation/data/repository.ts
+++ b/src/application/domain/experience/participation/data/repository.ts
@@ -28,15 +28,6 @@ export default class ParticipationRepository implements IParticipationRepository
     );
   }
 
-  async queryByReservationId(ctx: IContext, id: string) {
-    return ctx.issuer.public(ctx, (tx) => {
-      return tx.participation.findMany({
-        where: { reservationId: id },
-        select: participationSelectDetail,
-      });
-    });
-  }
-
   async count(ctx: IContext, where: Prisma.ParticipationWhereInput) {
     return ctx.issuer.public(ctx, (dbTx) => {
       return dbTx.participation.count({

--- a/src/application/domain/notification/presenter/richmenu/admin/admin_menu.json
+++ b/src/application/domain/notification/presenter/richmenu/admin/admin_menu.json
@@ -30,7 +30,7 @@
       "action": {
         "type": "uri",
         "label": "管理者ホーム",
-        "uri": "https://liff.line.me/2006078430-XGzG9kqm/admin"
+        "uri": "https://liff.line.me/2007252081-qlwyMQnK/admin"
       }
     },
     {
@@ -43,7 +43,7 @@
       "action": {
         "type": "uri",
         "label": "チケット送付",
-        "uri": "https://liff.line.me/2006078430-XGzG9kqm/admin/tickets"
+        "uri": "https://liff.line.me/2007252081-qlwyMQnK/admin/tickets"
       }
     },
     {
@@ -56,7 +56,7 @@
       "action": {
         "type": "uri",
         "label": "応募対応",
-        "uri": "https://liff.line.me/2006078430-XGzG9kqm/admin/reservations"
+        "uri": "https://liff.line.me/2007252081-qlwyMQnK/admin/reservations"
       }
     },
     {
@@ -69,7 +69,7 @@
       "action": {
         "type": "uri",
         "label": "出欠管理",
-        "uri": "https://liff.line.me/2006078430-XGzG9kqm/admin/opportunities"
+        "uri": "https://liff.line.me/2007252081-qlwyMQnK/admin/opportunities"
       }
     }
   ]

--- a/src/application/domain/notification/presenter/richmenu/admin/user_menu.json
+++ b/src/application/domain/notification/presenter/richmenu/admin/user_menu.json
@@ -30,7 +30,7 @@
       "action": {
         "type": "uri",
         "label": "ホームに戻る",
-        "uri": "https://liff.line.me/2006078430-XGzG9kqm"
+        "uri": "https://liff.line.me/2007252081-qlwyMQnK"
       }
     },
     {
@@ -43,7 +43,7 @@
       "action": {
         "type": "uri",
         "label": "みつける",
-        "uri": "https://liff.line.me/2006078430-XGzG9kqm/activities"
+        "uri": "https://liff.line.me/2007252081-qlwyMQnK/activities"
       }
     },
     {
@@ -56,7 +56,7 @@
       "action": {
         "type": "uri",
         "label": "拠点",
-        "uri": "https://liff.line.me/2006078430-XGzG9kqm/places?mode=map"
+        "uri": "https://liff.line.me/2007252081-qlwyMQnK/places?mode=map"
       }
     },
     {
@@ -69,7 +69,7 @@
       "action": {
         "type": "uri",
         "label": "マイページ",
-        "uri": "https://liff.line.me/2006078430-XGzG9kqm/users/me"
+        "uri": "https://liff.line.me/2007252081-qlwyMQnK/users/me"
       }
     }
   ]

--- a/src/application/domain/notification/presenter/richmenu/const.ts
+++ b/src/application/domain/notification/presenter/richmenu/const.ts
@@ -1,5 +1,5 @@
 export const LINE_RICHMENU = {
-  ADMIN_MANAGE: 'richmenu-b2506f21e04e4ebc4deb034cae199d65',
-  ADMIN_USER: 'richmenu-b198d58eade8aa97be0a7e7d15211f5c',
-  PUBLIC: 'richmenu-631d7b9741ac9adffa12da02c9a56831',
+  ADMIN_MANAGE: 'richmenu-4103686dee2ba894e67e90df71a4a0c4',
+  ADMIN_USER: 'richmenu-7acab3dd947794057453a56b1b83a905',
+  PUBLIC: 'richmenu-a533153c004dbc92b12b339e260eb416',
 };

--- a/src/application/domain/notification/presenter/richmenu/user/public_menu.json
+++ b/src/application/domain/notification/presenter/richmenu/user/public_menu.json
@@ -17,7 +17,7 @@
       "action": {
         "type": "uri",
         "label": "ホームに戻る",
-        "uri": "https://liff.line.me/2006078430-XGzG9kqm"
+        "uri": "https://liff.line.me/2007252081-qlwyMQnK"
       }
     },
     {
@@ -30,7 +30,7 @@
       "action": {
         "type": "uri",
         "label": "みつける",
-        "uri": "https://liff.line.me/2006078430-XGzG9kqm/activities"
+        "uri": "https://liff.line.me/2007252081-qlwyMQnK/activities"
       }
     },
     {
@@ -43,7 +43,7 @@
       "action": {
         "type": "uri",
         "label": "拠点",
-        "uri": "https://liff.line.me/2006078430-XGzG9kqm/places?mode=map"
+        "uri": "https://liff.line.me/2007252081-qlwyMQnK/places?mode=map"
       }
     },
     {
@@ -56,7 +56,7 @@
       "action": {
         "type": "uri",
         "label": "マイページ",
-        "uri": "https://liff.line.me/2006078430-XGzG9kqm/users/me"
+        "uri": "https://liff.line.me/2007252081-qlwyMQnK/users/me"
       }
     }
   ]

--- a/src/errors/graphql.ts
+++ b/src/errors/graphql.ts
@@ -67,6 +67,7 @@ export class RateLimitError extends ApolloError {
   }
 }
 
+// Wallet
 export class InsufficientBalanceError extends ApolloError {
   public currentBalance: number;
   public requestedAmount: number;
@@ -80,6 +81,36 @@ export class InsufficientBalanceError extends ApolloError {
   }
 }
 
+export class InvalidTransferMethodError extends ApolloError {
+  constructor(message: string = "Use validateTransferMemberToMember()") {
+    super(message, "INVALID_TRANSFER_METHOD");
+    Object.defineProperty(this, "name", { value: "InvalidTransferMethodError" });
+  }
+}
+
+export class MissingWalletInformationError extends ApolloError {
+  public missingWallets: string[];
+
+  constructor(missingWallets: string[]) {
+    const message = `Wallet information is missing for points transfer: ${missingWallets.join(", ")}`;
+    super(message, "MISSING_WALLET_INFORMATION");
+    this.missingWallets = missingWallets;
+    Object.defineProperty(this, "name", { value: "MissingWalletInformationError" });
+  }
+}
+
+export class UnsupportedTransactionReasonError extends ApolloError {
+  public reason: string;
+
+  constructor(reason: string) {
+    const message = `Unsupported TransactionReason: ${reason}`;
+    super(message, "UNSUPPORTED_TRANSACTION_REASON");
+    this.reason = reason;
+    Object.defineProperty(this, "name", { value: "UnsupportedTransactionReasonError" });
+  }
+}
+
+//Reservation
 export class ReservationFullError extends ApolloError {
   public capacity: number;
   public requested: number;
@@ -93,38 +124,10 @@ export class ReservationFullError extends ApolloError {
   }
 }
 
-export class AlreadyJoinedError extends ApolloError {
-  constructor(message: string = "You have already joined this reservation.") {
-    super(message, "ALREADY_JOINED");
-    Object.defineProperty(this, "name", { value: "AlreadyJoinedError" });
-  }
-}
-
 export class AlreadyStartedReservationError extends ApolloError {
   constructor(message: string = "This reservation has already started.") {
     super(message, "ALREADY_STARTED_RESERVATION");
     Object.defineProperty(this, "name", { value: "AlreadyStartedReservationError" });
-  }
-}
-
-export class AlreadyEvaluatedError extends ApolloError {
-  constructor(message: string = "This participation has already been evaluated.") {
-    super(message, "ALREADY_EVALUATED");
-    Object.defineProperty(this, "name", { value: "AlreadyEvaluatedError" });
-  }
-}
-
-export class AlreadyUsedClaimLinkError extends ApolloError {
-  constructor(message: string = "This claim link has already been used.") {
-    super(message, "ALREADY_USED_CLAIM_LINK");
-    Object.defineProperty(this, "name", { value: "AlreadyUsedClaimLinkError" });
-  }
-}
-
-export class ClaimLinkExpiredError extends ApolloError {
-  constructor(message: string = "This claim link has expired.") {
-    super(message, "CLAIM_LINK_EXPIRED");
-    Object.defineProperty(this, "name", { value: "ClaimLinkExpiredError" });
   }
 }
 
@@ -158,6 +161,27 @@ export class SlotNotScheduledError extends ApolloError {
   }
 }
 
+export class TicketParticipantMismatchError extends ApolloError {
+  public ticketCount: number;
+  public participantCount: number;
+
+  constructor(ticketCount: number, participantCount: number) {
+    const message = `The number of tickets (${ticketCount}) does not match the number of participants (${participantCount})`;
+    super(message, "TICKET_PARTICIPANT_MISMATCH");
+    this.ticketCount = ticketCount;
+    this.participantCount = participantCount;
+    Object.defineProperty(this, "name", { value: "TicketParticipantMismatchError" });
+  }
+}
+
+//Participation
+export class AlreadyJoinedError extends ApolloError {
+  constructor(message: string = "You have already joined this reservation.") {
+    super(message, "ALREADY_JOINED");
+    Object.defineProperty(this, "name", { value: "AlreadyJoinedError" });
+  }
+}
+
 export class NoAvailableParticipationSlotsError extends ApolloError {
   constructor(message: string = "No available participation slots.") {
     super(message, "NO_AVAILABLE_PARTICIPATION_SLOTS");
@@ -173,44 +197,34 @@ export class PersonalRecordOnlyDeletableError extends ApolloError {
   }
 }
 
-export class InvalidTransferMethodError extends ApolloError {
-  constructor(message: string = "Use validateTransferMemberToMember()") {
-    super(message, "INVALID_TRANSFER_METHOD");
-    Object.defineProperty(this, "name", { value: "InvalidTransferMethodError" });
+//Evaluation
+export class AlreadyEvaluatedError extends ApolloError {
+  constructor(message: string = "This participation has already been evaluated.") {
+    super(message, "ALREADY_EVALUATED");
+    Object.defineProperty(this, "name", { value: "AlreadyEvaluatedError" });
   }
 }
 
-export class MissingWalletInformationError extends ApolloError {
-  public missingWallets: string[];
-
-  constructor(missingWallets: string[]) {
-    const message = `Wallet information is missing for points transfer: ${missingWallets.join(", ")}`;
-    super(message, "MISSING_WALLET_INFORMATION");
-    this.missingWallets = missingWallets;
-    Object.defineProperty(this, "name", { value: "MissingWalletInformationError" });
+export class CannotEvaluateBeforeOpportunityStartError extends ApolloError {
+  constructor(
+    message: string = "You cannot evaluate this participation before the opportunity starts.",
+  ) {
+    super(message, "CANNOT_EVALUATE_BEFORE_OPPORTUNITY_START");
+    Object.defineProperty(this, "name", { value: "CannotEvaluateBeforeOpportunityStartError" });
   }
 }
 
-export class UnsupportedTransactionReasonError extends ApolloError {
-  public reason: string;
-
-  constructor(reason: string) {
-    const message = `Unsupported TransactionReason: ${reason}`;
-    super(message, "UNSUPPORTED_TRANSACTION_REASON");
-    this.reason = reason;
-    Object.defineProperty(this, "name", { value: "UnsupportedTransactionReasonError" });
+//Ticket
+export class AlreadyUsedClaimLinkError extends ApolloError {
+  constructor(message: string = "This claim link has already been used.") {
+    super(message, "ALREADY_USED_CLAIM_LINK");
+    Object.defineProperty(this, "name", { value: "AlreadyUsedClaimLinkError" });
   }
 }
 
-export class TicketParticipantMismatchError extends ApolloError {
-  public ticketCount: number;
-  public participantCount: number;
-
-  constructor(ticketCount: number, participantCount: number) {
-    const message = `The number of tickets (${ticketCount}) does not match the number of participants (${participantCount})`;
-    super(message, "TICKET_PARTICIPANT_MISMATCH");
-    this.ticketCount = ticketCount;
-    this.participantCount = participantCount;
-    Object.defineProperty(this, "name", { value: "TicketParticipantMismatchError" });
+export class ClaimLinkExpiredError extends ApolloError {
+  constructor(message: string = "This claim link has expired.") {
+    super(message, "CLAIM_LINK_EXPIRED");
+    Object.defineProperty(this, "name", { value: "ClaimLinkExpiredError" });
   }
 }

--- a/src/infrastructure/prisma/factories/__generated__/index.ts
+++ b/src/infrastructure/prisma/factories/__generated__/index.ts
@@ -30,6 +30,7 @@ import type { CurrentPointView } from "@prisma/client";
 import type { AccumulatedPointView } from "@prisma/client";
 import type { EarliestReservableSlotView } from "@prisma/client";
 import type { RemainingCapacityView } from "@prisma/client";
+import type { SlotEvaluationProgress } from "@prisma/client";
 import type { SysRole } from "@prisma/client";
 import type { CurrentPrefecture } from "@prisma/client";
 import type { IdentityPlatform } from "@prisma/client";
@@ -385,6 +386,10 @@ const modelFieldDefinitions: ModelWithFields[] = [{
                 type: "RemainingCapacityView",
                 relationName: "OpportunitySlotToRemainingCapacityView"
             }, {
+                name: "slotEvaluationProgress",
+                type: "SlotEvaluationProgress",
+                relationName: "OpportunitySlotToSlotEvaluationProgress"
+            }, {
                 name: "opportunity",
                 type: "Opportunity",
                 relationName: "OpportunityToOpportunitySlot"
@@ -649,6 +654,13 @@ const modelFieldDefinitions: ModelWithFields[] = [{
                 name: "slot",
                 type: "OpportunitySlot",
                 relationName: "OpportunitySlotToRemainingCapacityView"
+            }]
+    }, {
+        name: "SlotEvaluationProgress",
+        fields: [{
+                name: "slot",
+                type: "OpportunitySlot",
+                relationName: "OpportunitySlotToSlotEvaluationProgress"
             }]
     }];
 
@@ -2781,6 +2793,11 @@ type OpportunitySlotremainingCapacityViewFactory = {
     build: () => PromiseLike<Prisma.RemainingCapacityViewCreateNestedOneWithoutSlotInput["create"]>;
 };
 
+type OpportunitySlotslotEvaluationProgressFactory = {
+    _factoryFor: "SlotEvaluationProgress";
+    build: () => PromiseLike<Prisma.SlotEvaluationProgressCreateNestedOneWithoutSlotInput["create"]>;
+};
+
 type OpportunitySlotopportunityFactory = {
     _factoryFor: "Opportunity";
     build: () => PromiseLike<Prisma.OpportunityCreateNestedOneWithoutSlotsInput["create"]>;
@@ -2795,6 +2812,7 @@ type OpportunitySlotFactoryDefineInput = {
     createdAt?: Date;
     updatedAt?: Date | null;
     remainingCapacityView?: OpportunitySlotremainingCapacityViewFactory | Prisma.RemainingCapacityViewCreateNestedOneWithoutSlotInput;
+    slotEvaluationProgress?: OpportunitySlotslotEvaluationProgressFactory | Prisma.SlotEvaluationProgressCreateNestedOneWithoutSlotInput;
     opportunity: OpportunitySlotopportunityFactory | Prisma.OpportunityCreateNestedOneWithoutSlotsInput;
     reservations?: Prisma.ReservationCreateNestedManyWithoutOpportunitySlotInput;
 };
@@ -2814,6 +2832,10 @@ type OpportunitySlotFactoryDefineOptions<TTransients extends Record<string, unkn
 
 function isOpportunitySlotremainingCapacityViewFactory(x: OpportunitySlotremainingCapacityViewFactory | Prisma.RemainingCapacityViewCreateNestedOneWithoutSlotInput | undefined): x is OpportunitySlotremainingCapacityViewFactory {
     return (x as any)?._factoryFor === "RemainingCapacityView";
+}
+
+function isOpportunitySlotslotEvaluationProgressFactory(x: OpportunitySlotslotEvaluationProgressFactory | Prisma.SlotEvaluationProgressCreateNestedOneWithoutSlotInput | undefined): x is OpportunitySlotslotEvaluationProgressFactory {
+    return (x as any)?._factoryFor === "SlotEvaluationProgress";
 }
 
 function isOpportunitySlotopportunityFactory(x: OpportunitySlotopportunityFactory | Prisma.OpportunityCreateNestedOneWithoutSlotsInput | undefined): x is OpportunitySlotopportunityFactory {
@@ -2884,6 +2906,9 @@ function defineOpportunitySlotFactoryInternal<TTransients extends Record<string,
                 remainingCapacityView: isOpportunitySlotremainingCapacityViewFactory(defaultData.remainingCapacityView) ? {
                     create: await defaultData.remainingCapacityView.build()
                 } : defaultData.remainingCapacityView,
+                slotEvaluationProgress: isOpportunitySlotslotEvaluationProgressFactory(defaultData.slotEvaluationProgress) ? {
+                    create: await defaultData.slotEvaluationProgress.build()
+                } : defaultData.slotEvaluationProgress,
                 opportunity: isOpportunitySlotopportunityFactory(defaultData.opportunity) ? {
                     create: await defaultData.opportunity.build()
                 } : defaultData.opportunity
@@ -6112,3 +6137,157 @@ export const defineRemainingCapacityViewFactory = (<TOptions extends RemainingCa
 }) as RemainingCapacityViewFactoryBuilder;
 
 defineRemainingCapacityViewFactory.withTransientFields = defaultTransientFieldValues => options => defineRemainingCapacityViewFactoryInternal(options, defaultTransientFieldValues);
+
+type SlotEvaluationProgressScalarOrEnumFields = {
+    totalEvaluated: number;
+    validParticipations: number;
+};
+
+type SlotEvaluationProgressslotFactory = {
+    _factoryFor: "OpportunitySlot";
+    build: () => PromiseLike<Prisma.OpportunitySlotCreateNestedOneWithoutSlotEvaluationProgressInput["create"]>;
+};
+
+type SlotEvaluationProgressFactoryDefineInput = {
+    totalEvaluated?: number;
+    validParticipations?: number;
+    slot: SlotEvaluationProgressslotFactory | Prisma.OpportunitySlotCreateNestedOneWithoutSlotEvaluationProgressInput;
+};
+
+type SlotEvaluationProgressTransientFields = Record<string, unknown> & Partial<Record<keyof SlotEvaluationProgressFactoryDefineInput, never>>;
+
+type SlotEvaluationProgressFactoryTrait<TTransients extends Record<string, unknown>> = {
+    data?: Resolver<Partial<SlotEvaluationProgressFactoryDefineInput>, BuildDataOptions<TTransients>>;
+} & CallbackDefineOptions<SlotEvaluationProgress, Prisma.SlotEvaluationProgressCreateInput, TTransients>;
+
+type SlotEvaluationProgressFactoryDefineOptions<TTransients extends Record<string, unknown> = Record<string, unknown>> = {
+    defaultData: Resolver<SlotEvaluationProgressFactoryDefineInput, BuildDataOptions<TTransients>>;
+    traits?: {
+        [traitName: string | symbol]: SlotEvaluationProgressFactoryTrait<TTransients>;
+    };
+} & CallbackDefineOptions<SlotEvaluationProgress, Prisma.SlotEvaluationProgressCreateInput, TTransients>;
+
+function isSlotEvaluationProgressslotFactory(x: SlotEvaluationProgressslotFactory | Prisma.OpportunitySlotCreateNestedOneWithoutSlotEvaluationProgressInput | undefined): x is SlotEvaluationProgressslotFactory {
+    return (x as any)?._factoryFor === "OpportunitySlot";
+}
+
+type SlotEvaluationProgressTraitKeys<TOptions extends SlotEvaluationProgressFactoryDefineOptions<any>> = Exclude<keyof TOptions["traits"], number>;
+
+export interface SlotEvaluationProgressFactoryInterfaceWithoutTraits<TTransients extends Record<string, unknown>> {
+    readonly _factoryFor: "SlotEvaluationProgress";
+    build(inputData?: Partial<Prisma.SlotEvaluationProgressCreateInput & TTransients>): PromiseLike<Prisma.SlotEvaluationProgressCreateInput>;
+    buildCreateInput(inputData?: Partial<Prisma.SlotEvaluationProgressCreateInput & TTransients>): PromiseLike<Prisma.SlotEvaluationProgressCreateInput>;
+    buildList(list: readonly Partial<Prisma.SlotEvaluationProgressCreateInput & TTransients>[]): PromiseLike<Prisma.SlotEvaluationProgressCreateInput[]>;
+    buildList(count: number, item?: Partial<Prisma.SlotEvaluationProgressCreateInput & TTransients>): PromiseLike<Prisma.SlotEvaluationProgressCreateInput[]>;
+    pickForConnect(inputData: SlotEvaluationProgress): Pick<SlotEvaluationProgress, "slotId">;
+    create(inputData?: Partial<Prisma.SlotEvaluationProgressCreateInput & TTransients>): PromiseLike<SlotEvaluationProgress>;
+    createList(list: readonly Partial<Prisma.SlotEvaluationProgressCreateInput & TTransients>[]): PromiseLike<SlotEvaluationProgress[]>;
+    createList(count: number, item?: Partial<Prisma.SlotEvaluationProgressCreateInput & TTransients>): PromiseLike<SlotEvaluationProgress[]>;
+    createForConnect(inputData?: Partial<Prisma.SlotEvaluationProgressCreateInput & TTransients>): PromiseLike<Pick<SlotEvaluationProgress, "slotId">>;
+}
+
+export interface SlotEvaluationProgressFactoryInterface<TTransients extends Record<string, unknown> = Record<string, unknown>, TTraitName extends TraitName = TraitName> extends SlotEvaluationProgressFactoryInterfaceWithoutTraits<TTransients> {
+    use(name: TTraitName, ...names: readonly TTraitName[]): SlotEvaluationProgressFactoryInterfaceWithoutTraits<TTransients>;
+}
+
+function autoGenerateSlotEvaluationProgressScalarsOrEnums({ seq }: {
+    readonly seq: number;
+}): SlotEvaluationProgressScalarOrEnumFields {
+    return {
+        totalEvaluated: getScalarFieldValueGenerator().Int({ modelName: "SlotEvaluationProgress", fieldName: "totalEvaluated", isId: false, isUnique: false, seq }),
+        validParticipations: getScalarFieldValueGenerator().Int({ modelName: "SlotEvaluationProgress", fieldName: "validParticipations", isId: false, isUnique: false, seq })
+    };
+}
+
+function defineSlotEvaluationProgressFactoryInternal<TTransients extends Record<string, unknown>, TOptions extends SlotEvaluationProgressFactoryDefineOptions<TTransients>>({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }: TOptions, defaultTransientFieldValues: TTransients): SlotEvaluationProgressFactoryInterface<TTransients, SlotEvaluationProgressTraitKeys<TOptions>> {
+    const getFactoryWithTraits = (traitKeys: readonly SlotEvaluationProgressTraitKeys<TOptions>[] = []) => {
+        const seqKey = {};
+        const getSeq = () => getSequenceCounter(seqKey);
+        const screen = createScreener("SlotEvaluationProgress", modelFieldDefinitions);
+        const handleAfterBuild = createCallbackChain([
+            onAfterBuild,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterBuild),
+        ]);
+        const handleBeforeCreate = createCallbackChain([
+            ...traitKeys.slice().reverse().map(traitKey => traitsDefs[traitKey]?.onBeforeCreate),
+            onBeforeCreate,
+        ]);
+        const handleAfterCreate = createCallbackChain([
+            onAfterCreate,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterCreate),
+        ]);
+        const build = async (inputData: Partial<Prisma.SlotEvaluationProgressCreateInput & TTransients> = {}) => {
+            const seq = getSeq();
+            const requiredScalarData = autoGenerateSlotEvaluationProgressScalarsOrEnums({ seq });
+            const resolveValue = normalizeResolver<SlotEvaluationProgressFactoryDefineInput, BuildDataOptions<any>>(defaultDataResolver);
+            const [transientFields, filteredInputData] = destructure(defaultTransientFieldValues, inputData);
+            const resolverInput = { seq, ...transientFields };
+            const defaultData = await traitKeys.reduce(async (queue, traitKey) => {
+                const acc = await queue;
+                const resolveTraitValue = normalizeResolver<Partial<SlotEvaluationProgressFactoryDefineInput>, BuildDataOptions<TTransients>>(traitsDefs[traitKey]?.data ?? {});
+                const traitData = await resolveTraitValue(resolverInput);
+                return {
+                    ...acc,
+                    ...traitData,
+                };
+            }, resolveValue(resolverInput));
+            const defaultAssociations = {
+                slot: isSlotEvaluationProgressslotFactory(defaultData.slot) ? {
+                    create: await defaultData.slot.build()
+                } : defaultData.slot
+            } as Prisma.SlotEvaluationProgressCreateInput;
+            const data: Prisma.SlotEvaluationProgressCreateInput = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...filteredInputData };
+            await handleAfterBuild(data, transientFields);
+            return data;
+        };
+        const buildList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.SlotEvaluationProgressCreateInput & TTransients>>(...args).map(data => build(data)));
+        const pickForConnect = (inputData: SlotEvaluationProgress) => ({
+            slotId: inputData.slotId
+        });
+        const create = async (inputData: Partial<Prisma.SlotEvaluationProgressCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
+            const [transientFields] = destructure(defaultTransientFieldValues, inputData);
+            await handleBeforeCreate(data, transientFields);
+            const createdData = await getClient<PrismaClient>().slotEvaluationProgress.create({ data });
+            await handleAfterCreate(createdData, transientFields);
+            return createdData;
+        };
+        const createList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.SlotEvaluationProgressCreateInput & TTransients>>(...args).map(data => create(data)));
+        const createForConnect = (inputData: Partial<Prisma.SlotEvaluationProgressCreateInput & TTransients> = {}) => create(inputData).then(pickForConnect);
+        return {
+            _factoryFor: "SlotEvaluationProgress" as const,
+            build,
+            buildList,
+            buildCreateInput: build,
+            pickForConnect,
+            create,
+            createList,
+            createForConnect,
+        };
+    };
+    const factory = getFactoryWithTraits();
+    const useTraits = (name: SlotEvaluationProgressTraitKeys<TOptions>, ...names: readonly SlotEvaluationProgressTraitKeys<TOptions>[]) => {
+        return getFactoryWithTraits([name, ...names]);
+    };
+    return {
+        ...factory,
+        use: useTraits,
+    };
+}
+
+interface SlotEvaluationProgressFactoryBuilder {
+    <TOptions extends SlotEvaluationProgressFactoryDefineOptions>(options: TOptions): SlotEvaluationProgressFactoryInterface<{}, SlotEvaluationProgressTraitKeys<TOptions>>;
+    withTransientFields: <TTransients extends SlotEvaluationProgressTransientFields>(defaultTransientFieldValues: TTransients) => <TOptions extends SlotEvaluationProgressFactoryDefineOptions<TTransients>>(options: TOptions) => SlotEvaluationProgressFactoryInterface<TTransients, SlotEvaluationProgressTraitKeys<TOptions>>;
+}
+
+/**
+ * Define factory for {@link SlotEvaluationProgress} model.
+ *
+ * @param options
+ * @returns factory {@link SlotEvaluationProgressFactoryInterface}
+ */
+export const defineSlotEvaluationProgressFactory = (<TOptions extends SlotEvaluationProgressFactoryDefineOptions>(options: TOptions): SlotEvaluationProgressFactoryInterface<TOptions> => {
+    return defineSlotEvaluationProgressFactoryInternal(options, {});
+}) as SlotEvaluationProgressFactoryBuilder;
+
+defineSlotEvaluationProgressFactory.withTransientFields = defaultTransientFieldValues => options => defineSlotEvaluationProgressFactoryInternal(options, defaultTransientFieldValues);

--- a/src/infrastructure/prisma/factories/__generated__/index.ts
+++ b/src/infrastructure/prisma/factories/__generated__/index.ts
@@ -2620,7 +2620,7 @@ type OpportunityFactoryDefineInput = {
     community?: OpportunitycommunityFactory | Prisma.CommunityCreateNestedOneWithoutOpportunitiesInput;
     place?: OpportunityplaceFactory | Prisma.PlaceCreateNestedOneWithoutOpportunitiesInput;
     articles?: Prisma.ArticleCreateNestedManyWithoutOpportunitiesInput;
-    createdByUser: OpportunitycreatedByUserFactory | Prisma.UserCreateNestedOneWithoutOpportunitiesCreatedByMeInput;
+    createdByUser?: OpportunitycreatedByUserFactory | Prisma.UserCreateNestedOneWithoutOpportunitiesCreatedByMeInput;
 };
 
 type OpportunityTransientFields = Record<string, unknown> & Partial<Record<keyof OpportunityFactoryDefineInput, never>>;
@@ -2630,9 +2630,9 @@ type OpportunityFactoryTrait<TTransients extends Record<string, unknown>> = {
 } & CallbackDefineOptions<Opportunity, Prisma.OpportunityCreateInput, TTransients>;
 
 type OpportunityFactoryDefineOptions<TTransients extends Record<string, unknown> = Record<string, unknown>> = {
-    defaultData: Resolver<OpportunityFactoryDefineInput, BuildDataOptions<TTransients>>;
+    defaultData?: Resolver<OpportunityFactoryDefineInput, BuildDataOptions<TTransients>>;
     traits?: {
-        [traitName: string | symbol]: OpportunityFactoryTrait<TTransients>;
+        [traitName: TraitName]: OpportunityFactoryTrait<TTransients>;
     };
 } & CallbackDefineOptions<Opportunity, Prisma.OpportunityCreateInput, TTransients>;
 
@@ -2701,7 +2701,7 @@ function defineOpportunityFactoryInternal<TTransients extends Record<string, unk
         const build = async (inputData: Partial<Prisma.OpportunityCreateInput & TTransients> = {}) => {
             const seq = getSeq();
             const requiredScalarData = autoGenerateOpportunityScalarsOrEnums({ seq });
-            const resolveValue = normalizeResolver<OpportunityFactoryDefineInput, BuildDataOptions<any>>(defaultDataResolver);
+            const resolveValue = normalizeResolver<OpportunityFactoryDefineInput, BuildDataOptions<any>>(defaultDataResolver ?? {});
             const [transientFields, filteredInputData] = destructure(defaultTransientFieldValues, inputData);
             const resolverInput = { seq, ...transientFields };
             const defaultData = await traitKeys.reduce(async (queue, traitKey) => {
@@ -2767,8 +2767,8 @@ function defineOpportunityFactoryInternal<TTransients extends Record<string, unk
 }
 
 interface OpportunityFactoryBuilder {
-    <TOptions extends OpportunityFactoryDefineOptions>(options: TOptions): OpportunityFactoryInterface<{}, OpportunityTraitKeys<TOptions>>;
-    withTransientFields: <TTransients extends OpportunityTransientFields>(defaultTransientFieldValues: TTransients) => <TOptions extends OpportunityFactoryDefineOptions<TTransients>>(options: TOptions) => OpportunityFactoryInterface<TTransients, OpportunityTraitKeys<TOptions>>;
+    <TOptions extends OpportunityFactoryDefineOptions>(options?: TOptions): OpportunityFactoryInterface<{}, OpportunityTraitKeys<TOptions>>;
+    withTransientFields: <TTransients extends OpportunityTransientFields>(defaultTransientFieldValues: TTransients) => <TOptions extends OpportunityFactoryDefineOptions<TTransients>>(options?: TOptions) => OpportunityFactoryInterface<TTransients, OpportunityTraitKeys<TOptions>>;
 }
 
 /**
@@ -2777,11 +2777,11 @@ interface OpportunityFactoryBuilder {
  * @param options
  * @returns factory {@link OpportunityFactoryInterface}
  */
-export const defineOpportunityFactory = (<TOptions extends OpportunityFactoryDefineOptions>(options: TOptions): OpportunityFactoryInterface<TOptions> => {
-    return defineOpportunityFactoryInternal(options, {});
+export const defineOpportunityFactory = (<TOptions extends OpportunityFactoryDefineOptions>(options?: TOptions): OpportunityFactoryInterface<TOptions> => {
+    return defineOpportunityFactoryInternal(options ?? {}, {});
 }) as OpportunityFactoryBuilder;
 
-defineOpportunityFactory.withTransientFields = defaultTransientFieldValues => options => defineOpportunityFactoryInternal(options, defaultTransientFieldValues);
+defineOpportunityFactory.withTransientFields = defaultTransientFieldValues => options => defineOpportunityFactoryInternal(options ?? {}, defaultTransientFieldValues);
 
 type OpportunitySlotScalarOrEnumFields = {
     startsAt: Date;
@@ -3691,7 +3691,7 @@ type EvaluationFactoryDefineInput = {
     createdAt?: Date;
     updatedAt?: Date | null;
     participation: EvaluationparticipationFactory | Prisma.ParticipationCreateNestedOneWithoutEvaluationInput;
-    evaluator: EvaluationevaluatorFactory | Prisma.UserCreateNestedOneWithoutEvaluationsEvaluatedByMeInput;
+    evaluator?: EvaluationevaluatorFactory | Prisma.UserCreateNestedOneWithoutEvaluationsEvaluatedByMeInput;
     histories?: Prisma.EvaluationHistoryCreateNestedManyWithoutEvaluationInput;
 };
 

--- a/src/infrastructure/prisma/migrations/20250518145138_create_slot_evaluation_progress_view/migration.sql
+++ b/src/infrastructure/prisma/migrations/20250518145138_create_slot_evaluation_progress_view/migration.sql
@@ -1,0 +1,15 @@
+-- This is an empty migration.
+CREATE VIEW v_slot_evaluation_progress AS
+SELECT
+    s.id AS slot_id,
+    -- 評価が完了した参加者数（PASSED または FAILED）
+    COUNT(e.id) AS total_evaluated,
+    -- PARTICIPATING または PARTICIPATED ステータスの参加者数
+    COUNT(p.id) AS valid_participations
+FROM
+    t_opportunity_slots s
+        LEFT JOIN t_reservations r ON r.opportunity_slot_id = s.id
+        LEFT JOIN t_participations p ON p.reservation_id = r.id AND p.status IN ('PARTICIPATING', 'PARTICIPATED')
+        LEFT JOIN t_evaluations e ON e.participation_id = p.id AND e.status IN ('PASSED', 'FAILED')
+GROUP BY
+    s.id;

--- a/src/infrastructure/prisma/migrations/20250518152954_nullable_foreign_user_keys/migration.sql
+++ b/src/infrastructure/prisma/migrations/20250518152954_nullable_foreign_user_keys/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "t_evaluations" ALTER COLUMN "evaluator_id" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "t_opportunities" ALTER COLUMN "created_by" DROP NOT NULL;

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -517,8 +517,9 @@ model OpportunitySlot {
   startsAt DateTime @map("starts_at")
   endsAt   DateTime @map("ends_at")
 
-  capacity              Int?
-  remainingCapacityView RemainingCapacityView?
+  capacity               Int?
+  remainingCapacityView  RemainingCapacityView?
+  slotEvaluationProgress SlotEvaluationProgress?
 
   opportunityId String      @map("opportunity_id")
   opportunity   Opportunity @relation(fields: [opportunityId], references: [id], onDelete: Cascade)
@@ -544,6 +545,16 @@ view RemainingCapacityView {
   remainingCapacity Int? @map("remaining_capacity")
 
   @@map("v_slot_remaining_capacity")
+}
+
+view SlotEvaluationProgress {
+  slotId String          @id @map("slot_id")
+  slot   OpportunitySlot @relation(fields: [slotId], references: [id])
+
+  totalEvaluated      Int @map("total_evaluated")
+  validParticipations Int @map("valid_participations")
+
+  @@map("v_slot_evaluation_progress")
 }
 
 // ------------------------------ Reservation Domain ------------------------------

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -485,8 +485,8 @@ model Opportunity {
 
   articles Article[] @relation("t_opportunities_on_articles")
 
-  createdBy     String @map("created_by")
-  createdByUser User   @relation(fields: [createdBy], references: [id], onDelete: SetNull)
+  createdBy     String? @map("created_by")
+  createdByUser User?   @relation(fields: [createdBy], references: [id], onDelete: SetNull)
 
   createdAt DateTime  @default(now()) @map("created_at")
   updatedAt DateTime? @updatedAt @map("updated_at")
@@ -685,8 +685,8 @@ model Evaluation {
   participationId String        @unique @map("participation_id")
   participation   Participation @relation(fields: [participationId], references: [id], onDelete: Cascade)
 
-  evaluatorId String @map("evaluator_id")
-  evaluator   User   @relation(fields: [evaluatorId], references: [id], onDelete: SetNull)
+  evaluatorId String? @map("evaluator_id")
+  evaluator   User?   @relation(fields: [evaluatorId], references: [id], onDelete: SetNull)
 
   histories EvaluationHistory[]
 

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1064,6 +1064,7 @@ export type GqlOpportunitySlot = {
   capacity?: Maybe<Scalars['Int']['output']>;
   createdAt?: Maybe<Scalars['Datetime']['output']>;
   endsAt: Scalars['Datetime']['output'];
+  evaluationProgress?: Maybe<GqlSlotEvaluationProgress>;
   hostingStatus: GqlOpportunitySlotHostingStatus;
   id: Scalars['ID']['output'];
   opportunity?: Maybe<GqlOpportunity>;
@@ -1893,6 +1894,12 @@ export const GqlRole = {
 } as const;
 
 export type GqlRole = typeof GqlRole[keyof typeof GqlRole];
+export type GqlSlotEvaluationProgress = {
+  __typename?: 'SlotEvaluationProgress';
+  totalEvaluated?: Maybe<Scalars['Int']['output']>;
+  validParticipations?: Maybe<Scalars['Int']['output']>;
+};
+
 export type GqlSlotNotScheduledError = {
   __typename?: 'SlotNotScheduledError';
   message: Scalars['String']['output'];
@@ -2767,6 +2774,7 @@ export type GqlResolversTypes = ResolversObject<{
   ReservationStatus: GqlReservationStatus;
   ReservationsConnection: ResolverTypeWrapper<Omit<GqlReservationsConnection, 'edges'> & { edges: Array<GqlResolversTypes['ReservationEdge']> }>;
   Role: GqlRole;
+  SlotEvaluationProgress: ResolverTypeWrapper<GqlSlotEvaluationProgress>;
   SlotNotScheduledError: ResolverTypeWrapper<GqlSlotNotScheduledError>;
   SortDirection: GqlSortDirection;
   Source: GqlSource;
@@ -3035,6 +3043,7 @@ export type GqlResolversParentTypes = ResolversObject<{
   ReservationSetStatusSuccess: Omit<GqlReservationSetStatusSuccess, 'reservation'> & { reservation: GqlResolversParentTypes['Reservation'] };
   ReservationSortInput: GqlReservationSortInput;
   ReservationsConnection: Omit<GqlReservationsConnection, 'edges'> & { edges: Array<GqlResolversParentTypes['ReservationEdge']> };
+  SlotEvaluationProgress: GqlSlotEvaluationProgress;
   SlotNotScheduledError: GqlSlotNotScheduledError;
   State: State;
   StorePhoneAuthTokenInput: GqlStorePhoneAuthTokenInput;
@@ -3616,6 +3625,7 @@ export type GqlOpportunitySlotResolvers<ContextType = any, ParentType extends Gq
   capacity?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
   createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
   endsAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  evaluationProgress?: Resolver<Maybe<GqlResolversTypes['SlotEvaluationProgress']>, ParentType, ContextType>;
   hostingStatus?: Resolver<GqlResolversTypes['OpportunitySlotHostingStatus'], ParentType, ContextType>;
   id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
   opportunity?: Resolver<Maybe<GqlResolversTypes['Opportunity']>, ParentType, ContextType>;
@@ -3960,6 +3970,12 @@ export type GqlReservationsConnectionResolvers<ContextType = any, ParentType ext
   edges?: Resolver<Array<GqlResolversTypes['ReservationEdge']>, ParentType, ContextType>;
   pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
   totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlSlotEvaluationProgressResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SlotEvaluationProgress'] = GqlResolversParentTypes['SlotEvaluationProgress']> = ResolversObject<{
+  totalEvaluated?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  validParticipations?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -4450,6 +4466,7 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   ReservationSetStatusPayload?: GqlReservationSetStatusPayloadResolvers<ContextType>;
   ReservationSetStatusSuccess?: GqlReservationSetStatusSuccessResolvers<ContextType>;
   ReservationsConnection?: GqlReservationsConnectionResolvers<ContextType>;
+  SlotEvaluationProgress?: GqlSlotEvaluationProgressResolvers<ContextType>;
   SlotNotScheduledError?: GqlSlotNotScheduledErrorResolvers<ContextType>;
   State?: GqlStateResolvers<ContextType>;
   StorePhoneAuthTokenPayload?: GqlStorePhoneAuthTokenPayloadResolvers<ContextType>;


### PR DESCRIPTION
---

### Description of Changes

- Updated foreign key constraints (`createdByUser`, `evaluator`) to allow nulls in schema, migrations, and factories.
- Improved evaluation eligibility checks with the `validateEvaluatable` method and new error handling (`AlreadyEvaluatedError`, `CannotEvaluateBeforeOpportunityStartError`).
- Enhanced opportunity slot visitor view by implementing dedicated fetching logic via `visitorViewOpportunitySlot` and including `slotEvaluationProgress`.
- Added `SlotEvaluationProgress` schema integration, including the `v_slot_evaluation_progress` database view and updates to types and domain models.
- Improved error feedback by replacing `InvalidEvaluationStatusError` with a more descriptive `ValidationError`. 

--- 

### Checklist

- [ ] Tests are updated and passing.
- [ ] Documentation has been updated as needed.
- [ ] Changes adhere to coding standards and conventions. 

