### PR TITLE
Fix: refresh MV under RLS bypass after top-level ops

### DIFF
--- a/src/application/domain/experience/evaluation/usecase.ts
+++ b/src/application/domain/experience/evaluation/usecase.ts
@@ -98,6 +98,9 @@ export default class EvaluationUseCase {
           communityId,
         );
       });
+      await ctx.issuer.internal(async (tx) => {
+        await this.transactionService.refreshCurrentPoint(ctx, tx);
+      });
     } catch (error) {
       logger.warn("Point transfer failed for evaluation", {
         evaluationId: evaluation.id,

--- a/src/application/domain/experience/reservation/usecase.ts
+++ b/src/application/domain/experience/reservation/usecase.ts
@@ -138,6 +138,10 @@ export default class ReservationUseCase {
       return reservation;
     });
 
+    await ctx.issuer.internal(async (tx) => {
+      await this.transactionService.refreshCurrentPoint(ctx, tx);
+    });
+
     await this.notificationService.pushReservationAppliedMessage(ctx, reservation);
     if (!requireApproval) {
       await this.notificationService.pushReservationAcceptedMessage(ctx, reservation);
@@ -193,6 +197,10 @@ export default class ReservationUseCase {
       } else {
         throw new ValidationError("Cannot process reservation refund: opportunity community information is missing");
       }
+    });
+
+    await ctx.issuer.internal(async (tx) => {
+      await this.transactionService.refreshCurrentPoint(ctx, tx);
     });
 
     await this.notificationService.pushReservationCanceledMessage(ctx, reservation);
@@ -308,6 +316,10 @@ export default class ReservationUseCase {
 
       rejectedReservation = res;
       return res;
+    });
+
+    await ctx.issuer.internal(async (tx) => {
+      await this.transactionService.refreshCurrentPoint(ctx, tx);
     });
 
     if (rejectedReservation) {

--- a/src/application/domain/reward/ticket/usecase.ts
+++ b/src/application/domain/reward/ticket/usecase.ts
@@ -125,6 +125,10 @@ export default class TicketUseCase {
       );
     });
 
+    await ctx.issuer.internal(async (tx) => {
+      await this.transactionService.refreshCurrentPoint(ctx, tx);
+    });
+
     return TicketPresenter.claim(tickets);
   }
 
@@ -138,7 +142,7 @@ export default class TicketUseCase {
       input.communityId,
     );
 
