### PR TITLE
Change OpenTelemetry diagnostic log level from DEBUG to INFO

### DIFF
--- a/src/infrastructure/logging/tracing.ts
+++ b/src/infrastructure/logging/tracing.ts
@@ -35,7 +35,7 @@ export const tracingReady = (async () => {
 
   // ✅ 2. 非ローカルのみ初期化
   if (ENV !== "LOCAL") {
-    diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
+    diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
   }
 
   const resource = resourceFromAttributes({


### PR DESCRIPTION
This reduces excessive log output in production environments where 99% of requests are not sampled (TRACE_SAMPLE_RATE = 0.01), but were still generating DEBUG logs like "Recording is off, propagating context in a non-recording span" for every unsampled request.

With INFO level, only important messages will be logged while maintaining necessary troubleshooting information.