### PR TITLE
Refactor and fix: enhance BigInt typing and support in GraphQL

### DIFF
--- a/codegen.yaml
+++ b/codegen.yaml
@@ -16,7 +16,7 @@ generates:
       scalars:
         Datetime: Date
         Decimal: string
-        BigInt: number
+        BigInt: bigint
         JSON: any
         Upload: "typeof import('graphql-upload/GraphQLUpload.mjs')"
       enumsAsConst: true

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -666,13 +666,13 @@ TICKET_REFUNDED TICKET_REFUNDED
 
   "mv_current_points" {
     String walletId "🗝️"
-    Int currentPoint 
+    BigInt currentPoint 
     }
   
 
   "mv_accumulated_points" {
     String walletId "🗝️"
-    Int accumulatedPoint 
+    BigInt accumulatedPoint 
     }
   
 

--- a/docs/schema.dbml
+++ b/docs/schema.dbml
@@ -591,13 +591,13 @@ Table v_membership_hosted_opportunity_count {
 Table mv_current_points {
   walletId String [pk]
   wallet t_wallets [not null]
-  currentPoint Int [not null]
+  currentPoint BigInt [not null]
 }
 
 Table mv_accumulated_points {
   walletId String [pk]
   wallet t_wallets [not null]
-  accumulatedPoint Int [not null]
+  accumulatedPoint BigInt [not null]
 }
 
 Table v_earliest_reservable_slot {

--- a/src/__tests__/unit/account/wallet.validator.test.ts
+++ b/src/__tests__/unit/account/wallet.validator.test.ts
@@ -83,13 +83,13 @@ describe("WalletValidator", () => {
       const fromWallet = {
         ...memberWallet,
         id: "wallet-from",
-        currentPointView: { currentPoint: 500 },
+        currentPointView: { currentPoint: BigInt(500) },
       } as PrismaWallet;
 
       const toWallet = {
         ...memberWallet,
         id: "wallet-to",
-        currentPointView: { currentPoint: 0 },
+        currentPointView: { currentPoint: BigInt(0) },
       } as PrismaWallet;
 
       const result = await validator.validateTransferMemberToMember(fromWallet, toWallet, 100);
@@ -104,12 +104,12 @@ describe("WalletValidator", () => {
       const fromWallet = {
         ...memberWallet,
         id: "wallet-from",
-        currentPointView: { currentPoint: 50 },
+        currentPointView: { currentPoint: BigInt(50) },
       } as PrismaWallet;
       const toWallet = {
         ...memberWallet,
         id: "wallet-to",
-        currentPointView: { currentPoint: 0 },
+        currentPointView: { currentPoint: BigInt(0) },
       } as PrismaWallet;
 
       await expect(
@@ -122,11 +122,11 @@ describe("WalletValidator", () => {
     it("should pass if currentPoint is sufficient", async () => {
       const fromWallet = {
         id: "wallet-from",
-        currentPointView: { currentPoint: 500 },
+        currentPointView: { currentPoint: BigInt(500) },
       } as PrismaWallet;
       const toWallet = {
         id: "wallet-to",
-        currentPointView: { currentPoint: 0 },
+        currentPointView: { currentPoint: BigInt(0) },
       } as PrismaWallet;
 
       await expect(validator.validateTransfer(100, fromWallet, toWallet)).resolves.not.toThrow();
@@ -135,7 +135,7 @@ describe("WalletValidator", () => {
     it("should throw ValidationError if fromWallet is null", async () => {
       const toWallet = {
         id: "wallet-to",
-        currentPointView: { currentPoint: 0 },
+        currentPointView: { currentPoint: BigInt(0) },
       } as PrismaWallet;
 
       await expect(validator.validateTransfer(100, null, toWallet)).rejects.toThrow(
@@ -146,7 +146,7 @@ describe("WalletValidator", () => {
     it("should throw ValidationError if toWallet is null", async () => {
       const fromWallet = {
         id: "wallet-from",
-        currentPointView: { currentPoint: 500 },
+        currentPointView: { currentPoint: BigInt(500) },
       } as PrismaWallet;
 
       await expect(validator.validateTransfer(100, fromWallet, null)).rejects.toThrow(
@@ -161,7 +161,7 @@ describe("WalletValidator", () => {
       } as PrismaWallet;
       const toWallet = {
         id: "wallet-to",
-        currentPointView: { currentPoint: 0 },
+        currentPointView: { currentPoint: BigInt(0) },
       } as PrismaWallet;
 
       await expect(validator.validateTransfer(100, fromWallet, toWallet)).rejects.toThrow(
@@ -172,11 +172,11 @@ describe("WalletValidator", () => {
     it("should throw InsufficientBalanceError if currentPoint is insufficient", async () => {
       const fromWallet = {
         id: "wallet-from",
-        currentPointView: { currentPoint: 50 },
+        currentPointView: { currentPoint: BigInt(50) },
       } as PrismaWallet;
       const toWallet = {
         id: "wallet-to",
-        currentPointView: { currentPoint: 0 },
+        currentPointView: { currentPoint: BigInt(0) },
       } as PrismaWallet;
 
       await expect(validator.validateTransfer(100, fromWallet, toWallet)).rejects.toThrow(

--- a/src/application/domain/account/wallet/validator.ts
+++ b/src/application/domain/account/wallet/validator.ts
@@ -1,6 +1,6 @@
 import { IContext } from "@/types/server";
 import { Prisma, TransactionReason } from "@prisma/client";
-import { InsufficientBalanceError, ValidationError } from "@/errors/graphql";
+import { DatabaseError, InsufficientBalanceError, ValidationError } from "@/errors/graphql";
 import { PrismaWallet } from "@/application/domain/account/wallet/data/type";
 import WalletService from "@/application/domain/account/wallet/service";
 import { inject, injectable } from "tsyringe";
@@ -89,8 +89,11 @@ export default class WalletValidator {
     }
     const { currentPoint } = fromWallet.currentPointView || {};
 
-    if (currentPoint !== undefined && currentPoint < transferPoints) {
-      throw new InsufficientBalanceError(currentPoint ?? 0, transferPoints);
+    if (typeof currentPoint !== "bigint") {
+      throw new DatabaseError("Invalid point type: expected bigint");
+    }
+    if (currentPoint < BigInt(transferPoints)) {
+      throw new InsufficientBalanceError(Number(currentPoint), transferPoints);
     }
   }
 }

--- a/src/application/domain/content/image/service.ts
+++ b/src/application/domain/content/image/service.ts
@@ -4,6 +4,13 @@ import { gcsBucketName, storage } from "@/infrastructure/libs/storage";
 import path from "path";
 import { injectable } from "tsyringe";
 
+type FileUpload = {
+  filename: string;
+  mimetype: string;
+  encoding: string;
+  createReadStream: () => NodeJS.ReadableStream;
+};
+
 @injectable()
 export default class ImageService {
   async uploadPublicImage(
@@ -11,10 +18,9 @@ export default class ImageService {
     folderPath: string,
   ): Promise<Prisma.ImageCreateWithoutUsersInput> {
     const { file, alt, caption } = image;
-    const {
-      // @ts-expect-error Library type definition is not compatible with the original library
-      file: { createReadStream, filename: rawFilename, mimetype: mime },
-    } = await file;
+    const uploadFile = (await file) as unknown as FileUpload;
+
+    const { createReadStream, filename: rawFilename, mimetype: mime } = uploadFile;
 
     const ext = path.extname(rawFilename);
     const filename = `${Date.now()}_${rawFilename}`;

--- a/src/infrastructure/prisma/factories/__generated__/index.ts
+++ b/src/infrastructure/prisma/factories/__generated__/index.ts
@@ -7404,7 +7404,7 @@ export const defineMembershipHostedOpportunityCountViewFactory = (<TOptions exte
 defineMembershipHostedOpportunityCountViewFactory.withTransientFields = defaultTransientFieldValues => options => defineMembershipHostedOpportunityCountViewFactoryInternal(options, defaultTransientFieldValues);
 
 type CurrentPointViewScalarOrEnumFields = {
-    currentPoint: number;
+    currentPoint: (bigint | number);
 };
 
 type CurrentPointViewwalletFactory = {
@@ -7413,7 +7413,7 @@ type CurrentPointViewwalletFactory = {
 };
 
 type CurrentPointViewFactoryDefineInput = {
-    currentPoint?: number;
+    currentPoint?: (bigint | number);
     wallet: CurrentPointViewwalletFactory | Prisma.WalletCreateNestedOneWithoutCurrentPointViewInput;
 };
 
@@ -7457,7 +7457,7 @@ function autoGenerateCurrentPointViewScalarsOrEnums({ seq }: {
     readonly seq: number;
 }): CurrentPointViewScalarOrEnumFields {
     return {
-        currentPoint: getScalarFieldValueGenerator().Int({ modelName: "CurrentPointView", fieldName: "currentPoint", isId: false, isUnique: false, seq })
+        currentPoint: getScalarFieldValueGenerator().BigInt({ modelName: "CurrentPointView", fieldName: "currentPoint", isId: false, isUnique: false, seq })
     };
 }
 
@@ -7555,7 +7555,7 @@ export const defineCurrentPointViewFactory = (<TOptions extends CurrentPointView
 defineCurrentPointViewFactory.withTransientFields = defaultTransientFieldValues => options => defineCurrentPointViewFactoryInternal(options, defaultTransientFieldValues);
 
 type AccumulatedPointViewScalarOrEnumFields = {
-    accumulatedPoint: number;
+    accumulatedPoint: (bigint | number);
 };
 
 type AccumulatedPointViewwalletFactory = {
@@ -7564,7 +7564,7 @@ type AccumulatedPointViewwalletFactory = {
 };
 
 type AccumulatedPointViewFactoryDefineInput = {
-    accumulatedPoint?: number;
+    accumulatedPoint?: (bigint | number);
     wallet: AccumulatedPointViewwalletFactory | Prisma.WalletCreateNestedOneWithoutAccumulatedPointViewInput;
 };
 
@@ -7608,7 +7608,7 @@ function autoGenerateAccumulatedPointViewScalarsOrEnums({ seq }: {
     readonly seq: number;
 }): AccumulatedPointViewScalarOrEnumFields {
     return {
-        accumulatedPoint: getScalarFieldValueGenerator().Int({ modelName: "AccumulatedPointView", fieldName: "accumulatedPoint", isId: false, isUnique: false, seq })
+        accumulatedPoint: getScalarFieldValueGenerator().BigInt({ modelName: "AccumulatedPointView", fieldName: "accumulatedPoint", isId: false, isUnique: false, seq })
     };
 }
 

--- a/src/presentation/graphql/resolver.ts
+++ b/src/presentation/graphql/resolver.ts
@@ -19,6 +19,7 @@ import TicketClaimLinkResolver from "@/application/domain/reward/ticketClaimLink
 import TicketIssuerResolver from "@/application/domain/reward/ticketIssuer/controller/resolver";
 import VCIssuanceRequestResolver from "@/application/domain/experience/evaluation/vcIssuanceRequest/controller/resolver";
 import MasterResolver from "@/application/domain/location/master/controller/resolver";
+import scalarResolvers from "@/presentation/graphql/scalar";
 
 const identity = container.resolve(IdentityResolver);
 const user = container.resolve(UserResolver);
@@ -106,6 +107,8 @@ const resolvers = {
   Utility: utility.Utility,
 
   Transaction: transaction.Transaction,
+
+  ...scalarResolvers,
 };
 
 export default resolvers;

--- a/src/presentation/graphql/scalar/index.ts
+++ b/src/presentation/graphql/scalar/index.ts
@@ -25,9 +25,36 @@ const DecimalScalar = new GraphQLScalarType({
   },
 });
 
+const BigIntScalar = new GraphQLScalarType({
+  name: "BigInt",
+  description: "Custom scalar for bigint (serialized as string)",
+
+  parseValue(value: unknown) {
+    if (typeof value === "string" || typeof value === "number") {
+      return BigInt(value);
+    }
+    throw new Error("Invalid BigInt");
+  },
+
+  serialize(value: unknown) {
+    if (typeof value === "bigint") {
+      return value.toString(); // GraphQLは bigint を直接返せないため string 化
+    }
+    throw new Error("Expected bigint for serialization");
+  },
+
+  parseLiteral(ast) {
+    if (ast.kind === Kind.INT || ast.kind === Kind.STRING) {
+      return BigInt(ast.value);
+    }
+    throw new Error("Invalid BigInt literal");
+  },
+});
+
 const scalarResolvers = {
   Decimal: DecimalScalar,
   Upload: GraphQLUpload,
+  BigInt: BigIntScalar,
 };
 
 export default scalarResolvers;

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -16,7 +16,7 @@ export type Scalars = {
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }
   Float: { input: number; output: number; }
-  BigInt: { input: number; output: number; }
+  BigInt: { input: bigint; output: bigint; }
   Datetime: { input: Date; output: Date; }
   Decimal: { input: string; output: string; }
   JSON: { input: any; output: any; }


### PR DESCRIPTION
### Changes included in this pull request:

- **Enhancements in BigInt handling:**
  - Added a custom `BigInt` scalar type to the GraphQL schema for better parsing, serialization, and literal processing.
  - Updated scalar resolvers to include `BigIntScalar` for improved compatibility.

- **Refined type definitions:**
  - Replaced Int fields with BigInt across schema, factories, tests, and documentation to align with large number handling requirements.
  - Updated `file` operations in `ImageService` with stricter typing using a `FileUpload` type.

- **Bug fixes and validation:**
  - Corrected test cases to handle `BigInt` values properly for `currentPointView` in wallet transfer scenarios.
  - Added validation improvements to handle invalid `currentPoint` types and transitioned comparison logic to leverage `BigInt`.

- **Code generation updates:**
  - Revised `codegen.yaml` to map `BigInt` to `bigint`.
  - Ensured strong typing for `BigInt` input/output across generated GraphQL files.

### Checklist:
- [ ] Tests added/updated as necessary.
- [ ] Documentation updated for any user-facing changes.
- [ ] Code follows project's style and conventions.
- [ ] Changes are backward-compatible.

These improvements reinforce type safety and broaden support for BigInt usage across the application.