### PR TITLE
Skip reservation validation for specific opportunity ID

### DIFF
--- a/src/application/domain/experience/reservation/usecase.ts
+++ b/src/application/domain/experience/reservation/usecase.ts
@@ -90,11 +90,13 @@ export default class ReservationUseCase {
     );
     const { opportunity } = slot;
 
-    this.reservationValidator.validateReservable(
-      slot,
-      input.totalParticipantCount,
-      slot.remainingCapacityView?.remainingCapacity ?? undefined,
-    );
+    if (opportunity.id !== "cmc07866s0002s60nuuk8jakk") {
+      this.reservationValidator.validateReservable(
+        slot,
+        input.totalParticipantCount,
+        slot.remainingCapacityView?.remainingCapacity ?? undefined,
+      );
+    }
 
     const { communityId, requiredUtilities } = opportunity;
     if (!communityId) throw new NotFoundError("Community id not found", { communityId });


### PR DESCRIPTION
- Added logic to bypass `validateReservable` validation for opportunity ID `cmc07866s0002s60nuuk8jakk`.
- Special case handling ensures that standard validation checks are not unnecessarily triggered.