### PR TITLE
トランザクションフィルタにユーザー名とDID値の条件を追加

### DIFF
--- a/src/application/domain/transaction/data/converter.ts
+++ b/src/application/domain/transaction/data/converter.ts
@@ -116,7 +116,10 @@ function buildTransactionWhereInput(
   if (filter.toUserId) conditions.push({ toWallet: { user: { id: filter.toUserId } } });
   if (filter.fromWalletType) conditions.push({ fromWallet: { type: filter.fromWalletType } });
   if (filter.toWalletType) conditions.push({ toWallet: { type: filter.toWalletType } });
-
+  if (filter.fromUserName) conditions.push({ fromWallet: { user: { name: { contains: filter.fromUserName } } } });
+  if (filter.toUserName) conditions.push({ toWallet: { user: { name: { contains: filter.toUserName } } } });
+  if (filter.fromDidValue) conditions.push({ fromWallet: { user: { didIssuanceRequests: { some: { didValue: { contains: filter.fromDidValue } } } } } });
+  if (filter.toDidValue) conditions.push({ toWallet: { user: { didIssuanceRequests: { some: { didValue: { contains: filter.toDidValue } } } } } });
   // 再帰的に and/or/not を処理
   if (filter.and) {
     conditions.push({

--- a/src/application/domain/transaction/schema/query.graphql
+++ b/src/application/domain/transaction/schema/query.graphql
@@ -40,6 +40,12 @@ input TransactionFilterInput {
     fromUserId: ID
     toUserId: ID
 
+    fromUserName: String
+    toUserName: String
+
+    fromDidValue: String
+    toDidValue: String
+
     and: [TransactionFilterInput!]
     or: [TransactionFilterInput!]
     not: TransactionFilterInput

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -2308,13 +2308,17 @@ export type GqlTransactionEdge = GqlEdge & {
 export type GqlTransactionFilterInput = {
   and?: InputMaybe<Array<GqlTransactionFilterInput>>;
   communityId?: InputMaybe<Scalars['ID']['input']>;
+  fromDidValue?: InputMaybe<Scalars['String']['input']>;
   fromUserId?: InputMaybe<Scalars['ID']['input']>;
+  fromUserName?: InputMaybe<Scalars['String']['input']>;
   fromWalletId?: InputMaybe<Scalars['ID']['input']>;
   fromWalletType?: InputMaybe<GqlWalletType>;
   not?: InputMaybe<GqlTransactionFilterInput>;
   or?: InputMaybe<Array<GqlTransactionFilterInput>>;
   reason?: InputMaybe<GqlTransactionReason>;
+  toDidValue?: InputMaybe<Scalars['String']['input']>;
   toUserId?: InputMaybe<Scalars['ID']['input']>;
+  toUserName?: InputMaybe<Scalars['String']['input']>;
   toWalletId?: InputMaybe<Scalars['ID']['input']>;
   toWalletType?: InputMaybe<GqlWalletType>;
 };


### PR DESCRIPTION
- `TransactionFilterInput`に`fromUserName`、`toUserName`、`fromDidValue`、`toDidValue`を追加。
- `converter.ts`での条件構築ロジックを更新し、これらの新しいフィルタ条件をサポート。