### PR TITLE
Refactor opportunity input logic and schema for clarity

### DIFF
--- a/src/application/domain/experience/opportunity/data/converter.ts
+++ b/src/application/domain/experience/opportunity/data/converter.ts
@@ -116,14 +116,14 @@ export default class OpportunityConverter {
         ...(placeId && {
           place: { connect: { id: placeId } },
         }),
-        ...(requiredUtilityIds?.length && {
+        ...(requiredUtilityIds !== undefined && {
           requiredUtilities: {
-            connect: requiredUtilityIds.map((id) => ({ id })),
+            set: requiredUtilityIds.map((id) => ({ id }))
           },
         }),
-        ...(relatedArticleIds?.length && {
+        ...(relatedArticleIds !== undefined && {
           articles: {
-            connect: relatedArticleIds.map((id) => ({ id })),
+            set: relatedArticleIds.map((id) => ({ id }))
           },
         }),
       },

--- a/src/application/domain/experience/opportunity/data/converter.ts
+++ b/src/application/domain/experience/opportunity/data/converter.ts
@@ -108,29 +108,24 @@ export default class OpportunityConverter {
     data: Omit<Prisma.OpportunityUpdateInput, "images">;
     images: GqlImageInput[];
   } {
-    const { place, images, ...prop } = input;
-
-    let finalPlace: Prisma.PlaceUpdateOneWithoutOpportunitiesNestedInput | undefined = undefined;
-
-    if (place) {
-      finalPlace = place.where
-        ? { connect: { id: place.where } }
-        : (() => {
-            const { cityCode, communityId, ...restCreate } = place.create!;
-            return {
-              create: {
-                ...restCreate,
-                city: { connect: { code: cityCode } },
-                community: { connect: { id: communityId } },
-              },
-            };
-          })();
-    }
+    const { images, placeId, requiredUtilityIds, relatedArticleIds, ...prop } = input;
 
     return {
       data: {
         ...prop,
-        ...(finalPlace ? { place: finalPlace } : {}),
+        ...(placeId && {
+          place: { connect: { id: placeId } },
+        }),
+        ...(requiredUtilityIds?.length && {
+          requiredUtilities: {
+            connect: requiredUtilityIds.map((id) => ({ id })),
+          },
+        }),
+        ...(relatedArticleIds?.length && {
+          articles: {
+            connect: relatedArticleIds.map((id) => ({ id })),
+          },
+        }),
       },
       images: images ?? [],
     };

--- a/src/application/domain/experience/opportunity/schema/mutation.graphql
+++ b/src/application/domain/experience/opportunity/schema/mutation.graphql
@@ -62,17 +62,16 @@ input OpportunityUpdateContentInput {
     images: [ImageInput!]
 
     category: OpportunityCategory!
+
     publishStatus: PublishStatus!
     requireApproval: Boolean!
-
     requiredUtilityIds: [ID!]
-    capacity: Int
+
     pointsToEarn: Int
     feeRequired: Int
 
-    place: NestedPlaceConnectOrCreateInput
-    startsAt: Datetime
-    endsAt: Datetime
+    relatedArticleIds: [ID!]
+    placeId: ID
 }
 
 input OpportunitySetPublishStatusInput {

--- a/src/application/domain/experience/opportunity/service.ts
+++ b/src/application/domain/experience/opportunity/service.ts
@@ -1,5 +1,4 @@
 import {
-  GqlNestedPlaceConnectOrCreateInput,
   GqlOpportunityCreateInput,
   GqlOpportunityFilterInput,
   GqlOpportunityUpdateContentInput,
@@ -92,7 +91,6 @@ export default class OpportunityService {
     tx: Prisma.TransactionClient,
   ) {
     await this.findOpportunityOrThrow(ctx, id);
-    validatePlaceInput(input.place);
 
     const { data, images } = this.converter.update(input);
 
@@ -133,16 +131,6 @@ export default class OpportunityService {
         `Validation error: publishStatus must be one of ${allowedStatuses.join(", ")}`,
         [JSON.stringify(filter?.publishStatus)],
       );
-    }
-  }
-}
-
-function validatePlaceInput(place?: GqlNestedPlaceConnectOrCreateInput): void {
-  if (place) {
-    if ((place.where && place.create) || (!place.where && !place.create)) {
-      throw new ValidationError(`For Place, choose only one of "where" or "create."`, [
-        JSON.stringify(place),
-      ]);
     }
   }
 }

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1294,18 +1294,16 @@ export type GqlOpportunitySortInput = {
 
 export type GqlOpportunityUpdateContentInput = {
   body?: InputMaybe<Scalars['String']['input']>;
-  capacity?: InputMaybe<Scalars['Int']['input']>;
   category: GqlOpportunityCategory;
   description: Scalars['String']['input'];
-  endsAt?: InputMaybe<Scalars['Datetime']['input']>;
   feeRequired?: InputMaybe<Scalars['Int']['input']>;
   images?: InputMaybe<Array<GqlImageInput>>;
-  place?: InputMaybe<GqlNestedPlaceConnectOrCreateInput>;
+  placeId?: InputMaybe<Scalars['ID']['input']>;
   pointsToEarn?: InputMaybe<Scalars['Int']['input']>;
   publishStatus: GqlPublishStatus;
+  relatedArticleIds?: InputMaybe<Array<Scalars['ID']['input']>>;
   requireApproval: Scalars['Boolean']['input'];
   requiredUtilityIds?: InputMaybe<Array<Scalars['ID']['input']>>;
-  startsAt?: InputMaybe<Scalars['Datetime']['input']>;
   title: Scalars['String']['input'];
 };
 


### PR DESCRIPTION
### Description

This pull request refactors the opportunity input logic and schema to improve clarity and reduce redundancy:

- Simplified input data conversion logic by directly connecting `placeId` and adding support for `requiredUtilityIds` and `relatedArticleIds`.
- Removed the unused `validatePlaceInput` function along with related imports and redundant validation logic.
- Updated the Opportunity schema by:
  - Replacing the `place` field with `placeId`.
  - Adding the `relatedArticleIds` field for linking articles.
  - Removing `capacity`, `startsAt`, and `endsAt` fields for streamlined structure.
- Applied changes consistently in the GraphQL schema and TypeScript types.