### PR TITLE
Add ownerId filter to OpportunitySlot queries

### DIFF
--- a/src/application/domain/experience/opportunitySlot/data/converter.ts
+++ b/src/application/domain/experience/opportunitySlot/data/converter.ts
@@ -16,6 +16,10 @@ export default class OpportunitySlotConverter {
       slotConditions.push({ opportunityId: filter.opportunityId });
     }
 
+    if (filter?.ownerId) {
+      slotConditions.push({ opportunity: { createdBy: filter.ownerId } });
+    }
+
     if (filter?.hostingStatus) {
       slotConditions.push({ hostingStatus: filter.hostingStatus });
     }

--- a/src/application/domain/experience/opportunitySlot/schema/query.graphql
+++ b/src/application/domain/experience/opportunitySlot/schema/query.graphql
@@ -30,6 +30,7 @@ type OpportunitySlotEdge implements Edge {
 # ------------------------------
 input OpportunitySlotFilterInput {
     opportunityId: ID
+    ownerId: ID
     hostingStatus: OpportunitySlotHostingStatus
     dateRange: DateTimeRangeFilter
 }

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1083,6 +1083,7 @@ export type GqlOpportunitySlotFilterInput = {
   dateRange?: InputMaybe<GqlDateTimeRangeFilter>;
   hostingStatus?: InputMaybe<GqlOpportunitySlotHostingStatus>;
   opportunityId?: InputMaybe<Scalars['ID']['input']>;
+  ownerId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 export const GqlOpportunitySlotHostingStatus = {


### PR DESCRIPTION
```markdown
### Description
This pull request introduces an `ownerId` filter to the `OpportunitySlot` queries. The following changes have been made:
- Added `ownerId` to the `OpportunitySlotFilterInput` field in the GraphQL schema.
- Updated TypeScript definitions to reflect this new filter.
- Modified the query converter to enable filtering by the `ownerId` field.

### Related Issues
_No issues linked to this pull request._

### Checklist
- [ ] Tests added or updated
- [ ] Documentation updated
```