### PR TITLE
Hotfix: TypeScript compilation error in APPLIED case validation

### DIFF
--- a/src/presentation/batch/checkReservationParticipationConsistency.ts
+++ b/src/presentation/batch/checkReservationParticipationConsistency.ts
@@ -87,9 +87,8 @@ function validateConsistency(
     case ReservationStatus.APPLIED: {
       if (participation.reason === ParticipationStatusReason.RESERVATION_APPLIED) {
         if (
-          ![ParticipationStatus.PENDING, ParticipationStatus.NOT_PARTICIPATING].includes(
-            participation.status,
-          )
+          participation.status !== ParticipationStatus.PENDING &&
+          participation.status !== ParticipationStatus.NOT_PARTICIPATING
         ) {
           errors.push(
             `APPLIED reservation expects PENDING or NOT_PARTICIPATING, got ${participation.status}`,


### PR DESCRIPTION
# Hotfix: TypeScript compilation error in APPLIED case validation

## Summary
This PR fixes a TypeScript compilation error (TS2345) that was blocking the master build after PR #533 was merged. The error occurred in the APPLIED reservation status validation where an array `.includes()` call failed type checking due to TypeScript's literal type inference.

**Changed:** Replaced `.includes()` with direct `!==` comparisons in the APPLIED case validation (lines 89-92), matching the pattern already used in the ACCEPTED case from the previous refactoring.

**Root cause:** TypeScript infers `[ParticipationStatus.PENDING, ParticipationStatus.NOT_PARTICIPATING]` as a tuple of literal types, and `.includes()` on such tuples only accepts those specific literal types, not the broader `ParticipationStatus` enum.

## Review & Testing Checklist for Human
- [ ] Verify CI build passes (TypeScript compilation succeeds)
- [ ] (Optional) Run `checkReservationParticipationConsistency` batch job in dev/staging to ensure no runtime errors

**Recommended Test Plan:** Since this is a syntax-only change with preserved logic, CI passing is sufficient validation. If you want extra confidence, run the batch job in dev with `pnpm run batch:checkReservationParticipationConsistency`.

### Notes
- Logic is preserved: `![A, B].includes(x)` ≡ `x !== A && x !== B` (De Morgan's law)
- This pattern is already used in the ACCEPTED case (lines 70-73) from PR #533
- Build verified locally: `pnpm build` succeeded
- **Session**: https://app.devin.ai/sessions/3e8919e161e14bba8466aa0a7f74dd6a
- **Requested by**: Naoki Sakata (@709sakata)