### PR TITLE
Notify users when granted admin privileges

### DIFF
--- a/src/application/domain/notification/line.ts
+++ b/src/application/domain/notification/line.ts
@@ -2,14 +2,19 @@ import { lineClient } from "@/infrastructure/libs/line";
 import { logLineApiError, logLineApiSuccess } from "./logger";
 import { messagingApi } from "@line/bot-sdk";
 
-export async function safeLinkRichMenuIdToUser(userId: string, richMenuId: string) {
+export async function safeLinkRichMenuIdToUser(
+  userId: string,
+  richMenuId: string,
+): Promise<boolean> {
   const endpoint = `https://api.line.me/v2/bot/user/${userId}/richmenu/${richMenuId}`;
 
   try {
     const response = await lineClient.linkRichMenuIdToUserWithHttpInfo(userId, richMenuId);
     logLineApiSuccess("linkRichMenuIdToUser", endpoint, response.httpResponse);
+    return true;
   } catch (error) {
     logLineApiError("linkRichMenuIdToUser", endpoint, error);
+    return false;
   }
 }
 

--- a/src/application/domain/notification/presenter/message/switchRoleMessage.ts
+++ b/src/application/domain/notification/presenter/message/switchRoleMessage.ts
@@ -1,0 +1,36 @@
+import { messagingApi } from "@line/bot-sdk";
+
+export function buildAdminGrantedMessage(): messagingApi.FlexMessage {
+  const bubble: messagingApi.FlexBubble = {
+    type: "bubble",
+    body: {
+      type: "box",
+      layout: "vertical",
+      paddingAll: "xl",
+      spacing: "md",
+      contents: [
+        {
+          type: "text",
+          text: "管理者権限が付与されました 🎉",
+          size: "lg",
+          weight: "bold",
+          color: "#1DB446",
+          wrap: true,
+        },
+        {
+          type: "text",
+          text: "これから管理画面での操作が可能になります。",
+          size: "sm",
+          color: "#555555",
+          wrap: true,
+        },
+      ],
+    },
+  };
+
+  return {
+    type: "flex",
+    altText: "管理者権限が付与されました",
+    contents: bubble,
+  };
+}


### PR DESCRIPTION
### Description

This pull request introduces a feature that notifies users when they are granted admin privileges. Key changes include:

- Implementation of a `buildAdminGrantedMessage` function to craft notification messages for new admins.
- Improvement of `safeLinkRichMenuIdToUser` to return a success status, aiding in smoother handling of link operations.
- Enhanced role change logic to automatically send notifications upon admin privilege assignment.

### Checklist

- [ ] Tests have been added or updated
- [ ] Documentation has been updated if needed
- [ ] All checks have passed