### PR TITLE
Add support for Line RichMenu configuration and improve query logic

### DIFF
--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -16,6 +16,14 @@ EXTERNAL EXTERNAL
     
 
 
+        LineRichMenuType {
+            ADMIN ADMIN
+USER USER
+PUBLIC PUBLIC
+        }
+    
+
+
         SysRole {
             SYS_ADMIN SYS_ADMIN
 USER USER
@@ -274,6 +282,16 @@ TICKET_REFUNDED TICKET_REFUNDED
     String access_token 
     String liff_id 
     String liff_base_url 
+    DateTime created_at 
+    DateTime updated_at "❓"
+    }
+  
+
+  "t_community_line_rich_menus" {
+    String id "🗝️"
+    String config_id 
+    LineRichMenuType type 
+    String rich_menu_id 
     DateTime created_at 
     DateTime updated_at "❓"
     }
@@ -629,6 +647,9 @@ TICKET_REFUNDED TICKET_REFUNDED
     "t_community_configs" o{--}o "t_community_line_configs" : "lineConfig"
     "t_community_firebase_configs" o|--|o "t_community_configs" : "config"
     "t_community_line_configs" o|--|o "t_community_configs" : "config"
+    "t_community_line_configs" o{--}o "t_community_line_rich_menus" : "richMenus"
+    "t_community_line_rich_menus" o|--|| "t_community_line_configs" : "config"
+    "t_community_line_rich_menus" o|--|| "LineRichMenuType" : "enum:type"
     "t_users" o|--|| "SysRole" : "enum:sys_role"
     "t_users" o|--|| "CurrentPrefecture" : "enum:current_prefecture"
     "t_users" o|--|o "t_images" : "image"

