### PR TITLE
Fix: Support both 'session' and '__session' cookie names for session authentication

### DIFF
--- a/src/presentation/middleware/auth/extract-headers.ts
+++ b/src/presentation/middleware/auth/extract-headers.ts
@@ -15,10 +15,13 @@ export function extractAuthHeaders(req: http.IncomingMessage): AuthHeaders {
       .map(([k, v]) => [k, decodeURIComponent(v || "")]),
   );
 
-  const sessionCookie = cookies["__session"];
+  // Support both "session" and "__session" cookie names for compatibility
+  const sessionCookie = cookies["session"] || cookies["__session"];
 
-  const idToken =
-    authMode === "session" ? sessionCookie : getHeader("authorization")?.replace(/^Bearer\s+/, "");
+  const bearer = getHeader("authorization")?.replace(/^Bearer\s+/, "");
+
+  // In session mode, use only the session cookie; in id_token mode, use only Authorization header
+  const idToken = authMode === "session" ? sessionCookie : bearer;
 
   const headers: AuthHeaders = {
     authMode,


### PR DESCRIPTION
## Summary

Updates `extractAuthHeaders` to support both `session` and `__session` cookie names for session-based authentication. This fixes a cookie name mismatch where the API sets the cookie as `session` (in `session.ts:39`) but was only reading from `__session`.

This is the API-side fix for the "Not authenticated" error on `/admin/wallet/grant`. The companion Portal PR changes SSR helpers to forward cookies via the `cookie` header instead of incorrectly putting session cookies in the `Authorization` header.

**Changes:**
- Read session cookie from both `cookies["session"]` and `cookies["__session"]` for compatibility
- Clarified the separation: session mode uses only cookies, id_token mode uses only Authorization header

## Review & Testing Checklist for Human

- [ ] **Verify cookie name priority**: Confirm that `session` should take precedence over `__session` (or if the order should be reversed)
- [ ] **Test with companion Portal PR**: This fix requires the Portal changes (branch `devin/1764050589-fix-ssr-cookie-auth`) to work correctly. Test `/admin/wallet/grant` page after deploying both
- [ ] **Verify existing auth flows still work**: Ensure client-side authentication (Apollo Client with `id_token` mode) is unaffected

### Recommended Test Plan
1. Deploy both this API change and the companion Portal PR to a test environment
2. Log in via LINE authentication
3. Navigate to `/admin/wallet/grant` - should no longer show "Not authenticated" error
4. Verify other authenticated pages still work (`/admin/wallet`, `/users/me`, etc.)

### Notes
- **Companion PR**: Portal changes are in `Hopin-inc/civicship-portal` branch `devin/1764050589-fix-ssr-cookie-auth`
- **Root cause**: Portal was sending session cookies via `Authorization: Bearer` header, but API ignores Authorization header in session mode and only reads from cookies
- Link to Devin run: https://app.devin.ai/sessions/041a745dd72548758f49f50149329640
- Requested by: Naoki Sakata (@709sakata)