### PR TITLE
Add permission logic for viewing user phone numbers

### DIFF
--- a/src/application/domain/account/user/controller/resolver.ts
+++ b/src/application/domain/account/user/controller/resolver.ts
@@ -29,6 +29,14 @@ export default class UserResolver {
   };
 
   User = {
+    phoneNumber: async (parent, _: unknown, ctx: IContext) => {
+      const viewerId = ctx.currentUser?.id;
+      if (!viewerId || !parent.id) return null;
+
+      const canView = await this.userUseCase.canCurrentUserViewPhoneNumber(parent.id, viewerId);
+      return canView ? parent.phoneNumber : null;
+    },
+
     portfolios: async (parent, _: unknown, ctx: IContext) => {
       return await this.viewUseCase.visitorBrowsePortfolios(parent, ctx);
     },
@@ -38,6 +46,8 @@ export default class UserResolver {
     },
 
     identities: (parent, _: unknown, ctx: IContext) => {
+      const viewerId = ctx.currentUser?.id;
+      if (!viewerId || !parent.id) return null;
       return ctx.loaders.identitiesByUser.load(parent.id);
     },
 


### PR DESCRIPTION
- Implemented `canCurrentUserViewPhoneNumber` to determine if a user can view another user's phone number based on relationships like reservations or participant links.
- Integrated the new permission logic into the `phoneNumber` field resolver within the system.
- Refactored domain seeding to correct reservation and participation status logic, ensuring accurate and randomized status assignment