### PR TITLE
Make opportunitySlot fields nullable in GraphQL schema

### DIFF
--- a/src/application/domain/experience/opportunitySlot/schema/type.graphql
+++ b/src/application/domain/experience/opportunitySlot/schema/type.graphql
@@ -16,9 +16,9 @@ type OpportunitySlot {
     reservations: [Reservation!]
     
     # Evaluation statistics
-    isFullyEvaluated: Boolean!
-    numParticipants: Int!
-    numEvaluated: Int!
+    isFullyEvaluated: Boolean
+    numParticipants: Int
+    numEvaluated: Int
 
     createdAt: Datetime
     updatedAt: Datetime

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1085,9 +1085,9 @@ export type GqlOpportunitySlot = {
   endsAt: Scalars['Datetime']['output'];
   hostingStatus: GqlOpportunitySlotHostingStatus;
   id: Scalars['ID']['output'];
-  isFullyEvaluated: Scalars['Boolean']['output'];
-  numEvaluated: Scalars['Int']['output'];
-  numParticipants: Scalars['Int']['output'];
+  isFullyEvaluated?: Maybe<Scalars['Boolean']['output']>;
+  numEvaluated?: Maybe<Scalars['Int']['output']>;
+  numParticipants?: Maybe<Scalars['Int']['output']>;
   opportunity?: Maybe<GqlOpportunity>;
   remainingCapacity?: Maybe<Scalars['Int']['output']>;
   reservations?: Maybe<Array<GqlReservation>>;
@@ -3556,9 +3556,9 @@ export type GqlOpportunitySlotResolvers<ContextType = any, ParentType extends Gq
   endsAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
   hostingStatus?: Resolver<GqlResolversTypes['OpportunitySlotHostingStatus'], ParentType, ContextType>;
   id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
-  isFullyEvaluated?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
-  numEvaluated?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
-  numParticipants?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  isFullyEvaluated?: Resolver<Maybe<GqlResolversTypes['Boolean']>, ParentType, ContextType>;
+  numEvaluated?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  numParticipants?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
   opportunity?: Resolver<Maybe<GqlResolversTypes['Opportunity']>, ParentType, ContextType>;
   remainingCapacity?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
   reservations?: Resolver<Maybe<Array<GqlResolversTypes['Reservation']>>, ParentType, ContextType>;


### PR DESCRIPTION
### Overview

This pull request modifies the `opportunitySlot` fields in the GraphQL schema to allow null values. Key changes include:
- Updated `isFullyEvaluated`, `numParticipants`, and `numEvaluated` to be nullable.
- Adjusted TypeScript GraphQL types with `Maybe<>` to reflect new nullable status.
- Updated GraphQL resolvers to handle potential `null` values more effectively.

These changes aim to better align the schema with data scenarios where corresponding values might not be available.