### PR TITLE
refactor: NFT seed処理をfactoryパターンに統一

### DIFF
--- a/src/infrastructure/prisma/factories/factory.ts
+++ b/src/infrastructure/prisma/factories/factory.ts
@@ -5,6 +5,8 @@ import {
   IdentityPlatform,
   MembershipStatus,
   MembershipStatusReason,
+  NftInstanceStatus,
+  NftWalletType,
   OpportunityCategory,
   OpportunitySlotHostingStatus,
   ParticipationStatus,
@@ -44,6 +46,9 @@ import {
   defineEvaluationFactory,
   defineImageFactory,
   defineMembershipFactory,
+  defineNftInstanceFactory,
+  defineNftTokenFactory,
+  defineNftWalletFactory,
   defineOpportunityFactory,
   defineOpportunitySlotFactory,
   defineParticipationFactory,
@@ -669,6 +674,56 @@ export const TransactionFactory = defineTransactionFactory.withTransientFields<{
       toWallet: { connect: { id: toWallet.id } },
       fromPointChange: -10,
       toPointChange: 10,
+    };
+  },
+});
+
+
+export const NftTokenFactory = defineNftTokenFactory({
+  defaultData: () => ({
+    address: `0x${randUuid().replace(/-/g, "").substring(0, 40)}`,
+    type: "ERC-721",
+    name: `NFT Token ${randSlug()}`,
+    symbol: randSlug().substring(0, 5).toUpperCase(),
+    json: {},
+  }),
+});
+
+export const NftWalletFactory = defineNftWalletFactory.withTransientFields<{
+  transientUser?: { id: string };
+}>({
+  transientUser: undefined,
+})({
+  defaultData: async ({ transientUser }) => {
+    const user = transientUser ?? (await UserFactory.create());
+    return {
+      type: NftWalletType.EXTERNAL,
+      walletAddress: `0x${randUuid().replace(/-/g, "").substring(0, 40)}`,
+      user: { connect: { id: user.id } },
+    };
+  },
+});
+
+export const NftInstanceFactory = defineNftInstanceFactory.withTransientFields<{
+  transientNftToken?: { id: string };
+  transientNftWallet?: { id: string };
+}>({
+  transientNftToken: undefined,
+  transientNftWallet: undefined,
+})({
+  defaultData: async ({ transientNftToken, transientNftWallet }) => {
+    const token = transientNftToken ?? (await NftTokenFactory.create());
+    return {
+      instanceId: randUuid(),
+      status: NftInstanceStatus.OWNED,
+      name: `NFT Instance ${randSlug()}`,
+      description: randParagraph(),
+      imageUrl: `https://picsum.photos/seed/${randSlug()}/800/450`,
+      json: {},
+      nftToken: { connect: { id: token.id } },
+      ...(transientNftWallet && {
+        nftWallet: { connect: { id: transientNftWallet.id } },
+      }),
     };
   },
 });


### PR DESCRIPTION
# refactor: NFT seed処理をfactoryパターンに統一

## Summary
NFT seed処理を`prismaClient.createMany()`から`Factory.create()`パターンに変更し、他のドメイン（place、opportunity等）と統一しました。

**変更内容:**
- `factory.ts`に3つの新しいfactoryを追加: `NftTokenFactory`, `NftWalletFactory`, `NftInstanceFactory`
- `domains.ts`の`createNfts()`をバッチトランザクションからループ処理に変更
- 全てのNFTインスタンス（wallet有り/無し）でfactoryパターンを使用

**データ生成結果（変更なし）:**
- NFT Tokens: 2個（Ethereum ERC-721、Cardano CIP-25）
- NFT Wallets: 10個（各ユーザーにEXTERNAL + INTERNAL）
- NFT Instances: 11個（OWNED: 10個、STOCK: 1個）

## Review & Testing Checklist for Human

この変更には以下のリスクがあるため、人手での確認をお願いします：

- [ ] **Policy-only NFTインスタンス（`ins_ada_policy`）がwalletに接続されていないことを確認**
  - DB: `SELECT * FROM t_nft_instances WHERE id = 'ins_ada_policy'` → `nft_wallet_id`がNULLであること
  - 重要: `NftInstanceFactory`の`...(transientNftWallet && {...})`構文が正しく動作しているか
  
- [ ] **他の全NFTインスタンスが正しいwalletに接続されていることを確認**
  - ETHインスタンス（`ins_eth_1`～`ins_eth_5`）→ EXTERNALウォレット
  - ADAインスタンス（`ins_ada_1`～`ins_ada_5`）→ INTERNALウォレット
  
- [ ] **Portal linksが正常に動作することを確認**
  - `/nfts/ins_eth_1`, `/nfts/ins_ada_1`, `/nfts/ins_ada_policy`等にアクセス
  - ブロックチェーンリンク（Etherscan、Cardanoscan）が正しく生成されるか
  
- [ ] **Seed再実行時の動作確認（オプション）**
  - 以前は`skipDuplicates: true`があったが、factory版には明示的な重複保護がない
  - `pnpm db:seed-domain`を2回実行してエラーが出ないか確認

### Test Plan
```bash
# 1. クリーンなDBでseed実行
pnpm db:reset
pnpm db:seed-master
pnpm db:seed-domain

# 2. データ確認
psql -d civicship_dev -c "SELECT id, nft_wallet_id FROM t_nft_instances ORDER BY id;"

# 3. Portal動作確認（ポータルを起動して）
# - /nfts/ins_eth_1
# - /nfts/ins_ada_1
# - /nfts/ins_ada_policy
```

### Notes
- **State数の調査**: 以前の147個のstateはレガシーデータで、現在のコードは正しく47個（JP）のみを作成することを確認済み
- **パターン統一**: `createPlaces()`, `createOpportunities()`と同じfactory based patternに統一
- **トランザクション境界の変更**: 単一トランザクション（3つの`createMany()`）→ 複数の個別トランザクション（ループ内の`create()`）に変更。他のドメインと同じパターン

---
**Link to Devin run:** https://app.devin.ai/sessions/d65f8aae727b41c69730b04671a84763  
**Requested by:** Naoki Sakata (naoki.sakata@hopin.co.jp) / @709sakata