### PR TITLE
fix: update test to include missing parameter in createOpportunity

### DIFF
--- a/src/__tests__/unit/experience/opportunity.service.test.ts
+++ b/src/__tests__/unit/experience/opportunity.service.test.ts
@@ -59,7 +59,7 @@ describe("OpportunityService", () => {
       mockImageService.uploadPublicImage.mockResolvedValue({ id: "uploaded-image" });
       mockRepository.create.mockResolvedValue({ id: "created-opportunity" });
 
-      const result = await service.createOpportunity(mockCtx, input, mockTx);
+      const result = await service.createOpportunity(mockCtx, input, "community-id", mockTx);
 
       expect(mockConverter.create).toHaveBeenCalled();
       expect(mockImageService.uploadPublicImage).toHaveBeenCalled();


### PR DESCRIPTION
- Added the missing "community-id" parameter in service.createOpportunity call
- Ensures the test properly aligns with the updated method signature