### PR TITLE
Add communityId filtering to evaluations

### DIFF
--- a/src/application/domain/experience/evaluation/data/converter.ts
+++ b/src/application/domain/experience/evaluation/data/converter.ts
@@ -10,6 +10,7 @@ export default class EvaluationConverter {
     if (!filter) return {};
 
     if (filter.status) conditions.push({ status: filter.status });
+    if (filter.communityId) conditions.push({ participation: { communityId: filter.communityId } });
     if (filter.evaluatorId) conditions.push({ evaluatorId: filter.evaluatorId });
     if (filter.participationId) conditions.push({ participationId: filter.participationId });
 

--- a/src/application/domain/experience/evaluation/schema/query.graphql
+++ b/src/application/domain/experience/evaluation/schema/query.graphql
@@ -33,6 +33,7 @@ input EvaluationFilterInput {
     status: EvaluationStatus
     evaluatorId: ID
     participationId: ID
+    communityId: ID
 }
 
 input EvaluationSortInput {

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -412,6 +412,7 @@ export type GqlEvaluationEdge = GqlEdge & {
 };
 
 export type GqlEvaluationFilterInput = {
+  communityId?: InputMaybe<Scalars['ID']['input']>;
   evaluatorId?: InputMaybe<Scalars['ID']['input']>;
   participationId?: InputMaybe<Scalars['ID']['input']>;
   status?: InputMaybe<GqlEvaluationStatus>;


### PR DESCRIPTION
### Description

This pull request adds support for filtering evaluations by `communityId`.

- Introduced a `communityId` filter in the evaluation data converter.
- Extended the GraphQL schema by adding the `communityId` field to `EvaluationFilterInput`.
- Updated TypeScript types to reflect schema changes.
  
These changes enhance the flexibility and precision of evaluation data queries by allowing filtering based on community ID.  

### Tasks

- [ ] Add tests to verify filtering functionality with different `communityId` values.
- [ ] Update documentation regarding the new `communityId` filter in evaluation queries.  

### Related Issues and Discussion

N/A  

### Additional Notes

N/A  