### PR TITLE
Fix stateCodes filtering in opportunity search

### DIFF
--- a/src/application/domain/experience/opportunity/data/converter.ts
+++ b/src/application/domain/experience/opportunity/data/converter.ts
@@ -80,15 +80,15 @@ export default class OpportunityConverter {
       finalPlace = place.where
         ? { connect: { id: place.where } }
         : (() => {
-            const { cityCode, communityId, ...restCreate } = place.create!;
-            return {
-              create: {
-                ...restCreate,
-                city: { connect: { code: cityCode } },
-                community: { connect: { id: communityId } },
-              },
-            };
-          })();
+          const { cityCode, communityId, ...restCreate } = place.create!;
+          return {
+            create: {
+              ...restCreate,
+              city: { connect: { code: cityCode } },
+              community: { connect: { id: communityId } },
+            },
+          };
+        })();
     }
 
     return {
@@ -114,15 +114,15 @@ export default class OpportunityConverter {
       finalPlace = place.where
         ? { connect: { id: place.where } }
         : (() => {
-            const { cityCode, communityId, ...restCreate } = place.create!;
-            return {
-              create: {
-                ...restCreate,
-                city: { connect: { code: cityCode } },
-                community: { connect: { id: communityId } },
-              },
-            };
-          })();
+          const { cityCode, communityId, ...restCreate } = place.create!;
+          return {
+            create: {
+              ...restCreate,
+              city: { connect: { code: cityCode } },
+              community: { connect: { id: communityId } },
+            },
+          };
+        })();
     }
 
     return {
@@ -164,7 +164,7 @@ export default class OpportunityConverter {
     if (filter.cityCodes?.length)
       conditions.push({ place: { cityCode: { in: filter.cityCodes } } });
     if (filter.stateCodes?.length)
-      conditions.push({ place: { city: { state: { code: { in: filter.cityCodes } } } } });
+      conditions.push({ place: { city: { state: { code: { in: filter.stateCodes } } } } });
     if (filter.articleIds?.length)
       conditions.push({ articles: { some: { id: { in: filter.articleIds } } } });
     if (filter.requiredUtilityIds?.length)


### PR DESCRIPTION
## 概要
Opportunity 検索時の State コードによるフィルタリング機能に不具合があったため修正

## 修正内容
- OpportunityConverter クラスの opportunityFilter メソッドにおいて、stateCodes フィルタリング条件が誤って filter.cityCodes を使用していたため、正しく filter.stateCodes を使用するように修正しました
- 関連するコードのインデントも整理しました

## 影響範囲
StateCodes による機会検索が正しく機能するようになります