### PR TITLE
Refactor and enhance hosting status management

### DIFF
--- a/src/application/domain/experience/opportunitySlot/schema/mutation.graphql
+++ b/src/application/domain/experience/opportunitySlot/schema/mutation.graphql
@@ -22,6 +22,9 @@ extend type Mutation {
 input OpportunitySlotSetHostingStatusInput{
     status: OpportunitySlotHostingStatus!
     comment: String
+
+    # for admin
+    createdBy: ID
 }
 
 input OpportunitySlotsBulkUpdateInput {

--- a/src/application/domain/experience/opportunitySlot/usecase.ts
+++ b/src/application/domain/experience/opportunitySlot/usecase.ts
@@ -58,7 +58,7 @@ export default class OpportunitySlotUseCase {
     ctx: IContext,
   ): Promise<GqlOpportunitySlotSetHostingStatusPayload> {
     let cancelledSlot: PrismaOpportunitySlotSetHostingStatus | null = null;
-    const currentUserId = getCurrentUserId(ctx);
+    const currentUserId = getCurrentUserId(ctx, input.createdBy);
 
     const res = await ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
       const slot = await this.service.setOpportunitySlotHostingStatus(ctx, id, input.status, tx);
@@ -77,6 +77,7 @@ export default class OpportunitySlotUseCase {
           this.participationStatusHistoryService.bulkCreateStatusHistoriesForCancelledOpportunitySlot(
             ctx,
             participationIds,
+            currentUserId,
             tx,
           ),
           ...reservationIds.map((reservationId) =>

--- a/src/application/domain/experience/participation/statusHistory/service.ts
+++ b/src/application/domain/experience/participation/statusHistory/service.ts
@@ -17,9 +17,9 @@ export default class ParticipationStatusHistoryService {
   async bulkCreateStatusHistoriesForCancelledOpportunitySlot(
     ctx: IContext,
     participationIds: string[],
+    currentUserId: string,
     tx: Prisma.TransactionClient,
   ) {
-    const currentUserId = getCurrentUserId(ctx);
     const data = this.converter.createMany(
       participationIds,
       currentUserId,

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1225,6 +1225,7 @@ export const GqlOpportunitySlotHostingStatus = {
 export type GqlOpportunitySlotHostingStatus = typeof GqlOpportunitySlotHostingStatus[keyof typeof GqlOpportunitySlotHostingStatus];
 export type GqlOpportunitySlotSetHostingStatusInput = {
   comment?: InputMaybe<Scalars['String']['input']>;
+  createdBy?: InputMaybe<Scalars['ID']['input']>;
   status: GqlOpportunitySlotHostingStatus;
 };
 


### PR DESCRIPTION
### Description

This pull request implements the following changes:

1. **Refactor:**
   - Pass `currentUserId` explicitly as a parameter in `bulkCreateStatusHistoriesForCancelledOpportunitySlot`.
   - Removed dependency on the `getCurrentUserId` function, simplifying the code and enhancing testability.

2. **Feature:**
   - Add a `createdBy` field to the `OpportunitySlotSetHostingStatusInput` in the GraphQL schema.
   - Update the related TypeScript type, `GqlOpportunitySlotSetHostingStatusInput`, to include the `createdBy` field.
   - Facilitates tracking the admin responsible for setting hosting statuses.

### Checklist

- [ ] Tests added or updated as necessary.
- [ ] Documentation updated as needed.
- [ ] Verified all code changes adhere to quality guidelines.