### PR TITLE
Add `isReservableWithTicket` loader for reservation checks

### DIFF
--- a/src/application/domain/experience/opportunity/controller/dataloader.ts
+++ b/src/application/domain/experience/opportunity/controller/dataloader.ts
@@ -8,6 +8,7 @@ import {
 import OpportunityPresenter from "@/application/domain/experience/opportunity/presenter";
 import {
   createHasManyLoaderByKey,
+  createLoaderByCompositeKey,
   createLoaderById,
 } from "@/presentation/graphql/dataloader/utils";
 
@@ -101,5 +102,79 @@ export function createOpportunitiesByPlaceLoader(issuer: PrismaClientIssuer) {
       );
     },
     OpportunityPresenter.get,
+  );
+}
+
+type IsReservableKey = {
+  opportunityId: string;
+  userId: string;
+  communityId: string;
+};
+
+type IsReservableRecord = {
+  opportunityId: string;
+  userId: string;
+  communityId: string;
+};
+
+export function createIsReservableWithTicketLoader(issuer: PrismaClientIssuer) {
+  return createLoaderByCompositeKey<IsReservableKey, IsReservableRecord, boolean>(
+    async (keys) => {
+      const results: IsReservableRecord[] = [];
+
+      const userIds = [...new Set(keys.map((k) => k.userId))];
+      const communityIds = [...new Set(keys.map((k) => k.communityId))];
+      const opportunityIds = [...new Set(keys.map((k) => k.opportunityId))];
+
+      await issuer.internal(async (tx) => {
+        const tickets = await tx.ticket.findMany({
+          where: {
+            status: "AVAILABLE",
+            wallet: {
+              userId: { in: userIds },
+              communityId: { in: communityIds },
+            },
+            utility: {
+              requiredForOpportunities: {
+                some: {
+                  id: { in: opportunityIds },
+                },
+              },
+            },
+          },
+          select: {
+            wallet: { select: { userId: true, communityId: true } },
+            utility: {
+              select: {
+                requiredForOpportunities: { select: { id: true } },
+              },
+            },
+          },
+        });
+
+        for (const ticket of tickets) {
+          const { userId, communityId } = ticket.wallet;
+          const opps = ticket.utility?.requiredForOpportunities;
+
+          if (!userId || !communityId || !opps?.length) continue;
+
+          for (const opp of opps) {
+            results.push({
+              opportunityId: opp.id,
+              userId,
+              communityId,
+            });
+          }
+        }
+      });
+
+      return results;
+    },
+    (record) => ({
+      opportunityId: record.opportunityId,
+      userId: record.userId,
+      communityId: record.communityId,
+    }),
+    () => true, // 存在したものだけ true、null → GraphQL 側で false として扱う
   );
 }

--- a/src/presentation/graphql/dataloader/domain/experience.ts
+++ b/src/presentation/graphql/dataloader/domain/experience.ts
@@ -16,6 +16,8 @@ export function createExperienceLoaders(issuer: PrismaClientIssuer) {
     opportunitiesByCommunity: OpportunityLoaders.createOpportunitiesByCommunityLoader(issuer),
     opportunitiesByPlace: OpportunityLoaders.createOpportunitiesByPlaceLoader(issuer),
 
+    isReservableWithTicket: OpportunityLoaders.createIsReservableWithTicketLoader(issuer),
+
     opportunitySlot: OpportunitySlotLoaders.createOpportunitySlotLoader(issuer),
     opportunitySlotByOpportunity: OpportunitySlotLoaders.createSlotsByOpportunityLoader(issuer),
 


### PR DESCRIPTION
### Summary

This pull request introduces the following changes:

- Implements a new Dataloader `createIsReservableWithTicketLoader` to streamline opportunity reservation checks.
- Replaces existing resolver logic with the loader for improved performance and readability.
- Updates dataloader utilities to handle composite keys more effectively.

### Checklist

- [ ] Tests have been written for the new functionality.
- [ ] Docs have been updated to reflect the changes (if necessary).