### PR TITLE
Add filtering and sorting to opportunity slots resolver

### DIFF
--- a/src/application/domain/experience/opportunity/controller/resolver.ts
+++ b/src/application/domain/experience/opportunity/controller/resolver.ts
@@ -3,6 +3,7 @@ import {
   GqlMutationOpportunityDeleteArgs,
   GqlMutationOpportunitySetPublishStatusArgs,
   GqlMutationOpportunityUpdateContentArgs,
+  GqlOpportunitySlotsArgs,
   GqlQueryOpportunitiesArgs,
   GqlQueryOpportunityArgs,
 } from "@/types/graphql";
@@ -110,8 +111,12 @@ export default class OpportunityResolver {
       return ctx.loaders.utilitiesByOpportunity.load(parent.id);
     },
 
-    slots: (parent, _: unknown, ctx: IContext) => {
-      return ctx.loaders.opportunitySlotByOpportunity.load(parent.id);
+    slots: (parent, args: GqlOpportunitySlotsArgs, ctx: IContext) => {
+      return ctx.loaders.opportunitySlotByOpportunity.load({
+        key: parent.id,
+        filter: args.filter ?? {},
+        sort: args.sort ?? {},
+      });
     },
 
     articles: (parent, _: unknown, ctx: IContext) => {


### PR DESCRIPTION
Enhanced the `slots` resolver by introducing support for `filter` and `sort` arguments. Refactored the `createSlotsByOpportunityLoader` function to leverage `createFilterSortAwareHasManyLoaderByKey`, providing more advanced filtering and sorting capabilities for opportunity slot queries.