### PR TITLE
fix: handle label field as string or number in API response

### DIFF
--- a/src/application/domain/transaction/verification/presenter.ts
+++ b/src/application/domain/transaction/verification/presenter.ts
@@ -27,7 +27,8 @@ export default class TransactionVerificationPresenter {
       })(),
       transactionHash: result.transactionHash,
       rootHash: result.rootHash,
-      label: result.label,
+      // 外部APIが文字列で返す場合があるため、数値に変換
+      label: typeof result.label === "string" ? parseInt(result.label, 10) : result.label,
     };
   }
 }

--- a/src/infrastructure/libs/point-verify/client.ts
+++ b/src/infrastructure/libs/point-verify/client.ts
@@ -12,7 +12,7 @@ export interface VerifyResponse {
   status: "verified" | "not_verified" | "pending" | "error";
   transactionHash: string;
   rootHash: string;
-  label: number;
+  label: string | number; // 外部APIが文字列で返す場合があるため
 }
 
 @injectable()
@@ -47,7 +47,7 @@ export class PointVerifyClient {
       validStatuses.includes(response.status) &&
       typeof response.transactionHash === "string" &&
       typeof response.rootHash === "string" &&
-      typeof response.label === "number"
+      (typeof response.label === "number" || typeof response.label === "string")
     );
   }
 


### PR DESCRIPTION
External API (kyoso-identus-api) returns label as string ("2") instead of number (2), causing validation error: "Invalid response item format".

Changes:
- Update VerifyResponse.label type: number → string | number
- Update isValidVerifyResponse to accept both string and number
- Add type conversion in presenter: parse string to number using parseInt()

This fix resolves the production error:
- Error: "[PointVerifyClient] Invalid response item format"
- Caused by: label: "2" (string) vs expected: number

Root cause: API specification mismatch between our implementation and external service response format.