### PR TITLE
Allow admins enhanced access control and functionality

### DIFF
--- a/src/application/domain/experience/opportunity/schema/mutation.graphql
+++ b/src/application/domain/experience/opportunity/schema/mutation.graphql
@@ -52,7 +52,7 @@ input OpportunityCreateInput {
     placeId: ID
 
     # for isAdmin
-    createdBy: String
+    createdBy: ID
 }
 
 input OpportunityUpdateContentInput {

--- a/src/application/domain/experience/opportunity/schema/mutation.graphql
+++ b/src/application/domain/experience/opportunity/schema/mutation.graphql
@@ -39,19 +39,20 @@ input OpportunityCreateInput {
     images: [ImageInput!]
 
     category: OpportunityCategory!
+
     publishStatus: PublishStatus!
     requireApproval: Boolean!
-
     requiredUtilityIds: [ID!]
-    capacity: Int
+
     pointsToEarn: Int
     feeRequired: Int
 
-    place: NestedPlaceConnectOrCreateInput
-    startsAt: Datetime
-    endsAt: Datetime
+    slots: [OpportunitySlotCreateInput!]
+    relatedArticleIds: [ID!]
+    placeId: ID
 
-    communityId: ID!
+    # for isAdmin
+    createdBy: String
 }
 
 input OpportunityUpdateContentInput {

--- a/src/application/domain/experience/opportunity/service.ts
+++ b/src/application/domain/experience/opportunity/service.ts
@@ -58,12 +58,12 @@ export default class OpportunityService {
   async createOpportunity(
     ctx: IContext,
     input: GqlOpportunityCreateInput,
+    communityId: string,
     tx: Prisma.TransactionClient,
   ) {
-    const currentUserId = getCurrentUserId(ctx);
+    const currentUserId = getCurrentUserId(ctx, input.createdBy);
 
-    validatePlaceInput(input.place);
-    const { data, images } = this.converter.create(input, currentUserId);
+    const { data, images } = this.converter.create(input, communityId, currentUserId);
 
     const uploadedImages: Prisma.ImageCreateWithoutOpportunitiesInput[] = await Promise.all(
       images.map((img) => this.imageService.uploadPublicImage(img, "opportunities")),

--- a/src/application/domain/experience/opportunity/usecase.ts
+++ b/src/application/domain/experience/opportunity/usecase.ts
@@ -77,11 +77,11 @@ export default class OpportunityUseCase {
   }
 
   async managerCreateOpportunity(
-    { input }: GqlMutationOpportunityCreateArgs,
+    { input, permission }: GqlMutationOpportunityCreateArgs,
     ctx: IContext,
   ): Promise<GqlOpportunityCreatePayload> {
     return ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
-      const record = await this.service.createOpportunity(ctx, input, tx);
+      const record = await this.service.createOpportunity(ctx, input, permission.communityId, tx);
       return OpportunityPresenter.create(record);
     });
   }

--- a/src/application/domain/experience/opportunitySlot/schema/mutation.graphql
+++ b/src/application/domain/experience/opportunitySlot/schema/mutation.graphql
@@ -33,6 +33,7 @@ input OpportunitySlotsBulkUpdateInput {
 }
 
 input OpportunitySlotCreateInput {
+    capacity: Int!
     startsAt: Datetime!
     endsAt: Datetime!
 }

--- a/src/application/domain/utils.ts
+++ b/src/application/domain/utils.ts
@@ -2,7 +2,9 @@ import { IContext } from "@/types/server";
 import { Role } from "@prisma/client";
 import { AuthorizationError, RateLimitError } from "@/errors/graphql";
 
-export function getCurrentUserId(ctx: IContext): string {
+export function getCurrentUserId(ctx: IContext, inputUserId?: string): string {
+  if (ctx.isAdmin && inputUserId) return inputUserId;
+
   const currentUserId = ctx.currentUser?.id;
   if (!currentUserId) {
     throw new AuthorizationError("User must be logged in");

--- a/src/infrastructure/prisma/client.ts
+++ b/src/infrastructure/prisma/client.ts
@@ -37,11 +37,13 @@ export class PrismaClientIssuer {
     return this.bypassRls(callback);
   }
 
-  public onlyBelongingCommunity<T>({ currentUser }: IContext, callback: CallbackFn<T>): Promise<T> {
-    if (currentUser) {
+  public onlyBelongingCommunity<T>(ctx: IContext, callback: CallbackFn<T>): Promise<T> {
+    if (ctx.currentUser || ctx.isAdmin) {
       return this.client.$transaction(async (tx) => {
         await this.setRls(tx);
-        await this.setRlsConfigUserId(tx, currentUser.id);
+        if (ctx.currentUser) {
+          await this.setRlsConfigUserId(tx, ctx.currentUser.id);
+        }
         return await callback(tx);
       });
     } else {

--- a/src/presentation/graphql/rule.ts
+++ b/src/presentation/graphql/rule.ts
@@ -6,13 +6,15 @@ import { GqlUser } from "@/types/graphql";
 enum Role {
   OWNER = "OWNER",
   MANAGER = "MANAGER",
-  MEMBER = "MEMBER"
+  MEMBER = "MEMBER",
 }
 
 // 🔐 ログイン済みか
 const IsUser = preExecRule({
   error: new AuthenticationError("User must be logged in"),
 })((context: IContext) => {
+  if (context.isAdmin) return true;
+
   return !!context.currentUser;
 });
 
@@ -20,6 +22,8 @@ const IsUser = preExecRule({
 const IsAdmin = preExecRule({
   error: new AuthorizationError("User must be admin"),
 })((context: IContext) => {
+  if (context.isAdmin) return true;
+
   const user = context.currentUser;
   return !!user && user.sysRole === "SYS_ADMIN";
 });
@@ -37,6 +41,8 @@ const IsSelf = preExecRule({
 const IsCommunityOwner = preExecRule({
   error: new AuthorizationError("User must be community owner"),
 })((context: IContext, args: { permission?: { communityId?: string } }) => {
+  if (context.isAdmin) return true;
+
   const user = context.currentUser;
   const permission = args.permission;
 
@@ -54,6 +60,8 @@ const IsCommunityOwner = preExecRule({
 const IsCommunityManager = preExecRule({
   error: new AuthorizationError("User must be community manager or owner."),
 })((context: IContext, args: { permission?: { communityId?: string } }) => {
+  if (context.isAdmin) return true;
+
   const user = context.currentUser;
   const permission = args.permission;
 
@@ -69,6 +77,8 @@ const IsCommunityManager = preExecRule({
 const IsCommunityMember = preExecRule({
   error: new AuthorizationError("User must be a community member"),
 })((context: IContext, args: { permission?: { communityId?: string } }) => {
+  if (context.isAdmin) return true;
+
   const user = context.currentUser;
   const permission = args.permission;
 
@@ -96,7 +106,12 @@ const IsOpportunityOwner = preExecRule({
 
 const CanReadPhoneNumber = postExecRule({
   error: new AuthorizationError("Not authorized to read phone number"),
-})((context: IContext, args: { permission?: Record<string, unknown> }, phoneNumber: string | null, user: GqlUser) => {
+})((
+  context: IContext,
+  args: { permission?: Record<string, unknown> },
+  phoneNumber: string | null,
+  user: GqlUser,
+) => {
   return true;
 
   // TODO: コメントアウトしてあるTODOを解消したら、この部分全体を再度有効化

--- a/src/presentation/graphql/rule.ts
+++ b/src/presentation/graphql/rule.ts
@@ -94,6 +94,8 @@ const IsCommunityMember = preExecRule({
 const IsOpportunityOwner = preExecRule({
   error: new AuthorizationError("User must be opportunity owner"),
 })((context: IContext, args: { permission?: { opportunityId?: string } }) => {
+  if (context.isAdmin) return true;
+
   const user = context.currentUser;
   const opportunityId = args?.permission?.opportunityId;
 

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1012,19 +1012,18 @@ export const GqlOpportunityCategory = {
 export type GqlOpportunityCategory = typeof GqlOpportunityCategory[keyof typeof GqlOpportunityCategory];
 export type GqlOpportunityCreateInput = {
   body?: InputMaybe<Scalars['String']['input']>;
-  capacity?: InputMaybe<Scalars['Int']['input']>;
   category: GqlOpportunityCategory;
-  communityId: Scalars['ID']['input'];
+  createdBy?: InputMaybe<Scalars['String']['input']>;
   description: Scalars['String']['input'];
-  endsAt?: InputMaybe<Scalars['Datetime']['input']>;
   feeRequired?: InputMaybe<Scalars['Int']['input']>;
   images?: InputMaybe<Array<GqlImageInput>>;
-  place?: InputMaybe<GqlNestedPlaceConnectOrCreateInput>;
+  placeId?: InputMaybe<Scalars['ID']['input']>;
   pointsToEarn?: InputMaybe<Scalars['Int']['input']>;
   publishStatus: GqlPublishStatus;
+  relatedArticleIds?: InputMaybe<Array<Scalars['ID']['input']>>;
   requireApproval: Scalars['Boolean']['input'];
   requiredUtilityIds?: InputMaybe<Array<Scalars['ID']['input']>>;
-  startsAt?: InputMaybe<Scalars['Datetime']['input']>;
+  slots?: InputMaybe<Array<GqlOpportunitySlotCreateInput>>;
   title: Scalars['String']['input'];
 };
 
@@ -1097,6 +1096,7 @@ export type GqlOpportunitySlot = {
 };
 
 export type GqlOpportunitySlotCreateInput = {
+  capacity: Scalars['Int']['input'];
   endsAt: Scalars['Datetime']['input'];
   startsAt: Scalars['Datetime']['input'];
 };

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -5,17 +5,21 @@ import { GqlIdentityPlatform as IdentityPlatform } from "@/types/graphql";
 
 export type LoggedInUserInfo = {
   issuer: PrismaClientIssuer;
-  uid?: string;
+  loaders: Loaders;
+
   tenantId?: string;
   communityId: string;
   platform?: IdentityPlatform;
+  uid?: string;
+  phoneUid?: string;
+
   currentUser?: PrismaAuthUser | null;
   hasPermissions?: PrismaUserPermission | null;
-  loaders: Loaders;
+  isAdmin?: boolean;
+
   phoneAuthToken?: string;
   phoneRefreshToken?: string;
   phoneTokenExpiresAt?: string;
-  phoneUid?: string;
   refreshToken?: string;
   tokenExpiresAt?: string;
   idToken?: string;


### PR DESCRIPTION
---

### Description

This pull request introduces several improvements and features aimed at granting administrative users enhanced access controls and operational flexibility. Key updates include:

- **Access Control Enhancements**: 
  - Admin users can bypass opportunity ownership, community restrictions, and role-based access checks across GraphQL rules, improving administrative workflows.
  - Introduced admin API key authentication bypass for streamlined admin actions.
  
- **Schema and Data Handling Updates**:
  - Updated the `OpportunityCreateInput` schema to support `slots` and `relatedArticleIds`, and removed outdated fields.
  - Incorporated optional `inputUserId` parameter for admins to retrieve user-specific data with `getCurrentUserId`.
  - Added `isAdmin` field to `LoggedInUserInfo` type for enhanced role tracking.

- **Community Handling**:
  - Added support for `communityId` in opportunity creation, simplifying community-specific logic.

These changes collectively simplify administration tasks, ensure consistency, and improve schema adaptability for customized operations.