### PR TITLE
Add support for VC Issuance Request handling in GraphQL

### DIFF
--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -328,6 +328,7 @@ TICKET_REFUNDED TICKET_REFUNDED
     DateTime requested_at 
     DateTime processed_at "❓"
     DateTime completed_at "❓"
+    String evaluation_id 
     String user_id 
     DateTime created_at 
     DateTime updated_at "❓"
@@ -673,6 +674,7 @@ TICKET_REFUNDED TICKET_REFUNDED
     "t_did_issuance_requests" o|--|| "DidIssuanceStatus" : "enum:status"
     "t_did_issuance_requests" o|--|| "t_users" : "user"
     "t_vc_issuance_requests" o|--|| "VcIssuanceStatus" : "enum:status"
+    "t_vc_issuance_requests" o|--|| "t_evaluations" : "evaluation"
     "t_vc_issuance_requests" o|--|| "t_users" : "user"
     "t_memberships" o|--|| "t_users" : "user"
     "t_memberships" o|--|| "t_communities" : "community"
@@ -746,6 +748,7 @@ TICKET_REFUNDED TICKET_REFUNDED
     "t_evaluations" o|--|| "EvaluationStatus" : "enum:status"
     "t_evaluations" o|--|| "t_participations" : "participation"
     "t_evaluations" o|--|| "t_users" : "evaluator"
+    "t_evaluations" o{--}o "t_vc_issuance_requests" : "vcIssuanceRequest"
     "t_evaluations" o{--}o "t_evaluation_histories" : "histories"
     "t_evaluation_histories" o|--|| "EvaluationStatus" : "enum:status"
     "t_evaluation_histories" o|--|| "t_evaluations" : "evaluation"

