### PR TITLE
Add community association to identities

### DIFF
--- a/src/application/domain/account/identity/service.ts
+++ b/src/application/domain/account/identity/service.ts
@@ -37,7 +37,13 @@ export default class IdentityService {
     });
   }
 
-  async addIdentityToUser(ctx: IContext, userId: string, uid: string, platform: IdentityPlatform) {
+  async addIdentityToUser(
+    ctx: IContext,
+    userId: string,
+    uid: string,
+    platform: IdentityPlatform,
+    communityId: string,
+  ) {
     const expiryTime = ctx.phoneTokenExpiresAt
       ? new Date(parseInt(ctx.phoneTokenExpiresAt, 10))
       : new Date(Date.now() + 60 * 60 * 1000); // Default 1 hour expiry
@@ -49,6 +55,9 @@ export default class IdentityService {
       tokenExpiresAt: expiryTime,
       user: {
         connect: { id: userId },
+      },
+      community: {
+        connect: { id: communityId },
       },
     });
   }

--- a/src/application/domain/account/identity/usecase.ts
+++ b/src/application/domain/account/identity/usecase.ts
@@ -213,7 +213,13 @@ export default class IdentityUseCase {
       if (!ctx.uid || !ctx.platform) {
         throw new AuthenticationError();
       }
-      await this.identityService.addIdentityToUser(ctx, existingUser.id, ctx.uid, ctx.platform);
+      await this.identityService.addIdentityToUser(
+        ctx,
+        existingUser.id,
+        ctx.uid,
+        ctx.platform,
+        ctx.communityId,
+      );
       const membership = await this.membershipService.joinIfNeeded(
         ctx,
         existingUser.id,


### PR DESCRIPTION
This pull request introduces the ability to associate a user identity with a specific community during its creation. The `addIdentityToUser` method is updated to include a `communityId` parameter, enabling this linkage. Additionally, the context now passes `communityId` to the service layer to support this