-    return ctx.issuer.onlyBelongingCommunity(ctx, async (tx: Prisma.TransactionClient) => {
+    const result = await ctx.issuer.onlyBelongingCommunity(ctx, async (tx: Prisma.TransactionClient) => {
       await this.walletValidator.validateTransfer(
         input.pointsRequired,
         memberWallet,
@@ -162,6 +166,12 @@ export default class TicketUseCase {
       );
       return TicketPresenter.purchase(result);
     });
+
+    await ctx.issuer.internal(async (tx) => {
+      await this.transactionService.refreshCurrentPoint(ctx, tx);
+    });
+
+    return result;
   }
 
   async memberUseTicket(
@@ -187,7 +197,7 @@ export default class TicketUseCase {
       input.communityId,
     );
 
-    return ctx.issuer.onlyBelongingCommunity(ctx, async (tx: Prisma.TransactionClient) => {
+    const result = await ctx.issuer.onlyBelongingCommunity(ctx, async (tx: Prisma.TransactionClient) => {
       await this.walletValidator.validateTransfer(
         input.pointsRequired,
         communityWallet,
@@ -205,5 +215,11 @@ export default class TicketUseCase {
       const result = await this.ticketService.refundTicket(ctx, id, transaction.id, tx);
       return TicketPresenter.refund(result);
     });
+
+    await ctx.issuer.internal(async (tx) => {
+      await this.transactionService.refreshCurrentPoint(ctx, tx);
+    });
+
+    return result;
   }
 }

--- a/src/application/domain/transaction/service.ts
+++ b/src/application/domain/transaction/service.ts
@@ -42,7 +42,6 @@ export default class TransactionService implements ITransactionService {
     const currentUserId = getCurrentUserId(ctx);
     const data = this.converter.issueCommunityPoint(toWalletId, transferPoints, currentUserId, comment);
     const res = await this.repository.create(ctx, data, tx);
-    await this.repository.refreshCurrentPoints(ctx, tx);
     return res;
   }
 
@@ -57,7 +56,6 @@ export default class TransactionService implements ITransactionService {
     const currentUserId = getCurrentUserId(ctx);
     const data = this.converter.grantCommunityPoint(fromWalletId, transferPoints, memberWalletId, currentUserId, comment);
     const res = await this.repository.create(ctx, data, tx);
-    await this.repository.refreshCurrentPoints(ctx, tx);
     return res;
   }
 
@@ -72,7 +70,6 @@ export default class TransactionService implements ITransactionService {
     const currentUserId = getCurrentUserId(ctx);
     const data = this.converter.donateSelfPoint(fromWalletId, toWalletId, transferPoints, currentUserId, comment);
     const transaction = await this.repository.create(ctx, data, tx);
-    await this.repository.refreshCurrentPoints(ctx, tx);
     return transaction;
   }
 
@@ -88,7 +85,6 @@ export default class TransactionService implements ITransactionService {
     const currentUserId = getCurrentUserId(ctx);
     const data = this.converter.reservationCreated(fromWalletId, toWalletId, transferPoints, currentUserId, reservationId, reason);
     const transaction = await this.repository.create(ctx, data, tx);
-    await this.repository.refreshCurrentPoints(ctx, tx);
     return transaction;
   }
 
@@ -109,7 +105,6 @@ export default class TransactionService implements ITransactionService {
       currentUserId,
     );
     const res = await this.repository.create(ctx, data, tx);
-    await this.repository.refreshCurrentPoints(ctx, tx);
     return res;
   }
 
@@ -123,7 +118,6 @@ export default class TransactionService implements ITransactionService {
     const currentUserId = getCurrentUserId(ctx);
     const data = this.converter.purchaseTicket(fromWalletId, toWalletId, transferPoints, currentUserId);
     const res = await this.repository.create(ctx, data, tx);
-    await this.repository.refreshCurrentPoints(ctx, tx);
     return res;
   }
 
@@ -137,7 +131,6 @@ export default class TransactionService implements ITransactionService {
     const currentUserId = getCurrentUserId(ctx);
     const data = this.converter.refundTicket(fromWalletId, toWalletId, transferPoints, currentUserId);
     const res = await this.repository.create(ctx, data, tx);
-    await this.repository.refreshCurrentPoints(ctx, tx);
     return res;
   }
 

--- a/src/application/domain/transaction/usecase.ts
+++ b/src/application/domain/transaction/usecase.ts
@@ -81,6 +81,9 @@ export default class TransactionUseCase {
         );
       },
     );
+    await ctx.issuer.internal(async (tx) => {
+      await this.transactionService.refreshCurrentPoint(ctx, tx);
+    });
     return TransactionPresenter.issueCommunityPoint(res);
   }
 
@@ -130,6 +133,11 @@ export default class TransactionUseCase {
     });
 
     const communityName = community?.name ?? "コミュニティ";
+    
+    await ctx.issuer.internal(async (tx) => {
+      await this.transactionService.refreshCurrentPoint(ctx, tx);
+    });
+    
     this.notificationService
       .pushPointGrantReceivedMessage(
         ctx,
@@ -182,6 +190,10 @@ export default class TransactionUseCase {
         tx,
         comment,
       );
+    });
+
+    await ctx.issuer.internal(async (tx) => {
+      await this.transactionService.refreshCurrentPoint(ctx, tx);
     });
 
     const fromUserName = ctx.currentUser?.name ?? "ユーザー";


### PR DESCRIPTION
## 概要
currentPointが0ptになるバグを修正しました。RLS有効状態でマテリアライズドビューをリフレッシュすることで、対象コミュニティ以外の残高が一時的に0/欠損になる問題を解決します。

## 変更点
- TransactionService内のrefreshCurrentPoints呼び出しを全て削除（7箇所）
- 各UseCaseのトップレベル操作完了後に、issuer.internal()（RLSバイパス）で1回だけMVをリフレッシュ（10箇所）
- リフレッシュの実体は既存のtyped SQLを維持

## 期待効果
- どのコミュニティで操作しても、全コミュニティの残高が正しく維持される
- 15分バッチのみに依存しない即時反映

## 注意点
もしCI/本番で「REFRESH MATERIALIZED VIEW CONCURRENTLYはトランザクション内で実行できない」エラーが出る場合は、非CONCURRENTのリフレッシュに切り替える等、最小限の追従修正を別PRで提案します。

Link to Devin run: https://app.devin.ai/sessions/475bca1ada274533a3626d642ab176d1
Requested by: Naoki Sakata (naoki.sakata@hopin.co.jp) / @709sakata
