### PR TITLE
Add logging and timeout mechanism for transactions

### DIFF
--- a/src/infrastructure/prisma/client.ts
+++ b/src/infrastructure/prisma/client.ts
@@ -15,8 +15,20 @@ export const prismaClient = new PrismaClient({
     { level: "warn", emit: "stdout" },
   ],
 });
-prismaClient.$on("query", async ({ query, params }) => {
-  logger.debug("Prisma: Query issued.", { query, params });
+prismaClient.$on("query", async ({ query, params, duration }) => {
+  logger.debug("Prisma query executed", {
+    query,
+    params,
+    duration,
+  });
+
+  if (duration > 1000) {
+    logger.warn("Slow query detected", {
+      query,
+      params,
+      duration,
+    });
+  }
 });
 prismaClient.$on("error", async ({ message, target }) => {
   logger.error("Prisma: Error occurred.", { message, target });


### PR DESCRIPTION
### Description

This pull request introduces logging for transaction duration and slow Prisma queries, along with a new timeout configuration for certain database operations.

### Enhancements:
- **Transaction Duration Logs**: Logs are added to monitor execution time in `onlyBelongingCommunity` and `bypassRls` methods, with warnings for durations exceeding 3000ms.
- **Slow Query Logs**: Added logs to detect and warn about Prisma queries taking longer than 1 second.

### Features:
- **Timeout Configuration**: Implemented a 10-second transaction timeout in `setRls` and `bypassRls` methods to prevent indefinite execution. 

These changes improve performance monitoring and ensure better transaction handling.