### PR TITLE
Mutation reservationCreate で、ポイントを使って予約できるようにする

### DIFF
--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -207,6 +207,9 @@ DONATION DONATION
 GRANT GRANT
 TICKET_PURCHASED TICKET_PURCHASED
 TICKET_REFUNDED TICKET_REFUNDED
+OPPORTUNITY_RESERVATION_CREATED OPPORTUNITY_RESERVATION_CREATED
+OPPORTUNITY_RESERVATION_CANCELED OPPORTUNITY_RESERVATION_CANCELED
+OPPORTUNITY_RESERVATION_REJECTED OPPORTUNITY_RESERVATION_REJECTED
         }
     
   "t_images" {
@@ -470,6 +473,7 @@ TICKET_REFUNDED TICKET_REFUNDED
     String opportunity_slot_id 
     String comment "❓"
     ReservationStatus status 
+    Int participant_count_with_point 
     String created_by "❓"
     DateTime created_at 
     DateTime updated_at "❓"
@@ -600,6 +604,7 @@ TICKET_REFUNDED TICKET_REFUNDED
     String to "❓"
     Int to_point_change 
     String participation_id "❓"
+    String reservation_id "❓"
     String created_by "❓"
     DateTime created_at 
     DateTime updated_at "❓"
@@ -809,6 +814,7 @@ TICKET_REFUNDED TICKET_REFUNDED
     "t_reservations" o{--}o "t_participations" : "participations"
     "t_reservations" o|--|o "t_users" : "createdByUser"
     "t_reservations" o{--}o "t_reservation_histories" : "histories"
+    "t_reservations" o{--}o "t_transactions" : "transactions"
     "t_reservation_histories" o|--|| "t_reservations" : "reservation"
     "t_reservation_histories" o|--|| "ReservationStatus" : "enum:status"
     "t_reservation_histories" o|--|o "t_users" : "createdByUser"
@@ -865,6 +871,7 @@ TICKET_REFUNDED TICKET_REFUNDED
     "t_transactions" o|--|o "t_wallets" : "fromWallet"
     "t_transactions" o|--|o "t_wallets" : "toWallet"
     "t_transactions" o|--|o "t_participations" : "participation"
+    "t_transactions" o|--|o "t_reservations" : "reservation"
     "t_transactions" o{--}o "t_ticket_status_histories" : "ticketStatusHistory"
     "t_transactions" o|--|o "t_users" : "createdByUser"
     "t_nft_wallets" o|--|| "t_users" : "user"

--- a/docs/schema.dbml
+++ b/docs/schema.dbml
@@ -349,7 +349,7 @@ Table t_reservations {
   opportunitySlot t_opportunity_slots [not null]
   comment String
   status ReservationStatus [not null, default: 'APPLIED']
-  participantCountWithPoint Int [not null]
+  participantCountWithPoint Int [not null, default: 0]
   participations t_participations [not null]
   createdBy String
   createdByUser t_users

--- a/docs/schema.dbml
+++ b/docs/schema.dbml
@@ -349,10 +349,12 @@ Table t_reservations {
   opportunitySlot t_opportunity_slots [not null]
   comment String
   status ReservationStatus [not null, default: 'APPLIED']
+  participantCountWithPoint Int [not null]
   participations t_participations [not null]
   createdBy String
   createdByUser t_users
   histories t_reservation_histories [not null]
+  transactions t_transactions [not null]
   createdAt DateTime [default: `now()`, not null]
   updatedAt DateTime
 }
@@ -512,6 +514,8 @@ Table t_transactions {
   toPointChange Int [not null]
   participationId String
   participation t_participations
+  reservationId String
+  reservation t_reservations
   ticketStatusHistory t_ticket_status_histories
   createdBy String
   createdByUser t_users
@@ -814,6 +818,9 @@ Enum TransactionReason {
   GRANT
   TICKET_PURCHASED
   TICKET_REFUNDED
+  OPPORTUNITY_RESERVATION_CREATED
+  OPPORTUNITY_RESERVATION_CANCELED
+  OPPORTUNITY_RESERVATION_REJECTED
 }
 
 Ref: m_cities.(stateCode, countryCode) > m_states.(code, countryCode) [delete: Restrict]
@@ -927,6 +934,8 @@ Ref: t_transactions.from > t_wallets.id [delete: Set Null]
 Ref: t_transactions.to > t_wallets.id [delete: Set Null]
 
 Ref: t_transactions.participationId > t_participations.id [delete: Set Null]
+
+Ref: t_transactions.reservationId > t_reservations.id [delete: Set Null]
 
 Ref: t_transactions.createdBy > t_users.id [delete: Set Null]
 

--- a/src/application/domain/account/wallet/validator.ts
+++ b/src/application/domain/account/wallet/validator.ts
@@ -116,7 +116,10 @@ function getTransferDirection(reason: TransactionReason): TransferDirection {
     case TransactionReason.TICKET_PURCHASED:
     case TransactionReason.TICKET_REFUNDED:
     case TransactionReason.DONATION:
-      return TransferDirection.MEMBER_TO_MEMBER;
+    case TransactionReason.OPPORTUNITY_RESERVATION_CREATED:
+    case TransactionReason.OPPORTUNITY_RESERVATION_CANCELED:
+    case TransactionReason.OPPORTUNITY_RESERVATION_REJECTED:
+      return TransferDirection.MEMBER_TO_COMMUNITY;
     default:
       throw new ValidationError(`Unsupported TransactionReason`, [reason]);
   }

--- a/src/application/domain/account/wallet/validator.ts
+++ b/src/application/domain/account/wallet/validator.ts
@@ -111,14 +111,14 @@ function getTransferDirection(reason: TransactionReason): TransferDirection {
   switch (reason) {
     case TransactionReason.ONBOARDING:
     case TransactionReason.GRANT:
+    case TransactionReason.OPPORTUNITY_RESERVATION_CANCELED:
+    case TransactionReason.OPPORTUNITY_RESERVATION_REJECTED:
       return TransferDirection.COMMUNITY_TO_MEMBER;
     case TransactionReason.POINT_REWARD:
     case TransactionReason.TICKET_PURCHASED:
     case TransactionReason.TICKET_REFUNDED:
     case TransactionReason.DONATION:
     case TransactionReason.OPPORTUNITY_RESERVATION_CREATED:
-    case TransactionReason.OPPORTUNITY_RESERVATION_CANCELED:
-    case TransactionReason.OPPORTUNITY_RESERVATION_REJECTED:
       return TransferDirection.MEMBER_TO_COMMUNITY;
     default:
       throw new ValidationError(`Unsupported TransactionReason`, [reason]);

--- a/src/application/domain/experience/reservation/data/converter.ts
+++ b/src/application/domain/experience/reservation/data/converter.ts
@@ -108,6 +108,7 @@ export default class ReservationConverter {
     { reservationStatus, participationStatus, participationStatusReason }: ReservationStatuses,
     comment?: string,
     communityId?: string,
+    participantCountWithPoints?: number,
   ): Prisma.ReservationCreateInput {
     const userIds = [currentUserId, ...userIdsIfExists];
 
@@ -132,6 +133,7 @@ export default class ReservationConverter {
           createdByUser: { connect: { id: currentUserId } },
         },
       },
+      participantCountWithPoint: participantCountWithPoints ?? 0,
     };
   }
 

--- a/src/application/domain/experience/reservation/data/interface.ts
+++ b/src/application/domain/experience/reservation/data/interface.ts
@@ -32,6 +32,7 @@ export interface IReservationService {
     tx: Prisma.TransactionClient,
     comment?: string,
     communityId?: string,
+    participantCountWithPoint?: number,
   ): Promise<PrismaReservation>;
 
   setStatus(

--- a/src/application/domain/experience/reservation/schema/mutation.graphql
+++ b/src/application/domain/experience/reservation/schema/mutation.graphql
@@ -47,6 +47,7 @@ input ReservationCreateInput {
 
     paymentMethod: ReservationPaymentMethod!
     ticketIdsIfNeed: [ID!]
+    participantCountWithPoints: Int
 }
 
 input ReservationCancelInput {

--- a/src/application/domain/experience/reservation/schema/type.graphql
+++ b/src/application/domain/experience/reservation/schema/type.graphql
@@ -5,6 +5,7 @@ type Reservation {
     id: ID!
     status: ReservationStatus!
     comment: String
+    participantCountWithPoints: Int
 
     opportunitySlot: OpportunitySlot
     participations: [Participation!]

--- a/src/application/domain/experience/reservation/service.ts
+++ b/src/application/domain/experience/reservation/service.ts
@@ -60,6 +60,7 @@ export default class ReservationService implements IReservationService {
     tx: Prisma.TransactionClient,
     comment?: string,
     communityId?: string,
+    participantCountWithPoints?: number,
   ) {
     const currentUserId = getCurrentUserId(ctx);
     const data = this.converter.create(
@@ -70,6 +71,7 @@ export default class ReservationService implements IReservationService {
       reservationStatuses,
       comment,
       communityId,
+      participantCountWithPoints,
     );
     return this.repository.create(ctx, data, tx);
   }

--- a/src/application/domain/experience/reservation/usecase.ts
+++ b/src/application/domain/experience/reservation/usecase.ts
@@ -387,7 +387,7 @@ export default class ReservationUseCase {
     currentUserId: string,
     reservationId: string,
   ): Promise<void> {
-    if (participantCountWithPoints === 0) return;
+    if (participantCountWithPoints === 0 || !pointsRequired) return;
 
     const transferPoints = pointsRequired * participantCountWithPoints;
 

--- a/src/application/domain/transaction/data/converter.ts
+++ b/src/application/domain/transaction/data/converter.ts
@@ -58,6 +58,24 @@ export default class TransactionConverter {
     };
   }
 
+  reservationCreated(
+    fromWalletId: string,
+    toWalletId: string,
+    transferPoints: number,
+    createdBy: string,
+    reservationId: string,
+  ): Prisma.TransactionCreateInput {
+    return {
+      reason: TransactionReason.OPPORTUNITY_RESERVATION_CREATED,
+      fromWallet: { connect: { id: fromWalletId } },
+      fromPointChange: transferPoints,
+      toWallet: { connect: { id: toWalletId } },
+      toPointChange: transferPoints,
+      createdByUser: { connect: { id: createdBy } },
+      reservation: { connect: { id: reservationId } },
+    };
+  }
+
   giveRewardPoint(
     fromWalletId: string,
     toWalletId: string,

--- a/src/application/domain/transaction/data/converter.ts
+++ b/src/application/domain/transaction/data/converter.ts
@@ -64,9 +64,10 @@ export default class TransactionConverter {
     transferPoints: number,
     createdBy: string,
     reservationId: string,
+    reason: TransactionReason,
   ): Prisma.TransactionCreateInput {
     return {
-      reason: TransactionReason.OPPORTUNITY_RESERVATION_CREATED,
+      reason,
       fromWallet: { connect: { id: fromWalletId } },
       fromPointChange: transferPoints,
       toWallet: { connect: { id: toWalletId } },

--- a/src/application/domain/transaction/data/interface.ts
+++ b/src/application/domain/transaction/data/interface.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "@prisma/client";
+import { Prisma, TransactionReason } from "@prisma/client";
 import { IContext } from "@/types/server";
 import { PrismaTransactionDetail } from "@/application/domain/transaction/data/type";
 import { refreshMaterializedViewCurrentPoints } from "@prisma/client/sql";
@@ -34,6 +34,7 @@ export interface ITransactionService {
     toWalletId: string,
     transferPoints: number,
     tx: Prisma.TransactionClient,
+    reason: TransactionReason,
   ): Promise<PrismaTransactionDetail>;
 
   reservationCreated(
@@ -43,6 +44,7 @@ export interface ITransactionService {
     toWalletId: string,
     transferPoints: number,
     reservationId: string,
+    reason: TransactionReason,
   ): Promise<PrismaTransactionDetail>;
 
   giveRewardPoint(

--- a/src/application/domain/transaction/data/interface.ts
+++ b/src/application/domain/transaction/data/interface.ts
@@ -36,6 +36,15 @@ export interface ITransactionService {
     tx: Prisma.TransactionClient,
   ): Promise<PrismaTransactionDetail>;
 
+  reservationCreated(
+    ctx: IContext,
+    tx: Prisma.TransactionClient,
+    fromWalletId: string,
+    toWalletId: string,
+    transferPoints: number,
+    reservationId: string,
+  ): Promise<PrismaTransactionDetail>;
+
   giveRewardPoint(
     ctx: IContext,
     tx: Prisma.TransactionClient,

--- a/src/application/domain/transaction/schema/type.graphql
+++ b/src/application/domain/transaction/schema/type.graphql
@@ -2,36 +2,41 @@
 # Transaction Object Type Definitions
 # ------------------------------
 type Transaction {
-    id: ID!
-    reason: TransactionReason!
+  id: ID!
+  reason: TransactionReason!
 
-    fromWallet: Wallet
-    fromPointChange: Int
-    toWallet: Wallet
-    toPointChange: Int
+  fromWallet: Wallet
+  fromPointChange: Int
+  toWallet: Wallet
+  toPointChange: Int
 
-    participation: Participation
+  participation: Participation
+  reservation: Reservation
 
-    ticketStatusHistories: [TicketStatusHistory!]
+  ticketStatusHistories: [TicketStatusHistory!]
 
-    createdByUser: User
+  createdByUser: User
 
-    createdAt: Datetime
-    updatedAt: Datetime
+  createdAt: Datetime
+  updatedAt: Datetime
 }
 
 # ------------------------------
 # Transaction Enum Definitions
 # ------------------------------
 enum TransactionReason {
-    POINT_ISSUED
-    POINT_REWARD
+  POINT_ISSUED
+  POINT_REWARD
 
-    ONBOARDING
+  ONBOARDING
 
-    DONATION
-    GRANT
+  DONATION
+  GRANT
 
-    TICKET_PURCHASED
-    TICKET_REFUNDED
+  TICKET_PURCHASED
+  TICKET_REFUNDED
+
+  OPPORTUNITY_RESERVATION_CREATED
+  OPPORTUNITY_RESERVATION_CANCELED
+  OPPORTUNITY_RESERVATION_REJECTED
 }

--- a/src/application/domain/transaction/service.ts
+++ b/src/application/domain/transaction/service.ts
@@ -81,16 +81,6 @@ export default class TransactionService implements ITransactionService {
     transferPoints: number,
     reservationId: string,
   ): Promise<PrismaTransactionDetail> {
-    // Walletの存在確認
-    const fromWallet = await tx.wallet.findUnique({ where: { id: fromWalletId } });
-    const toWallet = await tx.wallet.findUnique({ where: { id: toWalletId } });
-
-    if (!fromWallet) {
-      throw new Error(`From wallet not found: ${fromWalletId}`);
-    }
-    if (!toWallet) {
-      throw new Error(`To wallet not found: ${toWalletId}`);
-    }
     const currentUserId = getCurrentUserId(ctx);
     const data = this.converter.reservationCreated(fromWalletId, toWalletId, transferPoints, currentUserId, reservationId);
     const transaction = await this.repository.create(ctx, data, tx);

--- a/src/application/domain/transaction/service.ts
+++ b/src/application/domain/transaction/service.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "@prisma/client";
+import { Prisma, TransactionReason } from "@prisma/client";
 import { IContext } from "@/types/server";
 import {
   ITransactionRepository,
@@ -80,9 +80,10 @@ export default class TransactionService implements ITransactionService {
     toWalletId: string,
     transferPoints: number,
     reservationId: string,
+    reason: TransactionReason
   ): Promise<PrismaTransactionDetail> {
     const currentUserId = getCurrentUserId(ctx);
-    const data = this.converter.reservationCreated(fromWalletId, toWalletId, transferPoints, currentUserId, reservationId);
+    const data = this.converter.reservationCreated(fromWalletId, toWalletId, transferPoints, currentUserId, reservationId, reason);
     const transaction = await this.repository.create(ctx, data, tx);
     await this.repository.refreshCurrentPoints(ctx, tx);
     return transaction;

--- a/src/infrastructure/prisma/factories/__generated__/index.ts
+++ b/src/infrastructure/prisma/factories/__generated__/index.ts
@@ -531,6 +531,10 @@ const modelFieldDefinitions: ModelWithFields[] = [{
                 name: "histories",
                 type: "ReservationHistory",
                 relationName: "ReservationToReservationHistory"
+            }, {
+                name: "transactions",
+                type: "Transaction",
+                relationName: "ReservationToTransaction"
             }]
     }, {
         name: "ReservationHistory",
@@ -728,6 +732,10 @@ const modelFieldDefinitions: ModelWithFields[] = [{
                 name: "participation",
                 type: "Participation",
                 relationName: "ParticipationToTransaction"
+            }, {
+                name: "reservation",
+                type: "Reservation",
+                relationName: "ReservationToTransaction"
             }, {
                 name: "ticketStatusHistory",
                 type: "TicketStatusHistory",
@@ -4183,7 +4191,9 @@ export const defineOpportunitySlotFactory = (<TOptions extends OpportunitySlotFa
 
 defineOpportunitySlotFactory.withTransientFields = defaultTransientFieldValues => options => defineOpportunitySlotFactoryInternal(options, defaultTransientFieldValues);
 
-type ReservationScalarOrEnumFields = {};
+type ReservationScalarOrEnumFields = {
+    participantCountWithPoint: number;
+};
 
 type ReservationopportunitySlotFactory = {
     _factoryFor: "OpportunitySlot";
@@ -4199,12 +4209,14 @@ type ReservationFactoryDefineInput = {
     id?: string;
     comment?: string | null;
     status?: ReservationStatus;
+    participantCountWithPoint?: number;
     createdAt?: Date;
     updatedAt?: Date | null;
     opportunitySlot: ReservationopportunitySlotFactory | Prisma.OpportunitySlotCreateNestedOneWithoutReservationsInput;
     participations?: Prisma.ParticipationCreateNestedManyWithoutReservationInput;
     createdByUser?: ReservationcreatedByUserFactory | Prisma.UserCreateNestedOneWithoutReservationsAppliedByMeInput;
     histories?: Prisma.ReservationHistoryCreateNestedManyWithoutReservationInput;
+    transactions?: Prisma.TransactionCreateNestedManyWithoutReservationInput;
 };
 
 type ReservationTransientFields = Record<string, unknown> & Partial<Record<keyof ReservationFactoryDefineInput, never>>;
@@ -4250,7 +4262,9 @@ export interface ReservationFactoryInterface<TTransients extends Record<string, 
 function autoGenerateReservationScalarsOrEnums({ seq }: {
     readonly seq: number;
 }): ReservationScalarOrEnumFields {
-    return {};
+    return {
+        participantCountWithPoint: getScalarFieldValueGenerator().Int({ modelName: "Reservation", fieldName: "participantCountWithPoint", isId: false, isUnique: false, seq })
+    };
 }
 
 function defineReservationFactoryInternal<TTransients extends Record<string, unknown>, TOptions extends ReservationFactoryDefineOptions<TTransients>>({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }: TOptions, defaultTransientFieldValues: TTransients): ReservationFactoryInterface<TTransients, ReservationTraitKeys<TOptions>> {
@@ -6138,6 +6152,11 @@ type TransactionparticipationFactory = {
     build: () => PromiseLike<Prisma.ParticipationCreateNestedOneWithoutTransactionsInput["create"]>;
 };
 
+type TransactionreservationFactory = {
+    _factoryFor: "Reservation";
+    build: () => PromiseLike<Prisma.ReservationCreateNestedOneWithoutTransactionsInput["create"]>;
+};
+
 type TransactionticketStatusHistoryFactory = {
     _factoryFor: "TicketStatusHistory";
     build: () => PromiseLike<Prisma.TicketStatusHistoryCreateNestedOneWithoutTransactionInput["create"]>;
@@ -6158,6 +6177,7 @@ type TransactionFactoryDefineInput = {
     fromWallet?: TransactionfromWalletFactory | Prisma.WalletCreateNestedOneWithoutFromTransactionsInput;
     toWallet?: TransactiontoWalletFactory | Prisma.WalletCreateNestedOneWithoutToTransactionsInput;
     participation?: TransactionparticipationFactory | Prisma.ParticipationCreateNestedOneWithoutTransactionsInput;
+    reservation?: TransactionreservationFactory | Prisma.ReservationCreateNestedOneWithoutTransactionsInput;
     ticketStatusHistory?: TransactionticketStatusHistoryFactory | Prisma.TicketStatusHistoryCreateNestedOneWithoutTransactionInput;
     createdByUser?: TransactioncreatedByUserFactory | Prisma.UserCreateNestedOneWithoutTransactionsCreatedByMeInput;
 };
@@ -6185,6 +6205,10 @@ function isTransactiontoWalletFactory(x: TransactiontoWalletFactory | Prisma.Wal
 
 function isTransactionparticipationFactory(x: TransactionparticipationFactory | Prisma.ParticipationCreateNestedOneWithoutTransactionsInput | undefined): x is TransactionparticipationFactory {
     return (x as any)?._factoryFor === "Participation";
+}
+
+function isTransactionreservationFactory(x: TransactionreservationFactory | Prisma.ReservationCreateNestedOneWithoutTransactionsInput | undefined): x is TransactionreservationFactory {
+    return (x as any)?._factoryFor === "Reservation";
 }
 
 function isTransactionticketStatusHistoryFactory(x: TransactionticketStatusHistoryFactory | Prisma.TicketStatusHistoryCreateNestedOneWithoutTransactionInput | undefined): x is TransactionticketStatusHistoryFactory {
@@ -6266,6 +6290,9 @@ function defineTransactionFactoryInternal<TTransients extends Record<string, unk
                 participation: isTransactionparticipationFactory(defaultData.participation) ? {
                     create: await defaultData.participation.build()
                 } : defaultData.participation,
+                reservation: isTransactionreservationFactory(defaultData.reservation) ? {
+                    create: await defaultData.reservation.build()
+                } : defaultData.reservation,
                 ticketStatusHistory: isTransactionticketStatusHistoryFactory(defaultData.ticketStatusHistory) ? {
                     create: await defaultData.ticketStatusHistory.build()
                 } : defaultData.ticketStatusHistory,

--- a/src/infrastructure/prisma/migrations/20250723110115__add_participant_count_with_point_to_reservations/migration.sql
+++ b/src/infrastructure/prisma/migrations/20250723110115__add_participant_count_with_point_to_reservations/migration.sql
@@ -1,8 +1,0 @@
-/*
-  Warnings:
-
-  - Added the required column `participant_count_with_point` to the `t_reservations` table without a default value. This is not possible if the table is not empty.
-
-*/
--- AlterTable
-ALTER TABLE "t_reservations" ADD COLUMN     "participant_count_with_point" INTEGER NOT NULL;

--- a/src/infrastructure/prisma/migrations/20250723110115__add_participant_count_with_point_to_reservations/migration.sql
+++ b/src/infrastructure/prisma/migrations/20250723110115__add_participant_count_with_point_to_reservations/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `participant_count_with_point` to the `t_reservations` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "t_reservations" ADD COLUMN     "participant_count_with_point" INTEGER NOT NULL;

--- a/src/infrastructure/prisma/migrations/20250723120853_add_opportunity_reservation_reasons_to_transaction_reason/migration.sql
+++ b/src/infrastructure/prisma/migrations/20250723120853_add_opportunity_reservation_reasons_to_transaction_reason/migration.sql
@@ -1,0 +1,11 @@
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "TransactionReason" ADD VALUE 'OPPORTUNITY_RESERVATION_CREATED';
+ALTER TYPE "TransactionReason" ADD VALUE 'OPPORTUNITY_RESERVATION_CANCELED';
+ALTER TYPE "TransactionReason" ADD VALUE 'OPPORTUNITY_RESERVATION_REJECTED';

--- a/src/infrastructure/prisma/migrations/20250723132558_connect_transactions_to_reservations/migration.sql
+++ b/src/infrastructure/prisma/migrations/20250723132558_connect_transactions_to_reservations/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "t_transactions" ADD COLUMN     "reservation_id" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "t_transactions" ADD CONSTRAINT "t_transactions_reservation_id_fkey" FOREIGN KEY ("reservation_id") REFERENCES "t_reservations"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/src/infrastructure/prisma/migrations/20250723153713_add_participant_count_with_point_to_reservations/migration.sql
+++ b/src/infrastructure/prisma/migrations/20250723153713_add_participant_count_with_point_to_reservations/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "t_reservations" ADD COLUMN     "participant_count_with_point" INTEGER NOT NULL DEFAULT 0;

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -739,7 +739,7 @@ model Reservation {
 
   comment                   String?
   status                    ReservationStatus @default(APPLIED)
-  participantCountWithPoint Int               @map("participant_count_with_point")
+  participantCountWithPoint Int               @default(0) @map("participant_count_with_point")
   participations            Participation[]
 
   createdBy     String? @map("created_by")

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -737,14 +737,16 @@ model Reservation {
   opportunitySlotId String          @map("opportunity_slot_id")
   opportunitySlot   OpportunitySlot @relation(fields: [opportunitySlotId], references: [id], onDelete: Cascade)
 
-  comment        String?
-  status         ReservationStatus @default(APPLIED)
-  participations Participation[]
+  comment                   String?
+  status                    ReservationStatus @default(APPLIED)
+  participantCountWithPoint Int               @map("participant_count_with_point")
+  participations            Participation[]
 
   createdBy     String? @map("created_by")
   createdByUser User?   @relation(fields: [createdBy], references: [id], onDelete: SetNull)
 
-  histories ReservationHistory[]
+  histories    ReservationHistory[]
+  transactions Transaction[]
 
   createdAt DateTime  @default(now()) @map("created_at")
   updatedAt DateTime? @updatedAt @map("updated_at")
@@ -1064,6 +1066,9 @@ model Transaction {
   participationId String?        @map("participation_id")
   participation   Participation? @relation(fields: [participationId], references: [id], onDelete: SetNull)
 
+  reservationId String?      @map("reservation_id")
+  reservation   Reservation? @relation(fields: [reservationId], references: [id], onDelete: SetNull)
+
   ticketStatusHistory TicketStatusHistory?
 
   createdBy     String? @map("created_by")
@@ -1086,6 +1091,10 @@ enum TransactionReason {
 
   TICKET_PURCHASED
   TICKET_REFUNDED
+
+  OPPORTUNITY_RESERVATION_CREATED
+  OPPORTUNITY_RESERVATION_CANCELED
+  OPPORTUNITY_RESERVATION_REJECTED
 }
 
 // ------------------------------ API Key Domain ------------------------------

--- a/src/infrastructure/prisma/seeds/index.ts
+++ b/src/infrastructure/prisma/seeds/index.ts
@@ -1,3 +1,4 @@
+import "reflect-metadata";
 import path from "path";
 import { fileURLToPath } from "url";
 import { seedMaster } from "@/infrastructure/prisma/seeds/master";

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -2005,6 +2005,7 @@ export type GqlReservation = {
   histories?: Maybe<Array<GqlReservationHistory>>;
   id: Scalars['ID']['output'];
   opportunitySlot?: Maybe<GqlOpportunitySlot>;
+  participantCountWithPoints?: Maybe<Scalars['Int']['output']>;
   participations?: Maybe<Array<GqlParticipation>>;
   status: GqlReservationStatus;
   updatedAt?: Maybe<Scalars['Datetime']['output']>;
@@ -2019,6 +2020,7 @@ export type GqlReservationCreateInput = {
   comment?: InputMaybe<Scalars['String']['input']>;
   opportunitySlotId: Scalars['ID']['input'];
   otherUserIds?: InputMaybe<Array<Scalars['ID']['input']>>;
+  participantCountWithPoints?: InputMaybe<Scalars['Int']['input']>;
   paymentMethod: GqlReservationPaymentMethod;
   ticketIdsIfNeed?: InputMaybe<Array<Scalars['ID']['input']>>;
   totalParticipantCount: Scalars['Int']['input'];
@@ -2409,6 +2411,7 @@ export type GqlTransaction = {
   id: Scalars['ID']['output'];
   participation?: Maybe<GqlParticipation>;
   reason: GqlTransactionReason;
+  reservation?: Maybe<GqlReservation>;
   ticketStatusHistories?: Maybe<Array<GqlTicketStatusHistory>>;
   toPointChange?: Maybe<Scalars['Int']['output']>;
   toWallet?: Maybe<GqlWallet>;
@@ -2479,6 +2482,9 @@ export const GqlTransactionReason = {
   Donation: 'DONATION',
   Grant: 'GRANT',
   Onboarding: 'ONBOARDING',
+  OpportunityReservationCanceled: 'OPPORTUNITY_RESERVATION_CANCELED',
+  OpportunityReservationCreated: 'OPPORTUNITY_RESERVATION_CREATED',
+  OpportunityReservationRejected: 'OPPORTUNITY_RESERVATION_REJECTED',
   PointIssued: 'POINT_ISSUED',
   PointReward: 'POINT_REWARD',
   TicketPurchased: 'TICKET_PURCHASED',
@@ -4351,6 +4357,7 @@ export type GqlReservationResolvers<ContextType = any, ParentType extends GqlRes
   histories?: Resolver<Maybe<Array<GqlResolversTypes['ReservationHistory']>>, ParentType, ContextType>;
   id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
   opportunitySlot?: Resolver<Maybe<GqlResolversTypes['OpportunitySlot']>, ParentType, ContextType>;
+  participantCountWithPoints?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
   participations?: Resolver<Maybe<Array<GqlResolversTypes['Participation']>>, ParentType, ContextType>;
   status?: Resolver<GqlResolversTypes['ReservationStatus'], ParentType, ContextType>;
   updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
@@ -4588,6 +4595,7 @@ export type GqlTransactionResolvers<ContextType = any, ParentType extends GqlRes
   id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
   participation?: Resolver<Maybe<GqlResolversTypes['Participation']>, ParentType, ContextType>;
   reason?: Resolver<GqlResolversTypes['TransactionReason'], ParentType, ContextType>;
+  reservation?: Resolver<Maybe<GqlResolversTypes['Reservation']>, ParentType, ContextType>;
   ticketStatusHistories?: Resolver<Maybe<Array<GqlResolversTypes['TicketStatusHistory']>>, ParentType, ContextType>;
   toPointChange?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
   toWallet?: Resolver<Maybe<GqlResolversTypes['Wallet']>, ParentType, ContextType>;


### PR DESCRIPTION
- `t_reservations`テーブルに`participant_count_with_point`カラムを追加し、参加者数に基づくポイントの管理を実装。
- トランザクション理由に`OPPORTUNITY_RESERVATION_CREATED`などの新しい理由を追加。
- 予約作成時にポイントを転送するロジックを追加し、関連するGraphQLスキーマとTypeScript型定義を更新。