### PR TITLE
fix: add permission parameter to storePhoneAuthToken mutation for IsSelf authorization

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -691,7 +691,7 @@ type Mutation {
   reservationCreate(input: ReservationCreateInput!): ReservationCreatePayload
   reservationJoin(id: ID!): ReservationSetStatusPayload
   reservationReject(id: ID!, input: ReservationRejectInput!, permission: CheckOpportunityPermissionInput!): ReservationSetStatusPayload
-  storePhoneAuthToken(input: StorePhoneAuthTokenInput!): StorePhoneAuthTokenPayload
+  storePhoneAuthToken(input: StorePhoneAuthTokenInput!, permission: CheckIsSelfPermissionInput!): StorePhoneAuthTokenPayload
   ticketClaim(input: TicketClaimInput!): TicketClaimPayload
   ticketIssue(input: TicketIssueInput!, permission: CheckCommunityPermissionInput!): TicketIssuePayload
   ticketPurchase(input: TicketPurchaseInput!, permission: CheckCommunityPermissionInput!): TicketPurchasePayload

--- a/src/application/domain/account/identity/schema/mutation.graphql
+++ b/src/application/domain/account/identity/schema/mutation.graphql
@@ -14,7 +14,10 @@ extend type Mutation {
         permission: CheckIsSelfPermissionInput!
     ): LinkPhoneAuthPayload
 
-    storePhoneAuthToken(input: StorePhoneAuthTokenInput!): StorePhoneAuthTokenPayload
+    storePhoneAuthToken(
+        input: StorePhoneAuthTokenInput!
+        permission: CheckIsSelfPermissionInput!
+    ): StorePhoneAuthTokenPayload
     @authz(rules: [IsSelf])
 
     identityCheckPhoneUser(

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1000,6 +1000,7 @@ export type GqlMutationReservationRejectArgs = {
 
 export type GqlMutationStorePhoneAuthTokenArgs = {
   input: GqlStorePhoneAuthTokenInput;
+  permission: GqlCheckIsSelfPermissionInput;
 };
 
 
@@ -4115,7 +4116,7 @@ export type GqlMutationResolvers<ContextType = any, ParentType extends GqlResolv
   reservationCreate?: Resolver<Maybe<GqlResolversTypes['ReservationCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationReservationCreateArgs, 'input'>>;
   reservationJoin?: Resolver<Maybe<GqlResolversTypes['ReservationSetStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationReservationJoinArgs, 'id'>>;
   reservationReject?: Resolver<Maybe<GqlResolversTypes['ReservationSetStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationReservationRejectArgs, 'id' | 'input' | 'permission'>>;
-  storePhoneAuthToken?: Resolver<Maybe<GqlResolversTypes['StorePhoneAuthTokenPayload']>, ParentType, ContextType, RequireFields<GqlMutationStorePhoneAuthTokenArgs, 'input'>>;
+  storePhoneAuthToken?: Resolver<Maybe<GqlResolversTypes['StorePhoneAuthTokenPayload']>, ParentType, ContextType, RequireFields<GqlMutationStorePhoneAuthTokenArgs, 'input' | 'permission'>>;
   ticketClaim?: Resolver<Maybe<GqlResolversTypes['TicketClaimPayload']>, ParentType, ContextType, RequireFields<GqlMutationTicketClaimArgs, 'input'>>;
   ticketIssue?: Resolver<Maybe<GqlResolversTypes['TicketIssuePayload']>, ParentType, ContextType, RequireFields<GqlMutationTicketIssueArgs, 'input' | 'permission'>>;
   ticketPurchase?: Resolver<Maybe<GqlResolversTypes['TicketPurchasePayload']>, ParentType, ContextType, RequireFields<GqlMutationTicketPurchaseArgs, 'input' | 'permission'>>;


### PR DESCRIPTION
## Summary

Adds the missing `permission: CheckIsSelfPermissionInput!` parameter to the `storePhoneAuthToken` mutation. This mutation had `@authz(rules: [IsSelf])` but was missing the `permission` parameter that the `IsSelf` rule requires to function.

The `IsSelf` rule checks `args.permission.userId` against `context.currentUser.id`. Without the `permission` parameter, `args.permission` was always `undefined`, causing authorization to always fail with "User is not self".

This follows the same pattern as other mutations using `IsSelf` (e.g., `userDeleteMe`, `linkPhoneAuth`).

## Review & Testing Checklist for Human

- [ ] Verify that the `storePhoneAuthToken` mutation is not currently called anywhere in production (it would have always failed before this fix)
- [ ] Confirm the frontend PR (civicship-portal#852) is updated to pass `permission: { userId }` when calling this mutation
- [ ] Test the phone reverification flow end-to-end after both PRs are merged

### Notes

This fix is required for the phone reverification feature in civicship-portal (Issue #727). The frontend PR will need to be updated to pass the `permission` parameter.

**Link to Devin run:** https://app.devin.ai/sessions/25d8c52a77744d43beaf5a28cb30a0ac
**Requested by:** Naoki Sakata (@709sakata)