### PR TITLE
Add transaction timeout configuration in Prisma client methods

### DIFF
--- a/src/infrastructure/prisma/client.ts
+++ b/src/infrastructure/prisma/client.ts
@@ -15,8 +15,20 @@ export const prismaClient = new PrismaClient({
     { level: "warn", emit: "stdout" },
   ],
 });
-prismaClient.$on("query", async ({ query, params }) => {
-  logger.debug("Prisma: Query issued.", { query, params });
+prismaClient.$on("query", async ({ query, params, duration }) => {
+  logger.debug("Prisma query executed", {
+    query,
+    params,
+    duration,
+  });
+
+  if (duration > 1000) {
+    logger.warn("Slow query detected", {
+      query,
+      params,
+      duration,
+    });
+  }
 });
 prismaClient.$on("error", async ({ message, target }) => {
   logger.error("Prisma: Error occurred.", { message, target });


### PR DESCRIPTION
###Error
```
{
  "insertId": "........G_wgI0pG_ipC6fGcA4V6eY71",
  "jsonPayload": {
    "message": "Invalid prisma.$queryRawTyped() invocation:\n\nTransaction API error: Transaction already closed: A query cannot be executed on an expired transaction. The timeout for this transaction was 5000 ms, however 5236 ms passed since the start of the transaction. Consider increasing the interactive transaction timeout or doing less work in the transaction.",
    "metadata": {
      "severity": "ERROR",
      "target": "$queryRawTyped"
    }
  },
  "logName": "projects/co-creation-dao-prod/logs/winston_log",
  "payload": "jsonPayload",
  "receiveLocation": "us-central1",
  "receiveTimestamp": "2025-07-08T15:43:25.787231285Z",
  "resource": {
    "type": "cloud_run_revision",
    "labels": {
      "configuration_name": "prod-civicship-api",
      "location": "us-central1",
      "project_id": "co-creation-dao-prod",
      "revision_name": "prod-civicship-api-00050-m5t",
      "service_name": "prod-civicship-api"
    }
  },
  "severity": "ERROR",
  "timestamp": "2025-07-08T15:43:25.714999914Z",
  "traceSampled": false
}
```

### Description

This pull request introduces a 10-second timeout for transactions in the `setRls` and `bypassRls` methods of the Prisma client.  
This ensures that transactions are bounded to prevent indefinite execution.  

### Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Code changes reviewed and approved
- [ ] All checks completed successfully