### PR TITLE
refactor: 過剰ログ是正 - 成功/通過ログをdebugに格下げ、本番ログレベルをwarnに変更

### DIFF
--- a/src/application/domain/account/identity/didIssuanceRequest/service.ts
+++ b/src/application/domain/account/identity/didIssuanceRequest/service.ts
@@ -232,7 +232,7 @@ export class DIDIssuanceService {
       retryCount: 0,
       errorMessage: `Auto-reset: ${reason}`,
     });
-    logger.info(`🔄 Reset request ${requestId} for retry: ${reason}`);
+    logger.debug(`🔄 Reset request ${requestId} for retry: ${reason}`);
   }
 
   private async attemptDidJob404Recovery(
@@ -258,7 +258,7 @@ export class DIDIssuanceService {
           completedAt: new Date(),
           errorMessage: "Recovered: Job expired but DID was already published",
         });
-        logger.info(`✅ DID recovered as completed: ${request.id}, didValue: ${existingDid.did}`);
+        logger.debug(`✅ DID recovered as completed: ${request.id}, didValue: ${existingDid.did}`);
         return "completed";
       }
     } catch (checkError) {
@@ -266,7 +266,7 @@ export class DIDIssuanceService {
       throw checkError;
     }
 
-    logger.info(`Resetting DID request ${request.id} for retry due to job expiration`);
+    logger.debug(`Resetting DID request ${request.id} for retry due to job expiration`);
     await this.resetRequestForRetry(ctx, request.id, "Job expired in Redis");
     return "reset";
   }
@@ -342,7 +342,7 @@ export class DIDIssuanceService {
           didValue: jobStatus.result.did,
           completedAt: new Date(),
         });
-        logger.info(`✅ DID completed: ${request.id}`);
+        logger.debug(`✅ DID completed: ${request.id}`);
         return { success: true, status: "completed" };
       }
 

