### PR TITLE
Add admin validation and community filter support

### DIFF
--- a/src/application/domain/experience/opportunity/usecase.ts
+++ b/src/application/domain/experience/opportunity/usecase.ts
@@ -82,6 +82,8 @@ export default class OpportunityUseCase {
       isMember,
       isManager,
       currentUserId,
+      undefined,
+      ctx.isAdmin,
     );
 
     const record = await this.service.findOpportunityAccessible(ctx, id, validatedFilter);
@@ -211,7 +213,12 @@ function validateByMembershipRoles(
   isMember: Record<string, boolean>,
   currentUserId?: string,
   filter?: GqlOpportunityFilterInput,
+  isAdmin?: boolean,
 ): GqlOpportunityFilterInput {
+  if (isAdmin) {
+    return filter ?? {};
+  }
+
   if (communityIds.length === 0) {
     return {
       and: [{ publishStatus: [PublishStatus.PUBLIC] }, ...(filter ? [filter] : [])],

--- a/src/application/domain/location/place/data/converter.ts
+++ b/src/application/domain/location/place/data/converter.ts
@@ -15,6 +15,7 @@ export default class PlaceConverter {
         filter?.keyword ? { name: { contains: filter.keyword } } : {},
         filter?.keyword ? { address: { contains: filter.keyword } } : {},
         filter?.cityCode ? { cityCode: filter.cityCode } : {},
+        filter?.communityId ? { communityId: filter.communityId } : {},
       ],
     };
   }

--- a/src/application/domain/location/place/schema/query.graphql
+++ b/src/application/domain/location/place/schema/query.graphql
@@ -31,6 +31,7 @@ type PlaceEdge implements Edge {
 input PlaceFilterInput {
     keyword: String
     cityCode: ID
+    communityId: ID
 }
 
 input PlaceSortInput {

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1649,6 +1649,7 @@ export type GqlPlaceEdge = GqlEdge & {
 
 export type GqlPlaceFilterInput = {
   cityCode?: InputMaybe<Scalars['ID']['input']>;
+  communityId?: InputMaybe<Scalars['ID']['input']>;
   keyword?: InputMaybe<Scalars['String']['input']>;
 };
 


### PR DESCRIPTION
### Changes

- Added validation for admin permissions in opportunity filter logic.
- Added support for `communityId` as a filter in Place queries.

### Checklist

- [ ] Unit tests added/updated.
- [ ] Documentation updated. 
- [ ] All checks pass.