### PR TITLE
Fix LINE identity check in switchRichMenuByRole

### DIFF
--- a/src/application/domain/notification/service.ts
+++ b/src/application/domain/notification/service.ts
@@ -300,7 +300,8 @@ export default class NotificationService {
 
   async switchRichMenuByRole(ctx: IContext, membership: PrismaMembership): Promise<void> {
     const lineUid = membership.user?.identities.find(
-      (identity) => identity.platform === IdentityPlatform.LINE,
+      (identity) =>
+        identity.platform === IdentityPlatform.LINE && identity.communityId === ctx.communityId,
     )?.uid;
 
     if (!lineUid) {


### PR DESCRIPTION
- Added validation to ensure `identity.communityId` matches `ctx.communityId`.  
- Prevents incorrect LINE identity assignment in scenarios with multiple communities.  