### PR TITLE
Add sorting functionality to cities list

### DIFF
--- a/src/application/domain/location/master/controller/resolver.ts
+++ b/src/application/domain/location/master/controller/resolver.ts
@@ -9,7 +9,7 @@ export default class MasterResolver {
 
   Query = {
     cities: async (_: unknown, args: GqlQueryCitiesArgs, ctx: IContext) => {
-      return this.useCase.getCities(args.filter, ctx, args.cursor, args.first);
+      return this.useCase.getCities(args.filter, ctx, args.cursor, args.first, args.sort);
     },
     states: async (_: unknown, args: GqlQueryStatesArgs, ctx: IContext) => {
       return this.useCase.getStates(args.filter, ctx, args.cursor, args.first);

--- a/src/application/domain/location/master/data/converter.ts
+++ b/src/application/domain/location/master/data/converter.ts
@@ -1,23 +1,19 @@
-import { GqlCitiesInput, GqlStatesInput } from "@/types/graphql";
+import { GqlCitiesInput, GqlCitiesSortInput, GqlStatesInput } from "@/types/graphql";
 import { Prisma } from "@prisma/client";
 import { injectable } from "tsyringe";
 
 @injectable()
 export default class MasterConverter {
   citiesFilter(input?: GqlCitiesInput): Prisma.CityWhereInput {
-    return input?.name
-      ? { name: { contains: input.name, mode: "insensitive" as const } }
-      : {};
+    return input?.name ? { name: { contains: input.name, mode: "insensitive" as const } } : {};
   }
 
-  citiesSort(): Prisma.CityOrderByWithRelationInput[] {
-    return [{ name: "asc" }];
+  citiesSort(sort?: GqlCitiesSortInput): Prisma.CityOrderByWithRelationInput[] {
+    return [{ code: sort?.code ?? Prisma.SortOrder.desc }];
   }
 
   statesFilter(input?: GqlStatesInput): Prisma.StateWhereInput {
-    return input?.name
-      ? { name: { contains: input.name, mode: "insensitive" as const } }
-      : {};
+    return input?.name ? { name: { contains: input.name, mode: "insensitive" as const } } : {};
   }
 
   statesSort(): Prisma.StateOrderByWithRelationInput[] {

--- a/src/application/domain/location/master/schema/query.graphql
+++ b/src/application/domain/location/master/schema/query.graphql
@@ -1,6 +1,7 @@
 extend type Query {
   cities(
     filter: CitiesInput
+    sort: CitiesSortInput
     cursor: String
     first: Int
   ): CitiesConnection!
@@ -35,6 +36,10 @@ type StateEdge implements Edge {
 
 input CitiesInput {
   name: String
+}
+
+input CitiesSortInput {
+  code: SortDirection
 }
 
 input StatesInput {

--- a/src/application/domain/location/master/service.ts
+++ b/src/application/domain/location/master/service.ts
@@ -1,5 +1,5 @@
 import { NotFoundError } from "@/errors/graphql";
-import { GqlCitiesInput, GqlStatesInput } from "@/types/graphql";
+import { GqlCitiesInput, GqlCitiesSortInput, GqlStatesInput } from "@/types/graphql";
 import { IContext } from "@/types/server";
 import { inject, injectable } from "tsyringe";
 import IMasterRepository from "@/application/domain/location/master/data/interface";
@@ -15,22 +15,33 @@ export default class MasterService {
     @inject("MasterConverter") private readonly converter: MasterConverter,
   ) {}
 
-  async getCities(filter: GqlCitiesInput | undefined, ctx: IContext, cursor?: string, first?: number) {
+  async getCities(
+    filter: GqlCitiesInput | undefined,
+    ctx: IContext,
+    cursor?: string,
+    first?: number,
+    sort?: GqlCitiesSortInput,
+  ) {
     const where = this.converter.citiesFilter(filter);
-    const orderBy = this.converter.citiesSort();
+    const orderBy = this.converter.citiesSort(sort);
     const take = clampFirst(first);
-    
+
     const cities = await this.repository.findCities(ctx, where, orderBy, take + 1, cursor);
     const hasNextPage = cities.length > take;
     const cityNodes = cities.slice(0, take).map((city) => MasterPresenter.get(city));
     return MasterPresenter.citiesQuery(cityNodes, hasNextPage, cursor);
   }
 
-  async getStates(filter: GqlStatesInput | undefined, ctx: IContext, cursor?: string, first?: number) {
+  async getStates(
+    filter: GqlStatesInput | undefined,
+    ctx: IContext,
+    cursor?: string,
+    first?: number,
+  ) {
     const where = this.converter.statesFilter(filter);
     const orderBy = this.converter.statesSort();
     const take = clampFirst(first);
-    
+
     const states = await this.repository.findStates(ctx, where, orderBy, take + 1, cursor);
     const hasNextPage = states.length > take;
     const stateNodes = states.slice(0, take).map((state) => this.converter.stateToGraphQL(state));

--- a/src/application/domain/location/master/usecase.ts
+++ b/src/application/domain/location/master/usecase.ts
@@ -1,5 +1,5 @@
 import { injectable, inject } from "tsyringe";
-import { GqlCitiesInput, GqlStatesInput } from "@/types/graphql";
+import { GqlCitiesInput, GqlCitiesSortInput, GqlStatesInput } from "@/types/graphql";
 import { IContext } from "@/types/server";
 import MasterService from "@/application/domain/location/master/service";
 
@@ -7,11 +7,22 @@ import MasterService from "@/application/domain/location/master/service";
 export default class MasterUseCase {
   constructor(@inject("MasterService") private readonly service: MasterService) {}
 
-  async getCities(filter: GqlCitiesInput | undefined, ctx: IContext, cursor?: string, first?: number) {
-    return this.service.getCities(filter, ctx, cursor, first);
+  async getCities(
+    filter: GqlCitiesInput | undefined,
+    ctx: IContext,
+    cursor?: string,
+    first?: number,
+    sort?: GqlCitiesSortInput,
+  ) {
+    return this.service.getCities(filter, ctx, cursor, first, sort);
   }
 
-  async getStates(filter: GqlStatesInput | undefined, ctx: IContext, cursor?: string, first?: number) {
+  async getStates(
+    filter: GqlStatesInput | undefined,
+    ctx: IContext,
+    cursor?: string,
+    first?: number,
+  ) {
     return this.service.getStates(filter, ctx, cursor, first);
   }
 }

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -183,6 +183,10 @@ export type GqlCitiesInput = {
   name?: InputMaybe<Scalars['String']['input']>;
 };
 
+export type GqlCitiesSortInput = {
+  code?: InputMaybe<GqlSortDirection>;
+};
+
 export type GqlCity = {
   __typename?: 'City';
   code: Scalars['ID']['output'];
@@ -1810,6 +1814,7 @@ export type GqlQueryCitiesArgs = {
   cursor?: InputMaybe<Scalars['String']['input']>;
   filter?: InputMaybe<GqlCitiesInput>;
   first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlCitiesSortInput>;
 };
 
 
@@ -3056,6 +3061,7 @@ export type GqlResolversTypes = ResolversObject<{
   CheckOpportunityPermissionInput: GqlCheckOpportunityPermissionInput;
   CitiesConnection: ResolverTypeWrapper<Omit<GqlCitiesConnection, 'edges'> & { edges: Array<GqlResolversTypes['CityEdge']> }>;
   CitiesInput: GqlCitiesInput;
+  CitiesSortInput: GqlCitiesSortInput;
   City: ResolverTypeWrapper<City>;
   CityEdge: ResolverTypeWrapper<Omit<GqlCityEdge, 'node'> & { node?: Maybe<GqlResolversTypes['City']> }>;
   ClaimLinkStatus: GqlClaimLinkStatus;
@@ -3381,6 +3387,7 @@ export type GqlResolversParentTypes = ResolversObject<{
   CheckOpportunityPermissionInput: GqlCheckOpportunityPermissionInput;
   CitiesConnection: Omit<GqlCitiesConnection, 'edges'> & { edges: Array<GqlResolversParentTypes['CityEdge']> };
   CitiesInput: GqlCitiesInput;
+  CitiesSortInput: GqlCitiesSortInput;
   City: City;
   CityEdge: Omit<GqlCityEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['City']> };
   CommunitiesConnection: Omit<GqlCommunitiesConnection, 'edges'> & { edges?: Maybe<Array<GqlResolversParentTypes['CommunityEdge']>> };


### PR DESCRIPTION
This pull request introduces sorting capability for the cities list in the Master module and the corresponding GraphQL schema. This enhancement allows users to fetch sorted lists of cities based on specific criteria, thereby improving the functionality and user experience.