### PR TITLE
membershipSelectDetailにuserとcommunityフィールドを追加

### DIFF
--- a/src/application/domain/account/membership/data/type.ts
+++ b/src/application/domain/account/membership/data/type.ts
@@ -26,6 +26,9 @@ export const membershipSelectDetail = Prisma.validator<Prisma.MembershipSelect>(
 
   createdAt: true,
   updatedAt: true,
+
+  user: true,
+  community: true,
 });
 
 export type PrismaMembership = Prisma.MembershipGetPayload<{


### PR DESCRIPTION
- PrismaのmembershipSelectDetailにuserとcommunityの選択フィールドを追加
- ユーザーとコミュニティに関連するデータの取得を強化