### PR TITLE
feat: add slot deadline filtering for opportunity fetching

### DIFF
--- a/src/__tests__/unit/experience/opportunity.service.test.ts
+++ b/src/__tests__/unit/experience/opportunity.service.test.ts
@@ -2,14 +2,17 @@ import "reflect-metadata";
 import { container } from "tsyringe";
 import OpportunityService from "@/application/domain/experience/opportunity/service";
 import { NotFoundError } from "@/errors/graphql";
-import { Prisma, PublishStatus } from "@prisma/client";
+import { Prisma, PublishStatus, OpportunitySlotHostingStatus } from "@prisma/client";
 import { IContext } from "@/types/server";
+import * as reservationConfig from "@/application/domain/experience/reservation/config";
 
 class MockOpportunityRepository {
   create = jest.fn();
   update = jest.fn();
   delete = jest.fn();
   find = jest.fn();
+  query = jest.fn();
+  queryWithSlots = jest.fn();
   setPublishStatus = jest.fn();
 }
 
@@ -179,6 +182,289 @@ describe("OpportunityService", () => {
     });
   });
 
+  describe("fetchOpportunities - Slot Deadline Filtering", () => {
+    const mockFilter = {};
+    const mockSort = {};
+    const mockArgs = { cursor: undefined, filter: mockFilter, sort: mockSort };
+    const take = 10;
+    const mockCurrentTime = new Date('2025-01-15T10:00:00Z');
+
+    beforeEach(() => {
+      mockConverter.filter.mockReturnValue({});
+      mockConverter.sort.mockReturnValue({});
+      // Mock current time to 2025-01-15 10:00 UTC
+      jest.useFakeTimers();
+      jest.setSystemTime(mockCurrentTime);
+      // Default advance booking days
+      jest.spyOn(reservationConfig, 'getAdvanceBookingDays').mockReturnValue(3);
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+      jest.restoreAllMocks();
+    });
+
+    describe("Search Filter Bypass", () => {
+      it("should bypass filtering when keyword filter is present", async () => {
+        const filterWithKeyword = { keyword: "test" };
+        const argsWithKeyword = { ...mockArgs, filter: filterWithKeyword };
+        const expectedResult = [{ id: "opp1", title: "Test Opportunity" }];
+        
+        mockRepository.query.mockResolvedValue(expectedResult);
+        
+        const result = await service.fetchOpportunities(mockCtx, argsWithKeyword, take);
+        
+        expect(mockRepository.query).toHaveBeenCalledWith(mockCtx, {}, {}, take, undefined);
+        expect(mockRepository.queryWithSlots).not.toHaveBeenCalled();
+        expect(result).toEqual(expectedResult);
+      });
+
+      it("should bypass filtering when stateCodes filter is present", async () => {
+        const filterWithStateCodes = { stateCodes: ["CA"] };
+        const argsWithStateCodes = { ...mockArgs, filter: filterWithStateCodes };
+        const expectedResult = [{ id: "opp1", title: "Test Opportunity" }];
+        
+        mockRepository.query.mockResolvedValue(expectedResult);
+        
+        const result = await service.fetchOpportunities(mockCtx, argsWithStateCodes, take);
+        
+        expect(mockRepository.query).toHaveBeenCalledWith(mockCtx, {}, {}, take, undefined);
+        expect(mockRepository.queryWithSlots).not.toHaveBeenCalled();
+        expect(result).toEqual(expectedResult);
+      });
+
+      it("should bypass filtering when slotDateRange filter is present", async () => {
+        const filterWithSlotDateRange = { slotDateRange: { start: "2025-01-01T00:00:00Z", end: "2025-01-31T23:59:59Z" } } as any;
+        const argsWithSlotDateRange = { ...mockArgs, filter: filterWithSlotDateRange };
+        const expectedResult = [{ id: "opp1", title: "Test Opportunity" }];
+        
+        mockRepository.query.mockResolvedValue(expectedResult);
+        
+        const result = await service.fetchOpportunities(mockCtx, argsWithSlotDateRange, take);
+        
+        expect(mockRepository.query).toHaveBeenCalledWith(mockCtx, {}, {}, take, undefined);
+        expect(mockRepository.queryWithSlots).not.toHaveBeenCalled();
+        expect(result).toEqual(expectedResult);
+      });
+
+      it("should bypass filtering when slotRemainingCapacity filter is present", async () => {
+        const filterWithSlotRemainingCapacity = { slotRemainingCapacity: 1 } as any;
+        const argsWithSlotRemainingCapacity = { ...mockArgs, filter: filterWithSlotRemainingCapacity };
+        const expectedResult = [{ id: "opp1", title: "Test Opportunity" }];
+        
+        mockRepository.query.mockResolvedValue(expectedResult);
+        
+        const result = await service.fetchOpportunities(mockCtx, argsWithSlotRemainingCapacity, take);
+        
+        expect(mockRepository.query).toHaveBeenCalledWith(mockCtx, {}, {}, take, undefined);
+        expect(mockRepository.queryWithSlots).not.toHaveBeenCalled();
+        expect(result).toEqual(expectedResult);
+      });
+    });
+
+    describe("Slot Deadline Filtering Logic", () => {
+      it("should include opportunities with no slots", async () => {
+        const opportunitiesWithSlots = [
+          {
+            id: "opp1",
+            title: "Opportunity with empty slots",
+            slots: []
+          },
+          {
+            id: "opp2",
+            title: "Opportunity with null slots",
+            slots: null
+          }
+        ];
+        
+        mockRepository.queryWithSlots.mockResolvedValue(opportunitiesWithSlots);
+        
+        const result = await service.fetchOpportunities(mockCtx, mockArgs, take);
+        
+        expect(mockRepository.queryWithSlots).toHaveBeenCalledWith(mockCtx, {}, {}, take * 2, undefined);
+        expect(result).toHaveLength(2);
+        expect(result.map(r => r.id)).toEqual(["opp1", "opp2"]);
+        // Verify slots are removed from result
+        result.forEach(opportunity => {
+          expect(opportunity).not.toHaveProperty('slots');
+        });
+      });
+
+      it("should exclude opportunities where all slots are past booking deadline", async () => {
+        const opportunitiesWithSlots = [
+          {
+            id: "opp1",
+            title: "Opportunity with past deadline slots",
+            slots: [
+              {
+                id: "slot1",
+                startsAt: new Date('2025-01-16T10:00:00Z'), // 1 day from now, but needs 3 days advance
+                hostingStatus: OpportunitySlotHostingStatus.SCHEDULED
+              },
+              {
+                id: "slot2",
+                startsAt: new Date('2025-01-10T10:00:00Z'), // 5 days ago, definitely past deadline
+                hostingStatus: OpportunitySlotHostingStatus.SCHEDULED
+              }
+            ]
+          }
+        ];
+        
+        mockRepository.queryWithSlots.mockResolvedValue(opportunitiesWithSlots);
+        
+        const result = await service.fetchOpportunities(mockCtx, mockArgs, take);
+        
+        // Should be excluded because all slots are past booking deadline (need 3 days advance)
+        expect(result).toHaveLength(0);
+      });
+
+      it("should include opportunities with at least one bookable slot", async () => {
+        const opportunitiesWithSlots = [
+          {
+            id: "opp1",
+            title: "Opportunity with mixed slots",
+            slots: [
+              {
+                id: "slot1",
+                startsAt: new Date('2025-01-16T10:00:00Z'), // 1 day from now, past deadline
+                hostingStatus: OpportunitySlotHostingStatus.SCHEDULED
+              },
+              {
+                id: "slot2",
+                startsAt: new Date('2025-01-20T10:00:00Z'), // 5 days from now, bookable
+                hostingStatus: OpportunitySlotHostingStatus.SCHEDULED
+              }
+            ]
+          }
+        ];
+        
+        mockRepository.queryWithSlots.mockResolvedValue(opportunitiesWithSlots);
+        
+        const result = await service.fetchOpportunities(mockCtx, mockArgs, take);
+        
+        expect(result).toHaveLength(1);
+        expect(result[0].id).toBe("opp1");
+        expect(result[0]).not.toHaveProperty('slots');
+      });
+
+      it("should only consider SCHEDULED slots for deadline calculation", async () => {
+        const opportunitiesWithSlots = [
+          {
+            id: "opp1",
+            title: "Opportunity with non-scheduled slots",
+            slots: [
+              {
+                id: "slot1",
+                startsAt: new Date('2025-01-20T10:00:00Z'), // Future date
+                hostingStatus: OpportunitySlotHostingStatus.COMPLETED
+              },
+              {
+                id: "slot2",
+                startsAt: new Date('2025-01-25T10:00:00Z'), // Future date
+                hostingStatus: OpportunitySlotHostingStatus.CANCELLED
+              }
+            ]
+          }
+        ];
+        
+        mockRepository.queryWithSlots.mockResolvedValue(opportunitiesWithSlots);
+        
+        const result = await service.fetchOpportunities(mockCtx, mockArgs, take);
+        
+        // Should be excluded because no SCHEDULED slots
+        expect(result).toHaveLength(0);
+      });
+
+      it("should use custom advance booking days per opportunity", async () => {
+        jest.spyOn(reservationConfig, 'getAdvanceBookingDays')
+          .mockImplementation((opportunityId) => {
+            return opportunityId === 'opp1' ? 1 : 5; // Different booking days
+          });
+        
+        const opportunitiesWithSlots = [
+          {
+            id: "opp1",
+            title: "Opportunity with 1-day advance", 
+            slots: [
+              {
+                id: "slot1",
+                startsAt: new Date('2025-01-16T10:00:00Z'), // 1 day from now, bookable with 1-day advance
+                hostingStatus: OpportunitySlotHostingStatus.SCHEDULED
+              }
+            ]
+          },
+          {
+            id: "opp2",
+            title: "Opportunity with 5-day advance",
+            slots: [
+              {
+                id: "slot2", 
+                startsAt: new Date('2025-01-16T10:00:00Z'), // 1 day from now, not bookable with 5-day advance
+                hostingStatus: OpportunitySlotHostingStatus.SCHEDULED
+              }
+            ]
+          }
+        ];
+        
+        mockRepository.queryWithSlots.mockResolvedValue(opportunitiesWithSlots);
+        
+        const result = await service.fetchOpportunities(mockCtx, mockArgs, take);
+        
+        expect(result).toHaveLength(1);
+        expect(result[0].id).toBe("opp1");
+        expect(reservationConfig.getAdvanceBookingDays).toHaveBeenCalledWith("opp1");
+        expect(reservationConfig.getAdvanceBookingDays).toHaveBeenCalledWith("opp2");
+      });
+
+      it("should handle edge case: slot starts exactly at deadline", async () => {
+        const opportunitiesWithSlots = [
+          {
+            id: "opp1",
+            title: "Opportunity at exact deadline",
+            slots: [
+              {
+                id: "slot1",
+                startsAt: new Date('2025-01-18T10:00:00Z'), // Exactly 3 days from now
+                hostingStatus: OpportunitySlotHostingStatus.SCHEDULED
+              }
+            ]
+          }
+        ];
+        
+        mockRepository.queryWithSlots.mockResolvedValue(opportunitiesWithSlots);
+        
+        const result = await service.fetchOpportunities(mockCtx, mockArgs, take);
+        
+        // Should be included because current time (2025-01-15 10:00) <= deadline (2025-01-15 10:00)
+        expect(result).toHaveLength(1);
+        expect(result[0].id).toBe("opp1");
+      });
+
+      it("should respect take limit and remove slots from result", async () => {
+        const opportunitiesWithSlots = Array.from({ length: 15 }, (_, i) => ({
+          id: `opp${i + 1}`,
+          title: `Opportunity ${i + 1}`,
+          slots: [
+            {
+              id: `slot${i + 1}`,
+              startsAt: new Date('2025-01-20T10:00:00Z'), // Future, bookable
+              hostingStatus: OpportunitySlotHostingStatus.SCHEDULED
+            }
+          ]
+        }));
+        
+        mockRepository.queryWithSlots.mockResolvedValue(opportunitiesWithSlots);
+        
+        const result = await service.fetchOpportunities(mockCtx, mockArgs, take);
+        
+        expect(result).toHaveLength(take + 1); // take + 1 for pagination
+        result.forEach(opportunity => {
+          expect(opportunity).not.toHaveProperty('slots');
+        });
+      });
+    });
+  });
+
   describe("validatePublishStatus", () => {
     it("should pass validation when filter publishStatus matches allowed statuses", async () => {
       const allowedStatuses = [PublishStatus.PUBLIC, PublishStatus.COMMUNITY_INTERNAL];
@@ -253,11 +539,11 @@ describe("OpportunityService", () => {
 
     it("should handle null and undefined edge cases", async () => {
       const allowedStatuses = [PublishStatus.PUBLIC];
-      
+
       await expect(
         service.validatePublishStatus(allowedStatuses, null as any),
       ).resolves.not.toThrow();
-      
+
       await expect(
         service.validatePublishStatus(allowedStatuses, { publishStatus: null } as any),
       ).resolves.not.toThrow();
@@ -265,7 +551,7 @@ describe("OpportunityService", () => {
 
     it("should handle empty allowed statuses array", async () => {
       const filter = { publishStatus: [PublishStatus.PUBLIC] } as any;
-      
+
       await expect(
         service.validatePublishStatus([], filter),
       ).rejects.toThrow("Validation error: publishStatus must be one of");
@@ -292,11 +578,11 @@ describe("OpportunityService", () => {
 
     it("should handle null and undefined edge cases", async () => {
       const allowedStatuses = [PublishStatus.PUBLIC];
-      
+
       await expect(
         service.validatePublishStatus(allowedStatuses, null as any),
       ).resolves.not.toThrow();
-      
+
       await expect(
         service.validatePublishStatus(allowedStatuses, { publishStatus: null } as any),
       ).resolves.not.toThrow();
@@ -304,7 +590,7 @@ describe("OpportunityService", () => {
 
     it("should handle empty allowed statuses array", async () => {
       const filter = { publishStatus: [PublishStatus.PUBLIC] } as any;
-      
+
       await expect(
         service.validatePublishStatus([], filter),
       ).rejects.toThrow("Validation error: publishStatus must be one of");

--- a/src/application/domain/experience/opportunity/data/interface.ts
+++ b/src/application/domain/experience/opportunity/data/interface.ts
@@ -1,6 +1,6 @@
 import { Prisma } from "@prisma/client";
 import { IContext } from "@/types/server";
-import { PrismaOpportunityDetail } from "./type";
+import { PrismaOpportunityDetail, PrismaOpportunityDetailWithSlots } from "./type";
 
 export interface IOpportunityRepository {
   query(
@@ -10,6 +10,14 @@ export interface IOpportunityRepository {
     take: number,
     cursor?: string,
   ): Promise<PrismaOpportunityDetail[]>;
+
+  queryWithSlots(
+    ctx: IContext,
+    where: Prisma.OpportunityWhereInput,
+    orderBy: Prisma.OpportunityOrderByWithRelationInput[],
+    take: number,
+    cursor?: string,
+  ): Promise<PrismaOpportunityDetailWithSlots[]>;
 
   find(ctx: IContext, id: string): Promise<PrismaOpportunityDetail | null>;
 

--- a/src/application/domain/experience/opportunity/data/repository.ts
+++ b/src/application/domain/experience/opportunity/data/repository.ts
@@ -1,5 +1,5 @@
 import { Prisma, PublishStatus } from "@prisma/client";
-import { opportunitySelectDetail } from "@/application/domain/experience/opportunity/data/type";
+import { opportunitySelectDetail, opportunitySelectDetailWithSlots } from "@/application/domain/experience/opportunity/data/type";
 import { IContext } from "@/types/server";
 import { injectable } from "tsyringe";
 import { IOpportunityRepository } from "./interface";
@@ -18,6 +18,25 @@ export default class OpportunityRepository implements IOpportunityRepository {
         where,
         orderBy,
         select: opportunitySelectDetail,
+        take: take + 1,
+        skip: cursor ? 1 : 0,
+        cursor: cursor ? { id: cursor } : undefined,
+      });
+    });
+  }
+
+  async queryWithSlots(
+    ctx: IContext,
+    where: Prisma.OpportunityWhereInput,
+    orderBy: Prisma.OpportunityOrderByWithRelationInput[],
+    take: number,
+    cursor?: string,
+  ) {
+    return ctx.issuer.public(ctx, (tx) => {
+      return tx.opportunity.findMany({
+        where,
+        orderBy,
+        select: opportunitySelectDetailWithSlots,
         take: take + 1,
         skip: cursor ? 1 : 0,
         cursor: cursor ? { id: cursor } : undefined,

--- a/src/application/domain/experience/opportunity/data/type.ts
+++ b/src/application/domain/experience/opportunity/data/type.ts
@@ -50,6 +50,22 @@ export type PrismaOpportunitySetHostingStatus = Prisma.OpportunityGetPayload<{
   include: typeof opportunitySetHostingStatusInclude;
 }>;
 
+export const opportunitySelectDetailWithSlots = Prisma.validator<Prisma.OpportunitySelect>()({
+  ...opportunitySelectDetail,
+  slots: {
+    select: {
+      id: true,
+      startsAt: true,
+      endsAt: true,
+      hostingStatus: true,
+    },
+  },
+});
+
 export type PrismaOpportunityDetail = Prisma.OpportunityGetPayload<{
   select: typeof opportunitySelectDetail;
+}>;
+
+export type PrismaOpportunityDetailWithSlots = Prisma.OpportunityGetPayload<{
+  select: typeof opportunitySelectDetailWithSlots;
 }>;


### PR DESCRIPTION
## 概要
- Opportunity 一覧で、ユーザーは予約可能なopportunityのみを閲覧できるように
  - GetOpportunities APIに slot deadline filtering を実装し、予約受付を締め切った opportunity を一覧から除外するようにした

## 動作への影響
- **一般閲覧**: ユーザーは予約可能なスロットがある opportunity のみを表示
- **検索結果**: すべての検索機能は従来通り（予約期限に関係なく検索結果を表示）

※ 既存のAPI呼び出しに対する（フロントエンド）変更はなし


## 確認項目
🧪 テスト項目（実装済み - 11テスト全て成功）
```
$ pnpm test -- src/__tests__/unit/experience/opportunity.service.test.ts --testNamePattern="fetchOpportunities"

    fetchOpportunities - Slot Deadline Filtering
      Search Filter Bypass
        ✓ should bypass filtering when keyword filter is present (2 ms)
        ✓ should bypass filtering when stateCodes filter is present
        ✓ should bypass filtering when slotDateRange filter is present
        ✓ should bypass filtering when slotRemainingCapacity filter is present (1 ms)
      Slot Deadline Filtering Logic
        ✓ should include opportunities with no slots
        ✓ should exclude opportunities where all slots are past booking deadline (1 ms)
        ✓ should include opportunities with at least one bookable slot
        ✓ should only consider SCHEDULED slots for deadline calculation
        ✓ should use custom advance booking days per opportunity
        ✓ should handle edge case: slot starts exactly at deadline
        ✓ should respect take limit and remove slots from result
```
### A. 検索フィルタバイパステスト（4項目）
- keywordフィルタ存在時に通常のqueryメソッドが呼ばれること queryWithSlots メソッドが呼ばれないこと
-  stateCodesフィルタ存在時に通常のqueryメソッドが呼ばれること
- slotDateRangeフィルタ存在時に通常のqueryメソッドが呼ばれること
- slotRemainingCapacityフィルタ存在時に通常のqueryメソッドが呼ばれること
### B. Slot締切フィルタリングロジックテスト（7項目）
- slotなしopportunityの包含
  - 空配列またはnullのslotを持つopportunityが結果に含まれること
  - レスポンスからslot情報が除去されていること
- 全slot締切済みopportunityの除外
  - 全てのslotが予約締切を過ぎているopportunityが除外されること
- 一部slot予約可能opportunityの包含
  - 混在状態（一部締切済み、一部予約可能）のopportunityが含まれること
- 非SCHEDULEDslotの除外
  - COMPLETED, CANCELLEDステータスのslotが判定から除外されること
  - SCHEDULED slotがない場合は opportunity が除外されること
- opportunity毎カスタム予約締切日数
  - getAdvanceBookingDaysが各opportunity IDで呼ばれること
  - 異なる締切日数が正しく適用されること
- 予約締切境界値テスト
  - slot開始がちょうど締切時刻の場合の動作確認
  - 境界値での包含/除外判定の正確性
- ページネーション制限とデータ変換
  - takeパラメータが正しく適用されること
  - レスポンスからslot情報が除去されること

### 📋 手動確認チェックリスト
動作確認
- [x] 通常の一覧取得で予約可能なopportunityのみ表示される
- [x] 検索時に全opportunityから検索結果が返される