### PR TITLE
Add community association to participation creation

### DIFF
--- a/src/application/domain/experience/participation/data/converter.ts
+++ b/src/application/domain/experience/participation/data/converter.ts
@@ -78,11 +78,11 @@ export default class ParticipationConverter {
         filter?.communityId ? { communityId: filter.communityId } : {},
         filter?.opportunityId
           ? {
-            OR: [
-              { reservation: { opportunitySlot: { opportunityId: filter.opportunityId } } },
-              { opportunitySlot: { opportunityId: filter.opportunityId } },
-            ],
-          }
+              OR: [
+                { reservation: { opportunitySlot: { opportunityId: filter.opportunityId } } },
+                { opportunitySlot: { opportunityId: filter.opportunityId } },
+              ],
+            }
           : {},
         filter?.opportunitySlotId
           ? { reservation: { opportunitySlotId: filter.opportunitySlotId } }
@@ -126,9 +126,13 @@ export default class ParticipationConverter {
     };
   }
 
-  createMany(input: GqlParticipationBulkCreateInput): Prisma.ParticipationCreateInput[] {
+  createMany(
+    input: GqlParticipationBulkCreateInput,
+    communityId: string,
+  ): Prisma.ParticipationCreateInput[] {
     return input.userIds.map((userId) => ({
       user: { connect: { id: userId } },
+      community: { connect: { id: communityId } },
       opportunitySlot: { connect: { id: input.slotId } },
       description: input.description ?? null,
       status: ParticipationStatus.PARTICIPATING,

--- a/src/application/domain/experience/participation/service.ts
+++ b/src/application/domain/experience/participation/service.ts
@@ -59,7 +59,7 @@ export default class ParticipationService implements IParticipationService {
     input: GqlParticipationBulkCreateInput,
     tx: Prisma.TransactionClient,
   ) {
-    const createInputs = this.converter.createMany(input);
+    const createInputs = this.converter.createMany(input, ctx.communityId);
     return await Promise.all(createInputs.map((d) => this.repository.create(ctx, d, tx)));
   }
 


### PR DESCRIPTION
Ensures that participations are linked to the appropriate community by including `communityId` in the creation inputs. Updated converter and service logic to facilitate this improvement.