### PR TITLE
Refactor `create` method in opportunity data converter

### DIFF
--- a/src/application/domain/experience/opportunity/data/converter.ts
+++ b/src/application/domain/experience/opportunity/data/converter.ts
@@ -65,44 +65,42 @@ export default class OpportunityConverter {
     };
   }
 
-  create(
+  create = (
     input: GqlOpportunityCreateInput,
     communityId: string,
-    currentUserId: string,
+    userId: string,
   ): {
     data: Omit<Prisma.OpportunityCreateInput, "images">;
     images: GqlImageInput[];
-  } {
-    const { images, placeId, createdBy, slots, requiredUtilityIds, relatedArticleIds, ...prop } =
+  } => {
+    const { images, placeId, slots, createdBy, requiredUtilityIds, relatedArticleIds, ...rest } =
       input;
 
     return {
       data: {
-        ...prop,
+        ...rest,
         community: { connect: { id: communityId } },
-        createdByUser: { connect: { id: currentUserId } },
+        createdByUser: { connect: { id: userId } },
         ...(placeId && {
           place: { connect: { id: placeId } },
         }),
-        ...(slots && {
-          slots: {
-            create: slots.map((slot) => ({ ...slot })),
-          },
+        ...(slots?.length && {
+          slots: { create: slots },
         }),
         ...(requiredUtilityIds?.length && {
           requiredUtilities: {
-            connect: requiredUtilityIds.map((id) => ({ id })),
+            connect: requiredUtilityIds.filter(Boolean).map((id) => ({ id })),
           },
         }),
         ...(relatedArticleIds?.length && {
           articles: {
-            connect: relatedArticleIds.map((id) => ({ id })),
+            connect: relatedArticleIds.filter(Boolean).map((id) => ({ id })),
           },
         }),
       },
       images: images ?? [],
     };
-  }
+  };
 
   update(input: GqlOpportunityUpdateContentInput): {
     data: Omit<Prisma.OpportunityUpdateInput, "images">;


### PR DESCRIPTION
### Description

This pull request refactors the `create` method in the opportunity data converter for improved clarity and consistency. Key changes include:

- Conversion of the `create` method to an arrow function.
- Renaming variables for better readability (`prop` to `rest`, `currentUserId` to `userId`).
- Simplification of conditional logic using optional chaining and `.filter(Boolean)`.
- Streamlining of `slots`, `requiredUtilityIds`, and `relatedArticleIds` handling to enhance readability. 

These adjustments aim to maintain the functionality while making the code more maintainable and easier to understand.

---

### Checklist

- [ ] Documentation has been updated to reflect these changes as needed.
- [ ] Tests have been added or updated to verify the functionality.  
- [ ] All automated tests pass successfully.