--- a/docs/schema.dbml
+++ b/docs/schema.dbml
@@ -120,8 +120,23 @@ Table t_community_line_configs {
   accessToken String [not null]
   liffId String [not null]
   liffBaseUrl String [not null]
+  richMenus t_community_line_rich_menus [not null]
   createdAt DateTime [default: `now()`, not null]
   updatedAt DateTime
+}
+
+Table t_community_line_rich_menus {
+  id String [pk]
+  configId String [not null]
+  config t_community_line_configs [not null]
+  type LineRichMenuType [not null]
+  richMenuId String [not null]
+  createdAt DateTime [default: `now()`, not null]
+  updatedAt DateTime
+
+  indexes {
+    (configId, type) [unique]
+  }
 }
 
 Table t_users {
@@ -581,6 +596,12 @@ Enum Source {
   EXTERNAL
 }
 
+Enum LineRichMenuType {
+  ADMIN
+  USER
+  PUBLIC
+}
+
 Enum SysRole {
   SYS_ADMIN
   USER
@@ -727,6 +748,8 @@ Ref: t_community_configs.communityId - t_communities.id
 Ref: t_community_firebase_configs.configId - t_community_configs.id
 
 Ref: t_community_line_configs.configId - t_community_configs.id
+
+Ref: t_community_line_rich_menus.configId > t_community_line_configs.id [delete: Cascade]
 
 Ref: t_users.imageId > t_images.id
 

--- a/src/application/domain/account/community/config/data/interface.ts
+++ b/src/application/domain/account/community/config/data/interface.ts
@@ -1,7 +1,17 @@
-import { CommunityFirebaseConfig, CommunityLineConfig } from "@prisma/client";
+import {
+  CommunityFirebaseConfig,
+  CommunityLineConfig,
+  CommunityLineRichMenuConfig,
+  LineRichMenuType,
+} from "@prisma/client";
 import { IContext } from "@/types/server";
 
 export default interface ICommunityConfigRepository {
   getFirebaseConfig(ctx: IContext, communityId: string): Promise<CommunityFirebaseConfig | null>;
   getLineConfig(ctx: IContext, communityId: string): Promise<CommunityLineConfig | null>;
+  getLineRichMenuByType(
+    ctx: IContext,
+    communityId: string,
+    type: LineRichMenuType,
+  ): Promise<CommunityLineRichMenuConfig | null>;
 }

--- a/src/application/domain/account/community/config/data/repository.ts
+++ b/src/application/domain/account/community/config/data/repository.ts
@@ -39,10 +39,18 @@ export default class CommunityConfigRepository implements ICommunityConfigReposi
     type: LineRichMenuType,
   ): Promise<CommunityLineRichMenuConfig | null> {
     return await ctx.issuer.public(ctx, async (tx) => {
+      const config = await tx.communityConfig.findUnique({
+        where: { communityId },
+        include: {
+          lineConfig: true,
+        },
+      });
+      if (!config?.lineConfig) return null;
+
       return tx.communityLineRichMenuConfig.findUnique({
         where: {
           configId_type: {
-            configId: communityId,
+            configId: config.lineConfig.id,
             type,
           },
         },

--- a/src/application/domain/account/community/config/data/repository.ts
+++ b/src/application/domain/account/community/config/data/repository.ts
@@ -1,11 +1,19 @@
 import { IContext } from "@/types/server";
-import { CommunityFirebaseConfig, CommunityLineConfig } from "@prisma/client";
+import {
+  CommunityFirebaseConfig,
+  CommunityLineConfig,
+  CommunityLineRichMenuConfig,
+  LineRichMenuType,
+} from "@prisma/client";
 import ICommunityConfigRepository from "@/application/domain/account/community/config/data/interface";
 import { injectable } from "tsyringe";
 
 @injectable()
 export default class CommunityConfigRepository implements ICommunityConfigRepository {
-  async getFirebaseConfig(ctx: IContext, communityId: string): Promise<CommunityFirebaseConfig | null> {
+  async getFirebaseConfig(
+    ctx: IContext,
+    communityId: string,
+  ): Promise<CommunityFirebaseConfig | null> {
     return await ctx.issuer.public(ctx, async (tx) => {
       const result = await tx.communityConfig.findUnique({
         where: { communityId },
@@ -22,6 +30,23 @@ export default class CommunityConfigRepository implements ICommunityConfigReposi
         include: { lineConfig: true },
       });
       return result?.lineConfig ?? null;
+    });
+  }
+
+  async getLineRichMenuByType(
+    ctx: IContext,
+    communityId: string,
+    type: LineRichMenuType,
+  ): Promise<CommunityLineRichMenuConfig | null> {
+    return await ctx.issuer.public(ctx, async (tx) => {
+      return tx.communityLineRichMenuConfig.findUnique({
+        where: {
+          configId_type: {
+            configId: communityId,
+            type,
+          },
+        },
+      });
     });
   }
 }

--- a/src/application/domain/account/community/config/service.ts
+++ b/src/application/domain/account/community/config/service.ts
@@ -2,6 +2,7 @@ import { IContext } from "@/types/server";
 import { NotFoundError } from "@/errors/graphql";
 import { inject, injectable } from "tsyringe";
 import ICommunityConfigRepository from "@/application/domain/account/community/config/data/interface";
+import { LineRichMenuType } from "@prisma/client";
 
 @injectable()
 export default class CommunityConfigService {
@@ -52,5 +53,14 @@ export default class CommunityConfigService {
       liffId: config.liffId,
       liffBaseUrl: config.liffBaseUrl,
     };
+  }
+
+  async getLineRichMenuIdByType(
+    ctx: IContext,
+    communityId: string,
+    type: LineRichMenuType,
+  ): Promise<string | null> {
+    const menu = await this.repository.getLineRichMenuByType(ctx, communityId, type);
+    return menu?.richMenuId ?? null;
   }
 }

--- a/src/infrastructure/prisma/factories/__generated__/index.ts
+++ b/src/infrastructure/prisma/factories/__generated__/index.ts
@@ -6,6 +6,7 @@ import type { Community } from "@prisma/client";
 import type { CommunityConfig } from "@prisma/client";
 import type { CommunityFirebaseConfig } from "@prisma/client";
 import type { CommunityLineConfig } from "@prisma/client";
+import type { CommunityLineRichMenuConfig } from "@prisma/client";
 import type { User } from "@prisma/client";
 import type { Identity } from "@prisma/client";
 import type { Membership } from "@prisma/client";
@@ -36,6 +37,7 @@ import type { AccumulatedPointView } from "@prisma/client";
 import type { EarliestReservableSlotView } from "@prisma/client";
 import type { OpportunityAccumulatedParticipantsView } from "@prisma/client";
 import type { RemainingCapacityView } from "@prisma/client";
+import type { LineRichMenuType } from "@prisma/client";
 import type { SysRole } from "@prisma/client";
 import type { CurrentPrefecture } from "@prisma/client";
 import type { IdentityPlatform } from "@prisma/client";
@@ -223,6 +225,17 @@ const modelFieldDefinitions: ModelWithFields[] = [{
                 name: "config",
                 type: "CommunityConfig",
                 relationName: "CommunityConfigToCommunityLineConfig"
+            }, {
+                name: "richMenus",
+                type: "CommunityLineRichMenuConfig",
+                relationName: "CommunityLineConfigToCommunityLineRichMenuConfig"
+            }]
+    }, {
+        name: "CommunityLineRichMenuConfig",
+        fields: [{
+                name: "config",
+                type: "CommunityLineConfig",
+                relationName: "CommunityLineConfigToCommunityLineRichMenuConfig"
             }]
     }, {
         name: "User",
@@ -1957,6 +1970,7 @@ type CommunityLineConfigFactoryDefineInput = {
     createdAt?: Date;
     updatedAt?: Date | null;
     config?: CommunityLineConfigconfigFactory | Prisma.CommunityConfigCreateNestedOneWithoutLineConfigInput;
+    richMenus?: Prisma.CommunityLineRichMenuConfigCreateNestedManyWithoutConfigInput;
 };
 
 type CommunityLineConfigTransientFields = Record<string, unknown> & Partial<Record<keyof CommunityLineConfigFactoryDefineInput, never>>;
@@ -2099,6 +2113,163 @@ export const defineCommunityLineConfigFactory = (<TOptions extends CommunityLine
 }) as CommunityLineConfigFactoryBuilder;
 
 defineCommunityLineConfigFactory.withTransientFields = defaultTransientFieldValues => options => defineCommunityLineConfigFactoryInternal(options ?? {}, defaultTransientFieldValues);
+
+type CommunityLineRichMenuConfigScalarOrEnumFields = {
+    type: LineRichMenuType;
+    richMenuId: string;
+};
+
+type CommunityLineRichMenuConfigconfigFactory = {
+    _factoryFor: "CommunityLineConfig";
+    build: () => PromiseLike<Prisma.CommunityLineConfigCreateNestedOneWithoutRichMenusInput["create"]>;
+};
+
+type CommunityLineRichMenuConfigFactoryDefineInput = {
+    id?: string;
+    type?: LineRichMenuType;
+    richMenuId?: string;
+    createdAt?: Date;
+    updatedAt?: Date | null;
+    config: CommunityLineRichMenuConfigconfigFactory | Prisma.CommunityLineConfigCreateNestedOneWithoutRichMenusInput;
+};
+
+type CommunityLineRichMenuConfigTransientFields = Record<string, unknown> & Partial<Record<keyof CommunityLineRichMenuConfigFactoryDefineInput, never>>;
+
+type CommunityLineRichMenuConfigFactoryTrait<TTransients extends Record<string, unknown>> = {
+    data?: Resolver<Partial<CommunityLineRichMenuConfigFactoryDefineInput>, BuildDataOptions<TTransients>>;
+} & CallbackDefineOptions<CommunityLineRichMenuConfig, Prisma.CommunityLineRichMenuConfigCreateInput, TTransients>;
+
+type CommunityLineRichMenuConfigFactoryDefineOptions<TTransients extends Record<string, unknown> = Record<string, unknown>> = {
+    defaultData: Resolver<CommunityLineRichMenuConfigFactoryDefineInput, BuildDataOptions<TTransients>>;
+    traits?: {
+        [traitName: string | symbol]: CommunityLineRichMenuConfigFactoryTrait<TTransients>;
+    };
+} & CallbackDefineOptions<CommunityLineRichMenuConfig, Prisma.CommunityLineRichMenuConfigCreateInput, TTransients>;
+
+function isCommunityLineRichMenuConfigconfigFactory(x: CommunityLineRichMenuConfigconfigFactory | Prisma.CommunityLineConfigCreateNestedOneWithoutRichMenusInput | undefined): x is CommunityLineRichMenuConfigconfigFactory {
+    return (x as any)?._factoryFor === "CommunityLineConfig";
+}
+
+type CommunityLineRichMenuConfigTraitKeys<TOptions extends CommunityLineRichMenuConfigFactoryDefineOptions<any>> = Exclude<keyof TOptions["traits"], number>;
+
+export interface CommunityLineRichMenuConfigFactoryInterfaceWithoutTraits<TTransients extends Record<string, unknown>> {
+    readonly _factoryFor: "CommunityLineRichMenuConfig";
+    build(inputData?: Partial<Prisma.CommunityLineRichMenuConfigCreateInput & TTransients>): PromiseLike<Prisma.CommunityLineRichMenuConfigCreateInput>;
+    buildCreateInput(inputData?: Partial<Prisma.CommunityLineRichMenuConfigCreateInput & TTransients>): PromiseLike<Prisma.CommunityLineRichMenuConfigCreateInput>;
+    buildList(list: readonly Partial<Prisma.CommunityLineRichMenuConfigCreateInput & TTransients>[]): PromiseLike<Prisma.CommunityLineRichMenuConfigCreateInput[]>;
+    buildList(count: number, item?: Partial<Prisma.CommunityLineRichMenuConfigCreateInput & TTransients>): PromiseLike<Prisma.CommunityLineRichMenuConfigCreateInput[]>;
+    pickForConnect(inputData: CommunityLineRichMenuConfig): Pick<CommunityLineRichMenuConfig, "id">;
+    create(inputData?: Partial<Prisma.CommunityLineRichMenuConfigCreateInput & TTransients>): PromiseLike<CommunityLineRichMenuConfig>;
+    createList(list: readonly Partial<Prisma.CommunityLineRichMenuConfigCreateInput & TTransients>[]): PromiseLike<CommunityLineRichMenuConfig[]>;
+    createList(count: number, item?: Partial<Prisma.CommunityLineRichMenuConfigCreateInput & TTransients>): PromiseLike<CommunityLineRichMenuConfig[]>;
+    createForConnect(inputData?: Partial<Prisma.CommunityLineRichMenuConfigCreateInput & TTransients>): PromiseLike<Pick<CommunityLineRichMenuConfig, "id">>;
+}
+
+export interface CommunityLineRichMenuConfigFactoryInterface<TTransients extends Record<string, unknown> = Record<string, unknown>, TTraitName extends TraitName = TraitName> extends CommunityLineRichMenuConfigFactoryInterfaceWithoutTraits<TTransients> {
+    use(name: TTraitName, ...names: readonly TTraitName[]): CommunityLineRichMenuConfigFactoryInterfaceWithoutTraits<TTransients>;
+}
+
+function autoGenerateCommunityLineRichMenuConfigScalarsOrEnums({ seq }: {
+    readonly seq: number;
+}): CommunityLineRichMenuConfigScalarOrEnumFields {
+    return {
+        type: "ADMIN",
+        richMenuId: getScalarFieldValueGenerator().String({ modelName: "CommunityLineRichMenuConfig", fieldName: "richMenuId", isId: false, isUnique: false, seq })
+    };
+}
+
+function defineCommunityLineRichMenuConfigFactoryInternal<TTransients extends Record<string, unknown>, TOptions extends CommunityLineRichMenuConfigFactoryDefineOptions<TTransients>>({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }: TOptions, defaultTransientFieldValues: TTransients): CommunityLineRichMenuConfigFactoryInterface<TTransients, CommunityLineRichMenuConfigTraitKeys<TOptions>> {
+    const getFactoryWithTraits = (traitKeys: readonly CommunityLineRichMenuConfigTraitKeys<TOptions>[] = []) => {
+        const seqKey = {};
+        const getSeq = () => getSequenceCounter(seqKey);
+        const screen = createScreener("CommunityLineRichMenuConfig", modelFieldDefinitions);
+        const handleAfterBuild = createCallbackChain([
+            onAfterBuild,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterBuild),
+        ]);
+        const handleBeforeCreate = createCallbackChain([
+            ...traitKeys.slice().reverse().map(traitKey => traitsDefs[traitKey]?.onBeforeCreate),
+            onBeforeCreate,
+        ]);
+        const handleAfterCreate = createCallbackChain([
+            onAfterCreate,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterCreate),
+        ]);
+        const build = async (inputData: Partial<Prisma.CommunityLineRichMenuConfigCreateInput & TTransients> = {}) => {
+            const seq = getSeq();
+            const requiredScalarData = autoGenerateCommunityLineRichMenuConfigScalarsOrEnums({ seq });
+            const resolveValue = normalizeResolver<CommunityLineRichMenuConfigFactoryDefineInput, BuildDataOptions<any>>(defaultDataResolver);
+            const [transientFields, filteredInputData] = destructure(defaultTransientFieldValues, inputData);
+            const resolverInput = { seq, ...transientFields };
+            const defaultData = await traitKeys.reduce(async (queue, traitKey) => {
+                const acc = await queue;
+                const resolveTraitValue = normalizeResolver<Partial<CommunityLineRichMenuConfigFactoryDefineInput>, BuildDataOptions<TTransients>>(traitsDefs[traitKey]?.data ?? {});
+                const traitData = await resolveTraitValue(resolverInput);
+                return {
+                    ...acc,
+                    ...traitData,
+                };
+            }, resolveValue(resolverInput));
+            const defaultAssociations = {
+                config: isCommunityLineRichMenuConfigconfigFactory(defaultData.config) ? {
+                    create: await defaultData.config.build()
+                } : defaultData.config
+            } as Prisma.CommunityLineRichMenuConfigCreateInput;
+            const data: Prisma.CommunityLineRichMenuConfigCreateInput = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...filteredInputData };
+            await handleAfterBuild(data, transientFields);
+            return data;
+        };
+        const buildList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.CommunityLineRichMenuConfigCreateInput & TTransients>>(...args).map(data => build(data)));
+        const pickForConnect = (inputData: CommunityLineRichMenuConfig) => ({
+            id: inputData.id
+        });
+        const create = async (inputData: Partial<Prisma.CommunityLineRichMenuConfigCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
+            const [transientFields] = destructure(defaultTransientFieldValues, inputData);
+            await handleBeforeCreate(data, transientFields);
+            const createdData = await getClient<PrismaClient>().communityLineRichMenuConfig.create({ data });
+            await handleAfterCreate(createdData, transientFields);
+            return createdData;
+        };
+        const createList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.CommunityLineRichMenuConfigCreateInput & TTransients>>(...args).map(data => create(data)));
+        const createForConnect = (inputData: Partial<Prisma.CommunityLineRichMenuConfigCreateInput & TTransients> = {}) => create(inputData).then(pickForConnect);
+        return {
+            _factoryFor: "CommunityLineRichMenuConfig" as const,
+            build,
+            buildList,
+            buildCreateInput: build,
+            pickForConnect,
+            create,
+            createList,
+            createForConnect,
+        };
+    };
+    const factory = getFactoryWithTraits();
+    const useTraits = (name: CommunityLineRichMenuConfigTraitKeys<TOptions>, ...names: readonly CommunityLineRichMenuConfigTraitKeys<TOptions>[]) => {
+        return getFactoryWithTraits([name, ...names]);
+    };
+    return {
+        ...factory,
+        use: useTraits,
+    };
+}
+
+interface CommunityLineRichMenuConfigFactoryBuilder {
+    <TOptions extends CommunityLineRichMenuConfigFactoryDefineOptions>(options: TOptions): CommunityLineRichMenuConfigFactoryInterface<{}, CommunityLineRichMenuConfigTraitKeys<TOptions>>;
+    withTransientFields: <TTransients extends CommunityLineRichMenuConfigTransientFields>(defaultTransientFieldValues: TTransients) => <TOptions extends CommunityLineRichMenuConfigFactoryDefineOptions<TTransients>>(options: TOptions) => CommunityLineRichMenuConfigFactoryInterface<TTransients, CommunityLineRichMenuConfigTraitKeys<TOptions>>;
+}
+
+/**
+ * Define factory for {@link CommunityLineRichMenuConfig} model.
+ *
+ * @param options
+ * @returns factory {@link CommunityLineRichMenuConfigFactoryInterface}
+ */
+export const defineCommunityLineRichMenuConfigFactory = (<TOptions extends CommunityLineRichMenuConfigFactoryDefineOptions>(options: TOptions): CommunityLineRichMenuConfigFactoryInterface<TOptions> => {
+    return defineCommunityLineRichMenuConfigFactoryInternal(options, {});
+}) as CommunityLineRichMenuConfigFactoryBuilder;
+
+defineCommunityLineRichMenuConfigFactory.withTransientFields = defaultTransientFieldValues => options => defineCommunityLineRichMenuConfigFactoryInternal(options, defaultTransientFieldValues);
 
 type UserScalarOrEnumFields = {
     name: string;

--- a/src/infrastructure/prisma/migrations/20250624041638_create_community_line_richmenu_config/migration.sql
+++ b/src/infrastructure/prisma/migrations/20250624041638_create_community_line_richmenu_config/migration.sql
@@ -1,0 +1,20 @@
+-- CreateEnum
+CREATE TYPE "LineRichMenuType" AS ENUM ('ADMIN', 'USER', 'PUBLIC');
+
+-- CreateTable
+CREATE TABLE "t_community_line_rich_menus" (
+    "id" TEXT NOT NULL,
+    "config_id" TEXT NOT NULL,
+    "type" "LineRichMenuType" NOT NULL,
+    "rich_menu_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3),
+
+    CONSTRAINT "t_community_line_rich_menus_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "t_community_line_rich_menus_config_id_type_key" ON "t_community_line_rich_menus"("config_id", "type");
+
+-- AddForeignKey
+ALTER TABLE "t_community_line_rich_menus" ADD CONSTRAINT "t_community_line_rich_menus_config_id_fkey" FOREIGN KEY ("config_id") REFERENCES "t_community_line_configs"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -234,10 +234,33 @@ model CommunityLineConfig {
   liffId      String @map("liff_id")
   liffBaseUrl String @map("liff_base_url")
 
+  richMenus CommunityLineRichMenuConfig[]
+
   createdAt DateTime  @default(now()) @map("created_at")
   updatedAt DateTime? @updatedAt @map("updated_at")
 
   @@map("t_community_line_configs")
+}
+
+model CommunityLineRichMenuConfig {
+  id       String              @id @default(cuid())
+  configId String              @map("config_id")
+  config   CommunityLineConfig @relation(fields: [configId], references: [id], onDelete: Cascade)
+
+  type       LineRichMenuType
+  richMenuId String           @map("rich_menu_id")
+
+  createdAt DateTime  @default(now()) @map("created_at")
+  updatedAt DateTime? @updatedAt @map("updated_at")
+
+  @@unique([configId, type])
+  @@map("t_community_line_rich_menus")
+}
+
+enum LineRichMenuType {
+  ADMIN
+  USER
+  PUBLIC
 }
 
 // ------------------------------ User Domain ------------------------------


### PR DESCRIPTION
```
### Summary
This pull request:
- Corrects query logic to fetch `CommunityLineRichMenuConfig` by resolving `configId` via `lineConfig.id` instead of `communityId`.
- Enhances rich menu configuration for Line users by implementing role-based handling and replacing hardcoded values.
- Adds support for fetching Line RichMenu by type through new methods in `CommunityConfigRepository` and `CommunityConfigService`.
- Introduces infrastructure for managing Community Line RichMenu configuration, including schema and database integration.

### Changes
- Fix query and ensure proper association in `CommunityLineRichMenuConfig`.
- Implement dynamic methods for fetching rich menus based on type, with fallback mechanisms.
- Add `t_community_line_rich_menus` table and update Prisma, DBML, and ERD schemas.
- Improve role flexibility by allowing dynamic rich menu retrieval.

### Checklist
- [ ] Code is documented.
- [ ] Unit tests have been added/updated if required.
- [ ] Database migrations are performed if needed.
- [ ] Code changes follow the project's contribution guidelines.
