### PR TITLE
Add context and communityId handling to opportunity filters  

### DIFF
--- a/src/application/domain/experience/opportunity/data/converter.ts
+++ b/src/application/domain/experience/opportunity/data/converter.ts
@@ -138,7 +138,16 @@ export default class OpportunityConverter {
     filter: GqlOpportunityFilterInput,
     communityId: string,
   ): Prisma.OpportunityWhereInput[] {
-    const conditions: Prisma.OpportunityWhereInput[] = [{ communityId }];
+    const conditions: Prisma.OpportunityWhereInput[] = [];
+
+    if (filter.communityIds?.length) {
+      if (!filter.communityIds.includes(communityId)) {
+        return [{ OR: [] }]; // ✅ AND: [{ OR: [] }] は常に false
+      }
+      conditions.push({ communityId: { in: filter.communityIds } });
+    } else {
+      conditions.push({ communityId: communityId });
+    }
 
     if (filter.keyword) {
       conditions.push({
@@ -166,7 +175,6 @@ export default class OpportunityConverter {
     if (filter.category) conditions.push({ category: filter.category });
     if (filter.publishStatus?.length)
       conditions.push({ publishStatus: { in: filter.publishStatus } });
-    if (filter.communityIds?.length) conditions.push({ communityId: { in: filter.communityIds } });
     if (filter.createdByUserIds?.length)
       conditions.push({ createdBy: { in: filter.createdByUserIds } });
     if (filter.placeIds?.length) conditions.push({ placeId: { in: filter.placeIds } });

--- a/src/application/domain/experience/opportunity/service.ts
+++ b/src/application/domain/experience/opportunity/service.ts
@@ -26,7 +26,7 @@ export default class OpportunityService {
     { cursor, filter, sort }: GqlQueryOpportunitiesArgs,
     take: number,
   ) {
-    const where = this.converter.filter(filter ?? {});
+    const where = this.converter.filter(ctx, filter ?? {});
     const orderBy = this.converter.sort(sort ?? {});
     return await this.repository.query(ctx, where, orderBy, take, cursor);
   }
@@ -36,7 +36,7 @@ export default class OpportunityService {
   }
 
   async findOpportunityAccessible(ctx: IContext, id: string, filter: GqlOpportunityFilterInput) {
-    const where = this.converter.findAccessible(id, filter ?? {});
+    const where = this.converter.findAccessible(ctx, id, filter ?? {});
 
     const opportunity = await this.repository.findAccessible(ctx, where);
     if (!opportunity) {


### PR DESCRIPTION
### Description  
This pull request enhances the opportunity filtering logic by:  
- Adding `communityId` support to the filter methods.  
- Passing `context (ctx)` to the `filter` and `findAccessible` methods within the opportunity service.  

### Related Issues  
(None provided)  

### Checklist  
- [ ] Tests added for new functionality  
- [ ] Documentation updated if applicable  
- [ ] All changes tested locally  