### PR TITLE
Add support for optional comment in reservations

### DIFF
--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -364,6 +364,7 @@ TICKET_REFUNDED TICKET_REFUNDED
   "t_reservations" {
     String id "🗝️"
     String opportunity_slot_id 
+    String comment "❓"
     ReservationStatus status 
     String created_by "❓"
     DateTime created_at 

--- a/docs/schema.dbml
+++ b/docs/schema.dbml
@@ -252,6 +252,7 @@ Table t_reservations {
   id String [pk]
   opportunitySlotId String [not null]
   opportunitySlot t_opportunity_slots [not null]
+  comment String
   status ReservationStatus [not null, default: 'APPLIED']
   participations t_participations [not null]
   createdBy String

--- a/src/application/domain/experience/reservation/data/converter.ts
+++ b/src/application/domain/experience/reservation/data/converter.ts
@@ -70,6 +70,7 @@ export default class ReservationConverter {
     participantCount: number,
     userIdsIfExists: string[],
     { reservationStatus, participationStatus, participationStatusReason }: ReservationStatuses,
+    comment?: string,
   ): Prisma.ReservationCreateInput {
     const userIds = [currentUserId, ...userIdsIfExists];
 
@@ -83,6 +84,7 @@ export default class ReservationConverter {
 
     return {
       status: reservationStatus,
+      comment,
       opportunitySlot: { connect: { id: opportunitySlotId } },
       createdByUser: { connect: { id: currentUserId } },
       participations: { create: participations },

--- a/src/application/domain/experience/reservation/data/interface.ts
+++ b/src/application/domain/experience/reservation/data/interface.ts
@@ -30,6 +30,7 @@ export interface IReservationService {
     userIdsIfExists: string[],
     reservationStatuses: ReservationStatuses,
     tx: Prisma.TransactionClient,
+    comment?: string,
   ): Promise<PrismaReservation>;
 
   setStatus(

--- a/src/application/domain/experience/reservation/schema/mutation.graphql
+++ b/src/application/domain/experience/reservation/schema/mutation.graphql
@@ -42,6 +42,8 @@ input ReservationCreateInput {
     totalParticipantCount: Int!
     otherUserIds: [ID!]
 
+    comment: String
+
     paymentMethod: ReservationPaymentMethod!
     ticketIdsIfNeed: [ID!]
 }

--- a/src/application/domain/experience/reservation/schema/type.graphql
+++ b/src/application/domain/experience/reservation/schema/type.graphql
@@ -4,6 +4,7 @@
 type Reservation {
     id: ID!
     status: ReservationStatus!
+    comment: String
 
     opportunitySlot: OpportunitySlot
     participations: [Participation!]

--- a/src/application/domain/experience/reservation/service.ts
+++ b/src/application/domain/experience/reservation/service.ts
@@ -58,6 +58,7 @@ export default class ReservationService implements IReservationService {
     userIdsIfExists: string[],
     reservationStatuses: ReservationStatuses,
     tx: Prisma.TransactionClient,
+    comment?: string,
   ) {
     const currentUserId = getCurrentUserId(ctx);
     const data = this.converter.create(
@@ -66,6 +67,7 @@ export default class ReservationService implements IReservationService {
       participantCount,
       userIdsIfExists,
       reservationStatuses,
+      comment,
     );
     return this.repository.create(ctx, data, tx);
   }

--- a/src/application/domain/experience/reservation/usecase.ts
+++ b/src/application/domain/experience/reservation/usecase.ts
@@ -111,6 +111,7 @@ export default class ReservationUseCase {
         input.otherUserIds ?? [],
         statuses,
         tx,
+        input.comment,
       );
 
       const participationIds = reservation.participations.map((p) => p.id);

--- a/src/infrastructure/prisma/factories/__generated__/index.ts
+++ b/src/infrastructure/prisma/factories/__generated__/index.ts
@@ -3033,6 +3033,7 @@ type ReservationcreatedByUserFactory = {
 
 type ReservationFactoryDefineInput = {
     id?: string;
+    comment?: string | null;
     status?: ReservationStatus;
     createdAt?: Date;
     updatedAt?: Date | null;

--- a/src/infrastructure/prisma/migrations/20250522142751_add_comment_to_reservation/migration.sql
+++ b/src/infrastructure/prisma/migrations/20250522142751_add_comment_to_reservation/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "t_reservations" ADD COLUMN     "comment" TEXT;

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -585,6 +585,7 @@ model Reservation {
   opportunitySlotId String          @map("opportunity_slot_id")
   opportunitySlot   OpportunitySlot @relation(fields: [opportunitySlotId], references: [id], onDelete: Cascade)
 
+  comment        String?
   status         ReservationStatus @default(APPLIED)
   participations Participation[]
 

--- a/src/infrastructure/prisma/seeds/domains.ts
+++ b/src/infrastructure/prisma/seeds/domains.ts
@@ -19,7 +19,7 @@ import { processInBatches } from "@/utils/array";
 import { Opportunity, OpportunitySlot, Place, Reservation, User, Wallet } from "@prisma/client";
 import { Community } from "@prisma/client/index.d";
 
-const BATCH_SIZE = 10;  // edit this ONLY when seeding is slow to the extent database connections are established properly
+const BATCH_SIZE = 10; // edit this ONLY when seeding is slow to the extent database connections are established properly
 const NUM_UTILITIES = 3;
 const NUM_SLOTS_PER_OPPORTUNITY = 3;
 const NUM_RESERVATIONS_PER_SLOT = 1;
@@ -27,10 +27,17 @@ const NUM_TRANSACTIONS = 5;
 const NUM_PLACES = 100;
 
 export async function seedUsecase() {
+  // await prismaClient.opportunity.updateMany({
+  //   where: {},
+  //   data: {
+  //     createdBy: "cmawfulj70004s60elzlotgd9",
+  //   },
+  // });
+
   console.info("🔥 Resetting DB...");
   await prismaClient.$transaction(async (tx) => {
     await tx.$executeRawUnsafe(`
-      TRUNCATE TABLE 
+      TRUNCATE TABLE
         t_evaluation_histories,
         t_evaluations,
         t_images,

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1776,6 +1776,7 @@ export type GqlQueryWalletsArgs = {
 
 export type GqlReservation = {
   __typename?: 'Reservation';
+  comment?: Maybe<Scalars['String']['output']>;
   createdAt?: Maybe<Scalars['Datetime']['output']>;
   createdByUser?: Maybe<GqlUser>;
   histories?: Maybe<Array<GqlReservationHistory>>;
@@ -1792,6 +1793,7 @@ export type GqlReservationCancelInput = {
 };
 
 export type GqlReservationCreateInput = {
+  comment?: InputMaybe<Scalars['String']['input']>;
   opportunitySlotId: Scalars['ID']['input'];
   otherUserIds?: InputMaybe<Array<Scalars['ID']['input']>>;
   paymentMethod: GqlReservationPaymentMethod;
@@ -3815,6 +3817,7 @@ export type GqlQueryResolvers<ContextType = any, ParentType extends GqlResolvers
 }>;
 
 export type GqlReservationResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Reservation'] = GqlResolversParentTypes['Reservation']> = ResolversObject<{
+  comment?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
   createdByUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
   histories?: Resolver<Maybe<Array<GqlResolversTypes['ReservationHistory']>>, ParentType, ContextType>;


### PR DESCRIPTION
**Summary of Changes:**

- Added support for an optional `comment` field in reservation creation, propagating it through the service, use case, and database layers.
- Updated Reservation GraphQL schema to include the `comment` field in both mutation and type definitions.
- Added the `comment` column to the Prisma schema with generated migrations and updated database documentation to reflect this change.