### PR TITLE
fix: リッチメニューデプロイのビルドエラー修正

### DIFF
--- a/src/infrastructure/richmenu/deployer.ts
+++ b/src/infrastructure/richmenu/deployer.ts
@@ -26,7 +26,7 @@ function getMimeType(imagePath: string): string {
 export async function deployRichMenu(
   ctx: DeployRichMenuContext,
   menu: RichMenuDefinition,
-): Promise<DeployMenuResult> {
+): Promise<void> {
   const { lineClient, lineBlobClient, prisma, communityBasePath, liffBaseUrl, configId } = ctx;
 
   const resolvedMenu = resolvePlaceholders(menu, liffBaseUrl);
@@ -73,7 +73,6 @@ export async function deployRichMenu(
   });
   logger.info(`Created alias: ${menu.alias} -> ${richMenuId}`);
 
-  let dbSaved = false;
   if (menu.roleEntryFor) {
     await prisma.communityLineRichMenuConfig.upsert({
       where: {
@@ -91,7 +90,6 @@ export async function deployRichMenu(
         richMenuId,
       },
     });
-    dbSaved = true;
     logger.info(`Saved to DB: ${menu.alias} as ${menu.roleEntryFor}`);
   }
 
@@ -99,13 +97,6 @@ export async function deployRichMenu(
     await lineClient.setDefaultRichMenu(richMenuId);
     logger.info(`Set default rich menu: ${menu.alias}`);
   }
-
-  return {
-    alias: menu.alias,
-    richMenuId,
-    dbSaved,
-    isDefault: menu.isDefault ?? false,
-  };
 }
 
 export async function deployRichMenus(


### PR DESCRIPTION
## Summary

PR #586 のマージ後に発生したビルドエラーを修正します。

`deployRichMenu` 関数が `DeployMenuResult` 型を返すように宣言されていましたが、この型は JSON 出力機能の削除時に `types.ts` から削除されていました。関数の戻り値の型を `void` に変更し、未使用の `dbSaved` 変数と return 文を削除しました。

## Review & Testing Checklist for Human

- [ ] `pnpm build` がエラーなく完了することを確認
- [ ] `pnpm richmenu:deploy --community=neo88` が正常に動作することを確認（DB保存、LINE API呼び出しが正常に行われる）

**テスト手順:**
1. `pnpm build` を実行してビルドが成功することを確認
2. 必要に応じて `pnpm richmenu:deploy --dry-run --community=neo88` でドライランを実行

### Notes

- 変更は `deployer.ts` のみで、機能的な変更はありません（戻り値を使用していた箇所はありません）
- `deployRichMenus` は元々戻り値を無視していたため、この変更による影響はありません

**Link to Devin run:** https://app.devin.ai/sessions/b573fa76ca6a453c92ccf16cb6d6cfe2
**Requested by:** Naoki Sakata (@709sakata)