### PR TITLE
feat: OpportunitySlotFilterInputにcommunityIds, category, publishStatusフィルターを追加

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -935,10 +935,13 @@ type OpportunitySlotEdge implements Edge {
 }
 
 input OpportunitySlotFilterInput {
+  category: OpportunityCategory
+  communityIds: [ID!]
   dateRange: DateTimeRangeFilter
   hostingStatus: [OpportunitySlotHostingStatus!]
   opportunityIds: [ID!]
   ownerId: ID
+  publishStatus: [PublishStatus!]
 }
 
 enum OpportunitySlotHostingStatus {

--- a/src/application/domain/experience/opportunitySlot/data/converter.ts
+++ b/src/application/domain/experience/opportunitySlot/data/converter.ts
@@ -43,6 +43,25 @@ export default class OpportunitySlotConverter {
       }
     }
 
+    // Filters through related opportunity
+    const opportunityConditions: Prisma.OpportunityWhereInput[] = [];
+
+    if (filter?.communityIds?.length) {
+      opportunityConditions.push({ communityId: { in: filter.communityIds } });
+    }
+
+    if (filter?.category) {
+      opportunityConditions.push({ category: filter.category });
+    }
+
+    if (filter?.publishStatus?.length) {
+      opportunityConditions.push({ publishStatus: { in: filter.publishStatus } });
+    }
+
+    if (opportunityConditions.length > 0) {
+      slotConditions.push({ opportunity: { AND: opportunityConditions } });
+    }
+
     return {
       AND: slotConditions,
     };

--- a/src/application/domain/experience/opportunitySlot/schema/query.graphql
+++ b/src/application/domain/experience/opportunitySlot/schema/query.graphql
@@ -33,6 +33,10 @@ input OpportunitySlotFilterInput {
     ownerId: ID
     hostingStatus: [OpportunitySlotHostingStatus!]
     dateRange: DateTimeRangeFilter
+    # Filters through related opportunity
+    communityIds: [ID!]
+    category: OpportunityCategory
+    publishStatus: [PublishStatus!]
 }
 
 input OpportunitySlotSortInput {

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1339,10 +1339,13 @@ export type GqlOpportunitySlotEdge = GqlEdge & {
 };
 
 export type GqlOpportunitySlotFilterInput = {
+  category?: InputMaybe<GqlOpportunityCategory>;
+  communityIds?: InputMaybe<Array<Scalars['ID']['input']>>;
   dateRange?: InputMaybe<GqlDateTimeRangeFilter>;
   hostingStatus?: InputMaybe<Array<GqlOpportunitySlotHostingStatus>>;
   opportunityIds?: InputMaybe<Array<Scalars['ID']['input']>>;
   ownerId?: InputMaybe<Scalars['ID']['input']>;
+  publishStatus?: InputMaybe<Array<GqlPublishStatus>>;
 };
 
 export const GqlOpportunitySlotHostingStatus = {


### PR DESCRIPTION
## Summary

Extends `OpportunitySlotFilterInput` with three new filter fields that filter through the related `opportunity` table:
- `communityIds: [ID!]` - Filter slots by their opportunity's community
- `category: OpportunityCategory` - Filter by Activity/Quest/Event
- `publishStatus: [PublishStatus!]` - Filter by opportunity publish status

This enables the frontend to query `opportunitySlots` directly with community/category filters, which is needed for the vertical layout feed pages to use slot-centric queries instead of opportunity-centric queries.

## Review & Testing Checklist for Human

- [ ] **Verify Prisma relation filter syntax**: Confirm that `{ opportunity: { AND: opportunityConditions } }` correctly filters slots through their parent opportunity relation
- [ ] **Test the GraphQL query**: Run a test query with the new filters to verify they work as expected:
  ```graphql
  query {
    opportunitySlots(filter: {
      communityIds: ["<community-id>"],
      category: ACTIVITY,
      publishStatus: [PUBLIC],
      hostingStatus: [SCHEDULED]
    }) {
      edges { node { id startsAt } }
    }
  }
  ```
- [ ] **Check query performance**: With large datasets, verify the query doesn't cause performance issues due to the relation join

### Notes

No unit tests were added for the converter changes. The existing lint errors in `src/types/graphql.ts` are pre-existing issues with the auto-generated file (644 `@typescript-eslint/no-explicit-any` errors), not related to this PR.

**Link to Devin run:** https://app.devin.ai/sessions/d4c14cbae5024fea8d3c5318158d32b5
**Requested by:** Naoki Sakata (@709sakata)