### PR TITLE
Add opportunity slot creation and capacity update features

### DIFF
--- a/src/__tests__/unit/experience/opportunitySlot.service.test.ts
+++ b/src/__tests__/unit/experience/opportunitySlot.service.test.ts
@@ -2,7 +2,7 @@ import "reflect-metadata";
 import { container } from "tsyringe";
 import OpportunitySlotService from "@/application/domain/experience/opportunitySlot/service";
 import { NotFoundError } from "@/errors/graphql";
-import { Prisma } from "@prisma/client";
+import { OpportunitySlotHostingStatus, Prisma } from "@prisma/client";
 import { IContext } from "@/types/server";
 
 class MockOpportunitySlotRepository {
@@ -45,12 +45,16 @@ describe("OpportunitySlotService", () => {
   describe("setOpportunitySlotHostingStatus", () => {
     it("should set hosting status after finding the slot", async () => {
       mockRepository.find.mockResolvedValue({ id: "slot-1" });
-      mockRepository.setHostingStatus.mockResolvedValue({ id: "slot-1", hostingStatus: "HOSTING" });
+      mockRepository.setHostingStatus.mockResolvedValue({
+        id: "slot-1",
+        hostingStatus: OpportunitySlotHostingStatus.SCHEDULED,
+      });
 
       const result = await service.setOpportunitySlotHostingStatus(
         mockCtx,
         "slot-1",
-        "HOSTING" as any,
+        OpportunitySlotHostingStatus.SCHEDULED,
+        20,
         mockTx,
       );
 
@@ -58,17 +62,27 @@ describe("OpportunitySlotService", () => {
       expect(mockRepository.setHostingStatus).toHaveBeenCalledWith(
         mockCtx,
         "slot-1",
-        "HOSTING",
+        OpportunitySlotHostingStatus.SCHEDULED,
+        20,
         mockTx,
       );
-      expect(result).toEqual({ id: "slot-1", hostingStatus: "HOSTING" });
+      expect(result).toEqual({
+        id: "slot-1",
+        hostingStatus: OpportunitySlotHostingStatus.SCHEDULED,
+      });
     });
 
     it("should throw NotFoundError if slot not found", async () => {
       mockRepository.find.mockResolvedValue(null);
 
       await expect(
-        service.setOpportunitySlotHostingStatus(mockCtx, "slot-1", "HOSTING" as any, mockTx),
+        service.setOpportunitySlotHostingStatus(
+          mockCtx,
+          "slot-1",
+          OpportunitySlotHostingStatus.SCHEDULED,
+          20,
+          mockTx,
+        ),
       ).rejects.toThrow(NotFoundError);
     });
   });

--- a/src/application/domain/experience/opportunitySlot/controller/resolver.ts
+++ b/src/application/domain/experience/opportunitySlot/controller/resolver.ts
@@ -3,6 +3,7 @@ import {
   GqlQueryOpportunitySlotArgs,
   GqlMutationOpportunitySlotSetHostingStatusArgs,
   GqlMutationOpportunitySlotsBulkUpdateArgs,
+  GqlMutationOpportunitySlotCreateArgs,
 } from "@/types/graphql";
 import { IContext } from "@/types/server";
 import { injectable, inject } from "tsyringe";
@@ -25,6 +26,14 @@ export default class OpportunitySlotResolver {
   };
 
   Mutation = {
+    opportunitySlotCreate: (
+      _: unknown,
+      args: GqlMutationOpportunitySlotCreateArgs,
+      ctx: IContext,
+    ) => {
+      return this.slotUseCase.managerCreateOpportunitySlot(args, ctx);
+    },
+
     opportunitySlotSetHostingStatus: (
       _: unknown,
       args: GqlMutationOpportunitySlotSetHostingStatusArgs,

--- a/src/application/domain/experience/opportunitySlot/data/converter.ts
+++ b/src/application/domain/experience/opportunitySlot/data/converter.ts
@@ -51,6 +51,18 @@ export default class OpportunitySlotConverter {
     return [{ startsAt: sort?.startsAt ?? Prisma.SortOrder.desc }];
   }
 
+  create(
+    opportunityId: string,
+    input: GqlOpportunitySlotCreateInput,
+  ): Prisma.OpportunitySlotCreateInput {
+    return {
+      opportunity: { connect: { id: opportunityId } },
+      capacity: input.capacity,
+      startsAt: input.startsAt,
+      endsAt: input.endsAt,
+    };
+  }
+
   createMany(
     opportunityId: string,
     inputs: GqlOpportunitySlotCreateInput[],

--- a/src/application/domain/experience/opportunitySlot/data/converter.ts
+++ b/src/application/domain/experience/opportunitySlot/data/converter.ts
@@ -2,6 +2,7 @@ import { Prisma } from "@prisma/client";
 import {
   GqlOpportunitySlotCreateInput,
   GqlOpportunitySlotFilterInput,
+  GqlOpportunitySlotSetHostingStatusInput,
   GqlOpportunitySlotSortInput,
   GqlOpportunitySlotUpdateInput,
 } from "@/types/graphql";
@@ -74,11 +75,14 @@ export default class OpportunitySlotConverter {
     }));
   }
 
-  setStatus(input: GqlOpportunitySlotUpdateInput): Prisma.OpportunitySlotUpdateInput {
-    const { startsAt, endsAt } = input;
+  setStatus(input: GqlOpportunitySlotSetHostingStatusInput): Prisma.OpportunitySlotUpdateInput {
+    const { hostingStatus, capacity, startsAt, endsAt } = input;
+
     return {
-      startsAt: startsAt,
-      endsAt: endsAt,
+      hostingStatus,
+      ...(capacity !== undefined ? { capacity } : {}),
+      ...(startsAt !== undefined ? { startsAt } : {}),
+      ...(endsAt !== undefined ? { endsAt } : {}),
     };
   }
 

--- a/src/application/domain/experience/opportunitySlot/data/interface.ts
+++ b/src/application/domain/experience/opportunitySlot/data/interface.ts
@@ -1,4 +1,4 @@
-import { OpportunitySlotHostingStatus, Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import { IContext } from "@/types/server";
 import {
   PrismaOpportunitySlotDetail,
@@ -39,8 +39,7 @@ export interface IOpportunitySlotRepository {
   setHostingStatus(
     ctx: IContext,
     id: string,
-    hostingStatus: OpportunitySlotHostingStatus,
-    capacity: number,
+    data: Prisma.OpportunitySlotUpdateInput,
     tx: Prisma.TransactionClient,
   ): Promise<PrismaOpportunitySlotSetHostingStatus>;
 

--- a/src/application/domain/experience/opportunitySlot/data/interface.ts
+++ b/src/application/domain/experience/opportunitySlot/data/interface.ts
@@ -40,6 +40,7 @@ export interface IOpportunitySlotRepository {
     ctx: IContext,
     id: string,
     hostingStatus: OpportunitySlotHostingStatus,
+    capacity: number,
     tx: Prisma.TransactionClient,
   ): Promise<PrismaOpportunitySlotSetHostingStatus>;
 

--- a/src/application/domain/experience/opportunitySlot/data/repository.ts
+++ b/src/application/domain/experience/opportunitySlot/data/repository.ts
@@ -52,6 +52,19 @@ export default class OpportunitySlotRepository implements IOpportunitySlotReposi
     });
   }
 
+  async create(
+    ctx: IContext,
+    data: Prisma.OpportunitySlotCreateInput,
+    tx?: Prisma.TransactionClient,
+  ) {
+    if (tx) {
+      return tx.opportunitySlot.create({ data, select: opportunitySlotSelectDetail });
+    }
+    return ctx.issuer.public(ctx, (tx) =>
+      tx.opportunitySlot.create({ data, select: opportunitySlotSelectDetail }),
+    );
+  }
+
   async createMany(
     ctx: IContext,
     data: Prisma.OpportunitySlotCreateManyInput[],

--- a/src/application/domain/experience/opportunitySlot/data/repository.ts
+++ b/src/application/domain/experience/opportunitySlot/data/repository.ts
@@ -1,4 +1,4 @@
-import { OpportunitySlotHostingStatus, Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import { IContext } from "@/types/server";
 import {
   opportunitySlotReserveInclude,
@@ -55,14 +55,9 @@ export default class OpportunitySlotRepository implements IOpportunitySlotReposi
   async create(
     ctx: IContext,
     data: Prisma.OpportunitySlotCreateInput,
-    tx?: Prisma.TransactionClient,
+    tx: Prisma.TransactionClient,
   ) {
-    if (tx) {
-      return tx.opportunitySlot.create({ data, select: opportunitySlotSelectDetail });
-    }
-    return ctx.issuer.public(ctx, (tx) =>
-      tx.opportunitySlot.create({ data, select: opportunitySlotSelectDetail }),
-    );
+    return tx.opportunitySlot.create({ data, select: opportunitySlotSelectDetail });
   }
 
   async createMany(
@@ -89,13 +84,12 @@ export default class OpportunitySlotRepository implements IOpportunitySlotReposi
   async setHostingStatus(
     ctx: IContext,
     id: string,
-    hostingStatus: OpportunitySlotHostingStatus,
-    capacity: number,
+    data: Prisma.OpportunitySlotUpdateInput,
     tx: Prisma.TransactionClient,
   ) {
     return tx.opportunitySlot.update({
       where: { id },
-      data: { hostingStatus, capacity },
+      data,
       include: opportunitySlotSetHostingStatusInclude,
     });
   }

--- a/src/application/domain/experience/opportunitySlot/data/repository.ts
+++ b/src/application/domain/experience/opportunitySlot/data/repository.ts
@@ -77,11 +77,12 @@ export default class OpportunitySlotRepository implements IOpportunitySlotReposi
     ctx: IContext,
     id: string,
     hostingStatus: OpportunitySlotHostingStatus,
+    capacity: number,
     tx: Prisma.TransactionClient,
   ) {
     return tx.opportunitySlot.update({
       where: { id },
-      data: { hostingStatus },
+      data: { hostingStatus, capacity },
       include: opportunitySlotSetHostingStatusInclude,
     });
   }

--- a/src/application/domain/experience/opportunitySlot/presenter.ts
+++ b/src/application/domain/experience/opportunitySlot/presenter.ts
@@ -1,5 +1,6 @@
 import {
   GqlOpportunitySlot,
+  GqlOpportunitySlotCreateSuccess,
   GqlOpportunitySlotsBulkUpdateSuccess,
   GqlOpportunitySlotsConnection,
   GqlOpportunitySlotSetHostingStatusSuccess,
@@ -10,7 +11,11 @@ import {
 } from "@/application/domain/experience/opportunitySlot/data/type";
 
 export default class OpportunitySlotPresenter {
-  static query(r: GqlOpportunitySlot[], hasNextPage: boolean, cursor?: string): GqlOpportunitySlotsConnection {
+  static query(
+    r: GqlOpportunitySlot[],
+    hasNextPage: boolean,
+    cursor?: string,
+  ): GqlOpportunitySlotsConnection {
     return {
       __typename: "OpportunitySlotsConnection",
       totalCount: r.length,
@@ -34,11 +39,17 @@ export default class OpportunitySlotPresenter {
       ...prop,
       remainingCapacity: remainingCapacityView ? remainingCapacityView.remainingCapacity : null,
       isFullyEvaluated: false, // デフォルト値を設定
-      numEvaluated: 0,         // デフォルト値を設定
-      numParticipants: 0,      // デフォルト値を設定
+      numEvaluated: 0, // デフォルト値を設定
+      numParticipants: 0, // デフォルト値を設定
     };
   }
 
+  static create(r: PrismaOpportunitySlotDetail): GqlOpportunitySlotCreateSuccess {
+    return {
+      __typename: "OpportunitySlotCreateSuccess",
+      slot: this.get(r),
+    };
+  }
   static setHostingStatus(
     r: Omit<PrismaOpportunitySlotSetHostingStatus, "reservations" | "opportunity">,
   ): GqlOpportunitySlotSetHostingStatusSuccess {
@@ -51,9 +62,9 @@ export default class OpportunitySlotPresenter {
         startsAt: r.startsAt,
         endsAt: r.endsAt,
         isFullyEvaluated: false, // デフォルト値を設定
-        numEvaluated: 0,         // デフォルト値を設定
-        numParticipants: 0,      // デフォルト値を設定
-        __typename: "OpportunitySlot"
+        numEvaluated: 0, // デフォルト値を設定
+        numParticipants: 0, // デフォルト値を設定
+        __typename: "OpportunitySlot",
       },
     };
   }

--- a/src/application/domain/experience/opportunitySlot/schema/mutation.graphql
+++ b/src/application/domain/experience/opportunitySlot/schema/mutation.graphql
@@ -27,8 +27,11 @@ extend type Mutation {
 # Opportunity Slot Mutation Input Definitions
 # ------------------------------
 input OpportunitySlotSetHostingStatusInput{
-    capacity: Int!
-    status: OpportunitySlotHostingStatus!
+    hostingStatus: OpportunitySlotHostingStatus!
+
+    capacity: Int
+    startsAt: Datetime
+    endsAt: Datetime
     comment: String
 
     # for admin

--- a/src/application/domain/experience/opportunitySlot/schema/mutation.graphql
+++ b/src/application/domain/experience/opportunitySlot/schema/mutation.graphql
@@ -2,6 +2,13 @@
 # Opportunity Slot Mutation Definitions
 # ------------------------------
 extend type Mutation {
+    opportunitySlotCreate(
+        opportunityId: ID!
+        input: OpportunitySlotCreateInput!
+        permission: CheckOpportunityPermissionInput!
+    ): OpportunitySlotCreatePayload
+    @authz(rules: [IsCommunityManager, IsOpportunityOwner])
+
     opportunitySlotSetHostingStatus(
         id: ID!
         input: OpportunitySlotSetHostingStatusInput!
@@ -20,6 +27,7 @@ extend type Mutation {
 # Opportunity Slot Mutation Input Definitions
 # ------------------------------
 input OpportunitySlotSetHostingStatusInput{
+    capacity: Int!
     status: OpportunitySlotHostingStatus!
     comment: String
 
@@ -50,6 +58,10 @@ input OpportunitySlotUpdateInput {
 # ------------------------------
 # Opportunity Slot Mutation Success Type Definitions
 # ------------------------------
+type OpportunitySlotCreateSuccess {
+    slot: OpportunitySlot!
+}
+
 type OpportunitySlotsBulkUpdateSuccess {
     slots: [OpportunitySlot!]!
 }
@@ -61,6 +73,9 @@ type OpportunitySlotSetHostingStatusSuccess{
 # ------------------------------
 # Opportunity Slot Mutation Union (Payload) Definitions
 # ------------------------------
+union OpportunitySlotCreatePayload =
+    OpportunitySlotCreateSuccess
+
 union OpportunitySlotsBulkUpdatePayload =
     OpportunitySlotsBulkUpdateSuccess
 

--- a/src/application/domain/experience/opportunitySlot/service.ts
+++ b/src/application/domain/experience/opportunitySlot/service.ts
@@ -58,10 +58,11 @@ export default class OpportunitySlotService {
     ctx: IContext,
     slotId: string,
     hostingStatus: OpportunitySlotHostingStatus,
+    capacity: number,
     tx: Prisma.TransactionClient,
   ) {
     await this.findOpportunitySlotOrThrow(ctx, slotId);
-    return await this.repository.setHostingStatus(ctx, slotId, hostingStatus, tx);
+    return await this.repository.setHostingStatus(ctx, slotId, hostingStatus, capacity, tx);
   }
 
   async bulkCreateOpportunitySlots(

--- a/src/application/domain/experience/opportunitySlot/service.ts
+++ b/src/application/domain/experience/opportunitySlot/service.ts
@@ -54,6 +54,16 @@ export default class OpportunitySlotService {
     return record;
   }
 
+  async createOpportunitySlot(
+    ctx: IContext,
+    opportunityId: string,
+    input: GqlOpportunitySlotCreateInput,
+    tx: Prisma.TransactionClient,
+  ) {
+    const data = this.converter.create(opportunityId, input);
+    return this.repository.create(ctx, data, tx);
+  }
+
   async setOpportunitySlotHostingStatus(
     ctx: IContext,
     slotId: string,

--- a/src/application/domain/experience/opportunitySlot/service.ts
+++ b/src/application/domain/experience/opportunitySlot/service.ts
@@ -1,8 +1,9 @@
 import { IContext } from "@/types/server";
-import { OpportunitySlotHostingStatus, Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import {
   GqlOpportunitySlotCreateInput,
   GqlOpportunitySlotFilterInput,
+  GqlOpportunitySlotSetHostingStatusInput,
   GqlOpportunitySlotSortInput,
   GqlOpportunitySlotUpdateInput,
   GqlQueryOpportunitySlotsArgs,
@@ -67,12 +68,12 @@ export default class OpportunitySlotService {
   async setOpportunitySlotHostingStatus(
     ctx: IContext,
     slotId: string,
-    hostingStatus: OpportunitySlotHostingStatus,
-    capacity: number,
+    input: GqlOpportunitySlotSetHostingStatusInput,
     tx: Prisma.TransactionClient,
   ) {
     await this.findOpportunitySlotOrThrow(ctx, slotId);
-    return await this.repository.setHostingStatus(ctx, slotId, hostingStatus, capacity, tx);
+    const data = this.converter.setStatus(input);
+    return await this.repository.setHostingStatus(ctx, slotId, data, tx);
   }
 
   async bulkCreateOpportunitySlots(

--- a/src/application/domain/experience/opportunitySlot/usecase.ts
+++ b/src/application/domain/experience/opportunitySlot/usecase.ts
@@ -7,6 +7,8 @@ import {
   GqlOpportunitySlotSetHostingStatusPayload,
   GqlOpportunitySlot,
   GqlQueryOpportunitySlotArgs,
+  GqlMutationOpportunitySlotCreateArgs,
+  GqlOpportunitySlotCreatePayload,
 } from "@/types/graphql";
 import { IContext } from "@/types/server";
 import OpportunitySlotService from "@/application/domain/experience/opportunitySlot/service";
@@ -53,6 +55,17 @@ export default class OpportunitySlotUseCase {
     return OpportunitySlotPresenter.get(slot);
   }
 
+  async managerCreateOpportunitySlot(
+    { opportunityId, input }: GqlMutationOpportunitySlotCreateArgs,
+    ctx: IContext,
+  ): Promise<GqlOpportunitySlotCreatePayload> {
+    const slot = await ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
+      return this.service.createOpportunitySlot(ctx, opportunityId, input, tx);
+    });
+
+    return OpportunitySlotPresenter.create(slot);
+  }
+
   async managerSetOpportunitySlotHostingStatus(
     { id, input }: GqlMutationOpportunitySlotSetHostingStatusArgs,
     ctx: IContext,
@@ -61,7 +74,13 @@ export default class OpportunitySlotUseCase {
     const currentUserId = getCurrentUserId(ctx, input.createdBy);
 
     const res = await ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
-      const slot = await this.service.setOpportunitySlotHostingStatus(ctx, id, input.status, tx);
+      const slot = await this.service.setOpportunitySlotHostingStatus(
+        ctx,
+        id,
+        input.status,
+        input.capacity,
+        tx,
+      );
 
       if (input.status === OpportunitySlotHostingStatus.CANCELLED) {
         const reservationIds = slot.reservations?.map((r) => r.id) ?? [];

--- a/src/application/domain/experience/opportunitySlot/usecase.ts
+++ b/src/application/domain/experience/opportunitySlot/usecase.ts
@@ -74,15 +74,9 @@ export default class OpportunitySlotUseCase {
     const currentUserId = getCurrentUserId(ctx, input.createdBy);
 
     const res = await ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
-      const slot = await this.service.setOpportunitySlotHostingStatus(
-        ctx,
-        id,
-        input.status,
-        input.capacity,
-        tx,
-      );
+      const slot = await this.service.setOpportunitySlotHostingStatus(ctx, id, input, tx);
 
-      if (input.status === OpportunitySlotHostingStatus.CANCELLED) {
+      if (input.hostingStatus === OpportunitySlotHostingStatus.CANCELLED) {
         const reservationIds = slot.reservations?.map((r) => r.id) ?? [];
         const participationIds =
           slot.reservations?.flatMap((r) => r.participations?.map((p) => p.id) ?? []) ?? [];

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1258,10 +1258,12 @@ export const GqlOpportunitySlotHostingStatus = {
 
 export type GqlOpportunitySlotHostingStatus = typeof GqlOpportunitySlotHostingStatus[keyof typeof GqlOpportunitySlotHostingStatus];
 export type GqlOpportunitySlotSetHostingStatusInput = {
-  capacity: Scalars['Int']['input'];
+  capacity?: InputMaybe<Scalars['Int']['input']>;
   comment?: InputMaybe<Scalars['String']['input']>;
   createdBy?: InputMaybe<Scalars['ID']['input']>;
-  status: GqlOpportunitySlotHostingStatus;
+  endsAt?: InputMaybe<Scalars['Datetime']['input']>;
+  hostingStatus: GqlOpportunitySlotHostingStatus;
+  startsAt?: InputMaybe<Scalars['Datetime']['input']>;
 };
 
 export type GqlOpportunitySlotSetHostingStatusPayload = GqlOpportunitySlotSetHostingStatusSuccess;

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -711,6 +711,7 @@ export type GqlMutation = {
   opportunityCreate?: Maybe<GqlOpportunityCreatePayload>;
   opportunityDelete?: Maybe<GqlOpportunityDeletePayload>;
   opportunitySetPublishStatus?: Maybe<GqlOpportunitySetPublishStatusPayload>;
+  opportunitySlotCreate?: Maybe<GqlOpportunitySlotCreatePayload>;
   opportunitySlotSetHostingStatus?: Maybe<GqlOpportunitySlotSetHostingStatusPayload>;
   opportunitySlotsBulkUpdate?: Maybe<GqlOpportunitySlotsBulkUpdatePayload>;
   opportunityUpdateContent?: Maybe<GqlOpportunityUpdateContentPayload>;
@@ -868,6 +869,13 @@ export type GqlMutationOpportunitySetPublishStatusArgs = {
   id: Scalars['ID']['input'];
   input: GqlOpportunitySetPublishStatusInput;
   permission: GqlCheckCommunityPermissionInput;
+};
+
+
+export type GqlMutationOpportunitySlotCreateArgs = {
+  input: GqlOpportunitySlotCreateInput;
+  opportunityId: Scalars['ID']['input'];
+  permission: GqlCheckOpportunityPermissionInput;
 };
 
 
@@ -1222,6 +1230,13 @@ export type GqlOpportunitySlotCreateInput = {
   startsAt: Scalars['Datetime']['input'];
 };
 
+export type GqlOpportunitySlotCreatePayload = GqlOpportunitySlotCreateSuccess;
+
+export type GqlOpportunitySlotCreateSuccess = {
+  __typename?: 'OpportunitySlotCreateSuccess';
+  slot: GqlOpportunitySlot;
+};
+
 export type GqlOpportunitySlotEdge = GqlEdge & {
   __typename?: 'OpportunitySlotEdge';
   cursor: Scalars['String']['output'];
@@ -1243,6 +1258,7 @@ export const GqlOpportunitySlotHostingStatus = {
 
 export type GqlOpportunitySlotHostingStatus = typeof GqlOpportunitySlotHostingStatus[keyof typeof GqlOpportunitySlotHostingStatus];
 export type GqlOpportunitySlotSetHostingStatusInput = {
+  capacity: Scalars['Int']['input'];
   comment?: InputMaybe<Scalars['String']['input']>;
   createdBy?: InputMaybe<Scalars['ID']['input']>;
   status: GqlOpportunitySlotHostingStatus;
@@ -2852,6 +2868,7 @@ export type GqlResolversUnionTypes<_RefType extends Record<string, unknown>> = R
   OpportunityCreatePayload: ( Omit<GqlOpportunityCreateSuccess, 'opportunity'> & { opportunity: _RefType['Opportunity'] } );
   OpportunityDeletePayload: ( GqlOpportunityDeleteSuccess );
   OpportunitySetPublishStatusPayload: ( Omit<GqlOpportunitySetPublishStatusSuccess, 'opportunity'> & { opportunity: _RefType['Opportunity'] } );
+  OpportunitySlotCreatePayload: ( Omit<GqlOpportunitySlotCreateSuccess, 'slot'> & { slot: _RefType['OpportunitySlot'] } );
   OpportunitySlotSetHostingStatusPayload: ( Omit<GqlOpportunitySlotSetHostingStatusSuccess, 'slot'> & { slot: _RefType['OpportunitySlot'] } );
   OpportunitySlotsBulkUpdatePayload: ( Omit<GqlOpportunitySlotsBulkUpdateSuccess, 'slots'> & { slots: Array<_RefType['OpportunitySlot']> } );
   OpportunityUpdateContentPayload: ( Omit<GqlOpportunityUpdateContentSuccess, 'opportunity'> & { opportunity: _RefType['Opportunity'] } );
@@ -3012,6 +3029,8 @@ export type GqlResolversTypes = ResolversObject<{
   OpportunitySetPublishStatusSuccess: ResolverTypeWrapper<Omit<GqlOpportunitySetPublishStatusSuccess, 'opportunity'> & { opportunity: GqlResolversTypes['Opportunity'] }>;
   OpportunitySlot: ResolverTypeWrapper<OpportunitySlot>;
   OpportunitySlotCreateInput: GqlOpportunitySlotCreateInput;
+  OpportunitySlotCreatePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['OpportunitySlotCreatePayload']>;
+  OpportunitySlotCreateSuccess: ResolverTypeWrapper<Omit<GqlOpportunitySlotCreateSuccess, 'slot'> & { slot: GqlResolversTypes['OpportunitySlot'] }>;
   OpportunitySlotEdge: ResolverTypeWrapper<Omit<GqlOpportunitySlotEdge, 'node'> & { node?: Maybe<GqlResolversTypes['OpportunitySlot']> }>;
   OpportunitySlotFilterInput: GqlOpportunitySlotFilterInput;
   OpportunitySlotHostingStatus: GqlOpportunitySlotHostingStatus;
@@ -3315,6 +3334,8 @@ export type GqlResolversParentTypes = ResolversObject<{
   OpportunitySetPublishStatusSuccess: Omit<GqlOpportunitySetPublishStatusSuccess, 'opportunity'> & { opportunity: GqlResolversParentTypes['Opportunity'] };
   OpportunitySlot: OpportunitySlot;
   OpportunitySlotCreateInput: GqlOpportunitySlotCreateInput;
+  OpportunitySlotCreatePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['OpportunitySlotCreatePayload'];
+  OpportunitySlotCreateSuccess: Omit<GqlOpportunitySlotCreateSuccess, 'slot'> & { slot: GqlResolversParentTypes['OpportunitySlot'] };
   OpportunitySlotEdge: Omit<GqlOpportunitySlotEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['OpportunitySlot']> };
   OpportunitySlotFilterInput: GqlOpportunitySlotFilterInput;
   OpportunitySlotSetHostingStatusInput: GqlOpportunitySlotSetHostingStatusInput;
@@ -3909,6 +3930,7 @@ export type GqlMutationResolvers<ContextType = any, ParentType extends GqlResolv
   opportunityCreate?: Resolver<Maybe<GqlResolversTypes['OpportunityCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationOpportunityCreateArgs, 'input' | 'permission'>>;
   opportunityDelete?: Resolver<Maybe<GqlResolversTypes['OpportunityDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationOpportunityDeleteArgs, 'id' | 'permission'>>;
   opportunitySetPublishStatus?: Resolver<Maybe<GqlResolversTypes['OpportunitySetPublishStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationOpportunitySetPublishStatusArgs, 'id' | 'input' | 'permission'>>;
+  opportunitySlotCreate?: Resolver<Maybe<GqlResolversTypes['OpportunitySlotCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationOpportunitySlotCreateArgs, 'input' | 'opportunityId' | 'permission'>>;
   opportunitySlotSetHostingStatus?: Resolver<Maybe<GqlResolversTypes['OpportunitySlotSetHostingStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationOpportunitySlotSetHostingStatusArgs, 'id' | 'input' | 'permission'>>;
   opportunitySlotsBulkUpdate?: Resolver<Maybe<GqlResolversTypes['OpportunitySlotsBulkUpdatePayload']>, ParentType, ContextType, RequireFields<GqlMutationOpportunitySlotsBulkUpdateArgs, 'input' | 'permission'>>;
   opportunityUpdateContent?: Resolver<Maybe<GqlResolversTypes['OpportunityUpdateContentPayload']>, ParentType, ContextType, RequireFields<GqlMutationOpportunityUpdateContentArgs, 'id' | 'input' | 'permission'>>;
@@ -4029,6 +4051,15 @@ export type GqlOpportunitySlotResolvers<ContextType = any, ParentType extends Gq
   startsAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
   updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
   vcIssuanceRequests?: Resolver<Maybe<Array<GqlResolversTypes['VcIssuanceRequest']>>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlOpportunitySlotCreatePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['OpportunitySlotCreatePayload'] = GqlResolversParentTypes['OpportunitySlotCreatePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'OpportunitySlotCreateSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlOpportunitySlotCreateSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['OpportunitySlotCreateSuccess'] = GqlResolversParentTypes['OpportunitySlotCreateSuccess']> = ResolversObject<{
+  slot?: Resolver<GqlResolversTypes['OpportunitySlot'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -4857,6 +4888,8 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   OpportunitySetPublishStatusPayload?: GqlOpportunitySetPublishStatusPayloadResolvers<ContextType>;
   OpportunitySetPublishStatusSuccess?: GqlOpportunitySetPublishStatusSuccessResolvers<ContextType>;
   OpportunitySlot?: GqlOpportunitySlotResolvers<ContextType>;
+  OpportunitySlotCreatePayload?: GqlOpportunitySlotCreatePayloadResolvers<ContextType>;
+  OpportunitySlotCreateSuccess?: GqlOpportunitySlotCreateSuccessResolvers<ContextType>;
   OpportunitySlotEdge?: GqlOpportunitySlotEdgeResolvers<ContextType>;
   OpportunitySlotSetHostingStatusPayload?: GqlOpportunitySlotSetHostingStatusPayloadResolvers<ContextType>;
   OpportunitySlotSetHostingStatusSuccess?: GqlOpportunitySlotSetHostingStatusSuccessResolvers<ContextType>;


### PR DESCRIPTION
### Summary

This pull request introduces the functionality for creating opportunity slots and updating their hosting status with capacity parameters. Additionally, a GraphQL mutation has been added to facilitate the creation of opportunity slots.

### Changes

- Added the ability to create opportunity slots.
- Introduced a capacity parameter for updating hosting status in `OpportunitySlot`.
- Implemented a GraphQL mutation for creating opportunity slots.

### Checklist

- [ ] Tests have been written/updated to ensure proper functionality.
- [ ] Documentation has been updated to reflect the new changes.
- [ ] Code has been reviewed for potential optimizations and standards compliance.