### PR TITLE
Add communityId filter to queries

### DIFF
--- a/src/application/domain/account/community/controller/resolver.ts
+++ b/src/application/domain/account/community/controller/resolver.ts
@@ -43,15 +43,16 @@ export default class CommunityResolver {
       const config = parent.config;
       if (!config) return null;
 
-      const lineConfig = config.lineConfig;
       if (!ctx.isAdmin) {
         return {
           ...config,
-          lineConfig: {
-            ...lineConfig,
-            accessToken: null,
-            channelSecret: null,
-          },
+          lineConfig: config.lineConfig
+            ? {
+                ...config.lineConfig,
+                accessToken: null,
+                channelSecret: null,
+              }
+            : null,
           firebaseConfig: null,
         };
       }

--- a/src/presentation/batch/checkReservationParticipationConsistency.ts
+++ b/src/presentation/batch/checkReservationParticipationConsistency.ts
@@ -52,8 +52,16 @@ export async function checkReservationParticipationConsistency() {
       });
 
       invalids.forEach((r) => {
+        const expected = EXPECTED_MAP[r.status];
+        if (!r.participations?.length) {
+          logger.error("❌ Reservation has no participations", {
+            reservationId: r.id,
+            reservationStatus: r.status,
+          });
+          return;
+        }
+
         r.participations.forEach((p) => {
-          const expected = EXPECTED_MAP[r.status];
           if (p.status !== expected.status || p.reason !== expected.reason) {
             logger.error("❌ Inconsistent reservation-participation pair", {
               reservationId: r.id,
@@ -61,6 +69,8 @@ export async function checkReservationParticipationConsistency() {
               participationId: p.id,
               actualStatus: p.status,
               actualReason: p.reason,
+              expectedStatus: expected.status,
+              expectedReason: expected.reason,
             });
           }
         });


### PR DESCRIPTION
### Description of changes

This pull request introduces a `communityId` filter to queries, including participation and article queries. Additionally, the multi-community filter logic has been commented out for potential future use. These changes ensure more precise filtering based on community identification. 

### Checklist

- [ ] Ensure the `communityId` filter works as intended in all relevant queries.
- [ ] Review commented-out multi-community filter logic for accuracy and completeness.