### PR TITLE
Add request filter logic to Apollo server tracing

### DIFF
--- a/src/presentation/graphql/server.ts
+++ b/src/presentation/graphql/server.ts
@@ -32,6 +32,10 @@ export async function createApolloServer(httpServer: http.Server) {
         fieldLevelInstrumentation: isProduction ? 0.05 : 1.0,
         sendReportsImmediately: !isProduction,
         sendVariableValues: { none: true },
+        includeRequest: async (requestContext) => {
+          const headerValue = requestContext.request.http?.headers.get("x-no-report");
+          return headerValue !== "true";
+        },
       }),
     );
   }


### PR DESCRIPTION
```markdown
**What does this implement/fix? Explain your changes.**
This pull request adds request filtering logic to the Apollo server tracing configuration. The new logic ensures that specific requests can be excluded from tracing based on customizable criteria.

**Does this close any currently open issues?**  
No

**Where has this been tested?**
- Apollo Server  
- Node.js environment  
```