### PR TITLE
Add comment support for cancel opportunity slot notifications

### DIFF
--- a/src/application/domain/experience/opportunitySlot/schema/mutation.graphql
+++ b/src/application/domain/experience/opportunitySlot/schema/mutation.graphql
@@ -21,6 +21,7 @@ extend type Mutation {
 # ------------------------------
 input OpportunitySlotSetHostingStatusInput{
     status: OpportunitySlotHostingStatus!
+    comment: String
 }
 
 input OpportunitySlotsBulkUpdateInput {

--- a/src/application/domain/experience/opportunitySlot/usecase.ts
+++ b/src/application/domain/experience/opportunitySlot/usecase.ts
@@ -97,7 +97,7 @@ export default class OpportunitySlotUseCase {
     });
 
     if (cancelledSlot) {
-      await this.notificationService.pushCancelOpportunitySlotMessage(cancelledSlot);
+      await this.notificationService.pushCancelOpportunitySlotMessage(cancelledSlot, input.comment);
     }
 
     return OpportunitySlotPresenter.setHostingStatus(res);

--- a/src/application/domain/notification/presenter/message/cancelOpportunitySlotMessage.ts
+++ b/src/application/domain/notification/presenter/message/cancelOpportunitySlotMessage.ts
@@ -8,6 +8,7 @@ interface CancelOpportunitySlotParams {
   hostName: string;
   hostImageUrl: string;
   redirectUrl: string;
+  comment?: string;
 }
 
 export function buildCancelOpportunitySlotMessage(
@@ -40,7 +41,7 @@ function buildBody(params: CancelOpportunitySlotParams): messagingApi.FlexBox {
     contents: [
       buildTitle(),
       buildOpportunityInfo(params),
-      buildApologyMessage(),
+      buildApologyMessage(params.comment),
       buildHostSection(params),
     ],
   };
@@ -82,7 +83,12 @@ function buildOpportunityInfo(params: CancelOpportunitySlotParams): messagingApi
   };
 }
 
-function buildApologyMessage(): messagingApi.FlexBox {
+function buildApologyMessage(comment?: string): messagingApi.FlexBox {
+  const fallbackMessage =
+    "誠に恐れ入りますが、やむを得ない事情により本開催を中止させていただきます。ご迷惑をおかけしますことをお詫び申し上げます。";
+  const safeComment = typeof comment === "string" ? comment.trim() : "";
+  const text = safeComment.length > 0 ? safeComment : fallbackMessage;
+
   return {
     type: "box",
     layout: "vertical",
@@ -92,14 +98,7 @@ function buildApologyMessage(): messagingApi.FlexBox {
     contents: [
       {
         type: "text",
-        text: "お申し込みいただいたイベントは、やむを得ず中止とさせていただきました。",
-        size: "sm",
-        color: "#111111",
-        wrap: true,
-      },
-      {
-        type: "text",
-        text: "楽しみにしてくださっていた皆様には、心よりお詫び申し上げます。",
+        text,
         size: "sm",
         color: "#111111",
         wrap: true,

--- a/src/application/domain/notification/presenter/message/rejectReservationMessage.ts
+++ b/src/application/domain/notification/presenter/message/rejectReservationMessage.ts
@@ -83,7 +83,7 @@ function buildOpportunityInfo(params: DeclineOpportunitySlotParams): messagingAp
 
 function buildDeclineMessage(comment?: string): messagingApi.FlexBox {
   const fallbackMessage =
-    "今回は日程の都合により申込を辞退させていただきました。またの機会がございましたら、どうぞよろしくお願い致します。";
+    "今回は日程や運営の都合により、申込をお受けできかねる結果となりました。またの機会がございましたら、ぜひご参加をご検討いただけますと幸いです。";
 
   const safeComment = typeof comment === "string" ? comment.trim() : "";
   const text = safeComment.length > 0 ? safeComment : fallbackMessage;

--- a/src/application/domain/notification/service.ts
+++ b/src/application/domain/notification/service.ts
@@ -25,7 +25,10 @@ export const DEFAULT_THUMBNAIL =
 
 @injectable()
 export default class NotificationService {
-  async pushCancelOpportunitySlotMessage(slot: PrismaOpportunitySlotSetHostingStatus) {
+  async pushCancelOpportunitySlotMessage(
+    slot: PrismaOpportunitySlotSetHostingStatus,
+    comment?: string,
+  ) {
     const participantInfos = this.extractLineUidsFromParticipations(
       slot.reservations.flatMap((r) => r.participations),
     );
@@ -48,6 +51,7 @@ export default class NotificationService {
       hostName: createdByUser?.name ?? "NEO88四国祭",
       hostImageUrl: this.safeImageUrl(createdByUser.image?.url, DEFAULT_HOST_IMAGE_URL),
       redirectUrl,
+      comment,
     });
 
     for (const { uid } of participantInfos) {

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1122,6 +1122,7 @@ export const GqlOpportunitySlotHostingStatus = {
 
 export type GqlOpportunitySlotHostingStatus = typeof GqlOpportunitySlotHostingStatus[keyof typeof GqlOpportunitySlotHostingStatus];
 export type GqlOpportunitySlotSetHostingStatusInput = {
+  comment?: InputMaybe<Scalars['String']['input']>;
   status: GqlOpportunitySlotHostingStatus;
 };
 


### PR DESCRIPTION
### Description of Changes
- Extended `pushCancelOpportunitySlotMessage` to handle an optional comment parameter.
- Updated the GraphQL schema to include `comment` in `OpportunitySlotSetHostingStatusInput`.
- Modified message builders to use custom comments or fallback messages.
- Improved apology messages with dynamic text based on provided comments.

### Checklist
- [ ] Tests added or updated as necessary
- [ ] Documentation updated as necessary 
- [ ] Relevant