### PR TITLE
Add `createdByUser` field to `GqlTransaction` type

### DIFF
--- a/codegen.yaml
+++ b/codegen.yaml
@@ -16,6 +16,7 @@ generates:
       scalars:
         Datetime: Date
         Decimal: string
+        BigInt: bigint
         JSON: any
         Upload: "typeof import('graphql-upload/GraphQLUpload.mjs')"
       enumsAsConst: true

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -611,13 +611,13 @@ TICKET_REFUNDED TICKET_REFUNDED
 
   "mv_current_points" {
     String walletId "🗝️"
-    Int currentPoint 
+    BigInt currentPoint 
     }
   
 
   "mv_accumulated_points" {
     String walletId "🗝️"
-    Int accumulatedPoint 
+    BigInt accumulatedPoint 
     }
   
 

--- a/docs/schema.dbml
+++ b/docs/schema.dbml
@@ -548,13 +548,13 @@ Table v_membership_hosted_opportunity_count {
 Table mv_current_points {
   walletId String [pk]
   wallet t_wallets [not null]
-  currentPoint Int [not null]
+  currentPoint BigInt [not null]
 }
 
 Table mv_accumulated_points {
   walletId String [pk]
   wallet t_wallets [not null]
-  accumulatedPoint Int [not null]
+  accumulatedPoint BigInt [not null]
 }
 
 Table v_earliest_reservable_slot {

--- a/src/__tests__/unit/account/wallet.validator.test.ts
+++ b/src/__tests__/unit/account/wallet.validator.test.ts
@@ -83,13 +83,13 @@ describe("WalletValidator", () => {
       const fromWallet = {
         ...memberWallet,
         id: "wallet-from",
-        currentPointView: { currentPoint: 500 },
+        currentPointView: { currentPoint: BigInt(500) },
       } as PrismaWallet;
 
       const toWallet = {
         ...memberWallet,
         id: "wallet-to",
-        currentPointView: { currentPoint: 0 },
+        currentPointView: { currentPoint: BigInt(0) },
       } as PrismaWallet;
 
       const result = await validator.validateTransferMemberToMember(fromWallet, toWallet, 100);
@@ -104,12 +104,12 @@ describe("WalletValidator", () => {
       const fromWallet = {
         ...memberWallet,
         id: "wallet-from",
-        currentPointView: { currentPoint: 50 },
+        currentPointView: { currentPoint: BigInt(50) },
       } as PrismaWallet;
       const toWallet = {
         ...memberWallet,
         id: "wallet-to",
-        currentPointView: { currentPoint: 0 },
+        currentPointView: { currentPoint: BigInt(0) },
       } as PrismaWallet;
 
       await expect(
@@ -122,11 +122,11 @@ describe("WalletValidator", () => {
     it("should pass if currentPoint is sufficient", async () => {
       const fromWallet = {
         id: "wallet-from",
-        currentPointView: { currentPoint: 500 },
+        currentPointView: { currentPoint: BigInt(500) },
       } as PrismaWallet;
       const toWallet = {
         id: "wallet-to",
-        currentPointView: { currentPoint: 0 },
+        currentPointView: { currentPoint: BigInt(0) },
       } as PrismaWallet;
 
       await expect(validator.validateTransfer(100, fromWallet, toWallet)).resolves.not.toThrow();
@@ -135,7 +135,7 @@ describe("WalletValidator", () => {
     it("should throw ValidationError if fromWallet is null", async () => {
       const toWallet = {
         id: "wallet-to",
-        currentPointView: { currentPoint: 0 },
+        currentPointView: { currentPoint: BigInt(0) },
       } as PrismaWallet;
 
       await expect(validator.validateTransfer(100, null, toWallet)).rejects.toThrow(
@@ -146,7 +146,7 @@ describe("WalletValidator", () => {
     it("should throw ValidationError if toWallet is null", async () => {
       const fromWallet = {
         id: "wallet-from",
-        currentPointView: { currentPoint: 500 },
+        currentPointView: { currentPoint: BigInt(500) },
       } as PrismaWallet;
 
       await expect(validator.validateTransfer(100, fromWallet, null)).rejects.toThrow(
@@ -161,7 +161,7 @@ describe("WalletValidator", () => {
       } as PrismaWallet;
       const toWallet = {
         id: "wallet-to",
-        currentPointView: { currentPoint: 0 },
+        currentPointView: { currentPoint: BigInt(0) },
       } as PrismaWallet;
 
       await expect(validator.validateTransfer(100, fromWallet, toWallet)).rejects.toThrow(
@@ -172,11 +172,11 @@ describe("WalletValidator", () => {
     it("should throw InsufficientBalanceError if currentPoint is insufficient", async () => {
       const fromWallet = {
         id: "wallet-from",
-        currentPointView: { currentPoint: 50 },
+        currentPointView: { currentPoint: BigInt(50) },
       } as PrismaWallet;
       const toWallet = {
         id: "wallet-to",
-        currentPointView: { currentPoint: 0 },
+        currentPointView: { currentPoint: BigInt(0) },
       } as PrismaWallet;
 
       await expect(validator.validateTransfer(100, fromWallet, toWallet)).rejects.toThrow(

--- a/src/application/domain/account/wallet/schema/type.graphql
+++ b/src/application/domain/account/wallet/schema/type.graphql
@@ -21,12 +21,12 @@ type Wallet {
 
 type CurrentPointView {
     walletId: String
-    currentPoint: Int!
+    currentPoint: BigInt!
 }
 
 type AccumulatedPointView {
     walletId: String
-    accumulatedPoint: Int!
+    accumulatedPoint: BigInt!
 }
 
 # ------------------------------

--- a/src/application/domain/account/wallet/validator.ts
+++ b/src/application/domain/account/wallet/validator.ts
@@ -1,6 +1,6 @@
 import { IContext } from "@/types/server";
 import { Prisma, TransactionReason } from "@prisma/client";
-import { InsufficientBalanceError, ValidationError } from "@/errors/graphql";
+import { DatabaseError, InsufficientBalanceError, ValidationError } from "@/errors/graphql";
 import { PrismaWallet } from "@/application/domain/account/wallet/data/type";
 import WalletService from "@/application/domain/account/wallet/service";
 import { inject, injectable } from "tsyringe";
@@ -89,8 +89,11 @@ export default class WalletValidator {
     }
     const { currentPoint } = fromWallet.currentPointView || {};
 
-    if (currentPoint !== undefined && currentPoint < transferPoints) {
-      throw new InsufficientBalanceError(currentPoint ?? 0, transferPoints);
+    if (typeof currentPoint !== "bigint") {
+      throw new DatabaseError("Invalid point type: expected bigint");
+    }
+    if (currentPoint < BigInt(transferPoints)) {
+      throw new InsufficientBalanceError(currentPoint.toString(), transferPoints);
     }
   }
 }

--- a/src/application/domain/content/image/service.ts
+++ b/src/application/domain/content/image/service.ts
@@ -4,6 +4,13 @@ import { gcsBucketName, storage } from "@/infrastructure/libs/storage";
 import path from "path";
 import { injectable } from "tsyringe";
 
+type FileUpload = {
+  filename: string;
+  mimetype: string;
+  encoding: string;
+  createReadStream: () => NodeJS.ReadableStream;
+};
+
 @injectable()
 export default class ImageService {
   async uploadPublicImage(
@@ -11,10 +18,9 @@ export default class ImageService {
     folderPath: string,
   ): Promise<Prisma.ImageCreateWithoutUsersInput> {
     const { file, alt, caption } = image;
-    const {
-      // @ts-expect-error Library type definition is not compatible with the original library
-      file: { createReadStream, filename: rawFilename, mimetype: mime },
-    } = await file;
+    const uploadFile = (await file) as unknown as FileUpload;
+
+    const { createReadStream, filename: rawFilename, mimetype: mime } = uploadFile;
 
     const ext = path.extname(rawFilename);
     const filename = `${Date.now()}_${rawFilename}`;

--- a/src/errors/graphql.ts
+++ b/src/errors/graphql.ts
@@ -69,10 +69,10 @@ export class RateLimitError extends ApolloError {
 
 // Wallet
 export class InsufficientBalanceError extends ApolloError {
-  public currentBalance: number;
+  public currentBalance: string;
   public requestedAmount: number;
 
-  constructor(currentBalance: number, requestedAmount: number) {
+  constructor(currentBalance: string, requestedAmount: number) {
     const message = `Insufficient balance: current balance ${currentBalance} is less than requested amount ${requestedAmount}`;
     super(message, "INSUFFICIENT_BALANCE");
     this.currentBalance = currentBalance;

--- a/src/infrastructure/prisma/factories/__generated__/index.ts
+++ b/src/infrastructure/prisma/factories/__generated__/index.ts
@@ -6999,7 +6999,7 @@ export const defineMembershipHostedOpportunityCountViewFactory = (<TOptions exte
 defineMembershipHostedOpportunityCountViewFactory.withTransientFields = defaultTransientFieldValues => options => defineMembershipHostedOpportunityCountViewFactoryInternal(options, defaultTransientFieldValues);
 
 type CurrentPointViewScalarOrEnumFields = {
-    currentPoint: number;
+    currentPoint: (bigint | number);
 };
 
 type CurrentPointViewwalletFactory = {
@@ -7008,7 +7008,7 @@ type CurrentPointViewwalletFactory = {
 };
 
 type CurrentPointViewFactoryDefineInput = {
-    currentPoint?: number;
+    currentPoint?: (bigint | number);
     wallet: CurrentPointViewwalletFactory | Prisma.WalletCreateNestedOneWithoutCurrentPointViewInput;
 };
 
@@ -7052,7 +7052,7 @@ function autoGenerateCurrentPointViewScalarsOrEnums({ seq }: {
     readonly seq: number;
 }): CurrentPointViewScalarOrEnumFields {
     return {
-        currentPoint: getScalarFieldValueGenerator().Int({ modelName: "CurrentPointView", fieldName: "currentPoint", isId: false, isUnique: false, seq })
+        currentPoint: getScalarFieldValueGenerator().BigInt({ modelName: "CurrentPointView", fieldName: "currentPoint", isId: false, isUnique: false, seq })
     };
 }
 
@@ -7150,7 +7150,7 @@ export const defineCurrentPointViewFactory = (<TOptions extends CurrentPointView
 defineCurrentPointViewFactory.withTransientFields = defaultTransientFieldValues => options => defineCurrentPointViewFactoryInternal(options, defaultTransientFieldValues);
 
 type AccumulatedPointViewScalarOrEnumFields = {
-    accumulatedPoint: number;
+    accumulatedPoint: (bigint | number);
 };
 
 type AccumulatedPointViewwalletFactory = {
@@ -7159,7 +7159,7 @@ type AccumulatedPointViewwalletFactory = {
 };
 
 type AccumulatedPointViewFactoryDefineInput = {
-    accumulatedPoint?: number;
+    accumulatedPoint?: (bigint | number);
     wallet: AccumulatedPointViewwalletFactory | Prisma.WalletCreateNestedOneWithoutAccumulatedPointViewInput;
 };
 
@@ -7203,7 +7203,7 @@ function autoGenerateAccumulatedPointViewScalarsOrEnums({ seq }: {
     readonly seq: number;
 }): AccumulatedPointViewScalarOrEnumFields {
     return {
-        accumulatedPoint: getScalarFieldValueGenerator().Int({ modelName: "AccumulatedPointView", fieldName: "accumulatedPoint", isId: false, isUnique: false, seq })
+        accumulatedPoint: getScalarFieldValueGenerator().BigInt({ modelName: "AccumulatedPointView", fieldName: "accumulatedPoint", isId: false, isUnique: false, seq })
     };
 }
 

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -505,7 +505,7 @@ view CurrentPointView {
   walletId String @id @map("wallet_id")
   wallet   Wallet @relation(fields: [walletId], references: [id])
 
-  currentPoint Int @map("current_point")
+  currentPoint BigInt @map("current_point") @db.BigInt
 
   @@map("mv_current_points")
 }
@@ -514,7 +514,7 @@ view AccumulatedPointView {
   walletId String @id @map("wallet_id")
   wallet   Wallet @relation(fields: [walletId], references: [id])
 
-  accumulatedPoint Int @map("accumulated_point")
+  accumulatedPoint BigInt @map("accumulated_point") @db.BigInt
 
   @@map("mv_accumulated_points")
 }

--- a/src/presentation/graphql/resolver.ts
+++ b/src/presentation/graphql/resolver.ts
@@ -18,6 +18,7 @@ import TransactionResolver from "@/application/domain/transaction/controller/res
 import TicketClaimLinkResolver from "@/application/domain/reward/ticketClaimLink/controller/resolver";
 import TicketIssuerResolver from "@/application/domain/reward/ticketIssuer/controller/resolver";
 import MasterResolver from "@/application/domain/location/master/controller/resolver";
+import scalarResolvers from "@/presentation/graphql/scalar";
 
 const identity = container.resolve(IdentityResolver);
 const user = container.resolve(UserResolver);
@@ -102,6 +103,8 @@ const resolvers = {
   Utility: utility.Utility,
 
   Transaction: transaction.Transaction,
+
+  ...scalarResolvers,
 };
 
 export default resolvers;

--- a/src/presentation/graphql/scalar/index.ts
+++ b/src/presentation/graphql/scalar/index.ts
@@ -25,9 +25,36 @@ const DecimalScalar = new GraphQLScalarType({
   },
 });
 
+const BigIntScalar = new GraphQLScalarType({
+  name: "BigInt",
+  description: "Custom scalar for bigint (serialized as string)",
+
+  parseValue(value: unknown) {
+    if (typeof value === "string" || typeof value === "number") {
+      return BigInt(value);
+    }
+    throw new Error("Invalid BigInt");
+  },
+
+  serialize(value: unknown) {
+    if (typeof value === "bigint") {
+      return value.toString(); // GraphQLは bigint を直接返せないため string 化
+    }
+    throw new Error("Expected bigint for serialization");
+  },
+
+  parseLiteral(ast) {
+    if (ast.kind === Kind.INT || ast.kind === Kind.STRING) {
+      return BigInt(ast.value);
+    }
+    throw new Error("Invalid BigInt literal");
+  },
+});
+
 const scalarResolvers = {
   Decimal: DecimalScalar,
   Upload: GraphQLUpload,
+  BigInt: BigIntScalar,
 };
 
 export default scalarResolvers;

--- a/src/presentation/graphql/schema/utils.graphql
+++ b/src/presentation/graphql/schema/utils.graphql
@@ -60,6 +60,7 @@ scalar Datetime
 scalar JSON
 scalar Decimal
 scalar Upload
+scalar BigInt
 
 # ------------------------------------------------
 # Input Types

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -16,6 +16,7 @@ export type Scalars = {
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }
   Float: { input: number; output: number; }
+  BigInt: { input: bigint; output: bigint; }
   Datetime: { input: Date; output: Date; }
   Decimal: { input: string; output: string; }
   JSON: { input: any; output: any; }
@@ -24,7 +25,7 @@ export type Scalars = {
 
 export type GqlAccumulatedPointView = {
   __typename?: 'AccumulatedPointView';
-  accumulatedPoint: Scalars['Int']['output'];
+  accumulatedPoint: Scalars['BigInt']['output'];
   walletId?: Maybe<Scalars['String']['output']>;
 };
 
@@ -288,7 +289,7 @@ export type GqlCommunityUpdateProfileSuccess = {
 
 export type GqlCurrentPointView = {
   __typename?: 'CurrentPointView';
-  currentPoint: Scalars['Int']['output'];
+  currentPoint: Scalars['BigInt']['output'];
   walletId?: Maybe<Scalars['String']['output']>;
 };
 
@@ -2764,6 +2765,7 @@ export type GqlResolversTypes = ResolversObject<{
   AuthZDirectiveCompositeRulesInput: GqlAuthZDirectiveCompositeRulesInput;
   AuthZDirectiveDeepCompositeRulesInput: GqlAuthZDirectiveDeepCompositeRulesInput;
   AuthZRules: GqlAuthZRules;
+  BigInt: ResolverTypeWrapper<Scalars['BigInt']['output']>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
   CheckCommunityPermissionInput: GqlCheckCommunityPermissionInput;
   CheckIsSelfPermissionInput: GqlCheckIsSelfPermissionInput;
@@ -3061,6 +3063,7 @@ export type GqlResolversParentTypes = ResolversObject<{
   ArticlesConnection: Omit<GqlArticlesConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['ArticleEdge']>>> };
   AuthZDirectiveCompositeRulesInput: GqlAuthZDirectiveCompositeRulesInput;
   AuthZDirectiveDeepCompositeRulesInput: GqlAuthZDirectiveDeepCompositeRulesInput;
+  BigInt: Scalars['BigInt']['output'];
   Boolean: Scalars['Boolean']['output'];
   CheckCommunityPermissionInput: GqlCheckCommunityPermissionInput;
   CheckIsSelfPermissionInput: GqlCheckIsSelfPermissionInput;
@@ -3328,7 +3331,7 @@ export type GqlRequireRoleDirectiveArgs = {
 export type GqlRequireRoleDirectiveResolver<Result, Parent, ContextType = any, Args = GqlRequireRoleDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
 export type GqlAccumulatedPointViewResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AccumulatedPointView'] = GqlResolversParentTypes['AccumulatedPointView']> = ResolversObject<{
-  accumulatedPoint?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  accumulatedPoint?: Resolver<GqlResolversTypes['BigInt'], ParentType, ContextType>;
   walletId?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
@@ -3390,6 +3393,10 @@ export type GqlArticlesConnectionResolvers<ContextType = any, ParentType extends
   totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
+
+export interface GqlBigIntScalarConfig extends GraphQLScalarTypeConfig<GqlResolversTypes['BigInt'], any> {
+  name: 'BigInt';
+}
 
 export type GqlCitiesConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CitiesConnection'] = GqlResolversParentTypes['CitiesConnection']> = ResolversObject<{
   edges?: Resolver<Array<GqlResolversTypes['CityEdge']>, ParentType, ContextType>;
@@ -3472,7 +3479,7 @@ export type GqlCommunityUpdateProfileSuccessResolvers<ContextType = any, ParentT
 }>;
 
 export type GqlCurrentPointViewResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CurrentPointView'] = GqlResolversParentTypes['CurrentPointView']> = ResolversObject<{
-  currentPoint?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  currentPoint?: Resolver<GqlResolversTypes['BigInt'], ParentType, ContextType>;
   walletId?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
@@ -4556,6 +4563,7 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   ArticleUpdateContentPayload?: GqlArticleUpdateContentPayloadResolvers<ContextType>;
   ArticleUpdateContentSuccess?: GqlArticleUpdateContentSuccessResolvers<ContextType>;
   ArticlesConnection?: GqlArticlesConnectionResolvers<ContextType>;
+  BigInt?: GraphQLScalarType;
   CitiesConnection?: GqlCitiesConnectionResolvers<ContextType>;
   City?: GqlCityResolvers<ContextType>;
   CityEdge?: GqlCityEdgeResolvers<ContextType>;

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -2306,6 +2306,7 @@ export type GqlTicketsConnection = {
 export type GqlTransaction = {
   __typename?: 'Transaction';
   createdAt?: Maybe<Scalars['Datetime']['output']>;
+  createdByUser?: Maybe<GqlUser>;
   fromPointChange?: Maybe<Scalars['Int']['output']>;
   fromWallet?: Maybe<GqlWallet>;
   id: Scalars['ID']['output'];
@@ -4342,6 +4343,7 @@ export type GqlTicketsConnectionResolvers<ContextType = any, ParentType extends 
 
 export type GqlTransactionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Transaction'] = GqlResolversParentTypes['Transaction']> = ResolversObject<{
   createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  createdByUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
   fromPointChange?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
   fromWallet?: Resolver<Maybe<GqlResolversTypes['Wallet']>, ParentType, ContextType>;
   id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;


### PR DESCRIPTION
- Introduced a new `createdByUser` field in the `GqlTransaction` GraphQL schema.
- Updated the relevant resolver to provide support for fetching this field.
- Enhances the schema to include user information linked to each transaction.
- No breaking changes were introduced, and functionality should remain stable.