### PR TITLE
ユーザー検索メソッドをuserId以外でも検索できるように修正

### DIFF
--- a/src/application/domain/account/membership/controller/resolver.ts
+++ b/src/application/domain/account/membership/controller/resolver.ts
@@ -23,7 +23,7 @@ export default class MembershipResolver {
   Query = {
     memberships: (_: unknown, args: GqlQueryMembershipsArgs, ctx: IContext) =>
       this.useCase.visitorBrowseMemberships(args, ctx),
-    membership: (_: unknown, args: GqlQueryMembershipArgs, ctx: IContext) => {
+    membership: (_: unknown, args: { communityId: string, userKey: string }, ctx: IContext) => {
       return this.useCase.visitorViewMembership(args, ctx);
     },
   };

--- a/src/application/domain/account/membership/data/converter.ts
+++ b/src/application/domain/account/membership/data/converter.ts
@@ -11,6 +11,13 @@ export default class MembershipConverter {
         filter?.communityId ? { communityId: filter.communityId } : {},
         filter?.status ? { status: filter.status } : {},
         filter?.role ? { role: filter.role } : {},
+        filter?.userNames && filter.userNames.length
+          ? {
+            user: {
+              name: { contains: filter.userNames.join(" ") }
+            }
+          }
+          : {},
       ],
     };
   }

--- a/src/application/domain/account/membership/data/interface.ts
+++ b/src/application/domain/account/membership/data/interface.ts
@@ -39,4 +39,10 @@ export interface IMembershipRepository {
     where: Prisma.MembershipWhereUniqueInput,
     tx: Prisma.TransactionClient,
   ): Promise<PrismaMembership>;
+
+  findFlexible(
+    ctx: IContext,
+    communityId: string,
+    userKey: string
+  ): Promise<PrismaMembership | null>;
 }

