### PR TITLE
Fix/membership cursor undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,5 @@
     "sharp": "^0.34.1",
     "tsconfig-paths": "^4.2.0",
     "winston": "^3.17.0"
-  },
-  "packageManager": "pnpm@9.15.9+sha512.68046141893c66fad01c079231128e9afb89ef87e2691d69e4d40eee228988295fd4682181bae55b58418c3a253bde65a505ec7c5f9403ece5cc3cd37dcf2531"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -123,5 +123,6 @@
     "sharp": "^0.34.1",
     "tsconfig-paths": "^4.2.0",
     "winston": "^3.17.0"
-  }
+  },
+  "packageManager": "pnpm@9.15.9+sha512.68046141893c66fad01c079231128e9afb89ef87e2691d69e4d40eee228988295fd4682181bae55b58418c3a253bde65a505ec7c5f9403ece5cc3cd37dcf2531"
 }

--- a/src/application/domain/account/membership/data/repository.ts
+++ b/src/application/domain/account/membership/data/repository.ts
@@ -3,6 +3,7 @@ import { IContext } from "@/types/server";
 import {
   membershipInclude,
   membershipSelectDetail,
+  PrismaMembershipDetail,
 } from "@/application/domain/account/membership/data/type";
 import { IMembershipRepository } from "@/application/domain/account/membership/data/interface";
 import { injectable } from "tsyringe";
@@ -15,7 +16,7 @@ export default class MembershipRepository implements IMembershipRepository {
     orderBy: Prisma.MembershipOrderByWithRelationInput[],
     take: number,
     cursor?: Prisma.MembershipUserIdCommunityIdCompoundUniqueInput,
-  ) {
+  ): Promise<PrismaMembershipDetail[]> {
     return ctx.issuer.onlyBelongingCommunity(ctx, (tx) => {
       return tx.membership.findMany({
         where,

--- a/src/application/domain/account/membership/presenter.ts
+++ b/src/application/domain/account/membership/presenter.ts
@@ -14,7 +14,7 @@ import {
 
 export default class MembershipPresenter {
   static query(
-    r: GqlMembership[],
+    r: PrismaMembershipDetail[],
     hasNextPage: boolean,
     cursor?: string,
   ): GqlMembershipsConnection {
@@ -24,14 +24,14 @@ export default class MembershipPresenter {
       pageInfo: {
         hasNextPage,
         hasPreviousPage: !!cursor,
-        startCursor: r[0]?.user?.id + "_" + r[0]?.community?.id,
+        startCursor: r[0]?.userId + "_" + r[0]?.communityId,
         endCursor: r.length
-          ? r[r.length - 1].user?.id + "_" + r[r.length - 1].community?.id
+          ? r[r.length - 1].userId + "_" + r[r.length - 1].communityId
           : undefined,
       },
       edges: r.map((edge) => ({
-        cursor: edge.user?.id + "_" + edge.community?.id,
-        node: edge,
+        cursor: edge.userId + "_" + edge.communityId,
+        node: this.get(edge),
       })),
     };
   }

--- a/src/application/domain/account/membership/presenter.ts
+++ b/src/application/domain/account/membership/presenter.ts
@@ -24,7 +24,7 @@ export default class MembershipPresenter {
       pageInfo: {
         hasNextPage,
         hasPreviousPage: !!cursor,
-        startCursor: r[0]?.userId + "_" + r[0]?.communityId,
+        startCursor: r.length ? r[0].userId + "_" + r[0].communityId : undefined,
         endCursor: r.length
           ? r[r.length - 1].userId + "_" + r[r.length - 1].communityId
           : undefined,

--- a/src/application/domain/account/membership/service.ts
+++ b/src/application/domain/account/membership/service.ts
@@ -12,6 +12,7 @@ import { getCurrentUserId } from "@/application/domain/utils";
 import { NotFoundError } from "@/errors/graphql";
 import { IMembershipRepository } from "@/application/domain/account/membership/data/interface";
 import MembershipConverter from "@/application/domain/account/membership/data/converter";
+import { PrismaMembershipDetail } from "@/application/domain/account/membership/data/type";
 import { inject, injectable } from "tsyringe";
 
 @injectable()
@@ -26,13 +27,13 @@ export default class MembershipService {
     ctx: IContext,
     { cursor, filter, sort }: GqlQueryMembershipsArgs,
     take: number,
-  ) {
+  ): Promise<PrismaMembershipDetail[]> {
     const where = this.converter.filter(filter ?? {});
     const orderBy = this.converter.sort(sort ?? {});
     return this.repository.query(ctx, where, orderBy, take, cursor);
   }
 
-  async findMembershipDetail(ctx: IContext, userId: string, communityId: string) {
+  async findMembershipDetail(ctx: IContext, userId: string, communityId: string): Promise<PrismaMembershipDetail | null> {
     return this.repository.findDetail(ctx, { userId_communityId: { userId, communityId } });
   }
 

--- a/src/application/domain/account/membership/usecase.ts
+++ b/src/application/domain/account/membership/usecase.ts
@@ -40,7 +40,7 @@ export default class MembershipUseCase {
 
     const hasNextPage = records.length > take;
     const data = records.slice(0, take);
-    return MembershipPresenter.query(data, hasNextPage, args.cursor?.userId + "_" + args.cursor?.communityId);
+    return MembershipPresenter.query(data, hasNextPage, args.cursor ? args.cursor.userId + "_" + args.cursor.communityId : undefined);
   }
 
   async visitorViewMembership(

--- a/src/application/domain/account/membership/usecase.ts
+++ b/src/application/domain/account/membership/usecase.ts
@@ -39,7 +39,7 @@ export default class MembershipUseCase {
     const records = await this.membershipService.fetchMemberships(ctx, args, take);
 
     const hasNextPage = records.length > take;
-    const data = records.slice(0, take).map(MembershipPresenter.get);
+    const data = records.slice(0, take);
     return MembershipPresenter.query(data, hasNextPage, args.cursor?.userId + "_" + args.cursor?.communityId);
   }
 


### PR DESCRIPTION
## 問題
GetMembershipListクエリでcursorが`undefined_undefined`として返される問題が発生していました。

## 原因
MembershipPresenterでcursorを生成する際に、`edge.user?.id`と`edge.community?.id`を使用していましたが、実際のデータには`user`と`community`のリレーションが含まれていませんでした。

```typescript
// 問題のあったコード
cursor: edge.user?.id + "_" + edge.community?.id  // undefined_undefined
```

## 解決方法
`userId`と`communityId`を直接使用するように修正しました。

```typescript
// 修正後
cursor: edge.userId + "_" + edge.communityId  // user123_community456
```

## 変更内容
- MembershipPresenter.query: cursor生成ロジックを修正
- 型定義をPrismaMembershipDetailに統一
- 不要なリレーションデータの取得を避けることで効率化

## テスト
- [x] フロントエンドでcursorが正しく取得されることを確認
- [x] ページネーションが正常に動作することを確認