### PR TITLE
fix: 本番workflowにNODE_ENV=production追加、STAGE修正

### DIFF
--- a/.github/workflows/deploy-external-api-prd.yml
+++ b/.github/workflows/deploy-external-api-prd.yml
@@ -101,7 +101,6 @@ jobs:
         flags: '--allow-unauthenticated --port=3000'
         env_vars: |
           NODE_ENV=production
-          ENV=prd
 
     - name: Create Git tag for External API
       run: |

--- a/.github/workflows/deploy-to-cloud-run-prd.yml
+++ b/.github/workflows/deploy-to-cloud-run-prd.yml
@@ -123,7 +123,6 @@ jobs:
         region: ${{ env.GCP_REGION }}
         env_vars: |
           NODE_ENV=production
-          ENV=prd
 
     - name: Build Docker image for batch job
       run: |


### PR DESCRIPTION
## Summary

本番デプロイワークフローに環境変数を追加し、ログレベル制御が正しく動作するよう修正しました。

**変更内容:**
- `deploy-to-cloud-run-prd.yml`: `STAGE: dev` → `STAGE: prd` に修正（バグ修正）
- `deploy-to-cloud-run-prd.yml`: Cloud Run deployに `NODE_ENV=production` を追加
- `deploy-external-api-prd.yml`: Cloud Run deployに `NODE_ENV=production` を追加

これにより、先にマージされた過剰ログ是正PR（#598）のログレベル制御（`isProduction ? "warn" : "debug"`）が本番環境で正しく動作します。

### Updates since last revision

- `ENV=prd` を削除し、`NODE_ENV=production` のみに変更
- 理由: 既存のCloud Run設定（`ENV=co-creation-dao-prod`）を上書きしないため。ENVはトレーシングラベルや監視ダッシュボードに影響する可能性があるため触らない方針に変更

## Review & Testing Checklist for Human

- [ ] **STAGE値の確認**: `STAGE: prd` が正しい値か確認（他の環境との整合性）
- [ ] **デプロイ後のログ確認**: 本番デプロイ後、Cloud Loggingで `warn`/`error` のみ出力されることを確認

**推奨テスト手順:**
1. developにマージ後、dev環境へのデプロイを確認
2. master → prdデプロイ後、Cloud Loggingでログ量が削減されていることを確認
3. アプリケーションが正常に動作することを確認

### Notes

- 関連PR: #598（過剰ログ是正）
- Link to Devin run: https://app.devin.ai/sessions/58441cc330d341869a7b714e91c8d5fe
- Requested by: Naoki Sakata (naoki.sakata@hopin.co.jp) @709sakata