### PR TITLE
Update GraphQL schema to use BigInt for point fields

### DIFF
--- a/codegen.yaml
+++ b/codegen.yaml
@@ -16,6 +16,7 @@ generates:
       scalars:
         Datetime: Date
         Decimal: string
+        BigInt: number
         JSON: any
         Upload: "typeof import('graphql-upload/GraphQLUpload.mjs')"
       enumsAsConst: true

--- a/src/application/domain/account/wallet/schema/type.graphql
+++ b/src/application/domain/account/wallet/schema/type.graphql
@@ -21,12 +21,12 @@ type Wallet {
 
 type CurrentPointView {
     walletId: String
-    currentPoint: Int!
+    currentPoint: BigInt!
 }
 
 type AccumulatedPointView {
     walletId: String
-    accumulatedPoint: Int!
+    accumulatedPoint: BigInt!
 }
 
 # ------------------------------

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -575,7 +575,7 @@ view CurrentPointView {
   walletId String @id @map("wallet_id")
   wallet   Wallet @relation(fields: [walletId], references: [id])
 
-  currentPoint Int @map("current_point")
+  currentPoint BigInt @map("current_point") @db.BigInt
 
   @@map("mv_current_points")
 }
@@ -584,7 +584,7 @@ view AccumulatedPointView {
   walletId String @id @map("wallet_id")
   wallet   Wallet @relation(fields: [walletId], references: [id])
 
-  accumulatedPoint Int @map("accumulated_point")
+  accumulatedPoint BigInt @map("accumulated_point") @db.BigInt
 
   @@map("mv_accumulated_points")
 }

--- a/src/presentation/graphql/schema/utils.graphql
+++ b/src/presentation/graphql/schema/utils.graphql
@@ -60,6 +60,7 @@ scalar Datetime
 scalar JSON
 scalar Decimal
 scalar Upload
+scalar BigInt
 
 # ------------------------------------------------
 # Input Types

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -16,6 +16,7 @@ export type Scalars = {
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }
   Float: { input: number; output: number; }
+  BigInt: { input: number; output: number; }
   Datetime: { input: Date; output: Date; }
   Decimal: { input: string; output: string; }
   JSON: { input: any; output: any; }
@@ -24,7 +25,7 @@ export type Scalars = {
 
 export type GqlAccumulatedPointView = {
   __typename?: 'AccumulatedPointView';
-  accumulatedPoint: Scalars['Int']['output'];
+  accumulatedPoint: Scalars['BigInt']['output'];
   walletId?: Maybe<Scalars['String']['output']>;
 };
 
@@ -288,7 +289,7 @@ export type GqlCommunityUpdateProfileSuccess = {
 
 export type GqlCurrentPointView = {
   __typename?: 'CurrentPointView';
-  currentPoint: Scalars['Int']['output'];
+  currentPoint: Scalars['BigInt']['output'];
   walletId?: Maybe<Scalars['String']['output']>;
 };
 
@@ -2903,6 +2904,7 @@ export type GqlResolversTypes = ResolversObject<{
   AuthZDirectiveCompositeRulesInput: GqlAuthZDirectiveCompositeRulesInput;
   AuthZDirectiveDeepCompositeRulesInput: GqlAuthZDirectiveDeepCompositeRulesInput;
   AuthZRules: GqlAuthZRules;
+  BigInt: ResolverTypeWrapper<Scalars['BigInt']['output']>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
   CheckCommunityPermissionInput: GqlCheckCommunityPermissionInput;
   CheckIsSelfPermissionInput: GqlCheckIsSelfPermissionInput;
@@ -3214,6 +3216,7 @@ export type GqlResolversParentTypes = ResolversObject<{
   ArticlesConnection: Omit<GqlArticlesConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['ArticleEdge']>>> };
   AuthZDirectiveCompositeRulesInput: GqlAuthZDirectiveCompositeRulesInput;
   AuthZDirectiveDeepCompositeRulesInput: GqlAuthZDirectiveDeepCompositeRulesInput;
+  BigInt: Scalars['BigInt']['output'];
   Boolean: Scalars['Boolean']['output'];
   CheckCommunityPermissionInput: GqlCheckCommunityPermissionInput;
   CheckIsSelfPermissionInput: GqlCheckIsSelfPermissionInput;
@@ -3493,7 +3496,7 @@ export type GqlRequireRoleDirectiveArgs = {
 export type GqlRequireRoleDirectiveResolver<Result, Parent, ContextType = any, Args = GqlRequireRoleDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
 export type GqlAccumulatedPointViewResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AccumulatedPointView'] = GqlResolversParentTypes['AccumulatedPointView']> = ResolversObject<{
-  accumulatedPoint?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  accumulatedPoint?: Resolver<GqlResolversTypes['BigInt'], ParentType, ContextType>;
   walletId?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
@@ -3555,6 +3558,10 @@ export type GqlArticlesConnectionResolvers<ContextType = any, ParentType extends
   totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
+
+export interface GqlBigIntScalarConfig extends GraphQLScalarTypeConfig<GqlResolversTypes['BigInt'], any> {
+  name: 'BigInt';
+}
 
 export type GqlCitiesConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CitiesConnection'] = GqlResolversParentTypes['CitiesConnection']> = ResolversObject<{
   edges?: Resolver<Array<GqlResolversTypes['CityEdge']>, ParentType, ContextType>;
@@ -3637,7 +3644,7 @@ export type GqlCommunityUpdateProfileSuccessResolvers<ContextType = any, ParentT
 }>;
 
 export type GqlCurrentPointViewResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CurrentPointView'] = GqlResolversParentTypes['CurrentPointView']> = ResolversObject<{
-  currentPoint?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  currentPoint?: Resolver<GqlResolversTypes['BigInt'], ParentType, ContextType>;
   walletId?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
@@ -4789,6 +4796,7 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   ArticleUpdateContentPayload?: GqlArticleUpdateContentPayloadResolvers<ContextType>;
   ArticleUpdateContentSuccess?: GqlArticleUpdateContentSuccessResolvers<ContextType>;
   ArticlesConnection?: GqlArticlesConnectionResolvers<ContextType>;
+  BigInt?: GraphQLScalarType;
   CitiesConnection?: GqlCitiesConnectionResolvers<ContextType>;
   City?: GqlCityResolvers<ContextType>;
   CityEdge?: GqlCityEdgeResolvers<ContextType>;


### PR DESCRIPTION
### Description

This pull request updates the GraphQL schema to utilize `BigInt` for the `currentPoint` and `accumulatedPoint` fields. It includes the following changes:
- Modified `currentPoint` and `accumulatedPoint` fields from `Int` to `BigInt`.
- Added support for the `BigInt` scalar type in the GraphQL configuration and codegen.
- Adjusted the resolver and type definitions to ensure compatibility with `BigInt`.

### Checklists

#### Tests
- [ ] Added unit tests.
- [ ] Updated integration tests.

#### Documentation
- [ ] Updated relevant documentation.