--- a/src/application/domain/account/membership/schema/query.graphql
+++ b/src/application/domain/account/membership/schema/query.graphql
@@ -2,37 +2,38 @@
 # Membership Query Definitions
 # ------------------------------
 extend type Query {
-    memberships(
-        filter: MembershipFilterInput
-        sort: MembershipSortInput
-        cursor: MembershipCursorInput
-        first: Int
-    ): MembershipsConnection!
-    membership(userId: ID!, communityId: ID!): Membership
+  memberships(
+    filter: MembershipFilterInput
+    sort: MembershipSortInput
+    cursor: MembershipCursorInput
+    first: Int
+  ): MembershipsConnection!
+  membership(userKey: String!, communityId: ID!): Membership
 }
 
 # ------------------------------
 # Membership Connection Type Definitions
 # ------------------------------
 type MembershipsConnection {
-    edges: [MembershipEdge]
-    pageInfo: PageInfo!
-    totalCount: Int!
+  edges: [MembershipEdge]
+  pageInfo: PageInfo!
+  totalCount: Int!
 }
 
 type MembershipEdge implements Edge {
-    cursor: String!
-    node: Membership
+  cursor: String!
+  node: Membership
 }
 
 # ------------------------------
 # Membership Query Input Definitions
 # ------------------------------
 input MembershipFilterInput {
-    userId: ID
-    communityId: ID
-    status: MembershipStatus
-    role: Role
+  userId: ID
+  communityId: ID
+  status: MembershipStatus
+  role: Role
+  userNames: [String!]
 }
 
 input MembershipSortInput {

--- a/src/application/domain/account/membership/service.ts
+++ b/src/application/domain/account/membership/service.ts
@@ -36,12 +36,12 @@ export default class MembershipService {
     return this.repository.findDetail(ctx, { userId_communityId: { userId, communityId } });
   }
 
-  async findMembership(ctx: IContext, userId: string, communityId: string) {
-    return this.repository.find(ctx, { userId_communityId: { userId, communityId } });
+  async findMembership(ctx: IContext, communityId: string, userKey: string) {
+    return this.repository.findFlexible(ctx, communityId, userKey);
   }
 
   async findMembershipOrThrow(ctx: IContext, userId: string, communityId: string) {
-    const membership = await this.findMembership(ctx, userId, communityId);
+    const membership = await this.findMembership(ctx, communityId, userId);
     if (!membership) {
       throw new NotFoundError("Membership", { userId, communityId });
     }

--- a/src/application/domain/account/membership/usecase.ts
+++ b/src/application/domain/account/membership/usecase.ts
@@ -43,16 +43,8 @@ export default class MembershipUseCase {
     return MembershipPresenter.query(data, hasNextPage);
   }
 
-  async visitorViewMembership(
-    args: GqlQueryMembershipArgs,
-    ctx: IContext,
-  ): Promise<GqlMembership | null> {
-    const membership = await this.membershipService.findMembershipDetail(
-      ctx,
-      args.userId,
-      args.communityId,
-    );
-    return membership ? MembershipPresenter.get(membership) : null;
+  async visitorViewMembership(args: { communityId: string, userKey: string }, ctx: IContext) {
+    return await this.membershipService.findMembership(ctx, args.communityId, args.userKey);
   }
 
   async ownerInviteMember(args: GqlMutationMembershipInviteArgs, ctx: IContext) {

--- a/src/application/domain/account/user/data/type.ts
+++ b/src/application/domain/account/user/data/type.ts
@@ -50,6 +50,7 @@ export const userAuthInclude = Prisma.validator<Prisma.UserInclude>()({
 
 export const userInclude = Prisma.validator<Prisma.UserInclude>()({
   image: true,
+  identities: true,
 });
 
 export const userArticlePortfolioInclude = Prisma.validator<Prisma.UserInclude>()({

--- a/src/application/domain/experience/evaluation/controller/resolver.ts
+++ b/src/application/domain/experience/evaluation/controller/resolver.ts
@@ -41,6 +41,10 @@ export default class EvaluationResolver {
       return parent.participationId ? ctx.loaders.participation.load(parent.participationId) : null;
     },
 
+    vcIssuanceRequest: (parent: PrismaEvaluationDetail, _: unknown, ctx: IContext) => {
+      return ctx.loaders.vcIssuanceRequestByEvaluation.load(parent.id);
+    },
+
     histories: (parent: PrismaEvaluationDetail, _: unknown, ctx: IContext) => {
       return ctx.loaders.evaluationHistoriesByEvaluation.load(parent.id);
     },

--- a/src/application/domain/experience/evaluation/schema/schema.graphql
+++ b/src/application/domain/experience/evaluation/schema/schema.graphql
@@ -12,6 +12,7 @@ type Evaluation {
     credentialUrl: String
     issuedAt: Datetime
 
+    vcIssuanceRequest: VcIssuanceRequest
     histories: [EvaluationHistory!]
 
     createdAt: Datetime

--- a/src/application/domain/experience/evaluation/service.ts
+++ b/src/application/domain/experience/evaluation/service.ts
@@ -12,7 +12,7 @@ export default class EvaluationService {
   constructor(
     @inject("EvaluationRepository") private readonly repository: IEvaluationRepository,
     @inject("EvaluationConverter") private readonly converter: EvaluationConverter,
-  ) {}
+  ) { }
 
   async fetchEvaluations(
     ctx: IContext,

--- a/src/application/domain/experience/evaluation/usecase.ts
+++ b/src/application/domain/experience/evaluation/usecase.ts
@@ -40,7 +40,7 @@ export default class EvaluationUseCase {
     @inject("VCIssuanceRequestConverter")
     private readonly vcIssuanceRequestConverter: VCIssuanceRequestConverter,
     @inject("NotificationService") private readonly notificationService: NotificationService,
-  ) {}
+  ) { }
 
   async visitorBrowseEvaluations(
     ctx: IContext,
@@ -202,11 +202,11 @@ export default class EvaluationUseCase {
       const vcRequest = this.vcIssuanceRequestConverter.toVCIssuanceRequestInput(evaluation);
 
       await this.vcIssuanceRequestService.requestVCIssuance(
-        evaluation.id,
         userId,
         phoneUid,
         vcRequest,
         ctx,
+        evaluation.id,
       );
     } catch (error) {
       logger.warn("tryIssueEvaluationVC failed (non-blocking)", error);

--- a/src/application/domain/experience/evaluation/vcIssuanceRequest/controller/dataloader.ts
+++ b/src/application/domain/experience/evaluation/vcIssuanceRequest/controller/dataloader.ts
@@ -1,0 +1,51 @@
+import DataLoader from "dataloader";
+import { PrismaClientIssuer } from "@/infrastructure/prisma/client";
+
+export const createVcIssuanceRequestByEvaluationLoader = (issuer: PrismaClientIssuer) => {
+    return new DataLoader(async (evaluationIds: readonly string[]) => {
+        const vcIssuanceRequests = await issuer.internal((tx) =>
+            tx.vcIssuanceRequest.findMany({
+                where: {
+                    evaluationId: { in: evaluationIds as string[] }
+                }
+            })
+        );
+
+        return evaluationIds.map(id =>
+            vcIssuanceRequests.find(request => request.evaluationId === id) || null
+        );
+    });
+};
+
+export const createVcIssuanceRequestsByOpportunitySlotLoader = (issuer: PrismaClientIssuer) => {
+    return new DataLoader(async (opportunitySlotIds: readonly string[]) => {
+        const vcRequests = await issuer.internal((tx) =>
+            tx.vcIssuanceRequest.findMany({
+                where: {
+                    evaluation: {
+                        participation: {
+                            opportunitySlotId: { in: opportunitySlotIds as string[] }
+                        }
+                    }
+                },
+                include: {
+                    evaluation: {
+                        include: {
+                            participation: true
+                        }
+                    }
+                }
+            })
+        );
+
+        // opportunitySlotIdごとにグループ化
+        const grouped = vcRequests.reduce((acc, request) => {
+            const slotId = request.evaluation.participation.opportunitySlotId;
+            if (slotId && !acc[slotId]) acc[slotId] = [];
+            if (slotId) acc[slotId].push(request);
+            return acc;
+        }, {} as Record<string, typeof vcRequests>);
+
+        return opportunitySlotIds.map(id => grouped[id] || []);
+    });
+}; 

--- a/src/application/domain/experience/evaluation/vcIssuanceRequest/service.ts
+++ b/src/application/domain/experience/evaluation/vcIssuanceRequest/service.ts
@@ -43,11 +43,11 @@ export class VCIssuanceRequestService {
   }
 
   async requestVCIssuance(
-    evaluationId: string,
     userId: string,
     phoneUid: string,
     vcRequest: EvaluationCredentialPayload,
     ctx: IContext,
+    evaluationId: string,
   ): Promise<{ success: boolean; requestId: string; jobId?: string }> {
     const userDid = await this.getUserDid(userId, ctx);
     if (!userDid) {

--- a/src/application/domain/experience/opportunitySlot/schema/type.graphql
+++ b/src/application/domain/experience/opportunitySlot/schema/type.graphql
@@ -2,26 +2,29 @@
 # Opportunity Slot Object Type Definitions
 # ------------------------------
 type OpportunitySlot {
-    id: ID!
+  id: ID!
 
-    hostingStatus: OpportunitySlotHostingStatus!
-    capacity: Int
-    remainingCapacity: Int
+  hostingStatus: OpportunitySlotHostingStatus!
+  capacity: Int
+  remainingCapacity: Int
 
-    startsAt: Datetime!
-    endsAt: Datetime!
+  startsAt: Datetime!
+  endsAt: Datetime!
 
-    opportunity: Opportunity
+  opportunity: Opportunity
 
-    reservations: [Reservation!]
-    
-    # Evaluation statistics
-    isFullyEvaluated: Boolean
-    numParticipants: Int
-    numEvaluated: Int
+  reservations: [Reservation!]
 
-    createdAt: Datetime
-    updatedAt: Datetime
+  # VC Issuance Requests
+  vcIssuanceRequests: [VcIssuanceRequest!]!
+
+  # Evaluation statistics
+  isFullyEvaluated: Boolean
+  numParticipants: Int
+  numEvaluated: Int
+
+  createdAt: Datetime
+  updatedAt: Datetime
 }
 
 enum OpportunitySlotHostingStatus {

--- a/src/application/domain/experience/participation/data/converter.ts
+++ b/src/application/domain/experience/participation/data/converter.ts
@@ -77,7 +77,12 @@ export default class ParticipationConverter {
         filter?.status ? { status: filter.status } : {},
         filter?.communityId ? { communityId: filter.communityId } : {},
         filter?.opportunityId
-          ? { reservation: { opportunitySlot: { opportunityId: filter.opportunityId } } }
+          ? {
+            OR: [
+              { reservation: { opportunitySlot: { opportunityId: filter.opportunityId } } },
+              { opportunitySlot: { opportunityId: filter.opportunityId } },
+            ],
+          }
           : {},
         filter?.opportunitySlotId
           ? { reservation: { opportunitySlotId: filter.opportunitySlotId } }

--- a/src/presentation/graphql/dataloader/domain/experience.ts
+++ b/src/presentation/graphql/dataloader/domain/experience.ts
@@ -5,6 +5,7 @@ import * as OpportunitySlotLoaders from "@/application/domain/experience/opportu
 import * as ReservationLoaders from "@/application/domain/experience/reservation/controller/dataloader";
 import * as EvaluationLoaders from "@/application/domain/experience/evaluation/controller/dataloader";
 import * as EvaluationHistoryLoaders from "@/application/domain/experience/evaluation/evaluationHistory/controller/dataloader";
+import * as VcIssuanceRequestLoaders from "@/application/domain/experience/evaluation/vcIssuanceRequest/controller/dataloader";
 import { PrismaClientIssuer } from "@/infrastructure/prisma/client";
 
 export function createExperienceLoaders(issuer: PrismaClientIssuer) {
@@ -47,5 +48,7 @@ export function createExperienceLoaders(issuer: PrismaClientIssuer) {
       EvaluationHistoryLoaders.createEvaluationHistoriesByEvaluationLoader(issuer),
     evaluationHistoriesCreatedByUser:
       EvaluationHistoryLoaders.createEvaluationHistoriesCreatedByUserLoader(issuer),
+
+    vcIssuanceRequestByEvaluation: VcIssuanceRequestLoaders.createVcIssuanceRequestByEvaluationLoader(issuer),
   };
 }

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -322,6 +322,7 @@ export type GqlEvaluation = {
   participation?: Maybe<GqlParticipation>;
   status: GqlEvaluationStatus;
   updatedAt?: Maybe<Scalars['Datetime']['output']>;
+  vcIssuanceRequest?: Maybe<GqlVcIssuanceRequest>;
 };
 
 export type GqlEvaluationBulkCreateInput = {
@@ -474,6 +475,7 @@ export type GqlMembershipFilterInput = {
   role?: InputMaybe<GqlRole>;
   status?: InputMaybe<GqlMembershipStatus>;
   userId?: InputMaybe<Scalars['ID']['input']>;
+  userNames?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 export type GqlMembershipHistory = {
@@ -1100,6 +1102,7 @@ export type GqlOpportunitySlot = {
   reservations?: Maybe<Array<GqlReservation>>;
   startsAt: Scalars['Datetime']['output'];
   updatedAt?: Maybe<Scalars['Datetime']['output']>;
+  vcIssuanceRequests: Array<GqlVcIssuanceRequest>;
 };
 
 export type GqlOpportunitySlotCreateInput = {
@@ -1595,7 +1598,7 @@ export type GqlQueryEvaluationsArgs = {
 
 export type GqlQueryMembershipArgs = {
   communityId: Scalars['ID']['input'];
-  userId: Scalars['ID']['input'];
+  userKey: Scalars['String']['input'];
 };
 
 
@@ -2734,7 +2737,7 @@ export type GqlResolversTypes = ResolversObject<{
   Edge: ResolverTypeWrapper<GqlResolversInterfaceTypes<GqlResolversTypes>['Edge']>;
   Error: ResolverTypeWrapper<GqlError>;
   ErrorCode: GqlErrorCode;
-  Evaluation: ResolverTypeWrapper<Omit<GqlEvaluation, 'evaluator' | 'histories' | 'participation'> & { evaluator?: Maybe<GqlResolversTypes['User']>, histories?: Maybe<Array<GqlResolversTypes['EvaluationHistory']>>, participation?: Maybe<GqlResolversTypes['Participation']> }>;
+  Evaluation: ResolverTypeWrapper<Omit<GqlEvaluation, 'evaluator' | 'histories' | 'participation' | 'vcIssuanceRequest'> & { evaluator?: Maybe<GqlResolversTypes['User']>, histories?: Maybe<Array<GqlResolversTypes['EvaluationHistory']>>, participation?: Maybe<GqlResolversTypes['Participation']>, vcIssuanceRequest?: Maybe<GqlResolversTypes['VcIssuanceRequest']> }>;
   EvaluationBulkCreateInput: GqlEvaluationBulkCreateInput;
   EvaluationBulkCreatePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['EvaluationBulkCreatePayload']>;
   EvaluationBulkCreateSuccess: ResolverTypeWrapper<Omit<GqlEvaluationBulkCreateSuccess, 'evaluations'> & { evaluations: Array<GqlResolversTypes['Evaluation']> }>;
@@ -3019,7 +3022,7 @@ export type GqlResolversParentTypes = ResolversObject<{
   DidIssuanceRequest: GqlDidIssuanceRequest;
   Edge: GqlResolversInterfaceTypes<GqlResolversParentTypes>['Edge'];
   Error: GqlError;
-  Evaluation: Omit<GqlEvaluation, 'evaluator' | 'histories' | 'participation'> & { evaluator?: Maybe<GqlResolversParentTypes['User']>, histories?: Maybe<Array<GqlResolversParentTypes['EvaluationHistory']>>, participation?: Maybe<GqlResolversParentTypes['Participation']> };
+  Evaluation: Omit<GqlEvaluation, 'evaluator' | 'histories' | 'participation' | 'vcIssuanceRequest'> & { evaluator?: Maybe<GqlResolversParentTypes['User']>, histories?: Maybe<Array<GqlResolversParentTypes['EvaluationHistory']>>, participation?: Maybe<GqlResolversParentTypes['Participation']>, vcIssuanceRequest?: Maybe<GqlResolversParentTypes['VcIssuanceRequest']> };
   EvaluationBulkCreateInput: GqlEvaluationBulkCreateInput;
   EvaluationBulkCreatePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['EvaluationBulkCreatePayload'];
   EvaluationBulkCreateSuccess: Omit<GqlEvaluationBulkCreateSuccess, 'evaluations'> & { evaluations: Array<GqlResolversParentTypes['Evaluation']> };
@@ -3415,6 +3418,7 @@ export type GqlEvaluationResolvers<ContextType = any, ParentType extends GqlReso
   participation?: Resolver<Maybe<GqlResolversTypes['Participation']>, ParentType, ContextType>;
   status?: Resolver<GqlResolversTypes['EvaluationStatus'], ParentType, ContextType>;
   updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  vcIssuanceRequest?: Resolver<Maybe<GqlResolversTypes['VcIssuanceRequest']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -3728,6 +3732,7 @@ export type GqlOpportunitySlotResolvers<ContextType = any, ParentType extends Gq
   reservations?: Resolver<Maybe<Array<GqlResolversTypes['Reservation']>>, ParentType, ContextType>;
   startsAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
   updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  vcIssuanceRequests?: Resolver<Array<GqlResolversTypes['VcIssuanceRequest']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -3955,7 +3960,7 @@ export type GqlQueryResolvers<ContextType = any, ParentType extends GqlResolvers
   evaluationHistories?: Resolver<GqlResolversTypes['EvaluationHistoriesConnection'], ParentType, ContextType, Partial<GqlQueryEvaluationHistoriesArgs>>;
   evaluationHistory?: Resolver<Maybe<GqlResolversTypes['EvaluationHistory']>, ParentType, ContextType, RequireFields<GqlQueryEvaluationHistoryArgs, 'id'>>;
   evaluations?: Resolver<GqlResolversTypes['EvaluationsConnection'], ParentType, ContextType, Partial<GqlQueryEvaluationsArgs>>;
-  membership?: Resolver<Maybe<GqlResolversTypes['Membership']>, ParentType, ContextType, RequireFields<GqlQueryMembershipArgs, 'communityId' | 'userId'>>;
+  membership?: Resolver<Maybe<GqlResolversTypes['Membership']>, ParentType, ContextType, RequireFields<GqlQueryMembershipArgs, 'communityId' | 'userKey'>>;
   memberships?: Resolver<GqlResolversTypes['MembershipsConnection'], ParentType, ContextType, Partial<GqlQueryMembershipsArgs>>;
   opportunities?: Resolver<GqlResolversTypes['OpportunitiesConnection'], ParentType, ContextType, Partial<GqlQueryOpportunitiesArgs>>;
   opportunity?: Resolver<Maybe<GqlResolversTypes['Opportunity']>, ParentType, ContextType, RequireFields<GqlQueryOpportunityArgs, 'id' | 'permission'>>;


### PR DESCRIPTION
- `findMembership`メソッドを`findFlexible`に変更し、ユーザー識別に`userKey`を使用するように更新
- `visitorViewMembership`メソッドの引数を変更し、`userId`から`userKey`に変更
- GraphQLスキーマの`membership`クエリを更新し、`userId`を`userKey`に変更
- メンバーシップフィルターに`userNames`フィールドを追加し、ユーザー名による検索をサポート