### PR TITLE
Add BigInt scalar support and extend GraphQL types

### DIFF
--- a/codegen.yaml
+++ b/codegen.yaml
@@ -14,6 +14,7 @@ generates:
       inputMaybeValue: T | undefined
       strictScalars: true
       scalars:
+        BigInt: number
         Datetime: Date
         Decimal: string
         JSON: any

--- a/src/application/domain/account/wallet/schema/type.graphql
+++ b/src/application/domain/account/wallet/schema/type.graphql
@@ -21,12 +21,12 @@ type Wallet {
 
 type CurrentPointView {
     walletId: String
-    currentPoint: Int!
+    currentPoint: BigInt!
 }
 
 type AccumulatedPointView {
     walletId: String
-    accumulatedPoint: Int!
+    accumulatedPoint: BigInt!
 }
 
 # ------------------------------

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -505,7 +505,7 @@ view CurrentPointView {
   walletId String @id @map("wallet_id")
   wallet   Wallet @relation(fields: [walletId], references: [id])
 
-  currentPoint Int @map("current_point")
+  currentPoint BigInt @map("current_point") @db.BigInt
 
   @@map("mv_current_points")
 }
@@ -514,7 +514,7 @@ view AccumulatedPointView {
   walletId String @id @map("wallet_id")
   wallet   Wallet @relation(fields: [walletId], references: [id])
 
-  accumulatedPoint Int @map("accumulated_point")
+  accumulatedPoint BigInt @map("accumulated_point") @db.BigInt
 
   @@map("mv_accumulated_points")
 }

--- a/src/presentation/graphql/schema/utils.graphql
+++ b/src/presentation/graphql/schema/utils.graphql
@@ -60,6 +60,7 @@ scalar Datetime
 scalar JSON
 scalar Decimal
 scalar Upload
+scalar BigInt
 
 # ------------------------------------------------
 # Input Types

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -16,6 +16,7 @@ export type Scalars = {
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }
   Float: { input: number; output: number; }
+  BigInt: { input: number; output: number; }
   Datetime: { input: Date; output: Date; }
   Decimal: { input: string; output: string; }
   JSON: { input: any; output: any; }
@@ -24,7 +25,7 @@ export type Scalars = {
 
 export type GqlAccumulatedPointView = {
   __typename?: 'AccumulatedPointView';
-  accumulatedPoint: Scalars['Int']['output'];
+  accumulatedPoint: Scalars['BigInt']['output'];
   walletId?: Maybe<Scalars['String']['output']>;
 };
 
@@ -288,7 +289,7 @@ export type GqlCommunityUpdateProfileSuccess = {
 
 export type GqlCurrentPointView = {
   __typename?: 'CurrentPointView';
-  currentPoint: Scalars['Int']['output'];
+  currentPoint: Scalars['BigInt']['output'];
   walletId?: Maybe<Scalars['String']['output']>;
 };
 
@@ -2305,6 +2306,7 @@ export type GqlTicketsConnection = {
 export type GqlTransaction = {
   __typename?: 'Transaction';
   createdAt?: Maybe<Scalars['Datetime']['output']>;
+  createdByUser?: Maybe<GqlUser>;
   fromPointChange?: Maybe<Scalars['Int']['output']>;
   fromWallet?: Maybe<GqlWallet>;
   id: Scalars['ID']['output'];
@@ -2764,6 +2766,7 @@ export type GqlResolversTypes = ResolversObject<{
   AuthZDirectiveCompositeRulesInput: GqlAuthZDirectiveCompositeRulesInput;
   AuthZDirectiveDeepCompositeRulesInput: GqlAuthZDirectiveDeepCompositeRulesInput;
   AuthZRules: GqlAuthZRules;
+  BigInt: ResolverTypeWrapper<Scalars['BigInt']['output']>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
   CheckCommunityPermissionInput: GqlCheckCommunityPermissionInput;
   CheckIsSelfPermissionInput: GqlCheckIsSelfPermissionInput;
@@ -3061,6 +3064,7 @@ export type GqlResolversParentTypes = ResolversObject<{
   ArticlesConnection: Omit<GqlArticlesConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['ArticleEdge']>>> };
   AuthZDirectiveCompositeRulesInput: GqlAuthZDirectiveCompositeRulesInput;
   AuthZDirectiveDeepCompositeRulesInput: GqlAuthZDirectiveDeepCompositeRulesInput;
+  BigInt: Scalars['BigInt']['output'];
   Boolean: Scalars['Boolean']['output'];
   CheckCommunityPermissionInput: GqlCheckCommunityPermissionInput;
   CheckIsSelfPermissionInput: GqlCheckIsSelfPermissionInput;
@@ -3328,7 +3332,7 @@ export type GqlRequireRoleDirectiveArgs = {
 export type GqlRequireRoleDirectiveResolver<Result, Parent, ContextType = any, Args = GqlRequireRoleDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
 export type GqlAccumulatedPointViewResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AccumulatedPointView'] = GqlResolversParentTypes['AccumulatedPointView']> = ResolversObject<{
-  accumulatedPoint?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  accumulatedPoint?: Resolver<GqlResolversTypes['BigInt'], ParentType, ContextType>;
   walletId?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
@@ -3390,6 +3394,10 @@ export type GqlArticlesConnectionResolvers<ContextType = any, ParentType extends
   totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
+
+export interface GqlBigIntScalarConfig extends GraphQLScalarTypeConfig<GqlResolversTypes['BigInt'], any> {
+  name: 'BigInt';
+}
 
 export type GqlCitiesConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CitiesConnection'] = GqlResolversParentTypes['CitiesConnection']> = ResolversObject<{
   edges?: Resolver<Array<GqlResolversTypes['CityEdge']>, ParentType, ContextType>;
@@ -3472,7 +3480,7 @@ export type GqlCommunityUpdateProfileSuccessResolvers<ContextType = any, ParentT
 }>;
 
 export type GqlCurrentPointViewResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CurrentPointView'] = GqlResolversParentTypes['CurrentPointView']> = ResolversObject<{
-  currentPoint?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  currentPoint?: Resolver<GqlResolversTypes['BigInt'], ParentType, ContextType>;
   walletId?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
@@ -4335,6 +4343,7 @@ export type GqlTicketsConnectionResolvers<ContextType = any, ParentType extends 
 
 export type GqlTransactionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Transaction'] = GqlResolversParentTypes['Transaction']> = ResolversObject<{
   createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  createdByUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
   fromPointChange?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
   fromWallet?: Resolver<Maybe<GqlResolversTypes['Wallet']>, ParentType, ContextType>;
   id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
@@ -4556,6 +4565,7 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   ArticleUpdateContentPayload?: GqlArticleUpdateContentPayloadResolvers<ContextType>;
   ArticleUpdateContentSuccess?: GqlArticleUpdateContentSuccessResolvers<ContextType>;
   ArticlesConnection?: GqlArticlesConnectionResolvers<ContextType>;
+  BigInt?: GraphQLScalarType;
   CitiesConnection?: GqlCitiesConnectionResolvers<ContextType>;
   City?: GqlCityResolvers<ContextType>;
   CityEdge?: GqlCityEdgeResolvers<ContextType>;


### PR DESCRIPTION
- Added support for `BigInt` scalar in the GraphQL schema.
- Updated `CurrentPointView` and `AccumulatedPointView` fields from `Int` to `BigInt`.
- Configured `BigInt` scalar mapping in `codegen.yaml` and GraphQL types.
- Introduced a `BigInt` scalar resolver implementation.
- Enhanced `GqlTransaction` type with a new `createdByUser` field.