### PR TITLE
Claude/investigate otel logging 01 x7 y6f mx rmn aiiq6 f qw1p vy

### DIFF
--- a/src/infrastructure/logging/tracing.ts
+++ b/src/infrastructure/logging/tracing.ts
@@ -13,7 +13,6 @@ import { HttpInstrumentation } from "@opentelemetry/instrumentation-http";
 import { ExpressInstrumentation, ExpressLayerType } from "@opentelemetry/instrumentation-express";
 import { GraphQLInstrumentation } from "@opentelemetry/instrumentation-graphql";
 import { UndiciInstrumentation } from "@opentelemetry/instrumentation-undici";
-import { PrismaInstrumentation } from "@prisma/instrumentation";
 import { ParentBasedSampler, TraceIdRatioBasedSampler } from "@opentelemetry/sdk-trace-node";
 import { diag, DiagConsoleLogger, DiagLogLevel } from "@opentelemetry/api";
 import logger from "./index";
@@ -71,7 +70,10 @@ export const tracingReady = (async () => {
       ignoreTrivialResolveSpans: true,
     }),
     new UndiciInstrumentation(),
-    new PrismaInstrumentation(),
+    // PrismaInstrumentation is disabled due to a bug in v6.19.0 that causes
+    // "Cannot execute operation on ended Span" errors in nested transaction scenarios.
+    // See: https://github.com/prisma/prisma/issues (nested transaction span bug)
+    // new PrismaInstrumentation(),
   ];
 
   sdk = new NodeSDK({


### PR DESCRIPTION
🎯 実装内容
変更ファイル: src/infrastructure/logging/tracing.ts
Import削除:

- import { PrismaInstrumentation } from "@prisma/instrumentation";

Instrumentation無効化:

- new PrismaInstrumentation(),
+ // PrismaInstrumentation is disabled due to a bug in v6.19.0 that causes
+ // "Cannot execute operation on ended Span" errors in nested transaction scenarios.
+ // See: https://github.com/prisma/prisma/issues (nested transaction span bug)
+ // new PrismaInstrumentation(),

💥 解決される問題
これで以下のエラーが解消されます：

❌ Cannot execute the operation on ended Span
❌ You can only call end() on a span once.
原因:
Prisma instrumentation v6.19.0 のバグ
多段ネストされたトランザクション（RLS実装）で span が二重に end() される
このアプリの多段トランザクション構造:
Context生成 (bypassRls)
  └─ $transaction
     └─ RLS設定 (setRls)
        └─ DataLoader
           └─ $transaction
              └─ UseCase
                 └─ $transaction (場合により)

📊 現在のトレーシング状況
有効なインストルメンテーション:

✅ HttpInstrumentation
✅ ExpressInstrumentation
✅ GraphQLInstrumentation
✅ UndiciInstrumentation
無効化:

❌ PrismaInstrumentation (バグのため)
Prisma クエリのトレーシングは無くなりますが、HTTP/GraphQL レベルのトレーシングは維持されるので、パフォーマンス監視は引き続き可能です👍