### PR TITLE
fix: Add HTTP method parameter to LINE API logging functions

### DIFF
--- a/src/application/domain/notification/line.ts
+++ b/src/application/domain/notification/line.ts
@@ -15,13 +15,13 @@ export async function safeLinkRichMenuIdToUser(
 
   try {
     const response = await client.linkRichMenuIdToUserWithHttpInfo(userId, richMenuId);
-    logLineApiSuccess("linkRichMenuIdToUser", endpoint, response.httpResponse, userId, undefined, {
+    logLineApiSuccess("linkRichMenuIdToUser", endpoint, "POST", response.httpResponse, userId, undefined, {
       userId,
       richMenuId,
     });
     return true;
   } catch (error) {
-    logLineApiError("linkRichMenuIdToUser", endpoint, error, userId, undefined, {
+    logLineApiError("linkRichMenuIdToUser", endpoint, "POST", error, userId, undefined, {
       userId,
       richMenuId,
     });
@@ -47,10 +47,10 @@ export async function safePushMessage(
   try {
     await client.validatePushWithHttpInfo({ messages });
     const response = await client.pushMessageWithHttpInfo({ to, messages });
-    logLineApiSuccess("pushMessage", endpoint, response.httpResponse, params.to, undefined, params);
+    logLineApiSuccess("pushMessage", endpoint, "POST", response.httpResponse, params.to, undefined, params);
     return true;
   } catch (error) {
-    logLineApiError("pushMessage", endpoint, error, params.to, undefined, params);
+    logLineApiError("pushMessage", endpoint, "POST", error, params.to, undefined, params);
     return false;
   }
 }
@@ -65,6 +65,7 @@ async function safeGetUserProfile(
     logLineApiSuccess(
       "getProfile",
       endpoint,
+      "GET",
       {
         status: 200,
         headers: new Headers({ [LINE_REQUEST_ID_HTTP_HEADER_NAME]: "N/A" }),
@@ -73,7 +74,7 @@ async function safeGetUserProfile(
     );
     return response;
   } catch (error) {
-    logLineApiError("getProfile", endpoint, error, userId);
+    logLineApiError("getProfile", endpoint, "GET", error, userId);
     return null;
   }
 }

--- a/src/application/domain/notification/logger.ts
+++ b/src/application/domain/notification/logger.ts
@@ -1,10 +1,10 @@
 import logger from "@/infrastructure/logging";
 import { HTTPFetchError, LINE_REQUEST_ID_HTTP_HEADER_NAME } from "@line/bot-sdk";
 
-function baseLogFields(endpoint: string, uid?: string, retryCount?: number) {
+function baseLogFields(endpoint: string, method: string, uid?: string, retryCount?: number) {
   return {
     endpoint,
-    method: "POST",
+    method,
     ...(uid ? { uid } : {}),
     ...(retryCount !== undefined ? { retryCount } : {}),
   };
@@ -13,13 +13,14 @@ function baseLogFields(endpoint: string, uid?: string, retryCount?: number) {
 export function logLineApiSuccess(
   operationName: string,
   endpoint: string,
+  method: string,
   response: Response,
   uid?: string,
   retryCount?: number,
   responseBody?: unknown,
 ) {
   logger.debug(`LINE ${operationName} success`, {
-    ...baseLogFields(endpoint, uid, retryCount),
+    ...baseLogFields(endpoint, method, uid, retryCount),
     requestId: response.headers.get(LINE_REQUEST_ID_HTTP_HEADER_NAME) ?? "N/A",
     statusCode: response.status,
     ...(responseBody ? { responseBody: JSON.stringify(responseBody) } : {}),
@@ -29,6 +30,7 @@ export function logLineApiSuccess(
 export function logLineApiError(
   operationName: string,
   endpoint: string,
+  method: string,
   error: unknown,
   uid?: string,
   retryCount?: number,
@@ -43,7 +45,7 @@ export function logLineApiError(
     }
 
     logger.error(`LINE ${operationName} failed`, {
-      ...baseLogFields(endpoint, uid, retryCount),
+      ...baseLogFields(endpoint, method, uid, retryCount),
       requestId: error.headers.get(LINE_REQUEST_ID_HTTP_HEADER_NAME) ?? "N/A",
       statusCode: error.status,
       message: typeof parsedBody === 'string' ? error.message : (parsedBody?.message as string) ?? error.message,
@@ -53,7 +55,7 @@ export function logLineApiError(
     });
   } else {
     logger.error(`LINE ${operationName} failed`, {
-      ...baseLogFields(endpoint, uid, retryCount),
+      ...baseLogFields(endpoint, method, uid, retryCount),
       message: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
     });


### PR DESCRIPTION
## Summary

Fixes a logging bug where all LINE API operations were logged with `method: "POST"` regardless of the actual HTTP method used. This was discovered during investigation of a 404 error from the LINE profile endpoint, where the logs incorrectly showed POST instead of GET.

**Changes:**
- Updated `baseLogFields` to accept a `method` parameter instead of hardcoding "POST"
- Updated `logLineApiSuccess` and `logLineApiError` to accept and pass the method parameter
- Updated all callers in `line.ts` to pass the correct HTTP method:
  - `linkRichMenuIdToUser`: POST
  - `pushMessage`: POST  
  - `getProfile`: GET

## Review & Testing Checklist for Human

- [ ] Verify the HTTP methods are correct for each LINE API endpoint (linkRichMenuIdToUser=POST, pushMessage=POST, getProfile=GET)
- [ ] Confirm no other callers of `logLineApiSuccess`/`logLineApiError` exist outside of `line.ts` that need updating

### Notes

This is a logging-only change with no impact on business logic. The fix ensures logs accurately reflect the HTTP method used when calling LINE APIs, which aids in debugging.

Link to Devin run: https://app.devin.ai/sessions/ee439d4d4f184643a7f16b5deb6f2ec4
Requested by: Shinji NAKASHIMA (@sigma-xing2)