### PR TITLE
Add admin check for user community role retrieval

### DIFF
--- a/src/application/domain/utils.ts
+++ b/src/application/domain/utils.ts
@@ -10,7 +10,6 @@ export function getCurrentUserId(ctx: IContext, inputUserId?: string): string {
     throw new AuthorizationError("User must be logged in");
   }
 
-
   return currentUserId;
 }
 
@@ -30,6 +29,11 @@ export function getMembershipRolesByCtx(
 ): { isManager: Record<string, boolean>; isMember: Record<string, boolean> } {
   if (!currentUserId || communityIds.length === 0) {
     return { isManager: {}, isMember: {} };
+  }
+
+  if (ctx.isAdmin) {
+    const allTrue = Object.fromEntries(communityIds.map((id) => [id, true]));
+    return { isManager: allTrue, isMember: allTrue };
   }
 
   const userMemberships = getUserMembershipMap(ctx);


### PR DESCRIPTION
This pull request adds logic to verify if the user has admin privileges when fetching community roles. It ensures access control and proper authorization during this process.

- [ ] Code changes tested
- [ ] Documentation updated
- [ ] Ready for review