--- a/docs/schema.dbml
+++ b/docs/schema.dbml
@@ -170,6 +170,8 @@ Table t_vc_issuance_requests {
   requestedAt DateTime [default: `now()`, not null]
   processedAt DateTime
   completedAt DateTime
+  evaluationId String [unique, not null]
+  evaluation t_evaluations [not null]
   userId String [not null]
   user t_users [not null]
   createdAt DateTime [default: `now()`, not null]
@@ -356,6 +358,7 @@ Table t_evaluations {
   participation t_participations [not null]
   evaluatorId String [not null]
   evaluator t_users [not null]
+  vcIssuanceRequest t_vc_issuance_requests
   histories t_evaluation_histories [not null]
   createdAt DateTime [default: `now()`, not null]
   updatedAt DateTime
@@ -748,6 +751,8 @@ Ref: t_users.imageId > t_images.id
 Ref: t_identities.userId > t_users.id [delete: Cascade]
 
 Ref: t_did_issuance_requests.userId > t_users.id [delete: Cascade]
+
+Ref: t_vc_issuance_requests.evaluationId - t_evaluations.id
 
 Ref: t_vc_issuance_requests.userId > t_users.id [delete: Cascade]
 

--- a/src/application/domain/account/identity/didIssuanceRequest/controller/dataloader.ts
+++ b/src/application/domain/account/identity/didIssuanceRequest/controller/dataloader.ts
@@ -1,0 +1,40 @@
+import { PrismaClientIssuer } from "@/infrastructure/prisma/client";
+import { createHasManyLoaderByKey } from "@/presentation/graphql/dataloader/utils";
+import { Prisma } from "@prisma/client";
+import { GqlDidIssuanceRequest } from "@/types/graphql";
+
+const select = Prisma.validator<Prisma.DidIssuanceRequestSelect>()({
+  id: true,
+  status: true,
+  didValue: true,
+  requestedAt: true,
+  processedAt: true,
+  completedAt: true,
+  createdAt: true,
+  updatedAt: true,
+  userId: true,
+});
+
+export function createDidIssuanceRequestsByUserIdLoader(issuer: PrismaClientIssuer) {
+  return createHasManyLoaderByKey(
+    "userId",
+    async (userIds) =>
+      issuer.internal((tx) =>
+        tx.didIssuanceRequest.findMany({
+          where: { userId: { in: [...userIds] } },
+          select,
+        }),
+      ),
+    (record): GqlDidIssuanceRequest => ({
+      __typename: "DidIssuanceRequest",
+      id: record.id,
+      status: record.status,
+      didValue: record.didValue ?? null,
+      requestedAt: record.requestedAt,
+      processedAt: record.processedAt ?? null,
+      completedAt: record.completedAt ?? null,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt ?? null,
+    }),
+  );
+}

--- a/src/application/domain/account/identity/didIssuanceRequest/schema/type.graphql
+++ b/src/application/domain/account/identity/didIssuanceRequest/schema/type.graphql
@@ -1,0 +1,27 @@
+
+# ------------------------------
+# DidIssuanceRequest Object Type
+# ------------------------------
+type DidIssuanceRequest {
+    id: ID!
+    status: DidIssuanceStatus!
+
+    didValue: String
+
+    requestedAt: Datetime
+    processedAt: Datetime
+    completedAt: Datetime
+
+    createdAt: Datetime
+    updatedAt: Datetime
+}
+
+# ------------------------------
+# DidIssuanceStatus Enum
+# ------------------------------
+enum DidIssuanceStatus {
+    PENDING
+    PROCESSING
+    COMPLETED
+    FAILED
+}

--- a/src/application/domain/account/identity/didIssuanceRequest/service.ts
+++ b/src/application/domain/account/identity/didIssuanceRequest/service.ts
@@ -15,7 +15,7 @@ export class DIDIssuanceService {
     @inject("IdentityService") private readonly identityService: IdentityService,
     @inject("IdentityRepository") private readonly identityRepository: IdentityRepository,
     @inject("DIDVCServerClient") private readonly client: DIDVCServerClient,
-    @inject("didIssuanceRequestRepository")
+    @inject("DIDIssuanceRequestRepository")
     private readonly didIssuanceRequestRepository: IDIDIssuanceRequestRepository,
   ) {}
 
@@ -89,7 +89,6 @@ export class DIDIssuanceService {
       isValid: !isExpired,
     };
   }
-
 
   private async markIssuanceFailed(
     ctx: IContext,

--- a/src/application/domain/account/user/controller/resolver.ts
+++ b/src/application/domain/account/user/controller/resolver.ts
@@ -51,6 +51,10 @@ export default class UserResolver {
       return ctx.loaders.identitiesByUser.load(parent.id);
     },
 
+    didIssuanceRequests: (parent, _, ctx: IContext) => {
+      return ctx.loaders.didIssuanceRequestsByUser.load(parent.id);
+    },
+
     memberships: (parent, _: unknown, ctx: IContext) => {
       return ctx.loaders.membershipsByUser.load(parent.id);
     },

--- a/src/application/domain/account/user/data/type.ts
+++ b/src/application/domain/account/user/data/type.ts
@@ -49,7 +49,6 @@ export const userAuthInclude = Prisma.validator<Prisma.UserInclude>()({
 });
 
 export const userInclude = Prisma.validator<Prisma.UserInclude>()({
-  identities: true,
   image: true,
 });
 
@@ -74,7 +73,7 @@ export const userParticipationPortfolioInclude = Prisma.validator<Prisma.UserInc
   participations: {
     include: {
       images: true,
-      evaluation: true,
+      evaluation: { include: { vcIssuanceRequest: true } },
       reservation: {
         include: {
           opportunitySlot: {
@@ -87,7 +86,18 @@ export const userParticipationPortfolioInclude = Prisma.validator<Prisma.UserInc
               },
             },
           },
-          participations: { include: { user: { include: userInclude } } },
+          participations: { include: { user: { include: { image: true } } } },
+        },
+      },
+      opportunitySlot: {
+        include: {
+          opportunity: {
+            include: {
+              images: true,
+              place: { include: placeInclude },
+            },
+          },
+          participations: { include: { user: { include: { image: true } } } },
         },
       },
     },

--- a/src/application/domain/account/user/presenter.ts
+++ b/src/application/domain/account/user/presenter.ts
@@ -34,11 +34,10 @@ export default class UserPresenter {
   }
 
   static formatPortfolio(r: PrismaUser): GqlUser {
-    const { identities, image, ...prop } = r;
+    const { image, ...prop } = r;
     return {
       __typename: "User",
       ...prop,
-      identities: identities,
       image: image?.url,
     };
   }

--- a/src/application/domain/account/user/schema/type.graphql
+++ b/src/application/domain/account/user/schema/type.graphql
@@ -21,6 +21,7 @@ type User {
     currentPrefecture: CurrentPrefecture
 
     identities: [Identity!]
+    didIssuanceRequests: [DidIssuanceRequest!]
     portfolios: [Portfolio!]
 
     memberships: [Membership!]

--- a/src/application/domain/experience/evaluation/usecase.ts
+++ b/src/application/domain/experience/evaluation/usecase.ts
@@ -22,7 +22,7 @@ import { ITransactionService } from "@/application/domain/transaction/data/inter
 import ParticipationService from "@/application/domain/experience/participation/service";
 import { CannotEvaluateBeforeOpportunityStartError, ValidationError } from "@/errors/graphql";
 import { IdentityPlatform, ParticipationStatusReason, Prisma } from "@prisma/client";
-import { VCIssuanceService } from "@/application/domain/experience/evaluation/vcIssuanceRequest/service";
+import { VCIssuanceRequestService } from "@/application/domain/experience/evaluation/vcIssuanceRequest/service";
 import { VCIssuanceRequestInput } from "@/application/domain/experience/evaluation/vcIssuanceRequest/data/type";
 import { toVCIssuanceRequestInput } from "@/application/domain/experience/evaluation/vcIssuanceRequest/data/converter";
 import NotificationService from "@/application/domain/notification/service";
@@ -35,7 +35,8 @@ export default class EvaluationUseCase {
     @inject("TransactionService") private readonly transactionService: ITransactionService,
     @inject("WalletService") private readonly walletService: WalletService,
     @inject("WalletValidator") private readonly walletValidator: WalletValidator,
-    @inject("VCIssuanceService") private readonly vcIssuanceService: VCIssuanceService,
+    @inject("VCIssuanceRequestService")
+    private readonly vcIssuanceRequestService: VCIssuanceRequestService,
     @inject("NotificationService") private readonly notificationService: NotificationService,
   ) {}
 
@@ -167,7 +168,7 @@ export default class EvaluationUseCase {
 
     if (phoneUid) {
       const vcRequest: VCIssuanceRequestInput = toVCIssuanceRequestInput(evaluation);
-      await this.vcIssuanceService.requestVCIssuance(userId, phoneUid, vcRequest, ctx);
+      await this.vcIssuanceRequestService.requestVCIssuance(userId, phoneUid, vcRequest, ctx);
     }
 
     if (opportunity.pointsToEarn && opportunity.pointsToEarn > 0) {

--- a/src/application/domain/experience/evaluation/vcIssuanceRequest/controller/resolver.ts
+++ b/src/application/domain/experience/evaluation/vcIssuanceRequest/controller/resolver.ts
@@ -5,14 +5,15 @@ import VCIssuanceRequestUseCase from "@/application/domain/experience/evaluation
 import { PrismaVCIssuanceRequestDetail } from "@/application/domain/experience/evaluation/vcIssuanceRequest/data/type";
 
 @injectable()
-export default class VcIssuanceRequestResolver {
+export default class VCIssuanceRequestResolver {
   constructor(
-    @inject("VCIssuanceUseCase")
+    @inject("VCIssuanceRequestUseCase")
     private readonly usecase: VCIssuanceRequestUseCase,
   ) {}
 
   Query = {
     vcIssuanceRequests: (_: unknown, args: GqlQueryVcIssuanceRequestsArgs, ctx: IContext) => {
+      console.log(args);
       return this.usecase.visitorBrowseVcIssuanceRequests(ctx, args);
     },
 

--- a/src/application/domain/experience/evaluation/vcIssuanceRequest/controller/resolver.ts
+++ b/src/application/domain/experience/evaluation/vcIssuanceRequest/controller/resolver.ts
@@ -1,0 +1,33 @@
+import { GqlQueryVcIssuanceRequestsArgs, GqlQueryVcIssuanceRequestArgs } from "@/types/graphql";
+import { IContext } from "@/types/server";
+import { injectable, inject } from "tsyringe";
+import VCIssuanceRequestUseCase from "@/application/domain/experience/evaluation/vcIssuanceRequest/usecase";
+import { PrismaVCIssuanceRequestDetail } from "@/application/domain/experience/evaluation/vcIssuanceRequest/data/type";
+
+@injectable()
+export default class VcIssuanceRequestResolver {
+  constructor(
+    @inject("VCIssuanceUseCase")
+    private readonly usecase: VCIssuanceRequestUseCase,
+  ) {}
+
+  Query = {
+    vcIssuanceRequests: (_: unknown, args: GqlQueryVcIssuanceRequestsArgs, ctx: IContext) => {
+      return this.usecase.visitorBrowseVcIssuanceRequests(ctx, args);
+    },
+
+    vcIssuanceRequest: (_: unknown, args: GqlQueryVcIssuanceRequestArgs, ctx: IContext) => {
+      return this.usecase.visitorViewVcIssuanceRequest(ctx, args);
+    },
+  };
+
+  VcIssuanceRequest = {
+    evaluation: (parent: PrismaVCIssuanceRequestDetail, _: unknown, ctx: IContext) => {
+      return parent.evaluationId ? ctx.loaders.evaluation.load(parent.evaluationId) : null;
+    },
+
+    user: (parent: PrismaVCIssuanceRequestDetail, _: unknown, ctx: IContext) => {
+      return parent.userId ? ctx.loaders.user.load(parent.userId) : null;
+    },
+  };
+}

--- a/src/application/domain/experience/evaluation/vcIssuanceRequest/data/converter.ts
+++ b/src/application/domain/experience/evaluation/vcIssuanceRequest/data/converter.ts
@@ -1,7 +1,31 @@
 import { VCIssuanceRequestInput } from "@/application/domain/experience/evaluation/vcIssuanceRequest/data/type";
 import { PrismaEvaluation } from "@/application/domain/experience/evaluation/data/type";
 import logger from "@/infrastructure/logging";
-import { ParticipationStatusReason } from "@prisma/client";
+import { ParticipationStatusReason, Prisma } from "@prisma/client";
+import { injectable } from "tsyringe";
+import { GqlVcIssuanceRequestFilterInput, GqlVcIssuanceRequestSortInput } from "@/types/graphql";
+
+@injectable()
+export default class VCIssuanceRequestConverter {
+  filter(filter?: GqlVcIssuanceRequestFilterInput): Prisma.VcIssuanceRequestWhereInput {
+    const conditions: Prisma.VcIssuanceRequestWhereInput[] = [];
+
+    if (!filter) return {};
+
+    if (filter.status) conditions.push({ status: filter.status });
+    if (filter.userId) conditions.push({ userId: filter.userId });
+    if (filter.evaluationId) conditions.push({ evaluationId: filter.evaluationId });
+
+    return conditions.length ? { AND: conditions } : {};
+  }
+
+  sort(sort?: GqlVcIssuanceRequestSortInput): Prisma.VcIssuanceRequestOrderByWithRelationInput[] {
+    return [
+      { createdAt: sort?.createdAt ?? Prisma.SortOrder.desc },
+      ...(sort?.updatedAt ? [{ updatedAt: sort.updatedAt }] : []),
+    ];
+  }
+}
 
 export const toVCIssuanceRequestInput = (evaluation: PrismaEvaluation): VCIssuanceRequestInput => {
   const { status, evaluator, participation } = evaluation;

--- a/src/application/domain/experience/evaluation/vcIssuanceRequest/data/interface.ts
+++ b/src/application/domain/experience/evaluation/vcIssuanceRequest/data/interface.ts
@@ -1,9 +1,17 @@
 import { IContext } from "@/types/server";
 import { Prisma, VcIssuanceStatus } from "@prisma/client";
-import { VCIssuanceRequestDetail, VCIssuanceRequestWithUser, VCClaimsData } from "./type";
+import { VCIssuanceRequestWithUser, VCClaimsData, PrismaVCIssuanceRequestDetail } from "./type";
 
 export interface IVCIssuanceRequestRepository {
-  findById(ctx: IContext, id: string): Promise<VCIssuanceRequestDetail | null>;
+  query(
+    ctx: IContext,
+    where: Prisma.VcIssuanceRequestWhereInput,
+    orderBy: Prisma.VcIssuanceRequestOrderByWithRelationInput[],
+    take: number,
+    cursor?: string,
+  ): Promise<PrismaVCIssuanceRequestDetail[]>;
+
+  findById(ctx: IContext, id: string): Promise<PrismaVCIssuanceRequestDetail | null>;
 
   findPending(
     ctx: IContext,
@@ -20,7 +28,7 @@ export interface IVCIssuanceRequestRepository {
       schemaId?: string;
       status?: VcIssuanceStatus;
     },
-  ): Promise<VCIssuanceRequestDetail>;
+  ): Promise<PrismaVCIssuanceRequestDetail>;
 
   update(
     ctx: IContext,
@@ -35,5 +43,5 @@ export interface IVCIssuanceRequestRepository {
       retryCount?: number | { increment: number };
     },
     tx?: Prisma.TransactionClient,
-  ): Promise<VCIssuanceRequestDetail>;
+  ): Promise<PrismaVCIssuanceRequestDetail>;
 }

--- a/src/application/domain/experience/evaluation/vcIssuanceRequest/data/type.ts
+++ b/src/application/domain/experience/evaluation/vcIssuanceRequest/data/type.ts
@@ -1,28 +1,43 @@
-import { User, VcIssuanceRequest } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 
 export interface VCClaimsData {
   [key: string]: string | number | boolean | Date | VCClaimsData | VCClaimsData[];
 }
 
-export { VcIssuanceRequest };
-
-export type VCIssuanceRequestWithUser = VcIssuanceRequest & {
-  user: User;
-};
-
-export type VCIssuanceRequestDetail = VcIssuanceRequest;
-
 export interface VCIssuanceRequestInput {
   claims: VCClaimsData;
-  credentialFormat?: 'JWT' | 'AnonCreds' | 'SDJWT';
+  credentialFormat?: "JWT" | "AnonCreds" | "SDJWT";
   schemaId?: string;
 }
 
 export interface VCJobStatusResponse {
-  status: 'pending' | 'processing' | 'completed' | 'failed';
+  status: "pending" | "processing" | "completed" | "failed";
   progress?: number;
   result?: {
     recordId: string;
   };
   errorReason?: string;
 }
+
+export const vcIssuanceRequestIncludeWithUser = Prisma.validator<Prisma.VcIssuanceRequestInclude>()(
+  { user: true },
+);
+
+export type VCIssuanceRequestWithUser = Prisma.VcIssuanceRequestGetPayload<{
+  include: typeof vcIssuanceRequestIncludeWithUser;
+}>;
+
+export const vcIssuanceRequestSelectDetail = Prisma.validator<Prisma.VcIssuanceRequestSelect>()({
+  id: true,
+  status: true,
+
+  evaluationId: true,
+  userId: true,
+
+  createdAt: true,
+  updatedAt: true,
+});
+
+export type PrismaVCIssuanceRequestDetail = Prisma.VcIssuanceRequestGetPayload<{
+  select: typeof vcIssuanceRequestSelectDetail;
+}>;

--- a/src/application/domain/experience/evaluation/vcIssuanceRequest/presenter.ts
+++ b/src/application/domain/experience/evaluation/vcIssuanceRequest/presenter.ts
@@ -1,0 +1,31 @@
+import { GqlVcIssuanceRequest, GqlVcIssuanceRequestsConnection } from "@/types/graphql";
+import { PrismaVCIssuanceRequestDetail } from "@/application/domain/experience/evaluation/vcIssuanceRequest/data/type";
+
+export default class VCIssuanceRequestPresenter {
+  static query(
+    records: GqlVcIssuanceRequest[],
+    hasNextPage: boolean,
+  ): GqlVcIssuanceRequestsConnection {
+    return {
+      __typename: "VcIssuanceRequestsConnection",
+      totalCount: records.length,
+      pageInfo: {
+        hasNextPage,
+        hasPreviousPage: true,
+        startCursor: records[0]?.id,
+        endCursor: records.length ? records[records.length - 1].id : undefined,
+      },
+      edges: records.map((record) => ({
+        cursor: record.id,
+        node: record,
+      })),
+    };
+  }
+
+  static get(record: PrismaVCIssuanceRequestDetail): GqlVcIssuanceRequest {
+    return {
+      __typename: "VcIssuanceRequest",
+      ...record,
+    };
+  }
+}

--- a/src/application/domain/experience/evaluation/vcIssuanceRequest/schema/query.graphql
+++ b/src/application/domain/experience/evaluation/vcIssuanceRequest/schema/query.graphql
@@ -1,0 +1,41 @@
+# ------------------------------
+# VcIssuanceRequest Query Definitions
+# ------------------------------
+extend type Query {
+    vcIssuanceRequests(
+        filter: VcIssuanceRequestFilterInput
+        sort: VcIssuanceRequestSortInput
+        cursor: String
+        first: Int
+    ): VcIssuanceRequestsConnection!
+
+    vcIssuanceRequest(id: ID!): VcIssuanceRequest
+}
+
+# ------------------------------
+# VcIssuanceRequest Connection Type
+# ------------------------------
+type VcIssuanceRequestsConnection {
+    edges: [VcIssuanceRequestEdge!]!
+    pageInfo: PageInfo!
+    totalCount: Int!
+}
+
+type VcIssuanceRequestEdge implements Edge {
+    cursor: String!
+    node: VcIssuanceRequest
+}
+
+# ------------------------------
+# VcIssuanceRequest Query Inputs
+# ------------------------------
+input VcIssuanceRequestFilterInput {
+    status: VcIssuanceStatus
+    userId: ID
+    evaluationId: ID
+}
+
+input VcIssuanceRequestSortInput {
+    createdAt: SortDirection
+    updatedAt: SortDirection
+}

--- a/src/application/domain/experience/evaluation/vcIssuanceRequest/schema/type.graphql
+++ b/src/application/domain/experience/evaluation/vcIssuanceRequest/schema/type.graphql
@@ -1,0 +1,27 @@
+# ------------------------------
+# VcIssuanceRequest Object Type
+# ------------------------------
+type VcIssuanceRequest {
+    id: ID!
+    status: VcIssuanceStatus!
+
+    requestedAt: Datetime
+    processedAt: Datetime
+    completedAt: Datetime
+
+    evaluation: Evaluation
+    user: User
+
+    createdAt: Datetime
+    updatedAt: Datetime
+}
+
+# ------------------------------
+# VcIssuanceStatus Enum
+# ------------------------------
+enum VcIssuanceStatus {
+    PENDING
+    PROCESSING
+    COMPLETED
+    FAILED
+}

--- a/src/application/domain/experience/evaluation/vcIssuanceRequest/usecase.ts
+++ b/src/application/domain/experience/evaluation/vcIssuanceRequest/usecase.ts
@@ -1,0 +1,43 @@
+import {
+  GqlVcIssuanceRequestsConnection,
+  GqlVcIssuanceRequest,
+  GqlQueryVcIssuanceRequestArgs,
+  GqlQueryVcIssuanceRequestsArgs,
+} from "@/types/graphql";
+import { IContext } from "@/types/server";
+import { injectable, inject } from "tsyringe";
+import { clampFirst } from "@/application/domain/utils";
+import { VCIssuanceRequestService } from "@/application/domain/experience/evaluation/vcIssuanceRequest/service";
+import VCIssuanceRequestPresenter from "@/application/domain/experience/evaluation/vcIssuanceRequest/presenter";
+
+@injectable()
+export default class VCIssuanceRequestUseCase {
+  constructor(
+    @inject("VcIssuanceService")
+    private readonly service: VCIssuanceRequestService,
+  ) {}
+
+  async visitorBrowseVcIssuanceRequests(
+    ctx: IContext,
+    { cursor, filter, sort, first }: GqlQueryVcIssuanceRequestsArgs,
+  ): Promise<GqlVcIssuanceRequestsConnection> {
+    const take = clampFirst(first);
+    const requests = await this.service.fetchVcIssuanceRequests(
+      ctx,
+      { cursor, filter, sort },
+      take,
+    );
+
+    const hasNextPage = requests.length > take;
+    const data = requests.slice(0, take).map(VCIssuanceRequestPresenter.get);
+    return VCIssuanceRequestPresenter.query(data, hasNextPage);
+  }
+
+  async visitorViewVcIssuanceRequest(
+    ctx: IContext,
+    { id }: GqlQueryVcIssuanceRequestArgs,
+  ): Promise<GqlVcIssuanceRequest | null> {
+    const request = await this.service.findVcIssuanceRequest(ctx, id);
+    return request ? VCIssuanceRequestPresenter.get(request) : null;
+  }
+}

--- a/src/application/domain/experience/evaluation/vcIssuanceRequest/usecase.ts
+++ b/src/application/domain/experience/evaluation/vcIssuanceRequest/usecase.ts
@@ -13,7 +13,7 @@ import VCIssuanceRequestPresenter from "@/application/domain/experience/evaluati
 @injectable()
 export default class VCIssuanceRequestUseCase {
   constructor(
-    @inject("VcIssuanceService")
+    @inject("VCIssuanceRequestService")
     private readonly service: VCIssuanceRequestService,
   ) {}
 

--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -80,8 +80,10 @@ import TicketClaimLinkConverter from "@/application/domain/reward/ticketClaimLin
 import { TicketIssuerUseCase } from "@/application/domain/reward/ticketIssuer/usecase";
 import { DIDVCServerClient } from "@/infrastructure/libs/did";
 import { DIDIssuanceService } from "@/application/domain/account/identity/didIssuanceRequest/service";
-import { VCIssuanceService } from "@/application/domain/experience/evaluation/vcIssuanceRequest/service";
+import { VCIssuanceRequestService } from "@/application/domain/experience/evaluation/vcIssuanceRequest/service";
 import { VCIssuanceRequestRepository } from "@/application/domain/experience/evaluation/vcIssuanceRequest/data/repository";
+import VCIssuanceRequestUseCase from "@/application/domain/experience/evaluation/vcIssuanceRequest/usecase";
+import VCIssuanceRequestConverter from "@/application/domain/experience/evaluation/vcIssuanceRequest/data/converter";
 
 export function registerProductionDependencies() {
   // ------------------------------
@@ -127,12 +129,15 @@ export function registerProductionDependencies() {
   container.register("IdentityRepository", { useClass: IdentityRepository });
   container.register("IdentityConverter", { useClass: IdentityConverter });
 
-  // DID?VC
+  // DID・VC
   container.register("DIDVCServerClient", { useClass: DIDVCServerClient });
   container.register("DIDIssuanceService", { useClass: DIDIssuanceService });
-  container.register("didIssuanceRequestRepository", { useClass: DIDIssuanceRequestRepository });
-  container.register("VCIssuanceService", { useClass: VCIssuanceService });
-  container.register("vcIssuanceRequestRepository", { useClass: VCIssuanceRequestRepository });
+  container.register("DIDIssuanceRequestRepository", { useClass: DIDIssuanceRequestRepository });
+
+  container.register("VCIssuanceRequestUseCase", { useClass: VCIssuanceRequestUseCase });
+  container.register("VCIssuanceRequestConverter", { useClass: VCIssuanceRequestConverter });
+  container.register("VCIssuanceRequestService", { useClass: VCIssuanceRequestService });
+  container.register("VCIssuanceRequestRepository", { useClass: VCIssuanceRequestRepository });
 
   // ------------------------------
   // 📰 Content

--- a/src/infrastructure/prisma/factories/__generated__/index.ts
+++ b/src/infrastructure/prisma/factories/__generated__/index.ts
@@ -288,6 +288,10 @@ const modelFieldDefinitions: ModelWithFields[] = [{
     }, {
         name: "VcIssuanceRequest",
         fields: [{
+                name: "evaluation",
+                type: "Evaluation",
+                relationName: "EvaluationToVcIssuanceRequest"
+            }, {
                 name: "user",
                 type: "User",
                 relationName: "UserToVcIssuanceRequest"
@@ -532,6 +536,10 @@ const modelFieldDefinitions: ModelWithFields[] = [{
                 name: "evaluator",
                 type: "User",
                 relationName: "EvaluationToUser"
+            }, {
+                name: "vcIssuanceRequest",
+                type: "VcIssuanceRequest",
+                relationName: "EvaluationToVcIssuanceRequest"
             }, {
                 name: "histories",
                 type: "EvaluationHistory",
@@ -2097,6 +2105,11 @@ type VcIssuanceRequestScalarOrEnumFields = {
     claims: Prisma.JsonNullValueInput | Prisma.InputJsonValue;
 };
 
+type VcIssuanceRequestevaluationFactory = {
+    _factoryFor: "Evaluation";
+    build: () => PromiseLike<Prisma.EvaluationCreateNestedOneWithoutVcIssuanceRequestInput["create"]>;
+};
+
 type VcIssuanceRequestuserFactory = {
     _factoryFor: "User";
     build: () => PromiseLike<Prisma.UserCreateNestedOneWithoutVcIssuanceRequestsInput["create"]>;
@@ -2117,6 +2130,7 @@ type VcIssuanceRequestFactoryDefineInput = {
     completedAt?: Date | null;
     createdAt?: Date;
     updatedAt?: Date | null;
+    evaluation: VcIssuanceRequestevaluationFactory | Prisma.EvaluationCreateNestedOneWithoutVcIssuanceRequestInput;
     user: VcIssuanceRequestuserFactory | Prisma.UserCreateNestedOneWithoutVcIssuanceRequestsInput;
 };
 
@@ -2132,6 +2146,10 @@ type VcIssuanceRequestFactoryDefineOptions<TTransients extends Record<string, un
         [traitName: string | symbol]: VcIssuanceRequestFactoryTrait<TTransients>;
     };
 } & CallbackDefineOptions<VcIssuanceRequest, Prisma.VcIssuanceRequestCreateInput, TTransients>;
+
+function isVcIssuanceRequestevaluationFactory(x: VcIssuanceRequestevaluationFactory | Prisma.EvaluationCreateNestedOneWithoutVcIssuanceRequestInput | undefined): x is VcIssuanceRequestevaluationFactory {
+    return (x as any)?._factoryFor === "Evaluation";
+}
 
 function isVcIssuanceRequestuserFactory(x: VcIssuanceRequestuserFactory | Prisma.UserCreateNestedOneWithoutVcIssuanceRequestsInput | undefined): x is VcIssuanceRequestuserFactory {
     return (x as any)?._factoryFor === "User";
@@ -2197,6 +2215,9 @@ function defineVcIssuanceRequestFactoryInternal<TTransients extends Record<strin
                 };
             }, resolveValue(resolverInput));
             const defaultAssociations = {
+                evaluation: isVcIssuanceRequestevaluationFactory(defaultData.evaluation) ? {
+                    create: await defaultData.evaluation.build()
+                } : defaultData.evaluation,
                 user: isVcIssuanceRequestuserFactory(defaultData.user) ? {
                     create: await defaultData.user.build()
                 } : defaultData.user
@@ -4113,6 +4134,11 @@ type EvaluationevaluatorFactory = {
     build: () => PromiseLike<Prisma.UserCreateNestedOneWithoutEvaluationsEvaluatedByMeInput["create"]>;
 };
 
+type EvaluationvcIssuanceRequestFactory = {
+    _factoryFor: "VcIssuanceRequest";
+    build: () => PromiseLike<Prisma.VcIssuanceRequestCreateNestedOneWithoutEvaluationInput["create"]>;
+};
+
 type EvaluationFactoryDefineInput = {
     id?: string;
     status?: EvaluationStatus;
@@ -4123,6 +4149,7 @@ type EvaluationFactoryDefineInput = {
     updatedAt?: Date | null;
     participation: EvaluationparticipationFactory | Prisma.ParticipationCreateNestedOneWithoutEvaluationInput;
     evaluator: EvaluationevaluatorFactory | Prisma.UserCreateNestedOneWithoutEvaluationsEvaluatedByMeInput;
+    vcIssuanceRequest?: EvaluationvcIssuanceRequestFactory | Prisma.VcIssuanceRequestCreateNestedOneWithoutEvaluationInput;
     histories?: Prisma.EvaluationHistoryCreateNestedManyWithoutEvaluationInput;
 };
 
@@ -4145,6 +4172,10 @@ function isEvaluationparticipationFactory(x: EvaluationparticipationFactory | Pr
 
 function isEvaluationevaluatorFactory(x: EvaluationevaluatorFactory | Prisma.UserCreateNestedOneWithoutEvaluationsEvaluatedByMeInput | undefined): x is EvaluationevaluatorFactory {
     return (x as any)?._factoryFor === "User";
+}
+
+function isEvaluationvcIssuanceRequestFactory(x: EvaluationvcIssuanceRequestFactory | Prisma.VcIssuanceRequestCreateNestedOneWithoutEvaluationInput | undefined): x is EvaluationvcIssuanceRequestFactory {
+    return (x as any)?._factoryFor === "VcIssuanceRequest";
 }
 
 type EvaluationTraitKeys<TOptions extends EvaluationFactoryDefineOptions<any>> = Exclude<keyof TOptions["traits"], number>;
@@ -4210,7 +4241,10 @@ function defineEvaluationFactoryInternal<TTransients extends Record<string, unkn
                 } : defaultData.participation,
                 evaluator: isEvaluationevaluatorFactory(defaultData.evaluator) ? {
                     create: await defaultData.evaluator.build()
-                } : defaultData.evaluator
+                } : defaultData.evaluator,
+                vcIssuanceRequest: isEvaluationvcIssuanceRequestFactory(defaultData.vcIssuanceRequest) ? {
+                    create: await defaultData.vcIssuanceRequest.build()
+                } : defaultData.vcIssuanceRequest
             } as Prisma.EvaluationCreateInput;
             const data: Prisma.EvaluationCreateInput = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...filteredInputData };
             await handleAfterBuild(data, transientFields);

--- a/src/infrastructure/prisma/migrations/20250624084353_link_evaluation_to_vc/migration.sql
+++ b/src/infrastructure/prisma/migrations/20250624084353_link_evaluation_to_vc/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[evaluation_id]` on the table `t_vc_issuance_requests` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `evaluation_id` to the `t_vc_issuance_requests` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "t_vc_issuance_requests" ADD COLUMN     "evaluation_id" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "t_vc_issuance_requests_evaluation_id_key" ON "t_vc_issuance_requests"("evaluation_id");
+
+-- AddForeignKey
+ALTER TABLE "t_vc_issuance_requests" ADD CONSTRAINT "t_vc_issuance_requests_evaluation_id_fkey" FOREIGN KEY ("evaluation_id") REFERENCES "t_evaluations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -336,6 +336,9 @@ model VcIssuanceRequest {
   processedAt DateTime? @map("processed_at")
   completedAt DateTime? @map("completed_at")
 
+  evaluationId String     @unique @map("evaluation_id")
+  evaluation   Evaluation @relation(fields: [evaluationId], references: [id])
+
   userId String @map("user_id")
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -781,7 +784,8 @@ model Evaluation {
   evaluatorId String @map("evaluator_id")
   evaluator   User   @relation(fields: [evaluatorId], references: [id], onDelete: SetNull)
 
-  histories EvaluationHistory[]
+  vcIssuanceRequest VcIssuanceRequest?
+  histories         EvaluationHistory[]
 
   createdAt DateTime  @default(now()) @map("created_at")
   updatedAt DateTime? @updatedAt @map("updated_at")

--- a/src/presentation/graphql/dataloader/domain/account.ts
+++ b/src/presentation/graphql/dataloader/domain/account.ts
@@ -5,6 +5,7 @@ import * as CommunityLoaders from "@/application/domain/account/community/contro
 import * as MembershipLoaders from "@/application/domain/account/membership/controller/dataloader";
 import * as IdentityLoaders from "@/application/domain/account/identity/controller/dataloader";
 import * as MembershipHistoryLoaders from "@/application/domain/account/membership/history/controller/dataloader";
+import { createDidIssuanceRequestsByUserIdLoader } from "@/application/domain/account/identity/didIssuanceRequest/controller/dataloader";
 
 export function createAccountLoaders(issuer: PrismaClientIssuer) {
   return {
@@ -17,6 +18,8 @@ export function createAccountLoaders(issuer: PrismaClientIssuer) {
 
     identity: IdentityLoaders.createIdentityLoader(issuer),
     identitiesByUser: IdentityLoaders.createIdentitiesByUserLoader(issuer),
+
+    didIssuanceRequestsByUser: createDidIssuanceRequestsByUserIdLoader(issuer),
 
     community: CommunityLoaders.createCommunityLoader(issuer),
 

--- a/src/presentation/graphql/resolver.ts
+++ b/src/presentation/graphql/resolver.ts
@@ -17,6 +17,7 @@ import UtilityResolver from "@/application/domain/reward/utility/controller/reso
 import TransactionResolver from "@/application/domain/transaction/controller/resolver";
 import TicketClaimLinkResolver from "@/application/domain/reward/ticketClaimLink/controller/resolver";
 import TicketIssuerResolver from "@/application/domain/reward/ticketIssuer/controller/resolver";
+import VCIssuanceRequestResolver from "@/application/domain/experience/evaluation/vcIssuanceRequest/controller/resolver";
 
 const identity = container.resolve(IdentityResolver);
 const user = container.resolve(UserResolver);
@@ -31,6 +32,7 @@ const opportunitySlot = container.resolve(OpportunitySlotResolver);
 const reservation = container.resolve(ReservationResolver);
 const participation = container.resolve(ParticipationResolver);
 const evaluation = container.resolve(EvaluationResolver);
+const vcIssuanceRequest = container.resolve(VCIssuanceRequestResolver);
 
 const place = container.resolve(PlaceResolver);
 
@@ -54,6 +56,7 @@ const resolvers = {
     ...reservation.Query,
     ...participation.Query,
     ...evaluation.Query,
+    ...vcIssuanceRequest.Query,
     ...place.Query,
     ...utility.Query,
     ...ticket.Query,
@@ -89,6 +92,7 @@ const resolvers = {
   Reservation: reservation.Reservation,
   Participation: participation.Participation,
   Evaluation: evaluation.Evaluation,
+  VcIssuanceRequest: vcIssuanceRequest.VcIssuanceRequest,
 
   Place: place.Place,
 

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -251,6 +251,26 @@ export type GqlDateTimeRangeFilter = {
   lte?: InputMaybe<Scalars['Datetime']['input']>;
 };
 
+export type GqlDidIssuanceRequest = {
+  __typename?: 'DidIssuanceRequest';
+  completedAt?: Maybe<Scalars['Datetime']['output']>;
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
+  didValue?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  processedAt?: Maybe<Scalars['Datetime']['output']>;
+  requestedAt?: Maybe<Scalars['Datetime']['output']>;
+  status: GqlDidIssuanceStatus;
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+};
+
+export const GqlDidIssuanceStatus = {
+  Completed: 'COMPLETED',
+  Failed: 'FAILED',
+  Pending: 'PENDING',
+  Processing: 'PROCESSING'
+} as const;
+
+export type GqlDidIssuanceStatus = typeof GqlDidIssuanceStatus[keyof typeof GqlDidIssuanceStatus];
 export type GqlEdge = {
   cursor: Scalars['String']['output'];
 };
@@ -2285,6 +2305,7 @@ export type GqlUser = {
   bio?: Maybe<Scalars['String']['output']>;
   createdAt?: Maybe<Scalars['Datetime']['output']>;
   currentPrefecture?: Maybe<GqlCurrentPrefecture>;
+  didIssuanceRequests?: Maybe<Array<GqlDidIssuanceRequest>>;
   evaluationCreatedByMe?: Maybe<Array<GqlEvaluationHistory>>;
   evaluations?: Maybe<Array<GqlEvaluation>>;
   id: Scalars['ID']['output'];
@@ -2707,6 +2728,8 @@ export type GqlResolversTypes = ResolversObject<{
   DateTimeRangeFilter: GqlDateTimeRangeFilter;
   Datetime: ResolverTypeWrapper<Scalars['Datetime']['output']>;
   Decimal: ResolverTypeWrapper<Scalars['Decimal']['output']>;
+  DidIssuanceRequest: ResolverTypeWrapper<GqlDidIssuanceRequest>;
+  DidIssuanceStatus: GqlDidIssuanceStatus;
   Edge: ResolverTypeWrapper<GqlResolversInterfaceTypes<GqlResolversTypes>['Edge']>;
   Error: ResolverTypeWrapper<GqlError>;
   ErrorCode: GqlErrorCode;
@@ -2992,6 +3015,7 @@ export type GqlResolversParentTypes = ResolversObject<{
   DateTimeRangeFilter: GqlDateTimeRangeFilter;
   Datetime: Scalars['Datetime']['output'];
   Decimal: Scalars['Decimal']['output'];
+  DidIssuanceRequest: GqlDidIssuanceRequest;
   Edge: GqlResolversInterfaceTypes<GqlResolversParentTypes>['Edge'];
   Error: GqlError;
   Evaluation: Omit<GqlEvaluation, 'evaluator' | 'histories' | 'participation'> & { evaluator?: Maybe<GqlResolversParentTypes['User']>, histories?: Maybe<Array<GqlResolversParentTypes['EvaluationHistory']>>, participation?: Maybe<GqlResolversParentTypes['Participation']> };
@@ -3355,6 +3379,18 @@ export interface GqlDatetimeScalarConfig extends GraphQLScalarTypeConfig<GqlReso
 export interface GqlDecimalScalarConfig extends GraphQLScalarTypeConfig<GqlResolversTypes['Decimal'], any> {
   name: 'Decimal';
 }
+
+export type GqlDidIssuanceRequestResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['DidIssuanceRequest'] = GqlResolversParentTypes['DidIssuanceRequest']> = ResolversObject<{
+  completedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  didValue?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  processedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  requestedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  status?: Resolver<GqlResolversTypes['DidIssuanceStatus'], ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
 
 export type GqlEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Edge'] = GqlResolversParentTypes['Edge']> = ResolversObject<{
   __resolveType: TypeResolveFn<'ArticleEdge' | 'CommunityEdge' | 'EvaluationEdge' | 'EvaluationHistoryEdge' | 'MembershipEdge' | 'OpportunityEdge' | 'OpportunitySlotEdge' | 'ParticipationEdge' | 'ParticipationStatusHistoryEdge' | 'PlaceEdge' | 'ReservationEdge' | 'ReservationHistoryEdge' | 'TicketClaimLinkEdge' | 'TicketEdge' | 'TicketIssuerEdge' | 'TicketStatusHistoryEdge' | 'TransactionEdge' | 'UserEdge' | 'UtilityEdge' | 'VcIssuanceRequestEdge' | 'WalletEdge', ParentType, ContextType>;
@@ -4241,6 +4277,7 @@ export type GqlUserResolvers<ContextType = any, ParentType extends GqlResolversP
   bio?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
   currentPrefecture?: Resolver<Maybe<GqlResolversTypes['CurrentPrefecture']>, ParentType, ContextType>;
+  didIssuanceRequests?: Resolver<Maybe<Array<GqlResolversTypes['DidIssuanceRequest']>>, ParentType, ContextType>;
   evaluationCreatedByMe?: Resolver<Maybe<Array<GqlResolversTypes['EvaluationHistory']>>, ParentType, ContextType>;
   evaluations?: Resolver<Maybe<Array<GqlResolversTypes['Evaluation']>>, ParentType, ContextType>;
   id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
@@ -4434,6 +4471,7 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   CurrentUserPayload?: GqlCurrentUserPayloadResolvers<ContextType>;
   Datetime?: GraphQLScalarType;
   Decimal?: GraphQLScalarType;
+  DidIssuanceRequest?: GqlDidIssuanceRequestResolvers<ContextType>;
   Edge?: GqlEdgeResolvers<ContextType>;
   Error?: GqlErrorResolvers<ContextType>;
   Evaluation?: GqlEvaluationResolvers<ContextType>;

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1507,6 +1507,8 @@ export type GqlQuery = {
   users: GqlUsersConnection;
   utilities: GqlUtilitiesConnection;
   utility?: Maybe<GqlUtility>;
+  vcIssuanceRequest?: Maybe<GqlVcIssuanceRequest>;
+  vcIssuanceRequests: GqlVcIssuanceRequestsConnection;
   wallet?: Maybe<GqlWallet>;
   wallets: GqlWalletsConnection;
 };
@@ -1770,6 +1772,19 @@ export type GqlQueryUtilitiesArgs = {
 export type GqlQueryUtilityArgs = {
   id: Scalars['ID']['input'];
   permission: GqlCheckCommunityPermissionInput;
+};
+
+
+export type GqlQueryVcIssuanceRequestArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryVcIssuanceRequestsArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlVcIssuanceRequestFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlVcIssuanceRequestSortInput>;
 };
 
 
@@ -2454,6 +2469,51 @@ export const GqlValueType = {
 } as const;
 
 export type GqlValueType = typeof GqlValueType[keyof typeof GqlValueType];
+export type GqlVcIssuanceRequest = {
+  __typename?: 'VcIssuanceRequest';
+  completedAt?: Maybe<Scalars['Datetime']['output']>;
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
+  evaluation?: Maybe<GqlEvaluation>;
+  id: Scalars['ID']['output'];
+  processedAt?: Maybe<Scalars['Datetime']['output']>;
+  requestedAt?: Maybe<Scalars['Datetime']['output']>;
+  status: GqlVcIssuanceStatus;
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+  user?: Maybe<GqlUser>;
+};
+
+export type GqlVcIssuanceRequestEdge = GqlEdge & {
+  __typename?: 'VcIssuanceRequestEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlVcIssuanceRequest>;
+};
+
+export type GqlVcIssuanceRequestFilterInput = {
+  evaluationId?: InputMaybe<Scalars['ID']['input']>;
+  status?: InputMaybe<GqlVcIssuanceStatus>;
+  userId?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type GqlVcIssuanceRequestSortInput = {
+  createdAt?: InputMaybe<GqlSortDirection>;
+  updatedAt?: InputMaybe<GqlSortDirection>;
+};
+
+export type GqlVcIssuanceRequestsConnection = {
+  __typename?: 'VcIssuanceRequestsConnection';
+  edges: Array<GqlVcIssuanceRequestEdge>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export const GqlVcIssuanceStatus = {
+  Completed: 'COMPLETED',
+  Failed: 'FAILED',
+  Pending: 'PENDING',
+  Processing: 'PROCESSING'
+} as const;
+
+export type GqlVcIssuanceStatus = typeof GqlVcIssuanceStatus[keyof typeof GqlVcIssuanceStatus];
 export type GqlWallet = {
   __typename?: 'Wallet';
   accumulatedPointView?: Maybe<GqlAccumulatedPointView>;
@@ -2607,7 +2667,7 @@ export type GqlResolversUnionTypes<_RefType extends Record<string, unknown>> = R
 
 /** Mapping of interface types */
 export type GqlResolversInterfaceTypes<_RefType extends Record<string, unknown>> = ResolversObject<{
-  Edge: ( Omit<GqlArticleEdge, 'node'> & { node?: Maybe<_RefType['Article']> } ) | ( Omit<GqlCommunityEdge, 'node'> & { node?: Maybe<_RefType['Community']> } ) | ( Omit<GqlEvaluationEdge, 'node'> & { node?: Maybe<_RefType['Evaluation']> } ) | ( Omit<GqlEvaluationHistoryEdge, 'node'> & { node?: Maybe<_RefType['EvaluationHistory']> } ) | ( Omit<GqlMembershipEdge, 'node'> & { node?: Maybe<_RefType['Membership']> } ) | ( Omit<GqlOpportunityEdge, 'node'> & { node?: Maybe<_RefType['Opportunity']> } ) | ( Omit<GqlOpportunitySlotEdge, 'node'> & { node?: Maybe<_RefType['OpportunitySlot']> } ) | ( Omit<GqlParticipationEdge, 'node'> & { node?: Maybe<_RefType['Participation']> } ) | ( Omit<GqlParticipationStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['ParticipationStatusHistory']> } ) | ( Omit<GqlPlaceEdge, 'node'> & { node?: Maybe<_RefType['Place']> } ) | ( Omit<GqlReservationEdge, 'node'> & { node?: Maybe<_RefType['Reservation']> } ) | ( Omit<GqlReservationHistoryEdge, 'node'> & { node?: Maybe<_RefType['ReservationHistory']> } ) | ( Omit<GqlTicketClaimLinkEdge, 'node'> & { node?: Maybe<_RefType['TicketClaimLink']> } ) | ( Omit<GqlTicketEdge, 'node'> & { node?: Maybe<_RefType['Ticket']> } ) | ( Omit<GqlTicketIssuerEdge, 'node'> & { node?: Maybe<_RefType['TicketIssuer']> } ) | ( Omit<GqlTicketStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['TicketStatusHistory']> } ) | ( Omit<GqlTransactionEdge, 'node'> & { node?: Maybe<_RefType['Transaction']> } ) | ( Omit<GqlUserEdge, 'node'> & { node?: Maybe<_RefType['User']> } ) | ( Omit<GqlUtilityEdge, 'node'> & { node?: Maybe<_RefType['Utility']> } ) | ( Omit<GqlWalletEdge, 'node'> & { node?: Maybe<_RefType['Wallet']> } );
+  Edge: ( Omit<GqlArticleEdge, 'node'> & { node?: Maybe<_RefType['Article']> } ) | ( Omit<GqlCommunityEdge, 'node'> & { node?: Maybe<_RefType['Community']> } ) | ( Omit<GqlEvaluationEdge, 'node'> & { node?: Maybe<_RefType['Evaluation']> } ) | ( Omit<GqlEvaluationHistoryEdge, 'node'> & { node?: Maybe<_RefType['EvaluationHistory']> } ) | ( Omit<GqlMembershipEdge, 'node'> & { node?: Maybe<_RefType['Membership']> } ) | ( Omit<GqlOpportunityEdge, 'node'> & { node?: Maybe<_RefType['Opportunity']> } ) | ( Omit<GqlOpportunitySlotEdge, 'node'> & { node?: Maybe<_RefType['OpportunitySlot']> } ) | ( Omit<GqlParticipationEdge, 'node'> & { node?: Maybe<_RefType['Participation']> } ) | ( Omit<GqlParticipationStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['ParticipationStatusHistory']> } ) | ( Omit<GqlPlaceEdge, 'node'> & { node?: Maybe<_RefType['Place']> } ) | ( Omit<GqlReservationEdge, 'node'> & { node?: Maybe<_RefType['Reservation']> } ) | ( Omit<GqlReservationHistoryEdge, 'node'> & { node?: Maybe<_RefType['ReservationHistory']> } ) | ( Omit<GqlTicketClaimLinkEdge, 'node'> & { node?: Maybe<_RefType['TicketClaimLink']> } ) | ( Omit<GqlTicketEdge, 'node'> & { node?: Maybe<_RefType['Ticket']> } ) | ( Omit<GqlTicketIssuerEdge, 'node'> & { node?: Maybe<_RefType['TicketIssuer']> } ) | ( Omit<GqlTicketStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['TicketStatusHistory']> } ) | ( Omit<GqlTransactionEdge, 'node'> & { node?: Maybe<_RefType['Transaction']> } ) | ( Omit<GqlUserEdge, 'node'> & { node?: Maybe<_RefType['User']> } ) | ( Omit<GqlUtilityEdge, 'node'> & { node?: Maybe<_RefType['Utility']> } ) | ( Omit<GqlVcIssuanceRequestEdge, 'node'> & { node?: Maybe<_RefType['VcIssuanceRequest']> } ) | ( Omit<GqlWalletEdge, 'node'> & { node?: Maybe<_RefType['Wallet']> } );
 }>;
 
 /** Mapping between all available schema types and the resolvers types */
@@ -2885,6 +2945,12 @@ export type GqlResolversTypes = ResolversObject<{
   UtilityUpdateInfoPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['UtilityUpdateInfoPayload']>;
   UtilityUpdateInfoSuccess: ResolverTypeWrapper<Omit<GqlUtilityUpdateInfoSuccess, 'utility'> & { utility: GqlResolversTypes['Utility'] }>;
   ValueType: GqlValueType;
+  VcIssuanceRequest: ResolverTypeWrapper<Omit<GqlVcIssuanceRequest, 'evaluation' | 'user'> & { evaluation?: Maybe<GqlResolversTypes['Evaluation']>, user?: Maybe<GqlResolversTypes['User']> }>;
+  VcIssuanceRequestEdge: ResolverTypeWrapper<Omit<GqlVcIssuanceRequestEdge, 'node'> & { node?: Maybe<GqlResolversTypes['VcIssuanceRequest']> }>;
+  VcIssuanceRequestFilterInput: GqlVcIssuanceRequestFilterInput;
+  VcIssuanceRequestSortInput: GqlVcIssuanceRequestSortInput;
+  VcIssuanceRequestsConnection: ResolverTypeWrapper<Omit<GqlVcIssuanceRequestsConnection, 'edges'> & { edges: Array<GqlResolversTypes['VcIssuanceRequestEdge']> }>;
+  VcIssuanceStatus: GqlVcIssuanceStatus;
   Wallet: ResolverTypeWrapper<Wallet>;
   WalletEdge: ResolverTypeWrapper<Omit<GqlWalletEdge, 'node'> & { node?: Maybe<GqlResolversTypes['Wallet']> }>;
   WalletFilterInput: GqlWalletFilterInput;
@@ -3141,6 +3207,11 @@ export type GqlResolversParentTypes = ResolversObject<{
   UtilityUpdateInfoInput: GqlUtilityUpdateInfoInput;
   UtilityUpdateInfoPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['UtilityUpdateInfoPayload'];
   UtilityUpdateInfoSuccess: Omit<GqlUtilityUpdateInfoSuccess, 'utility'> & { utility: GqlResolversParentTypes['Utility'] };
+  VcIssuanceRequest: Omit<GqlVcIssuanceRequest, 'evaluation' | 'user'> & { evaluation?: Maybe<GqlResolversParentTypes['Evaluation']>, user?: Maybe<GqlResolversParentTypes['User']> };
+  VcIssuanceRequestEdge: Omit<GqlVcIssuanceRequestEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['VcIssuanceRequest']> };
+  VcIssuanceRequestFilterInput: GqlVcIssuanceRequestFilterInput;
+  VcIssuanceRequestSortInput: GqlVcIssuanceRequestSortInput;
+  VcIssuanceRequestsConnection: Omit<GqlVcIssuanceRequestsConnection, 'edges'> & { edges: Array<GqlResolversParentTypes['VcIssuanceRequestEdge']> };
   Wallet: Wallet;
   WalletEdge: Omit<GqlWalletEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['Wallet']> };
   WalletFilterInput: GqlWalletFilterInput;
@@ -3286,7 +3357,7 @@ export interface GqlDecimalScalarConfig extends GraphQLScalarTypeConfig<GqlResol
 }
 
 export type GqlEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Edge'] = GqlResolversParentTypes['Edge']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'ArticleEdge' | 'CommunityEdge' | 'EvaluationEdge' | 'EvaluationHistoryEdge' | 'MembershipEdge' | 'OpportunityEdge' | 'OpportunitySlotEdge' | 'ParticipationEdge' | 'ParticipationStatusHistoryEdge' | 'PlaceEdge' | 'ReservationEdge' | 'ReservationHistoryEdge' | 'TicketClaimLinkEdge' | 'TicketEdge' | 'TicketIssuerEdge' | 'TicketStatusHistoryEdge' | 'TransactionEdge' | 'UserEdge' | 'UtilityEdge' | 'WalletEdge', ParentType, ContextType>;
+  __resolveType: TypeResolveFn<'ArticleEdge' | 'CommunityEdge' | 'EvaluationEdge' | 'EvaluationHistoryEdge' | 'MembershipEdge' | 'OpportunityEdge' | 'OpportunitySlotEdge' | 'ParticipationEdge' | 'ParticipationStatusHistoryEdge' | 'PlaceEdge' | 'ReservationEdge' | 'ReservationHistoryEdge' | 'TicketClaimLinkEdge' | 'TicketEdge' | 'TicketIssuerEdge' | 'TicketStatusHistoryEdge' | 'TransactionEdge' | 'UserEdge' | 'UtilityEdge' | 'VcIssuanceRequestEdge' | 'WalletEdge', ParentType, ContextType>;
   cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
 }>;
 
@@ -3877,6 +3948,8 @@ export type GqlQueryResolvers<ContextType = any, ParentType extends GqlResolvers
   users?: Resolver<GqlResolversTypes['UsersConnection'], ParentType, ContextType, Partial<GqlQueryUsersArgs>>;
   utilities?: Resolver<GqlResolversTypes['UtilitiesConnection'], ParentType, ContextType, Partial<GqlQueryUtilitiesArgs>>;
   utility?: Resolver<Maybe<GqlResolversTypes['Utility']>, ParentType, ContextType, RequireFields<GqlQueryUtilityArgs, 'id' | 'permission'>>;
+  vcIssuanceRequest?: Resolver<Maybe<GqlResolversTypes['VcIssuanceRequest']>, ParentType, ContextType, RequireFields<GqlQueryVcIssuanceRequestArgs, 'id'>>;
+  vcIssuanceRequests?: Resolver<GqlResolversTypes['VcIssuanceRequestsConnection'], ParentType, ContextType, Partial<GqlQueryVcIssuanceRequestsArgs>>;
   wallet?: Resolver<Maybe<GqlResolversTypes['Wallet']>, ParentType, ContextType, RequireFields<GqlQueryWalletArgs, 'id'>>;
   wallets?: Resolver<GqlResolversTypes['WalletsConnection'], ParentType, ContextType, Partial<GqlQueryWalletsArgs>>;
 }>;
@@ -4289,6 +4362,32 @@ export type GqlUtilityUpdateInfoSuccessResolvers<ContextType = any, ParentType e
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type GqlVcIssuanceRequestResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VcIssuanceRequest'] = GqlResolversParentTypes['VcIssuanceRequest']> = ResolversObject<{
+  completedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  evaluation?: Resolver<Maybe<GqlResolversTypes['Evaluation']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  processedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  requestedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  status?: Resolver<GqlResolversTypes['VcIssuanceStatus'], ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  user?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVcIssuanceRequestEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VcIssuanceRequestEdge'] = GqlResolversParentTypes['VcIssuanceRequestEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['VcIssuanceRequest']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVcIssuanceRequestsConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VcIssuanceRequestsConnection'] = GqlResolversParentTypes['VcIssuanceRequestsConnection']> = ResolversObject<{
+  edges?: Resolver<Array<GqlResolversTypes['VcIssuanceRequestEdge']>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type GqlWalletResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Wallet'] = GqlResolversParentTypes['Wallet']> = ResolversObject<{
   accumulatedPointView?: Resolver<Maybe<GqlResolversTypes['AccumulatedPointView']>, ParentType, ContextType>;
   community?: Resolver<Maybe<GqlResolversTypes['Community']>, ParentType, ContextType>;
@@ -4471,6 +4570,9 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   UtilitySetPublishStatusSuccess?: GqlUtilitySetPublishStatusSuccessResolvers<ContextType>;
   UtilityUpdateInfoPayload?: GqlUtilityUpdateInfoPayloadResolvers<ContextType>;
   UtilityUpdateInfoSuccess?: GqlUtilityUpdateInfoSuccessResolvers<ContextType>;
+  VcIssuanceRequest?: GqlVcIssuanceRequestResolvers<ContextType>;
+  VcIssuanceRequestEdge?: GqlVcIssuanceRequestEdgeResolvers<ContextType>;
+  VcIssuanceRequestsConnection?: GqlVcIssuanceRequestsConnectionResolvers<ContextType>;
   Wallet?: GqlWalletResolvers<ContextType>;
   WalletEdge?: GqlWalletEdgeResolvers<ContextType>;
   WalletsConnection?: GqlWalletsConnectionResolvers<ContextType>;


### PR DESCRIPTION
### Description

This pull request introduces complete support for VC Issuance Request handling in the GraphQL layer, including schema, resolvers, and related services. Key features and updates include:

- **GraphQL Enhancements**:
  - Added `VCIssuanceRequest`, `DidIssuanceRequest`, and associated types to the GraphQL schema.
  - Defined queries for fetching VC and DID issuance requests with filtering, pagination, and sorting options.
  - Integrated `VCIssuanceRequestResolver` and `DidIssuanceRequestResolver` into the GraphQL implementation.

- **Service Enhancements**:
  - Introduced dedicated services (`VCIssuanceRequestService`) and loaders for fetching, transforming, and processing data related to issuance requests.
  - Implemented methods to handle filtering, sorting, and querying issuance requests efficiently using Prisma.

- **Database and Domain Updates**:
  - Enhanced database schema and Prisma models to establish a relationship between `VcIssuanceRequest` and `Evaluation`.
  - Updated repositories, converters, and interfaces for improved consistency and extensibility.

- **Refactoring**:
  - Renamed multiple classes, services, and repositories for domain alignment.
  - Streamlined data handling with reusable constructs for consistent and optimized queries.

These changes aim to provide a robust and extendable implementation for handling issuance requests via GraphQL.