### PR TITLE
Fix RLS violation in participation creation by adding communityId

### DIFF
--- a/src/application/domain/experience/reservation/data/converter.ts
+++ b/src/application/domain/experience/reservation/data/converter.ts
@@ -107,6 +107,7 @@ export default class ReservationConverter {
     userIdsIfExists: string[],
     { reservationStatus, participationStatus, participationStatusReason }: ReservationStatuses,
     comment?: string,
+    communityId?: string,
   ): Prisma.ReservationCreateInput {
     const userIds = [currentUserId, ...userIdsIfExists];
 
@@ -116,6 +117,7 @@ export default class ReservationConverter {
       participantCount,
       participationStatus,
       participationStatusReason,
+      communityId,
     );
 
     return {
@@ -152,11 +154,12 @@ function createParticipations(
   count: number,
   status: ParticipationStatus,
   reason: ParticipationStatusReason,
+  communityId?: string,
 ): Prisma.ParticipationCreateWithoutReservationInput[] {
   const results: Prisma.ParticipationCreateWithoutReservationInput[] = [];
 
   for (let i = 0; i < count; i++) {
-    results.push(createParticipationInput(currentUserId, userIds[i], status, reason));
+    results.push(createParticipationInput(currentUserId, userIds[i], status, reason, communityId));
   }
 
   return results;
@@ -167,12 +170,16 @@ function createParticipationInput(
   userId: string | undefined,
   status: ParticipationStatus,
   reason: ParticipationStatusReason,
+  communityId?: string,
 ): Prisma.ParticipationCreateWithoutReservationInput {
   return {
     status,
     reason,
     ...(userId && {
       user: { connect: { id: userId } },
+    }),
+    ...(communityId && {
+      community: { connect: { id: communityId } },
     }),
     statusHistories: {
       create: {

--- a/src/application/domain/experience/reservation/data/interface.ts
+++ b/src/application/domain/experience/reservation/data/interface.ts
@@ -31,6 +31,7 @@ export interface IReservationService {
     reservationStatuses: ReservationStatuses,
     tx: Prisma.TransactionClient,
     comment?: string,
+    communityId?: string,
   ): Promise<PrismaReservation>;
 
   setStatus(

--- a/src/application/domain/experience/reservation/service.ts
+++ b/src/application/domain/experience/reservation/service.ts
@@ -59,6 +59,7 @@ export default class ReservationService implements IReservationService {
     reservationStatuses: ReservationStatuses,
     tx: Prisma.TransactionClient,
     comment?: string,
+    communityId?: string,
   ) {
     const currentUserId = getCurrentUserId(ctx);
     const data = this.converter.create(
@@ -68,6 +69,7 @@ export default class ReservationService implements IReservationService {
       userIdsIfExists,
       reservationStatuses,
       comment,
+      communityId,
     );
     return this.repository.create(ctx, data, tx);
   }

--- a/src/application/domain/experience/reservation/usecase.ts
+++ b/src/application/domain/experience/reservation/usecase.ts
@@ -114,6 +114,7 @@ export default class ReservationUseCase {
         statuses,
         tx,
         input.comment,
+        communityId,
       );
 
       const participationIds = reservation.participations.map((p) => p.id);

--- a/src/infrastructure/prisma/factories/factory.ts
+++ b/src/infrastructure/prisma/factories/factory.ts
@@ -39,6 +39,7 @@ import {
 import {
   defineArticleFactory,
   defineCityFactory,
+  defineCommunityConfigFactory,
   defineCommunityFactory,
   defineEvaluationFactory,
   defineImageFactory,
@@ -59,6 +60,7 @@ import {
 import { prismaClient } from "@/infrastructure/prisma/client";
 import { randomEnum } from "@/infrastructure/prisma/factories/helper";
 import { registerScalarFieldValueGenerator } from "@quramy/prisma-fabbrica";
+import * as process from "node:process";
 
 registerScalarFieldValueGenerator({
   Decimal: ({ modelName, fieldName }) => {
@@ -104,6 +106,34 @@ export const CommunityFactory = defineCommunityFactory({
     name: randAnimal(),
     pointName: randAirportName(),
   }),
+});
+
+export const CommunityConfigFactory = defineCommunityConfigFactory.withTransientFields<{
+  transientCommunity?: { id: string };
+}>({
+  transientCommunity: undefined,
+})({
+  defaultData: async ({ transientCommunity }) => {
+    const community = transientCommunity ?? (await CommunityFactory.create());
+
+    return {
+      community: { connect: { id: community.id } },
+      firebaseConfig: {
+        create: {
+          tenantId: process.env.FIREBASE_AUTH_TENANT_ID ?? "",
+        },
+      },
+      lineConfig: {
+        create: {
+          channelId: process.env.LINE_LIFF_CHANNEL_ID ?? "",
+          channelSecret: process.env.LINE_MESSAGING_CHANNEL_SECRET ?? "",
+          accessToken: process.env.LINE_MESSAGING_CHANNEL_ACCESS_TOKEN ?? "",
+          liffId: process.env.LIFF_ID ?? "",
+          liffBaseUrl: process.env.LIFF_BASE_URL ?? "",
+        },
+      },
+    };
+  },
 });
 
 export const UserFactory = defineUserFactory.withTransientFields<{

--- a/src/infrastructure/prisma/seeds/domains.ts
+++ b/src/infrastructure/prisma/seeds/domains.ts
@@ -1,5 +1,6 @@
 import {
   ArticleFactory,
+  CommunityConfigFactory,
   CommunityFactory,
   MembershipFactory,
   OpportunityFactory,
@@ -102,6 +103,7 @@ export async function seedUsecase() {
 // STEP 1
 async function createBaseEntitiesForUsers() {
   const community = await CommunityFactory.create({ id: "neo88" });
+  await CommunityConfigFactory.create({ transientCommunity: community });
   const users = await UserFactory.createList(10);
 
   const membershipsAndWallets = await processInBatches(users, BATCH_SIZE, async (user) => {


### PR DESCRIPTION
### Description

This pull request addresses a Row-Level Security (RLS) policy violation in the `t_participations` table by ensuring that `community_id` is properly propagated during the participation creation process. Specifically:

- Added a `communityId` parameter to the `createReservation` method chain.
- Updated `converter.ts` to set the community connection in participation records.
- Resolved a PostgreSQL error 42501 caused by missing `community_id` in participation records, ensuring compliance with RLS policies which mandate `community_id` alignment with user community memberships.

Additionally:

- Introduced `CommunityConfigFactory` to enable community configuration creation during seeding, enhancing flexibility for community-related operations.
- Incorporated environment variable support for `firebaseConfig` and `lineConfig` initialization.
- Updated `createBaseEntitiesForUsers` to include `CommunityConfigFactory` for improved seed data creation.

### Checklist

- [ ] Relevant tests have been added.
- [ ] Documentation has been updated where necessary.
- [ ] Code changes adhere to coding standards.