### PR TITLE
NftWallet関連の機能を追加

### DIFF
--- a/src/application/domain/account/nft-wallet/controller/dataloader.ts
+++ b/src/application/domain/account/nft-wallet/controller/dataloader.ts
@@ -1,0 +1,23 @@
+import { GqlNftWallet } from "@/types/graphql";
+import NftWalletPresenter from "../presenter";
+import { PrismaClientIssuer } from "@/infrastructure/prisma/client";
+import DataLoader from "dataloader";
+import { nftWalletSelectDetail } from "../data/type";
+
+export function createNftWalletByUserIdLoader(issuer: PrismaClientIssuer) {
+    return new DataLoader<string, GqlNftWallet | null>(async (userIds) => {
+        const records = await issuer.internal((tx) =>
+            tx.nftWallet.findMany({
+                where: { userId: { in: [...userIds] } },
+                select: nftWalletSelectDetail,
+            }),
+        );
+
+        const map = new Map<string, GqlNftWallet>();
+        for (const record of records) {
+            map.set(record.userId, NftWalletPresenter.get(record));
+        }
+
+        return userIds.map((userId) => map.get(userId) ?? null);
+    });
+}

--- a/src/application/domain/account/nft-wallet/data/type.ts
+++ b/src/application/domain/account/nft-wallet/data/type.ts
@@ -1,0 +1,15 @@
+export const nftWalletSelectDetail = {
+    id: true,
+    userId: true,
+    walletAddress: true,
+    createdAt: true,
+    updatedAt: true,
+} as const;
+
+export type PrismaNftWalletDetail = {
+    id: string;
+    userId: string;
+    walletAddress: string;
+    createdAt: Date;
+    updatedAt: Date | null;
+};

--- a/src/application/domain/account/nft-wallet/presenter.ts
+++ b/src/application/domain/account/nft-wallet/presenter.ts
@@ -1,0 +1,12 @@
+import { PrismaNftWalletDetail } from "./data/type";
+
+export default class NftWalletPresenter {
+    static get(nftWallet: PrismaNftWalletDetail) {
+        return {
+            id: nftWallet.id,
+            walletAddress: nftWallet.walletAddress,
+            createdAt: nftWallet.createdAt,
+            updatedAt: nftWallet.updatedAt,
+        };
+    }
+}

--- a/src/application/domain/account/nft-wallet/schema/type.graphql
+++ b/src/application/domain/account/nft-wallet/schema/type.graphql
@@ -1,0 +1,6 @@
+type NftWallet {
+  id: ID!
+  walletAddress: String!
+  createdAt: Datetime
+  updatedAt: Datetime
+}

--- a/src/application/domain/account/user/controller/resolver.ts
+++ b/src/application/domain/account/user/controller/resolver.ts
@@ -98,5 +98,9 @@ export default class UserResolver {
     articlesAboutMe: (parent, _, ctx: IContext) => {
       return ctx.loaders.articlesAboutMe.load(parent.id);
     },
+
+    nftWallet: (parent, _, ctx: IContext) => {
+      return ctx.loaders.nftWalletByUserId.load(parent.id);
+    },
   };
 }