--- a/src/application/domain/account/identity/usecase.ts
+++ b/src/application/domain/account/identity/usecase.ts
@@ -196,7 +196,7 @@ export default class IdentityUseCase {
   ): Promise<GqlIdentityCheckPhoneUserPayload> {
     const { phoneUid } = args.input;
 
-    logger.info("[checkPhoneUser] Starting phone user check", {
+    logger.debug("[checkPhoneUser] Starting phone user check", {
       phoneUid,
       communityId: ctx.communityId,
       uid: ctx.uid,
@@ -205,7 +205,7 @@ export default class IdentityUseCase {
 
     const existingUser = await this.identityService.findUserByIdentity(ctx, phoneUid);
 
-    logger.info("[checkPhoneUser] User lookup result", {
+    logger.debug("[checkPhoneUser] User lookup result", {
       phoneUid,
       existingUserId: existingUser?.id,
       existingUserFound: !!existingUser,
@@ -213,7 +213,7 @@ export default class IdentityUseCase {
     });
 
     if (!existingUser) {
-      logger.info("[checkPhoneUser] Returning NEW_USER status", {
+      logger.debug("[checkPhoneUser] Returning NEW_USER status", {
         phoneUid,
         communityId: ctx.communityId,
       });
@@ -230,7 +230,7 @@ export default class IdentityUseCase {
       ctx.communityId,
     );
 
-    logger.info("[checkPhoneUser] Membership lookup result", {
+    logger.debug("[checkPhoneUser] Membership lookup result", {
       phoneUid,
       userId: existingUser.id,
       communityId: ctx.communityId,
@@ -240,7 +240,7 @@ export default class IdentityUseCase {
     });
 
     if (existingMembership) {
-      logger.info("[checkPhoneUser] Returning EXISTING_SAME_COMMUNITY status", {
+      logger.debug("[checkPhoneUser] Returning EXISTING_SAME_COMMUNITY status", {
         phoneUid,
         userId: existingUser.id,
         communityId: ctx.communityId,
@@ -254,7 +254,7 @@ export default class IdentityUseCase {
       };
     }
 
-    logger.info(
+    logger.debug(
       "[checkPhoneUser] User exists but no membership in current community, proceeding with EXISTING_DIFFERENT_COMMUNITY flow",
       {
         phoneUid,
@@ -279,7 +279,7 @@ export default class IdentityUseCase {
 
       const existingIdentity = await this.identityService.findUserByIdentity(ctx, ctx.uid);
 
-      logger.info("[checkPhoneUser] Checking if current LINE identity exists", {
+      logger.debug("[checkPhoneUser] Checking if current LINE identity exists", {
         phoneUid,
         currentUid: ctx.uid,
         currentPlatform: ctx.platform,
@@ -299,14 +299,14 @@ export default class IdentityUseCase {
           });
           throw new Error("This LINE account is already linked to another user");
         }
-        logger.info("Identity already exists for this user, skipping creation", {
+        logger.debug("Identity already exists for this user, skipping creation", {
           uid: ctx.uid,
           platform: ctx.platform,
           userId: existingUser.id,
           communityId: ctx.communityId,
         });
       } else {
-        logger.info("[checkPhoneUser] Creating new LINE identity for existing user", {
+        logger.debug("[checkPhoneUser] Creating new LINE identity for existing user", {
           phoneUid,
           currentUid: ctx.uid,
           currentPlatform: ctx.platform,
@@ -321,7 +321,7 @@ export default class IdentityUseCase {
           ctx.communityId,
           tx,
         );
-        logger.info("[checkPhoneUser] Successfully created new identity for user", {
+        logger.debug("[checkPhoneUser] Successfully created new identity for user", {
           uid: ctx.uid,
           platform: ctx.platform,
           userId: existingUser.id,
@@ -329,7 +329,7 @@ export default class IdentityUseCase {
         });
       }
 
-      logger.info("[checkPhoneUser] Creating membership for user in new community", {
+      logger.debug("[checkPhoneUser] Creating membership for user in new community", {
         phoneUid,
         userId: existingUser.id,
         communityId: ctx.communityId,
@@ -342,7 +342,7 @@ export default class IdentityUseCase {
         tx,
       );
 
-      logger.info("[checkPhoneUser] Membership created, creating wallet", {
+      logger.debug("[checkPhoneUser] Membership created, creating wallet", {
         phoneUid,
         userId: existingUser.id,
         communityId: ctx.communityId,
@@ -357,7 +357,7 @@ export default class IdentityUseCase {
         tx,
       );
 
-      logger.info("[checkPhoneUser] Wallet created successfully", {
+      logger.debug("[checkPhoneUser] Wallet created successfully", {
         phoneUid,
         userId: existingUser.id,
         communityId: ctx.communityId,
@@ -366,7 +366,7 @@ export default class IdentityUseCase {
       return membership;
     });
 
-    logger.info("[checkPhoneUser] Returning EXISTING_DIFFERENT_COMMUNITY status", {
+    logger.debug("[checkPhoneUser] Returning EXISTING_DIFFERENT_COMMUNITY status", {
       phoneUid,
       userId: existingUser.id,
       communityId: ctx.communityId,

--- a/src/application/domain/account/nft-wallet/service.ts
+++ b/src/application/domain/account/nft-wallet/service.ts
@@ -106,14 +106,14 @@ export default class NFTWalletService {
       );
 
       if (!response.items?.length) {
-        logger.info("📭 No NFTs found", { 
+        logger.debug("📭 No NFTs found", { 
           walletAddress, 
           durationMs: Date.now() - startTime 
         });
         return { items: [] };
       }
 
-      logger.info("📥 Fetched NFTs from Blockscout", {
+      logger.debug("📥 Fetched NFTs from Blockscout", {
         walletAddress,
         nftCount: response.items.length,
         durationMs: Date.now() - startTime,
@@ -240,7 +240,7 @@ export default class NFTWalletService {
       }
     }
 
-    logger.info("✅ Token info fetch completed", {
+    logger.debug("✅ Token info fetch completed", {
       totalTokens: uniqueAddresses.length,
       cachedCount,
       fetchedCount,
@@ -320,7 +320,7 @@ export default class NFTWalletService {
       processedCount++;
     }
 
-    logger.info("✅ NFT metadata persisted", {
+    logger.debug("✅ NFT metadata persisted", {
       walletAddress: wallet.walletAddress,
       processedCount,
       skippedCount,

--- a/src/application/domain/account/nft-wallet/usecase.ts
+++ b/src/application/domain/account/nft-wallet/usecase.ts
@@ -43,10 +43,10 @@ export default class NFTWalletUsecase {
           where: { id: userId },
           data: { name: userName },
         });
-        logger.info("✅ Updated user name", { userId, userName });
+        logger.debug("✅ Updated user name", { userId, userName });
       }
 
-      logger.info("✅ Wallet registered", { userId, walletAddress });
+      logger.debug("✅ Wallet registered", { userId, walletAddress });
       
       return {
         id: wallet.id,
@@ -63,7 +63,7 @@ export default class NFTWalletUsecase {
     const startTime = Date.now();
     
     try {
-      logger.info("🔄 Starting NFT metadata sync", { walletAddress: wallet.walletAddress });
+      logger.debug("🔄 Starting NFT metadata sync", { walletAddress: wallet.walletAddress });
       
       const metadata = await this.nftWalletService.fetchMetadata(wallet.walletAddress);
 
@@ -75,14 +75,14 @@ export default class NFTWalletUsecase {
           });
         });
 
-        logger.info("📭 No NFTs found for wallet", {
+        logger.debug("📭 No NFTs found for wallet", {
           walletAddress: wallet.walletAddress,
           durationMs: Date.now() - startTime,
         });
         return { success: true, itemsProcessed: 0 };
       }
 
-      logger.debug("📦 Fetching token info", { 
+      logger.debug("📦 Fetching token info", {
         walletAddress: wallet.walletAddress,
         nftCount: metadata.items.length,
       });
@@ -103,7 +103,7 @@ export default class NFTWalletUsecase {
         });
       });
 
-      logger.info("✅ NFT metadata sync completed", {
+      logger.debug("✅ NFT metadata sync completed", {
         walletAddress: wallet.walletAddress,
         itemsProcessed: metadata.items.length,
         durationMs: Date.now() - startTime,

--- a/src/application/domain/experience/evaluation/vcIssuanceRequest/service.ts
+++ b/src/application/domain/experience/evaluation/vcIssuanceRequest/service.ts
@@ -318,7 +318,7 @@ export class VCIssuanceRequestService {
           vcRecordId: jobStatus.result.recordId,
           completedAt: new Date(),
         });
-        logger.info(`✅ VC completed: ${request.id}`);
+        logger.debug(`✅ VC completed: ${request.id}`);
         return { success: true, status: "completed" };
       }
 

--- a/src/application/domain/experience/reservation/config.ts
+++ b/src/application/domain/experience/reservation/config.ts
@@ -30,9 +30,9 @@ try {
     const envConfig = process.env.ACTIVITY_ADVANCE_BOOKING_DAYS_CONFIG;
     if (envConfig) {
         configFromEnv = JSON.parse(envConfig);
-        logger.info('Loaded activity advance booking days config from environment variable');
+        logger.debug('Loaded activity advance booking days config from environment variable');
     } else {
-        logger.info('No environment variable for activity advance booking days config found, using defaults');
+        logger.debug('No environment variable for activity advance booking days config found, using defaults');
     }
 } catch (error) {
     logger.error('Error parsing ACTIVITY_ADVANCE_BOOKING_DAYS_CONFIG environment variable:', error);

--- a/src/application/domain/notification/logger.ts
+++ b/src/application/domain/notification/logger.ts
@@ -18,7 +18,7 @@ export function logLineApiSuccess(
   retryCount?: number,
   responseBody?: unknown,
 ) {
-  logger.info(`LINE ${operationName} success`, {
+  logger.debug(`LINE ${operationName} success`, {
     ...baseLogFields(endpoint, uid, retryCount),
     requestId: response.headers.get(LINE_REQUEST_ID_HTTP_HEADER_NAME) ?? "N/A",
     statusCode: response.status,

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,9 +86,9 @@ async function startServer() {
 
 async function main() {
   if (process.env.PROCESS_TYPE === "batch") {
-    logger.info(`Batch process started: ${process.env.BATCH_PROCESS_NAME}`);
+    logger.debug(`Batch process started: ${process.env.BATCH_PROCESS_NAME}`);
     await batchProcess();
-    logger.info(`Batch process completed: ${process.env.BATCH_PROCESS_NAME}`);
+    logger.debug(`Batch process completed: ${process.env.BATCH_PROCESS_NAME}`);
     if (process.env.ENV === "LOCAL") {
       process.exit(0);
     }

--- a/src/infrastructure/libs/line.ts
+++ b/src/infrastructure/libs/line.ts
@@ -22,7 +22,7 @@ export async function createLineClient(
   const configService = container.resolve(CommunityConfigService);
   const { accessToken } = await configService.getLineMessagingConfig(ctx, communityId);
 
-  logger.info("LINE client created", {
+  logger.debug("LINE client created", {
     communityId,
     tokenPreview: accessToken.slice(0, 10),
   });
@@ -39,7 +39,7 @@ export async function createLineMiddleware(
   const configService = container.resolve(CommunityConfigService);
   const { channelSecret } = await configService.getLineMessagingConfig(ctx, communityId);
 
-  logger.info("LINE middleware created", {
+  logger.debug("LINE middleware created", {
     communityId,
     secretPreview: channelSecret.slice(0, 6),
   });

--- a/src/infrastructure/logging/index.ts
+++ b/src/infrastructure/logging/index.ts
@@ -47,7 +47,7 @@ if (isLocal) {
 }
 
 const logger = winston.createLogger({
-  level: isProduction ? "info" : "debug",
+  level: isProduction ? "warn" : "debug",
   format: winston.format.combine(...baseFormats),
   transports,
 });

--- a/src/infrastructure/logging/tracing.ts
+++ b/src/infrastructure/logging/tracing.ts
@@ -33,7 +33,7 @@ let sdk: NodeSDK | undefined;
 export const tracingReady = (async () => {
   // ✅ 1. ローカルなら完全スキップ
   if (isLocal || isTest) {
-    logger.info("🟡 OpenTelemetry disabled in local/test environment");
+    logger.debug("🟡 OpenTelemetry disabled in local/test environment");
     return;
   }
 
@@ -97,13 +97,13 @@ export const tracingReady = (async () => {
   });
 
   await sdk.start();
-  logger.info(`✅ OpenTelemetry tracing initialized (sampling: ${TRACE_SAMPLE_RATE * 100}%)`);
+  logger.debug(`✅ OpenTelemetry tracing initialized (sampling: ${TRACE_SAMPLE_RATE * 100}%)`);
 
   const handleShutdown = async () => {
     if (sdk) {
       try {
         await sdk.shutdown();
-        logger.info("🔍 OpenTelemetry tracing shut down successfully");
+        logger.debug("🔍 OpenTelemetry tracing shut down successfully");
       } catch (error) {
         logger.error("Error shutting down OpenTelemetry:", error);
       }
@@ -118,7 +118,7 @@ export const shutdown = async () => {
   if (sdk) {
     try {
       await sdk.shutdown();
-      logger.info("🔍 OpenTelemetry tracing shut down successfully");
+      logger.debug("🔍 OpenTelemetry tracing shut down successfully");
     } catch (error) {
       logger.error("Error shutting down OpenTelemetry:", error);
     }

--- a/src/infrastructure/richmenu/cli.ts
+++ b/src/infrastructure/richmenu/cli.ts
@@ -67,14 +67,14 @@ async function deployCommunity(
   const lineConfig = await getLineConfig(prisma, communityId);
 
   if (dryRun) {
-    logger.info(`[DRY RUN] Would deploy ${config.menus.length} menus for ${communityId}`);
+    logger.debug(`[DRY RUN] Would deploy ${config.menus.length} menus for ${communityId}`);
     for (const menu of config.menus) {
-      logger.info(
+      logger.debug(
         `  - ${menu.alias} (roleEntryFor: ${menu.roleEntryFor ?? "none"}, isDefault: ${menu.isDefault ?? false})`,
       );
       if (verbose) {
-        logger.info(`    imagePath: ${menu.imagePath}`);
-        logger.info(`    areas: ${menu.areas.length}`);
+        logger.debug(`    imagePath: ${menu.imagePath}`);
+        logger.debug(`    areas: ${menu.areas.length}`);
       }
     }
     return;
@@ -99,11 +99,11 @@ async function deployCommunity(
     configId: lineConfig.configId,
   };
 
-  logger.info(`Deploying ${config.menus.length} menus for ${communityId}...`);
+  logger.debug(`Deploying ${config.menus.length} menus for ${communityId}...`);
 
   await deployRichMenus(ctx, config.menus);
 
-  logger.info(`Deployment complete for ${communityId}`);
+  logger.debug(`Deployment complete for ${communityId}`);
 }
 
 async function main(): Promise<void> {

--- a/src/infrastructure/richmenu/deployer.ts
+++ b/src/infrastructure/richmenu/deployer.ts
@@ -53,16 +53,16 @@ export async function deployRichMenu(
   const createResponse = await lineClient.createRichMenu(richMenuRequest);
   const richMenuId = createResponse.richMenuId;
 
-  logger.info(`Created rich menu: ${menu.alias} -> ${richMenuId}`);
+  logger.debug(`Created rich menu: ${menu.alias} -> ${richMenuId}`);
 
   const imagePath = path.resolve(communityBasePath, menu.imagePath);
   if (fs.existsSync(imagePath)) {
     const imageBuffer = fs.readFileSync(imagePath);
     const imageBlob = new Blob([imageBuffer], { type: getMimeType(imagePath) });
 
-    logger.info(`Uploading image for ${menu.alias}: ${imagePath}`);
+    logger.debug(`Uploading image for ${menu.alias}: ${imagePath}`);
     await lineBlobClient.setRichMenuImage(richMenuId, imageBlob);
-    logger.info(`Uploaded image for ${menu.alias}`);
+    logger.debug(`Uploaded image for ${menu.alias}`);
   } else {
     logger.warn(`Image not found for ${menu.alias}: ${imagePath}`);
   }
@@ -71,7 +71,7 @@ export async function deployRichMenu(
     richMenuAliasId: menu.alias,
     richMenuId,
   });
-  logger.info(`Created alias: ${menu.alias} -> ${richMenuId}`);
+  logger.debug(`Created alias: ${menu.alias} -> ${richMenuId}`);
 
   if (menu.roleEntryFor) {
     await prisma.communityLineRichMenuConfig.upsert({
@@ -90,12 +90,12 @@ export async function deployRichMenu(
         richMenuId,
       },
     });
-    logger.info(`Saved to DB: ${menu.alias} as ${menu.roleEntryFor}`);
+    logger.debug(`Saved to DB: ${menu.alias} as ${menu.roleEntryFor}`);
   }
 
   if (menu.isDefault) {
     await lineClient.setDefaultRichMenu(richMenuId);
-    logger.info(`Set default rich menu: ${menu.alias}`);
+    logger.debug(`Set default rich menu: ${menu.alias}`);
   }
 }
 

--- a/src/infrastructure/richmenu/utils.ts
+++ b/src/infrastructure/richmenu/utils.ts
@@ -37,10 +37,10 @@ export async function safeDeleteAlias(
 ): Promise<void> {
   try {
     await client.deleteRichMenuAlias(alias);
-    logger.info(`Deleted alias: ${alias}`);
+    logger.debug(`Deleted alias: ${alias}`);
   } catch (e: unknown) {
     if (isNotFoundError(e)) {
-      logger.info(`Alias "${alias}" not found, skipping deletion`);
+      logger.debug(`Alias "${alias}" not found, skipping deletion`);
       return;
     }
     throw e;
@@ -53,10 +53,10 @@ export async function safeDeleteRichMenu(
 ): Promise<void> {
   try {
     await client.deleteRichMenu(richMenuId);
-    logger.info(`Deleted rich menu: ${richMenuId}`);
+    logger.debug(`Deleted rich menu: ${richMenuId}`);
   } catch (e: unknown) {
     if (isNotFoundError(e)) {
-      logger.info(`Rich menu "${richMenuId}" not found, skipping deletion`);
+      logger.debug(`Rich menu "${richMenuId}" not found, skipping deletion`);
       return;
     }
     throw e;

--- a/src/presentation/batch/checkReservationParticipationConsistency.ts
+++ b/src/presentation/batch/checkReservationParticipationConsistency.ts
@@ -178,7 +178,7 @@ function validateConsistency(
 export async function checkReservationParticipationConsistency() {
   const issuer = container.resolve<PrismaClientIssuer>("PrismaClientIssuer");
 
-  logger.info("🔍 Checking reservation-participation consistency...");
+  logger.debug("🔍 Checking reservation-participation consistency...");
 
   try {
     await issuer.internal(async (tx) => {
@@ -237,7 +237,7 @@ export async function checkReservationParticipationConsistency() {
 
             if (fixDetails) {
               // Auto-fixable pattern detected
-              logger.info("🔧 Auto-fixing inconsistent participation", {
+              logger.debug("🔧 Auto-fixing inconsistent participation", {
                 reservationId: r.id,
                 reservationStatus: r.status,
                 participationId: p.id,
@@ -260,7 +260,7 @@ export async function checkReservationParticipationConsistency() {
               });
 
               autoFixedCount++;
-              logger.info("✅ Fixed participation", {
+              logger.debug("✅ Fixed participation", {
                 participationId: p.id,
                 newStatus: fixDetails.status,
                 newReason: fixDetails.reason,
@@ -289,7 +289,7 @@ export async function checkReservationParticipationConsistency() {
         }
       }
 
-      logger.info(
+      logger.debug(
         `🔎 Checked ${reservations.length} reservations. Auto-fixed ${autoFixedCount} participations. Found ${totalErrors} unfixable violations in ${reservationsWithErrors} reservations.`,
       );
     });

--- a/src/presentation/batch/completeOpportunitySlots.ts
+++ b/src/presentation/batch/completeOpportunitySlots.ts
@@ -21,7 +21,7 @@ import { endOfDay } from "date-fns";
 export async function completeOpportunitySlots() {
   const issuer = container.resolve<PrismaClientIssuer>("PrismaClientIssuer");
 
-  logger.info("🕓 Starting opportunity slot auto-completion batch...");
+  logger.debug("🕓 Starting opportunity slot auto-completion batch...");
 
   const todayEnd = endOfDay(new Date()); // Local time (JST) assumed
 
@@ -36,7 +36,7 @@ export async function completeOpportunitySlots() {
         },
       });
 
-      logger.info(
+      logger.debug(
         `🎯 Found ${targets.length} slots to complete (startsAt <= today)`,
       );
 
@@ -57,7 +57,7 @@ export async function completeOpportunitySlots() {
       };
     });
 
-    logger.info(`✅ Completed ${result.updatedCount} out of ${result.total} scheduled slots.`);
+    logger.debug(`✅ Completed ${result.updatedCount} out of ${result.total} scheduled slots.`);
   } catch (error) {
     logger.error("❌ Error in opportunity slot completion batch:", error);
   }

--- a/src/presentation/batch/refreshPointViews.ts
+++ b/src/presentation/batch/refreshPointViews.ts
@@ -10,19 +10,19 @@ export async function refreshPointViews() {
   const issuer = container.resolve<PrismaClientIssuer>("PrismaClientIssuer");
   const transactionRepository = container.resolve<ITransactionRepository>("TransactionRepository");
 
-  logger.info("🔄 Starting point views refresh batch...");
+  logger.debug("🔄 Starting point views refresh batch...");
 
   const ctx = { issuer } as IContext;
 
   try {
     await issuer.internal(async (tx) => {
-      logger.info("📊 Refreshing materialized view for current points...");
+      logger.debug("📊 Refreshing materialized view for current points...");
       const result = await transactionRepository.refreshCurrentPoints(ctx, tx);
-      logger.info(`✅ Successfully refreshed current points view. Processed ${result.length} records.`);
+      logger.debug(`✅ Successfully refreshed current points view. Processed ${result.length} records.`);
       return result;
     });
 
-    logger.info("✅ Point views refresh batch completed successfully");
+    logger.debug("✅ Point views refresh batch completed successfully");
   } catch (error) {
     logger.error("❌ Error in point views refresh batch:", error);
     throw error;

--- a/src/presentation/batch/requestDIDVC/index.ts
+++ b/src/presentation/batch/requestDIDVC/index.ts
@@ -30,13 +30,13 @@ export async function requestDIDVC() {
 
   let limit = process.env.BATCH_LIMIT ? parseInt(process.env.BATCH_LIMIT) : undefined;
   if (limit && limit > 0) {
-    logger.info(`🚀 Starting DID & VC request batch (MODE: ${ requestMode }, LIMIT: ${ limit })`, {
+    logger.debug(`🚀 Starting DID & VC request batch (MODE: ${ requestMode }, LIMIT: ${ limit })`, {
       executeDID,
       executeVC,
     });
   } else {
     limit = undefined;
-    logger.info(`🚀 Starting DID & VC request batch (MODE: ${ requestMode })`, {
+    logger.debug(`🚀 Starting DID & VC request batch (MODE: ${ requestMode })`, {
       executeDID,
       executeVC,
     });
@@ -52,7 +52,7 @@ export async function requestDIDVC() {
     // --- DID ---
     if (executeDID) {
       const didResult = await createDIDRequests(issuer, didService, ctx, limit);
-      logger.info(
+      logger.debug(
         `📦 DID Requests: ${ didResult.total } total, ` +
         `${ didResult.successCount } succeeded, ` +
         `${ didResult.failureCount } failed, ` +
@@ -63,7 +63,7 @@ export async function requestDIDVC() {
     // --- VC ---
     if (executeVC) {
       const vcResult = await createVCRequests(issuer, vcService, vcConverter, ctx, limit);
-      logger.info(
+      logger.debug(
         `📦 VC Requests: ${ vcResult.total } total, ` +
         `${ vcResult.successCount } succeeded, ` +
         `${ vcResult.failureCount } failed, ` +
@@ -71,7 +71,7 @@ export async function requestDIDVC() {
       );
     }
 
-    logger.info("✅ DID & VC request batch completed");
+    logger.debug("✅ DID & VC request batch completed");
   } catch (error) {
     logger.error("💥 Error in DID/VC request batch", error);
   }

--- a/src/presentation/batch/requestDIDVC/requestDID.ts
+++ b/src/presentation/batch/requestDIDVC/requestDID.ts
@@ -67,7 +67,7 @@ export async function createDIDRequests(
     });
   });
 
-  logger.info(`🆕 Found ${users.length} users for DID issuance processing`);
+  logger.debug(`🆕 Found ${users.length} users for DID issuance processing`);
 
   let successCount = 0;
   let failureCount = 0;
@@ -108,7 +108,7 @@ export async function createDIDRequests(
       );
 
       if (result.success) {
-        logger.info(`✅ DID request created: user=${user.id}, request=${result.requestId}`);
+        logger.debug(`✅ DID request created: user=${user.id}, request=${result.requestId}`);
         successCount++;
       } else {
         logger.warn(`❌ DID request failed for user ${user.id}`);

--- a/src/presentation/batch/requestDIDVC/requestVC.ts
+++ b/src/presentation/batch/requestDIDVC/requestVC.ts
@@ -63,7 +63,7 @@ export async function createVCRequests(
     });
   });
 
-  logger.info(`🆕 Found ${evaluations.length} PASSED evaluations without VC request`);
+  logger.debug(`🆕 Found ${evaluations.length} PASSED evaluations without VC request`);
 
   let successCount = 0;
   let failureCount = 0;
@@ -96,7 +96,7 @@ export async function createVCRequests(
       );
 
       if (result.success) {
-        logger.info(`✅ VC requested: evaluation=${evaluation.id}, user=${user.id}`);
+        logger.debug(`✅ VC requested: evaluation=${evaluation.id}, user=${user.id}`);
         successCount++;
       } else {
         logger.warn(`❌ VC request failed: evaluation=${evaluation.id}, user=${user.id}`);

--- a/src/presentation/batch/resizeImages/index.ts
+++ b/src/presentation/batch/resizeImages/index.ts
@@ -6,20 +6,20 @@ import logger from "@/infrastructure/logging";
  * メイン処理：順番に実行（進捗と件数をログ）
  */
 export async function resizeImages() {
-  logger.info("🚚 Starting relocation of undefined images...");
+  logger.debug("🚚 Starting relocation of undefined images...");
 
   const result = await relocateUndefinedImages();
-  logger.info(
+  logger.debug(
     `📦 Processed ${result.total} image(s): ` +
       `${result.successCount} succeeded, ` +
       `${result.failureCount} failed, ` +
       `${result.skippedCount} skipped.`,
   );
 
-  logger.info("🖼 Starting image resizing...");
+  logger.debug("🖼 Starting image resizing...");
 
   const resize = await resizeAllImages();
-  logger.info(
+  logger.debug(
     `🖼 Processed ${resize.total} image(s): ` +
       `${resize.resizedCount} succeeded, ` +
       `${resize.failureCount} failed, ` +

--- a/src/presentation/batch/resizeImages/resizeAndUploadMobileImage.ts
+++ b/src/presentation/batch/resizeImages/resizeAndUploadMobileImage.ts
@@ -74,7 +74,7 @@ export async function resizeAllImages(): Promise<{
 
   const total = images.length;
 
-  logger.info(
+  logger.debug(
     `📦 Resize Summary: ${total} total / ✅ ${resizedCount} / 🔁 ${skippedCount} / ❌ ${failureCount}`,
   );
 
@@ -114,7 +114,7 @@ async function resizeAndUploadMobileImage(filePath: string): Promise<string | nu
       },
     });
 
-    logger.info(`✅ Uploaded: ${targetPath}`);
+    logger.debug(`✅ Uploaded: ${targetPath}`);
     return getPublicUrl(path.basename(targetPath), path.dirname(targetPath));
   } catch (err) {
     logger.error(`❌ Resize failed for ${filePath}`, err);

--- a/src/presentation/batch/syncDIDVC/index.ts
+++ b/src/presentation/batch/syncDIDVC/index.ts
@@ -11,7 +11,7 @@ import { VCIssuanceRequestService } from "@/application/domain/experience/evalua
 import NotificationService from "@/application/domain/notification/service";
 
 export async function syncDIDVC() {
-  logger.info("🚀 Starting DID/VC synchronization batch");
+  logger.debug("🚀 Starting DID/VC synchronization batch");
 
   const issuer = container.resolve<PrismaClientIssuer>("PrismaClientIssuer");
   const client = container.resolve<DIDVCServerClient>("DIDVCServerClient");
@@ -20,25 +20,25 @@ export async function syncDIDVC() {
   const notificationService = container.resolve<NotificationService>("NotificationService");
 
   try {
-    logger.info("🔄 Processing DID issuance requests...");
+    logger.debug("🔄 Processing DID issuance requests...");
     const didResult = await processDIDRequests(issuer, client, didService);
-    logger.info(
+    logger.debug(
       `📦 DID Results: ${didResult.total} total, ` +
         `${didResult.successCount} succeeded, ` +
         `${didResult.failureCount} failed, ` +
         `${didResult.skippedCount} skipped.`,
     );
 
-    logger.info("🔄 Processing VC issuance requests...");
+    logger.debug("🔄 Processing VC issuance requests...");
     const vcResult = await processVCRequests(issuer, client, vcService, notificationService);
-    logger.info(
+    logger.debug(
       `📦 VC Results: ${vcResult.total} total, ` +
         `${vcResult.successCount} succeeded, ` +
         `${vcResult.failureCount} failed, ` +
         `${vcResult.skippedCount} skipped.`,
     );
 
-    logger.info("✅ DID/VC synchronization batch completed");
+    logger.debug("✅ DID/VC synchronization batch completed");
   } catch (error) {
     logger.error("💥 Batch process error:", error);
   }

--- a/src/presentation/batch/syncDIDVC/syncDID.ts
+++ b/src/presentation/batch/syncDIDVC/syncDID.ts
@@ -41,7 +41,7 @@ export async function processDIDRequests(
     });
   });
 
-  logger.info(`📡 Found ${requests.length} processing DID issuance requests`);
+  logger.debug(`📡 Found ${requests.length} processing DID issuance requests`);
 
   let successCount = 0;
   let failureCount = 0;

--- a/src/presentation/batch/syncDIDVC/syncVC.ts
+++ b/src/presentation/batch/syncDIDVC/syncVC.ts
@@ -45,7 +45,7 @@ export async function processVCRequests(
     });
   });
 
-  logger.info(`📡 Found ${requests.length} processing VC issuance requests`);
+  logger.debug(`📡 Found ${requests.length} processing VC issuance requests`);
 
   let successCount = 0;
   let failureCount = 0;

--- a/src/presentation/batch/syncNftMetadata.ts
+++ b/src/presentation/batch/syncNftMetadata.ts
@@ -9,7 +9,7 @@ import { NftWalletType } from "@prisma/client";
 
 export async function syncNftMetadata() {
   const batchStartTime = Date.now();
-  logger.info("🚀 Starting NFT metadata synchronization batch", {
+  logger.debug("🚀 Starting NFT metadata synchronization batch", {
     startTime: new Date().toISOString(),
   });
 
@@ -57,7 +57,7 @@ export async function syncNftMetadata() {
         break;
       }
 
-      logger.info("📦 Processing batch", {
+      logger.debug("📦 Processing batch", {
         batchNumber: Math.floor(skip / BATCH_SIZE) + 1,
         walletCount: nftWallets.length,
         skip,
@@ -84,7 +84,7 @@ export async function syncNftMetadata() {
         await new Promise(resolve => setTimeout(resolve, RATE_LIMIT_DELAY_MS));
       }
 
-      logger.info("✅ Batch iteration completed", {
+      logger.debug("✅ Batch iteration completed", {
         batchNumber: Math.floor(skip / BATCH_SIZE) + 1,
         durationMs: Date.now() - batchIterationStartTime,
       });
@@ -95,7 +95,7 @@ export async function syncNftMetadata() {
       }
     }
 
-    logger.info("🎯 NFT metadata sync completed", {
+    logger.debug("🎯 NFT metadata sync completed", {
       totalWalletsProcessed: totalProcessed,
       totalWalletsSkipped: totalSkipped,
       totalWalletsErrors: totalErrors,

--- a/src/presentation/batch/syncNmkr/requestMintNft.ts
+++ b/src/presentation/batch/syncNmkr/requestMintNft.ts
@@ -7,7 +7,7 @@ import { NmkrClient } from "@/infrastructure/libs/nmkr/api/client";
 import { NftMintStatus, NftInstanceStatus } from "@prisma/client";
 
 export async function processQueuedMints() {
-  logger.info("🚀 Starting batch for QUEUED nftMints...");
+  logger.debug("🚀 Starting batch for QUEUED nftMints...");
 
   const issuer = container.resolve<PrismaClientIssuer>("PrismaClientIssuer");
   const nmkrClient = container.resolve(NmkrClient);
@@ -39,7 +39,7 @@ export async function processQueuedMints() {
         break;
       }
 
-      logger.info(`📦 Processing ${mints.length} QUEUED mints`);
+      logger.debug(`📦 Processing ${mints.length} QUEUED mints`);
 
       for (const mint of mints) {
         try {
@@ -79,7 +79,7 @@ export async function processQueuedMints() {
             });
           });
 
-          logger.info(`✅ Submitted mint ${mint.id}`);
+          logger.debug(`✅ Submitted mint ${mint.id}`);
         } catch (err) {
           logger.error(`❌ Mint ${mint.id} submission failed: ${(err as Error).message}`);
           await issuer.internal((tx) =>
@@ -99,7 +99,7 @@ export async function processQueuedMints() {
       if (mints.length < BATCH_SIZE) hasMore = false;
     }
 
-    logger.info("🎯 Batch completed");
+    logger.debug("🎯 Batch completed");
   } catch (error) {
     logger.error("💥 Batch process error:", error);
     throw error;

--- a/src/presentation/batch/syncNmkr/syncNftInstance.ts
+++ b/src/presentation/batch/syncNmkr/syncNftInstance.ts
@@ -9,7 +9,7 @@ import { NftInstance, NftInstanceStatus, NftMint, NftMintStatus } from "@prisma/
 const MAX_RETRIES = 3;
 
 export async function syncMintingInstances() {
-  logger.info("🚀 Starting sync for MINTING nftInstances...");
+  logger.debug("🚀 Starting sync for MINTING nftInstances...");
 
   const issuer = container.resolve<PrismaClientIssuer>("PrismaClientIssuer");
   const client = container.resolve(NmkrClient);
@@ -41,7 +41,7 @@ export async function syncMintingInstances() {
         break;
       }
 
-      logger.info(
+      logger.debug(
         `📦 Processing batch ${Math.floor(skip / BATCH_SIZE) + 1}: ${instances.length} instances`,
       );
 
@@ -82,7 +82,7 @@ export async function syncMintingInstances() {
       if (instances.length < BATCH_SIZE) hasMore = false;
     }
 
-    logger.info(`🎯 Sync completed: ${totalProcessed} updated, ${totalErrors} errors`);
+    logger.debug(`🎯 Sync completed: ${totalProcessed} updated, ${totalErrors} errors`);
   } catch (error) {
     logger.error("💥 Batch process error:", error);
     throw error;
@@ -115,7 +115,7 @@ async function handleInstanceState(
         },
       });
     });
-    logger.info(`✅ Updated instance ${instance.id} to OWNED`);
+    logger.debug(`✅ Updated instance ${instance.id} to OWNED`);
     return "processed";
   }
 
@@ -127,7 +127,7 @@ async function handleInstanceState(
           data: { status: NftMintStatus.SUBMITTED, error: null },
         });
       });
-      logger.info(`⏳ Instance ${instance.id} is SOLD, still minting`);
+      logger.debug(`⏳ Instance ${instance.id} is SOLD, still minting`);
       return "skipped";
 
     case "error":
@@ -151,7 +151,7 @@ async function handleInstanceState(
       return "error";
 
     default:
-      logger.info(`⏳ Still minting: ${instance.id} (state=${state})`);
+      logger.debug(`⏳ Still minting: ${instance.id} (state=${state})`);
       return "skipped";
   }
 }

--- a/src/presentation/middleware/auth/firebase-auth.ts
+++ b/src/presentation/middleware/auth/firebase-auth.ts
@@ -58,7 +58,7 @@ export async function handleFirebaseAuth(
       }),
     );
 
-    logger.info("✅ Firebase user verified", {
+    logger.debug("✅ Firebase user verified", {
       method: verificationMethod,
       uid: decoded.uid.slice(-6),
       tenantId,

--- a/src/presentation/middleware/custom-process-request.ts
+++ b/src/presentation/middleware/custom-process-request.ts
@@ -106,7 +106,7 @@ export const customProcessRequest = async (
 ): Promise<GraphQLOperations | GraphQLOperations[]> => {
   const contentType = request.headers['content-type'] || '';
   
-  logger.info('[CustomProcessRequest] Processing request', {
+  logger.debug('[CustomProcessRequest] Processing request', {
     contentType,
     isMultipart: contentType.includes('multipart/form-data'),
     method: request.method,
@@ -114,7 +114,7 @@ export const customProcessRequest = async (
   });
   
   if (!contentType.includes('multipart/form-data')) {
-    logger.info('[CustomProcessRequest] Non-multipart request, using default processor');
+    logger.debug('[CustomProcessRequest] Non-multipart request, using default processor');
     return defaultProcessRequest(request, response, options);
   }
 
@@ -154,7 +154,7 @@ export const customProcessRequest = async (
       
       const safeFilename = filename ? filename.substring(0, 50) + (filename.length > 50 ? '...' : '') : 'none';
       
-      logger.info('[CustomProcessRequest] File detected', {
+      logger.debug('[CustomProcessRequest] File detected', {
         name,
         filename: safeFilename,
         mimeType,
@@ -198,11 +198,11 @@ export const customProcessRequest = async (
 
         if (removedCount > 0) {
           if (Object.keys(sanitizedMap).length === 0) {
-            logger.info('[CustomProcessRequest] Converting to JSON (no real files detected)');
+            logger.debug('[CustomProcessRequest] Converting to JSON (no real files detected)');
             return resolve(operations);
           }
           
-          logger.info('[CustomProcessRequest] Filtering multipart request', {
+          logger.debug('[CustomProcessRequest] Filtering multipart request', {
             uploadCount: Object.keys(sanitizedMap).length,
             removedNullFiles: removedCount
           });
@@ -262,7 +262,7 @@ export const customProcessRequest = async (
           const filteredRequest = await createReconstructedRequest(updatedBody, request, true);
           return resolve(await defaultProcessRequest(filteredRequest, response, options));
         } else {
-          logger.info('[CustomProcessRequest] Passing through unmodified multipart request', {
+          logger.debug('[CustomProcessRequest] Passing through unmodified multipart request', {
             uploadCount: Object.keys(map).length
           });
           

--- a/src/presentation/middleware/firebase-phone-auth.ts
+++ b/src/presentation/middleware/firebase-phone-auth.ts
@@ -22,11 +22,11 @@ export async function validateFirebasePhoneAuth(req: Request, res: Response, nex
       });
 
       if (existingUser) {
-        logger.info(`👤 Existing user found for uid=${uid}, userId=${existingUser.id}`);
+        logger.debug(`👤 Existing user found for uid=${uid}, userId=${existingUser.id}`);
         return existingUser;
       }
 
-      logger.info(`🆕 Creating new user for uid=${uid}`);
+      logger.debug(`🆕 Creating new user for uid=${uid}`);
       
       const newUser = await tx.user.create({
         data: {
@@ -44,7 +44,7 @@ export async function validateFirebasePhoneAuth(req: Request, res: Response, nex
         },
       });
 
-      logger.info(`✅ New user created: userId=${newUser.id}`);
+      logger.debug(`✅ New user created: userId=${newUser.id}`);
       return newUser;
     });
 

--- a/src/presentation/middleware/session.ts
+++ b/src/presentation/middleware/session.ts
@@ -6,7 +6,7 @@ import { SESSION_EXPIRATION_MS, SESSION_COOKIE_NAME } from "@/config/constants";
 export async function handleSessionLogin(req: Request, res: Response) {
   const { idToken } = req.body;
 
-  logger.info("📥 [handleSessionLogin] Incoming request", {
+  logger.debug("📥 [handleSessionLogin] Incoming request", {
     hasIdToken: !!idToken,
     origin: req.headers.origin,
     referer: req.headers.referer,
@@ -32,7 +32,7 @@ export async function handleSessionLogin(req: Request, res: Response) {
 
     const sessionCookie = await auth.createSessionCookie(idToken, { expiresIn });
 
-    logger.info("✅ [handleSessionLogin] Session cookie created", {
+    logger.debug("✅ [handleSessionLogin] Session cookie created", {
       expiresAt: new Date(Date.now() + expiresIn).toISOString(),
     });
 

--- a/src/presentation/router/line.ts
+++ b/src/presentation/router/line.ts
@@ -69,7 +69,7 @@ const handleEvent = async (
   client: messagingApi.MessagingApiClient,
 ): Promise<ReplyMessageResponse | null> => {
   if (event.type !== "message" || event.message.type !== "text" || !event.replyToken) {
-    logger.info("Skipped non-text or invalid event", { type: event.type });
+    logger.debug("Skipped non-text or invalid event", { type: event.type });
     return null;
   }
 
@@ -77,7 +77,7 @@ const handleEvent = async (
     const userId = event.source?.userId ?? "unknown";
     const messageText = event.message.text;
 
-    logger.info("LINE message received", { userId, messageText });
+    logger.debug("LINE message received", { userId, messageText });
 
     const res = await client.replyMessage({
       replyToken: event.replyToken,
@@ -89,7 +89,7 @@ const handleEvent = async (
       ],
     });
 
-    logger.info("LINE replyMessage success", { userId, replyToken: event.replyToken });
+    logger.debug("LINE replyMessage success", { userId, replyToken: event.replyToken });
     return res;
   } catch (err) {
     logger.error("LINE replyMessage failed", {


### PR DESCRIPTION
# refactor: 過剰ログ是正 - 成功/通過ログをdebugに格下げ、本番ログレベルをwarnに変更

## Summary

本番環境での過剰なログ出力を是正するため、「削除しないでガードする」方針に基づいて以下の変更を実施しました：

1. **本番ログレベルを `warn` に変更** (`src/infrastructure/logging/index.ts`)
   - 変更前: `level: isProduction ? "info" : "debug"`
   - 変更後: `level: isProduction ? "warn" : "debug"`

2. **成功/通過ログを `debug` に格下げ** (33ファイル、約120箇所)
   - `✅ ...` 形式の成功ログ
   - `🔄 Starting ...` 形式の開始ログ
   - バッチ処理の進捗・完了ログ
   - 認証成功ログ、リクエスト処理ログなど

3. **維持したログ**
   - サーバー起動ログ (`🚀 Server ready`, `🌐 External API Server ready`) は `info` のまま
   - すべての `warn` / `error` ログは変更なし

## Review & Testing Checklist for Human

- [ ] **本番ログレベル変更の確認**: `src/infrastructure/logging/index.ts:50` で `isProduction ? "warn" : "debug"` になっていることを確認
- [ ] **サーバー起動ログの維持確認**: `src/index.ts:83` と `src/external-api.ts:40` が `logger.info` のままであることを確認
- [ ] **本番環境でのログ出力テスト**: デプロイ後、Cloud Logging で `warn` / `error` のみが出力されることを確認
- [ ] **開発環境でのログ出力テスト**: ローカルで `debug` レベルのログが正常に出力されることを確認

**推奨テスト手順:**
1. ローカル環境で `pnpm dev:https` を実行し、各種操作（認証、バッチ処理など）でログが出力されることを確認
2. ステージング環境にデプロイし、Cloud Logging で過剰なログが削減されていることを確認

### Notes

- ログは削除せず `debug` に格下げしているため、将来的にデバッグが必要な場合はログレベルを変更するだけで復活可能
- 既存のテストファイルに `@typescript-eslint/no-explicit-any` エラーがありますが、本PRの変更とは無関係です

**Link to Devin run:** https://app.devin.ai/sessions/58441cc330d341869a7b714e91c8d5fe
**Requested by:** Naoki Sakata (@709sakata)