### PR TITLE
DID/VC発行リクエストの件数制御を追加

### DIFF
--- a/src/presentation/batch/requestDIDVC/index.ts
+++ b/src/presentation/batch/requestDIDVC/index.ts
@@ -9,6 +9,7 @@ import { createDIDRequests } from "./requestDID";
 import { IContext } from "@/types/server";
 import { createVCRequests } from "@/presentation/batch/requestDIDVC/requestVC";
 import VCIssuanceRequestConverter from "@/application/domain/experience/evaluation/vcIssuanceRequest/data/converter";
+import { checkBit } from "@/utils/misc";
 
 /**
  * EvaluationとIdentityに基づいて、
@@ -16,7 +17,30 @@ import VCIssuanceRequestConverter from "@/application/domain/experience/evaluati
  * - Evaluation(PASSED)だがVCリクエスト未発行のユーザーにVCを送信
  */
 export async function requestDIDVC() {
-  logger.info("🚀 Starting DID & VC request batch");
+  /**
+   * BATCH_DID_VC_REQUEST_MODE:
+   *   3: DID 実行 / VC 実行
+   *   2: DID 実行 / VC 無効
+   *   1: DID 無効 / VC 実行
+   *   0: DID 無効 / VC 無効
+   */
+  const requestMode = process.env.BATCH_DID_VC_REQUEST_MODE ? parseInt(process.env.BATCH_DID_VC_REQUEST_MODE) : 3; // デフォルトで全て実行
+  const executeDID = checkBit(requestMode, 2);
+  const executeVC = checkBit(requestMode, 1);
+
+  let limit = process.env.BATCH_LIMIT ? parseInt(process.env.BATCH_LIMIT) : undefined;
+  if (limit && limit > 0) {
+    logger.info(`🚀 Starting DID & VC request batch (MODE: ${ requestMode }, LIMIT: ${ limit })`, {
+      executeDID,
+      executeVC,
+    });
+  } else {
+    limit = undefined;
+    logger.info(`🚀 Starting DID & VC request batch (MODE: ${ requestMode })`, {
+      executeDID,
+      executeVC,
+    });
+  }
 
   const issuer = container.resolve<PrismaClientIssuer>("PrismaClientIssuer");
   const didService = container.resolve<DIDIssuanceService>("DIDIssuanceService");
@@ -26,22 +50,26 @@ export async function requestDIDVC() {
 
   try {
     // --- DID ---
-    const didResult = await createDIDRequests(issuer, didService, ctx);
-    logger.info(
-      `📦 DID Requests: ${didResult.total} total, ` +
-        `${didResult.successCount} succeeded, ` +
-        `${didResult.failureCount} failed, ` +
-        `${didResult.skippedCount} skipped.`,
-    );
+    if (executeDID) {
+      const didResult = await createDIDRequests(issuer, didService, ctx, limit);
+      logger.info(
+        `📦 DID Requests: ${ didResult.total } total, ` +
+        `${ didResult.successCount } succeeded, ` +
+        `${ didResult.failureCount } failed, ` +
+        `${ didResult.skippedCount } skipped.`,
+      );
+    }
 
     // --- VC ---
-    const vcResult = await createVCRequests(issuer, vcService, vcConverter, ctx);
-    logger.info(
-      `📦 VC Requests: ${vcResult.total} total, ` +
-        `${vcResult.successCount} succeeded, ` +
-        `${vcResult.failureCount} failed, ` +
-        `${vcResult.skippedCount} skipped.`,
-    );
+    if (executeVC) {
+      const vcResult = await createVCRequests(issuer, vcService, vcConverter, ctx, limit);
+      logger.info(
+        `📦 VC Requests: ${ vcResult.total } total, ` +
+        `${ vcResult.successCount } succeeded, ` +
+        `${ vcResult.failureCount } failed, ` +
+        `${ vcResult.skippedCount } skipped.`,
+      );
+    }
 
     logger.info("✅ DID & VC request batch completed");
   } catch (error) {

--- a/src/presentation/batch/requestDIDVC/requestDID.ts
+++ b/src/presentation/batch/requestDIDVC/requestDID.ts
@@ -18,6 +18,7 @@ export async function createDIDRequests(
   issuer: PrismaClientIssuer,
   didService: DIDIssuanceService,
   ctx: IContext,
+  limit?: number,
 ): Promise<BatchResult> {
   const users = await issuer.public(ctx, async (tx) => {
     return tx.user.findMany({
@@ -43,6 +44,7 @@ export async function createDIDRequests(
         identities: { where: { platform: IdentityPlatform.PHONE } },
         didIssuanceRequests: true,
       },
+      take: limit,
     });
   });
 

--- a/src/presentation/batch/requestDIDVC/requestVC.ts
+++ b/src/presentation/batch/requestDIDVC/requestVC.ts
@@ -21,6 +21,7 @@ export async function createVCRequests(
   vcService: VCIssuanceRequestService,
   vcConverter: VCIssuanceRequestConverter,
   ctx: IContext,
+  limit?: number,
 ): Promise<BatchResult> {
   const evaluations = await issuer.public(ctx, async (tx) => {
     return tx.evaluation.findMany({
@@ -58,6 +59,7 @@ export async function createVCRequests(
         ],
       },
       include: evaluationInclude,
+      take: limit,
     });
   });
 

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -1,10 +1,3 @@
-import { IdentityPlatform } from "@prisma/client";
-
-export const getPlatform = (providerId?: string): IdentityPlatform | undefined => {
-  switch (providerId) {
-    case "oidc.line":
-      return IdentityPlatform.LINE;
-    default:
-      return undefined;
-  }
+export const checkBit = (a: number, n: number): boolean => {
+  return (a & (1 << (n - 1))) !== 0;
 };


### PR DESCRIPTION
バッチ処理 `request-did-vc` について、

- DID/VC, DIDのみ, VCのみ を選択して実行（指定ない場合はDID/VC）
- 1回のバッチ処理で処理する件数を指定して実行（指定ない場合は全件）

を環境変数で制御できるようにしました。