--- a/src/application/domain/account/user/schema/type.graphql
+++ b/src/application/domain/account/user/schema/type.graphql
@@ -28,6 +28,7 @@ type User {
     membershipChangedByMe: [MembershipHistory!]
 
     wallets: [Wallet!]
+    nftWallet: NftWallet
 
     opportunitiesCreatedByMe: [Opportunity!]
     reservations: [Reservation!]

--- a/src/presentation/graphql/dataloader/domain/account.ts
+++ b/src/presentation/graphql/dataloader/domain/account.ts
@@ -6,6 +6,7 @@ import * as MembershipLoaders from "@/application/domain/account/membership/cont
 import * as IdentityLoaders from "@/application/domain/account/identity/controller/dataloader";
 import * as MembershipHistoryLoaders from "@/application/domain/account/membership/history/controller/dataloader";
 import { createDidIssuanceRequestsByUserIdLoader } from "@/application/domain/account/identity/didIssuanceRequest/controller/dataloader";
+import { createNftWalletByUserIdLoader } from "@/application/domain/account/nft-wallet/controller/dataloader";
 
 export function createAccountLoaders(issuer: PrismaClientIssuer) {
   return {
@@ -35,5 +36,7 @@ export function createAccountLoaders(issuer: PrismaClientIssuer) {
       MembershipHistoryLoaders.createMembershipHistoriesCreatedByUserLoader(issuer),
     membershipHistoriesByMembership:
       MembershipHistoryLoaders.createMembershipStatusHistoriesByMembershipLoader(issuer),
+
+    nftWalletByUserId: createNftWalletByUserIdLoader(issuer),
   };
 }

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1007,6 +1007,14 @@ export type GqlNestedPlacesBulkUpdateInput = {
   disconnect?: InputMaybe<Array<Scalars['ID']['input']>>;
 };
 
+export type GqlNftWallet = {
+  __typename?: 'NftWallet';
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
+  id: Scalars['ID']['output'];
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+  walletAddress: Scalars['String']['output'];
+};
+
 export type GqlOpportunitiesConnection = {
   __typename?: 'OpportunitiesConnection';
   edges: Array<GqlOpportunityEdge>;
@@ -2380,6 +2388,7 @@ export type GqlUser = {
   membershipChangedByMe?: Maybe<Array<GqlMembershipHistory>>;
   memberships?: Maybe<Array<GqlMembership>>;
   name: Scalars['String']['output'];
+  nftWallet?: Maybe<GqlNftWallet>;
   opportunitiesCreatedByMe?: Maybe<Array<GqlOpportunity>>;
   participationStatusChangedByMe?: Maybe<Array<GqlParticipationStatusHistory>>;
   participations?: Maybe<Array<GqlParticipation>>;
@@ -2862,6 +2871,7 @@ export type GqlResolversTypes = ResolversObject<{
   NestedPlaceCreateInput: GqlNestedPlaceCreateInput;
   NestedPlacesBulkConnectOrCreateInput: GqlNestedPlacesBulkConnectOrCreateInput;
   NestedPlacesBulkUpdateInput: GqlNestedPlacesBulkUpdateInput;
+  NftWallet: ResolverTypeWrapper<GqlNftWallet>;
   OpportunitiesConnection: ResolverTypeWrapper<Omit<GqlOpportunitiesConnection, 'edges'> & { edges: Array<GqlResolversTypes['OpportunityEdge']> }>;
   Opportunity: ResolverTypeWrapper<Opportunity>;
   OpportunityCategory: GqlOpportunityCategory;
@@ -3152,6 +3162,7 @@ export type GqlResolversParentTypes = ResolversObject<{
   NestedPlaceCreateInput: GqlNestedPlaceCreateInput;
   NestedPlacesBulkConnectOrCreateInput: GqlNestedPlacesBulkConnectOrCreateInput;
   NestedPlacesBulkUpdateInput: GqlNestedPlacesBulkUpdateInput;
+  NftWallet: GqlNftWallet;
   OpportunitiesConnection: Omit<GqlOpportunitiesConnection, 'edges'> & { edges: Array<GqlResolversParentTypes['OpportunityEdge']> };
   Opportunity: Opportunity;
   OpportunityCreateInput: GqlOpportunityCreateInput;
@@ -3752,6 +3763,14 @@ export type GqlMutationResolvers<ContextType = any, ParentType extends GqlResolv
   utilityDelete?: Resolver<Maybe<GqlResolversTypes['UtilityDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationUtilityDeleteArgs, 'id' | 'permission'>>;
   utilitySetPublishStatus?: Resolver<Maybe<GqlResolversTypes['UtilitySetPublishStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationUtilitySetPublishStatusArgs, 'id' | 'input' | 'permission'>>;
   utilityUpdateInfo?: Resolver<Maybe<GqlResolversTypes['UtilityUpdateInfoPayload']>, ParentType, ContextType, RequireFields<GqlMutationUtilityUpdateInfoArgs, 'id' | 'input' | 'permission'>>;
+}>;
+
+export type GqlNftWalletResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['NftWallet'] = GqlResolversParentTypes['NftWallet']> = ResolversObject<{
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  walletAddress?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
 export type GqlOpportunitiesConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['OpportunitiesConnection'] = GqlResolversParentTypes['OpportunitiesConnection']> = ResolversObject<{
@@ -4407,6 +4426,7 @@ export type GqlUserResolvers<ContextType = any, ParentType extends GqlResolversP
   membershipChangedByMe?: Resolver<Maybe<Array<GqlResolversTypes['MembershipHistory']>>, ParentType, ContextType>;
   memberships?: Resolver<Maybe<Array<GqlResolversTypes['Membership']>>, ParentType, ContextType>;
   name?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  nftWallet?: Resolver<Maybe<GqlResolversTypes['NftWallet']>, ParentType, ContextType>;
   opportunitiesCreatedByMe?: Resolver<Maybe<Array<GqlResolversTypes['Opportunity']>>, ParentType, ContextType>;
   participationStatusChangedByMe?: Resolver<Maybe<Array<GqlResolversTypes['ParticipationStatusHistory']>>, ParentType, ContextType>;
   participations?: Resolver<Maybe<Array<GqlResolversTypes['Participation']>>, ParentType, ContextType>;
@@ -4628,6 +4648,7 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   MembershipWithdrawSuccess?: GqlMembershipWithdrawSuccessResolvers<ContextType>;
   MembershipsConnection?: GqlMembershipsConnectionResolvers<ContextType>;
   Mutation?: GqlMutationResolvers<ContextType>;
+  NftWallet?: GqlNftWalletResolvers<ContextType>;
   OpportunitiesConnection?: GqlOpportunitiesConnectionResolvers<ContextType>;
   Opportunity?: GqlOpportunityResolvers<ContextType>;
   OpportunityCreatePayload?: GqlOpportunityCreatePayloadResolvers<ContextType>;


### PR DESCRIPTION
- NftWalletPresenterを作成し、NftWalletの詳細を取得するメソッドを実装
- NftWallet用のDataLoaderを作成し、ユーザーIDに基づいてNftWalletを取得
- NftWalletのGraphQL型定義を追加し、User型にnftWalletフィールドを追加
- アカウントドメインのDataLoaderを更新し、nftWalletを含めるように変更
- GqlNftWallet型をGraphQLの型定義に追加

これにより、ユーザーのNftWallet情報が取得可能になりました。