### PR TITLE
コミュニティ設定のDB移行（CommunityPortalConfig モデルと GraphQL API の追加） (Re-apply)

### DIFF
--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -342,6 +342,7 @@ RIGHT RIGHT
     String channel_secret 
     String access_token 
     String liff_id 
+    String liff_app_id "❓"
     String liff_base_url 
     DateTime created_at 
     DateTime updated_at "❓"
@@ -353,6 +354,30 @@ RIGHT RIGHT
     String config_id 
     LineRichMenuType type 
     String rich_menu_id 
+    DateTime created_at 
+    DateTime updated_at "❓"
+    }
+  
+
+  "t_community_portal_configs" {
+    String id "🗝️"
+    String config_id 
+    String token_name 
+    String title 
+    String description 
+    String short_description "❓"
+    String domain 
+    String favicon_prefix 
+    String logo_path 
+    String square_logo_path 
+    String og_image_path 
+    Json enable_features 
+    String root_path 
+    String admin_root_path 
+    Json documents "❓"
+    Json common_document_overrides "❓"
+    String region_name "❓"
+    String region_key "❓"
     DateTime created_at 
     DateTime updated_at "❓"
     }
@@ -834,11 +859,13 @@ RIGHT RIGHT
     "t_community_configs" o|--|| "t_communities" : "community"
     "t_community_configs" o{--}o "t_community_firebase_configs" : "firebaseConfig"
     "t_community_configs" o{--}o "t_community_line_configs" : "lineConfig"
+    "t_community_configs" o{--}o "t_community_portal_configs" : "portalConfig"
     "t_community_firebase_configs" o|--|o "t_community_configs" : "config"
     "t_community_line_configs" o|--|o "t_community_configs" : "config"
     "t_community_line_configs" o{--}o "t_community_line_rich_menus" : "richMenus"
     "t_community_line_rich_menus" o|--|| "t_community_line_configs" : "config"
     "t_community_line_rich_menus" o|--|| "LineRichMenuType" : "enum:type"
+    "t_community_portal_configs" o|--|| "t_community_configs" : "config"
     "t_users" o|--|| "SysRole" : "enum:sys_role"
     "t_users" o|--|| "CurrentPrefecture" : "enum:current_prefecture"
     "t_users" o|--|| "Language" : "enum:preferred_language"

--- a/docs/schema.dbml
+++ b/docs/schema.dbml
@@ -100,6 +100,7 @@ Table t_community_configs {
   community t_communities [not null]
   firebaseConfig t_community_firebase_configs
   lineConfig t_community_line_configs
+  portalConfig t_community_portal_configs
   createdAt DateTime [default: `now()`, not null]
   updatedAt DateTime
 }
@@ -121,6 +122,7 @@ Table t_community_line_configs {
   channelSecret String [not null]
   accessToken String [not null]
   liffId String [not null]
+  liffAppId String
   liffBaseUrl String [not null]
   richMenus t_community_line_rich_menus [not null]
   createdAt DateTime [default: `now()`, not null]
@@ -139,6 +141,30 @@ Table t_community_line_rich_menus {
   indexes {
     (configId, type) [unique]
   }
+}
+
+Table t_community_portal_configs {
+  id String [pk]
+  configId String [unique, not null]
+  config t_community_configs [not null]
+  tokenName String [not null]
+  title String [not null]
+  description String [not null]
+  shortDescription String
+  domain String [not null]
+  faviconPrefix String [not null]
+  logoPath String [not null]
+  squareLogoPath String [not null]
+  ogImagePath String [not null]
+  enableFeatures Json [not null, note: '[FeaturesType]']
+  rootPath String [not null, default: '/']
+  adminRootPath String [not null, default: '/admin']
+  documents Json [note: '[CommunityDocument]']
+  commonDocumentOverrides Json [note: '[CommonDocumentOverrides]']
+  regionName String
+  regionKey String
+  createdAt DateTime [default: `now()`, not null]
+  updatedAt DateTime
 }
 
 Table t_users {
@@ -946,6 +972,8 @@ Ref: t_community_firebase_configs.configId - t_community_configs.id
 Ref: t_community_line_configs.configId - t_community_configs.id
 
 Ref: t_community_line_rich_menus.configId > t_community_line_configs.id [delete: Cascade]
+
+Ref: t_community_portal_configs.configId - t_community_configs.id
 
 Ref: t_users.imageId > t_images.id
 

--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -174,6 +174,11 @@ enum ClaimLinkStatus {
   ISSUED
 }
 
+type CommonDocumentOverrides {
+  privacy: CommunityDocument
+  terms: CommunityDocument
+}
+
 type CommunitiesConnection {
   edges: [CommunityEdge!]
   pageInfo: PageInfo!
@@ -234,6 +239,14 @@ type CommunityDeleteSuccess {
   communityId: String!
 }
 
+type CommunityDocument {
+  id: String!
+  order: Int
+  path: String!
+  title: String!
+  type: String!
+}
+
 type CommunityEdge implements Edge {
   cursor: String!
   node: Community
@@ -257,6 +270,7 @@ type CommunityLineConfig {
   accessToken: String
   channelId: String
   channelSecret: String
+  liffAppId: String
   liffBaseUrl: String
   liffId: String
   richMenus: [CommunityLineRichMenuConfig!]
@@ -279,6 +293,30 @@ type CommunityLineRichMenuConfig {
 input CommunityLineRichMenuConfigInput {
   richMenuId: String!
   type: LineRichMenuType!
+}
+
+type CommunityPortalConfig {
+  adminRootPath: String!
+  commonDocumentOverrides: CommonDocumentOverrides
+  communityId: String!
+  description: String!
+  documents: [CommunityDocument!]
+  domain: String!
+  enableFeatures: [String!]!
+  faviconPrefix: String!
+  firebaseTenantId: String
+  liffAppId: String
+  liffBaseUrl: String
+  liffId: String
+  logoPath: String!
+  ogImagePath: String!
+  regionKey: String
+  regionName: String
+  rootPath: String!
+  shortDescription: String
+  squareLogoPath: String!
+  title: String!
+  tokenName: String!
 }
 
 input CommunitySortInput {
@@ -1320,6 +1358,7 @@ type Query {
   cities(cursor: String, filter: CitiesInput, first: Int, sort: CitiesSortInput): CitiesConnection!
   communities(cursor: String, filter: CommunityFilterInput, first: Int, sort: CommunitySortInput): CommunitiesConnection!
   community(id: ID!): Community
+  communityPortalConfig(communityId: String!): CommunityPortalConfig
   currentUser: CurrentUserPayload
   echo: String!
   evaluation(id: ID!): Evaluation

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "db:seed-domain": "tsx src/infrastructure/prisma/seeds/index.ts -- --domain",
     "db:generate": "prisma-case-format --file src/infrastructure/prisma/schema.prisma && prisma format --schema src/infrastructure/prisma/schema.prisma && prisma generate --sql --schema src/infrastructure/prisma/schema.prisma",
     "db:migrate": "prisma migrate dev --schema src/infrastructure/prisma/schema.prisma --create-only",
+    "db:migrate-diff": "./scripts/prisma/migrate-diff.sh",
     "db:deploy": "prisma migrate deploy --schema src/infrastructure/prisma/schema.prisma",
     "db:mark-rolled-back": "prisma migrate resolve --schema src/infrastructure/prisma/schema.prisma --rolled-back",
     "db:migrate-reset": "prisma migrate reset --schema src/infrastructure/prisma/schema.prisma",

--- a/scripts/prisma/migrate-diff.sh
+++ b/scripts/prisma/migrate-diff.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# 第一引数を取得
+NAME=$1
+
+# 引数チェック: 名前が空（未指定）の場合はエラーを表示して終了
+if [ -z "$NAME" ]; then
+  echo "❌ Error: マイグレーション名が指定されていません。"
+  echo "Usage: pnpm db:migrate-diff <migration_name>"
+  echo "Example: pnpm db:migrate-diff add_user_table"
+  exit 1
+fi
+
+TIMESTAMP=$(date +%Y%m%d%H%M%S)
+DIR_NAME="${TIMESTAMP}_${NAME}"
+SCHEMA_PATH="src/infrastructure/prisma/schema.prisma"
+MIGRATIONS_DIR="src/infrastructure/prisma/migrations/${DIR_NAME}"
+
+echo "🚀 Creating migration: ${DIR_NAME}..."
+
+# フォルダ作成
+mkdir -p "$MIGRATIONS_DIR"
+
+# diffの実行と保存
+npx prisma migrate diff \
+  --from-schema-datasource "$SCHEMA_PATH" \
+  --to-schema-datamodel "$SCHEMA_PATH" \
+  --script > "$MIGRATIONS_DIR/migration.sql"
+
+# 実行結果の確認
+if [ $? -eq 0 ]; then
+  echo "✅ Success! Migration file created at: $MIGRATIONS_DIR/migration.sql"
+  echo "---------------------------------------------------"
+  echo "Next steps:"
+  echo "1. SQLの内容を確認してください。"
+  echo "2. npx prisma db push --schema $SCHEMA_PATH でDBに反映します。"
+  echo "3. npx prisma migrate resolve --applied ${DIR_NAME} --schema ${SCHEMA_PATH} で履歴を同期します。"
+else
+  echo "❌ Error: SQLの生成に失敗しました。スキーマファイルの設定を確認してください。"
+  exit 1
+fi

--- a/src/application/domain/account/community/config/portal/controller/resolver.ts
+++ b/src/application/domain/account/community/config/portal/controller/resolver.ts
@@ -1,0 +1,22 @@
+import { GqlQueryCommunityPortalConfigArgs } from "@/types/graphql";
+import { IContext } from "@/types/server";
+import { inject, injectable } from "tsyringe";
+import CommunityPortalConfigService from "@/application/domain/account/community/config/portal/service";
+
+@injectable()
+export default class CommunityPortalConfigResolver {
+  constructor(
+    @inject("CommunityPortalConfigService")
+    private readonly portalConfigService: CommunityPortalConfigService,
+  ) {}
+
+  Query = {
+    communityPortalConfig: async (
+      _: unknown,
+      args: GqlQueryCommunityPortalConfigArgs,
+      ctx: IContext,
+    ) => {
+      return this.portalConfigService.getPortalConfig(ctx, args.communityId);
+    },
+  };
+}

--- a/src/application/domain/account/community/config/portal/data/interface.ts
+++ b/src/application/domain/account/community/config/portal/data/interface.ts
@@ -1,0 +1,6 @@
+import { CommunityPortalConfig } from "@prisma/client";
+import { IContext } from "@/types/server";
+
+export default interface ICommunityPortalConfigRepository {
+  getPortalConfig(ctx: IContext, communityId: string): Promise<CommunityPortalConfig | null>;
+}

--- a/src/application/domain/account/community/config/portal/data/repository.ts
+++ b/src/application/domain/account/community/config/portal/data/repository.ts
@@ -1,0 +1,20 @@
+import { IContext } from "@/types/server";
+import { CommunityPortalConfig } from "@prisma/client";
+import ICommunityPortalConfigRepository from "@/application/domain/account/community/config/portal/data/interface";
+import { injectable } from "tsyringe";
+
+@injectable()
+export default class CommunityPortalConfigRepository implements ICommunityPortalConfigRepository {
+  async getPortalConfig(
+    ctx: IContext,
+    communityId: string,
+  ): Promise<CommunityPortalConfig | null> {
+    return await ctx.issuer.public(ctx, async (tx) => {
+      const result = await tx.communityConfig.findUnique({
+        where: { communityId },
+        include: { portalConfig: true },
+      });
+      return result?.portalConfig ?? null;
+    });
+  }
+}

--- a/src/application/domain/account/community/config/portal/schema/query.graphql
+++ b/src/application/domain/account/community/config/portal/schema/query.graphql
@@ -1,0 +1,6 @@
+# ------------------------------
+# CommunityPortalConfig Query Definitions
+# ------------------------------
+extend type Query {
+    communityPortalConfig(communityId: String!): CommunityPortalConfig
+}

--- a/src/application/domain/account/community/config/portal/schema/type.graphql
+++ b/src/application/domain/account/community/config/portal/schema/type.graphql
@@ -1,0 +1,39 @@
+# ------------------------------
+# CommunityPortalConfig Object Type Definitions
+# ------------------------------
+type CommunityPortalConfig {
+    communityId: String!
+    tokenName: String!
+    title: String!
+    description: String!
+    shortDescription: String
+    domain: String!
+    faviconPrefix: String!
+    logoPath: String!
+    squareLogoPath: String!
+    ogImagePath: String!
+    enableFeatures: [String!]!
+    rootPath: String!
+    adminRootPath: String!
+    documents: [CommunityDocument!]
+    commonDocumentOverrides: CommonDocumentOverrides
+    regionName: String
+    regionKey: String
+    liffId: String
+    liffAppId: String
+    liffBaseUrl: String
+    firebaseTenantId: String
+}
+
+type CommunityDocument {
+    id: String!
+    title: String!
+    path: String!
+    type: String!
+    order: Int
+}
+
+type CommonDocumentOverrides {
+    terms: CommunityDocument
+    privacy: CommunityDocument
+}

--- a/src/application/domain/account/community/config/portal/service.ts
+++ b/src/application/domain/account/community/config/portal/service.ts
@@ -1,0 +1,88 @@
+import { IContext } from "@/types/server";
+import { NotFoundError } from "@/errors/graphql";
+import { inject, injectable } from "tsyringe";
+import ICommunityPortalConfigRepository from "@/application/domain/account/community/config/portal/data/interface";
+import ICommunityConfigRepository from "@/application/domain/account/community/config/data/interface";
+
+export interface CommunityPortalConfigResult {
+  communityId: string;
+  tokenName: string;
+  title: string;
+  description: string;
+  shortDescription: string | null;
+  domain: string;
+  faviconPrefix: string;
+  logoPath: string;
+  squareLogoPath: string;
+  ogImagePath: string;
+  enableFeatures: string[];
+  rootPath: string;
+  adminRootPath: string;
+  documents: CommunityDocument[] | null;
+  commonDocumentOverrides: CommonDocumentOverrides | null;
+  regionName: string | null;
+  regionKey: string | null;
+  liffId: string | null;
+  liffAppId: string | null;
+  liffBaseUrl: string | null;
+  firebaseTenantId: string | null;
+}
+
+export interface CommunityDocument {
+  id: string;
+  title: string;
+  path: string;
+  type: string;
+  order?: number;
+}
+
+export interface CommonDocumentOverrides {
+  terms?: CommunityDocument;
+  privacy?: CommunityDocument;
+}
+
+@injectable()
+export default class CommunityPortalConfigService {
+  constructor(
+    @inject("CommunityPortalConfigRepository")
+    private readonly portalRepository: ICommunityPortalConfigRepository,
+    @inject("CommunityConfigRepository")
+    private readonly configRepository: ICommunityConfigRepository,
+  ) {}
+
+  async getPortalConfig(ctx: IContext, communityId: string): Promise<CommunityPortalConfigResult> {
+    const portalConfig = await this.portalRepository.getPortalConfig(ctx, communityId);
+    if (!portalConfig) {
+      throw new NotFoundError("Portal config not found", { communityId });
+    }
+
+    const [lineConfig, firebaseConfig] = await Promise.all([
+      this.configRepository.getLineConfig(ctx, communityId),
+      this.configRepository.getFirebaseConfig(ctx, communityId),
+    ]);
+
+    return {
+      communityId,
+      tokenName: portalConfig.tokenName,
+      title: portalConfig.title,
+      description: portalConfig.description,
+      shortDescription: portalConfig.shortDescription,
+      domain: portalConfig.domain,
+      faviconPrefix: portalConfig.faviconPrefix,
+      logoPath: portalConfig.logoPath,
+      squareLogoPath: portalConfig.squareLogoPath,
+      ogImagePath: portalConfig.ogImagePath,
+      enableFeatures: portalConfig.enableFeatures as string[],
+      rootPath: portalConfig.rootPath,
+      adminRootPath: portalConfig.adminRootPath,
+      documents: portalConfig.documents as CommunityDocument[] | null,
+      commonDocumentOverrides: portalConfig.commonDocumentOverrides as CommonDocumentOverrides | null,
+      regionName: portalConfig.regionName,
+      regionKey: portalConfig.regionKey,
+      liffId: lineConfig?.liffId ?? null,
+      liffAppId: lineConfig?.liffAppId ?? null,
+      liffBaseUrl: lineConfig?.liffBaseUrl ?? null,
+      firebaseTenantId: firebaseConfig?.tenantId ?? null,
+    };
+  }
+}

--- a/src/application/domain/account/community/config/schema/type.graphql
+++ b/src/application/domain/account/community/config/schema/type.graphql
@@ -12,6 +12,7 @@ type CommunityLineConfig {
     channelSecret: String
     accessToken: String
     liffId: String
+    liffAppId: String
     liffBaseUrl: String
     richMenus: [CommunityLineRichMenuConfig!]
 }

--- a/src/application/domain/notification/line.ts
+++ b/src/application/domain/notification/line.ts
@@ -15,13 +15,13 @@ export async function safeLinkRichMenuIdToUser(
 
   try {
     const response = await client.linkRichMenuIdToUserWithHttpInfo(userId, richMenuId);
-    logLineApiSuccess("linkRichMenuIdToUser", endpoint, response.httpResponse, userId, undefined, {
+    logLineApiSuccess("linkRichMenuIdToUser", endpoint, "POST", response.httpResponse, userId, undefined, {
       userId,
       richMenuId,
     });
     return true;
   } catch (error) {
-    logLineApiError("linkRichMenuIdToUser", endpoint, error, userId, undefined, {
+    logLineApiError("linkRichMenuIdToUser", endpoint, "POST", error, userId, undefined, {
       userId,
       richMenuId,
     });
@@ -47,10 +47,10 @@ export async function safePushMessage(
   try {
     await client.validatePushWithHttpInfo({ messages });
     const response = await client.pushMessageWithHttpInfo({ to, messages });
-    logLineApiSuccess("pushMessage", endpoint, response.httpResponse, params.to, undefined, params);
+    logLineApiSuccess("pushMessage", endpoint, "POST", response.httpResponse, params.to, undefined, params);
     return true;
   } catch (error) {
-    logLineApiError("pushMessage", endpoint, error, params.to, undefined, params);
+    logLineApiError("pushMessage", endpoint, "POST", error, params.to, undefined, params);
     return false;
   }
 }
@@ -65,6 +65,7 @@ async function safeGetUserProfile(
     logLineApiSuccess(
       "getProfile",
       endpoint,
+      "GET",
       {
         status: 200,
         headers: new Headers({ [LINE_REQUEST_ID_HTTP_HEADER_NAME]: "N/A" }),
@@ -73,7 +74,7 @@ async function safeGetUserProfile(
     );
     return response;
   } catch (error) {
-    logLineApiError("getProfile", endpoint, error, userId);
+    logLineApiError("getProfile", endpoint, "GET", error, userId);
     return null;
   }
 }

--- a/src/application/domain/notification/logger.ts
+++ b/src/application/domain/notification/logger.ts
@@ -1,10 +1,10 @@
 import logger from "@/infrastructure/logging";
 import { HTTPFetchError, LINE_REQUEST_ID_HTTP_HEADER_NAME } from "@line/bot-sdk";
 
-function baseLogFields(endpoint: string, uid?: string, retryCount?: number) {
+function baseLogFields(endpoint: string, method: string, uid?: string, retryCount?: number) {
   return {
     endpoint,
-    method: "POST",
+    method,
     ...(uid ? { uid } : {}),
     ...(retryCount !== undefined ? { retryCount } : {}),
   };
@@ -13,13 +13,14 @@ function baseLogFields(endpoint: string, uid?: string, retryCount?: number) {
 export function logLineApiSuccess(
   operationName: string,
   endpoint: string,
+  method: string,
   response: Response,
   uid?: string,
   retryCount?: number,
   responseBody?: unknown,
 ) {
   logger.debug(`LINE ${operationName} success`, {
-    ...baseLogFields(endpoint, uid, retryCount),
+    ...baseLogFields(endpoint, method, uid, retryCount),
     requestId: response.headers.get(LINE_REQUEST_ID_HTTP_HEADER_NAME) ?? "N/A",
     statusCode: response.status,
     ...(responseBody ? { responseBody: JSON.stringify(responseBody) } : {}),
@@ -29,6 +30,7 @@ export function logLineApiSuccess(
 export function logLineApiError(
   operationName: string,
   endpoint: string,
+  method: string,
   error: unknown,
   uid?: string,
   retryCount?: number,
@@ -43,7 +45,7 @@ export function logLineApiError(
     }
 
     logger.error(`LINE ${operationName} failed`, {
-      ...baseLogFields(endpoint, uid, retryCount),
+      ...baseLogFields(endpoint, method, uid, retryCount),
       requestId: error.headers.get(LINE_REQUEST_ID_HTTP_HEADER_NAME) ?? "N/A",
       statusCode: error.status,
       message: typeof parsedBody === 'string' ? error.message : (parsedBody?.message as string) ?? error.message,
@@ -53,7 +55,7 @@ export function logLineApiError(
     });
   } else {
     logger.error(`LINE ${operationName} failed`, {
-      ...baseLogFields(endpoint, uid, retryCount),
+      ...baseLogFields(endpoint, method, uid, retryCount),
       message: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
     });

--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -100,6 +100,8 @@ import VCIssuanceRequestUseCase from "@/application/domain/experience/evaluation
 import VCIssuanceRequestConverter from "@/application/domain/experience/evaluation/vcIssuanceRequest/data/converter";
 import CommunityConfigService from "@/application/domain/account/community/config/service";
 import CommunityConfigRepository from "@/application/domain/account/community/config/data/repository";
+import CommunityPortalConfigService from "@/application/domain/account/community/config/portal/service";
+import CommunityPortalConfigRepository from "@/application/domain/account/community/config/portal/data/repository";
 import { PointVerifyClient } from "@/infrastructure/libs/point-verify/client";
 import TransactionVerificationService from "@/application/domain/transaction/verification/service";
 import TransactionVerificationUseCase from "@/application/domain/transaction/verification/usecase";
@@ -154,6 +156,9 @@ export function registerProductionDependencies() {
 
   container.register("CommunityConfigService", { useClass: CommunityConfigService });
   container.register("CommunityConfigRepository", { useClass: CommunityConfigRepository });
+
+  container.register("CommunityPortalConfigService", { useClass: CommunityPortalConfigService });
+  container.register("CommunityPortalConfigRepository", { useClass: CommunityPortalConfigRepository });
 
   // 🆔 Identity
   container.register("IdentityService", { useClass: IdentityService });

--- a/src/infrastructure/prisma/factories/__generated__/index.ts
+++ b/src/infrastructure/prisma/factories/__generated__/index.ts
@@ -7,6 +7,7 @@ import type { CommunityConfig } from "@prisma/client";
 import type { CommunityFirebaseConfig } from "@prisma/client";
 import type { CommunityLineConfig } from "@prisma/client";
 import type { CommunityLineRichMenuConfig } from "@prisma/client";
+import type { CommunityPortalConfig } from "@prisma/client";
 import type { User } from "@prisma/client";
 import type { Identity } from "@prisma/client";
 import type { DidIssuanceRequest } from "@prisma/client";
@@ -235,6 +236,10 @@ const modelFieldDefinitions: ModelWithFields[] = [{
                 name: "lineConfig",
                 type: "CommunityLineConfig",
                 relationName: "CommunityConfigToCommunityLineConfig"
+            }, {
+                name: "portalConfig",
+                type: "CommunityPortalConfig",
+                relationName: "CommunityConfigToCommunityPortalConfig"
             }]
     }, {
         name: "CommunityFirebaseConfig",
@@ -260,6 +265,13 @@ const modelFieldDefinitions: ModelWithFields[] = [{
                 name: "config",
                 type: "CommunityLineConfig",
                 relationName: "CommunityLineConfigToCommunityLineRichMenuConfig"
+            }]
+    }, {
+        name: "CommunityPortalConfig",
+        fields: [{
+                name: "config",
+                type: "CommunityConfig",
+                relationName: "CommunityConfigToCommunityPortalConfig"
             }]
     }, {
         name: "User",
@@ -1792,6 +1804,11 @@ type CommunityConfiglineConfigFactory = {
     build: () => PromiseLike<Prisma.CommunityLineConfigCreateNestedOneWithoutConfigInput["create"]>;
 };
 
+type CommunityConfigportalConfigFactory = {
+    _factoryFor: "CommunityPortalConfig";
+    build: () => PromiseLike<Prisma.CommunityPortalConfigCreateNestedOneWithoutConfigInput["create"]>;
+};
+
 type CommunityConfigFactoryDefineInput = {
     id?: string;
     createdAt?: Date;
@@ -1799,6 +1816,7 @@ type CommunityConfigFactoryDefineInput = {
     community: CommunityConfigcommunityFactory | Prisma.CommunityCreateNestedOneWithoutConfigInput;
     firebaseConfig?: CommunityConfigfirebaseConfigFactory | Prisma.CommunityFirebaseConfigCreateNestedOneWithoutConfigInput;
     lineConfig?: CommunityConfiglineConfigFactory | Prisma.CommunityLineConfigCreateNestedOneWithoutConfigInput;
+    portalConfig?: CommunityConfigportalConfigFactory | Prisma.CommunityPortalConfigCreateNestedOneWithoutConfigInput;
 };
 
 type CommunityConfigTransientFields = Record<string, unknown> & Partial<Record<keyof CommunityConfigFactoryDefineInput, never>>;
@@ -1824,6 +1842,10 @@ function isCommunityConfigfirebaseConfigFactory(x: CommunityConfigfirebaseConfig
 
 function isCommunityConfiglineConfigFactory(x: CommunityConfiglineConfigFactory | Prisma.CommunityLineConfigCreateNestedOneWithoutConfigInput | undefined): x is CommunityConfiglineConfigFactory {
     return (x as any)?._factoryFor === "CommunityLineConfig";
+}
+
+function isCommunityConfigportalConfigFactory(x: CommunityConfigportalConfigFactory | Prisma.CommunityPortalConfigCreateNestedOneWithoutConfigInput | undefined): x is CommunityConfigportalConfigFactory {
+    return (x as any)?._factoryFor === "CommunityPortalConfig";
 }
 
 type CommunityConfigTraitKeys<TOptions extends CommunityConfigFactoryDefineOptions<any>> = Exclude<keyof TOptions["traits"], number>;
@@ -1892,7 +1914,10 @@ function defineCommunityConfigFactoryInternal<TTransients extends Record<string,
                 } : defaultData.firebaseConfig,
                 lineConfig: isCommunityConfiglineConfigFactory(defaultData.lineConfig) ? {
                     create: await defaultData.lineConfig.build()
-                } : defaultData.lineConfig
+                } : defaultData.lineConfig,
+                portalConfig: isCommunityConfigportalConfigFactory(defaultData.portalConfig) ? {
+                    create: await defaultData.portalConfig.build()
+                } : defaultData.portalConfig
             } as Prisma.CommunityConfigCreateInput;
             const data: Prisma.CommunityConfigCreateInput = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...filteredInputData };
             await handleAfterBuild(data, transientFields);
@@ -2123,6 +2148,7 @@ type CommunityLineConfigFactoryDefineInput = {
     channelSecret?: string;
     accessToken?: string;
     liffId?: string;
+    liffAppId?: string | null;
     liffBaseUrl?: string;
     createdAt?: Date;
     updatedAt?: Date | null;
@@ -2427,6 +2453,191 @@ export const defineCommunityLineRichMenuConfigFactory = (<TOptions extends Commu
 }) as CommunityLineRichMenuConfigFactoryBuilder;
 
 defineCommunityLineRichMenuConfigFactory.withTransientFields = defaultTransientFieldValues => options => defineCommunityLineRichMenuConfigFactoryInternal(options, defaultTransientFieldValues);
+
+type CommunityPortalConfigScalarOrEnumFields = {
+    tokenName: string;
+    title: string;
+    description: string;
+    domain: string;
+    faviconPrefix: string;
+    logoPath: string;
+    squareLogoPath: string;
+    ogImagePath: string;
+    enableFeatures: Prisma.JsonNullValueInput | Prisma.InputJsonValue;
+};
+
+type CommunityPortalConfigconfigFactory = {
+    _factoryFor: "CommunityConfig";
+    build: () => PromiseLike<Prisma.CommunityConfigCreateNestedOneWithoutPortalConfigInput["create"]>;
+};
+
+type CommunityPortalConfigFactoryDefineInput = {
+    id?: string;
+    tokenName?: string;
+    title?: string;
+    description?: string;
+    shortDescription?: string | null;
+    domain?: string;
+    faviconPrefix?: string;
+    logoPath?: string;
+    squareLogoPath?: string;
+    ogImagePath?: string;
+    enableFeatures?: Prisma.JsonNullValueInput | Prisma.InputJsonValue;
+    rootPath?: string;
+    adminRootPath?: string;
+    documents?: Prisma.NullableJsonNullValueInput | Prisma.InputJsonValue;
+    commonDocumentOverrides?: Prisma.NullableJsonNullValueInput | Prisma.InputJsonValue;
+    regionName?: string | null;
+    regionKey?: string | null;
+    createdAt?: Date;
+    updatedAt?: Date | null;
+    config: CommunityPortalConfigconfigFactory | Prisma.CommunityConfigCreateNestedOneWithoutPortalConfigInput;
+};
+
+type CommunityPortalConfigTransientFields = Record<string, unknown> & Partial<Record<keyof CommunityPortalConfigFactoryDefineInput, never>>;
+
+type CommunityPortalConfigFactoryTrait<TTransients extends Record<string, unknown>> = {
+    data?: Resolver<Partial<CommunityPortalConfigFactoryDefineInput>, BuildDataOptions<TTransients>>;
+} & CallbackDefineOptions<CommunityPortalConfig, Prisma.CommunityPortalConfigCreateInput, TTransients>;
+
+type CommunityPortalConfigFactoryDefineOptions<TTransients extends Record<string, unknown> = Record<string, unknown>> = {
+    defaultData: Resolver<CommunityPortalConfigFactoryDefineInput, BuildDataOptions<TTransients>>;
+    traits?: {
+        [traitName: string | symbol]: CommunityPortalConfigFactoryTrait<TTransients>;
+    };
+} & CallbackDefineOptions<CommunityPortalConfig, Prisma.CommunityPortalConfigCreateInput, TTransients>;
+
+function isCommunityPortalConfigconfigFactory(x: CommunityPortalConfigconfigFactory | Prisma.CommunityConfigCreateNestedOneWithoutPortalConfigInput | undefined): x is CommunityPortalConfigconfigFactory {
+    return (x as any)?._factoryFor === "CommunityConfig";
+}
+
+type CommunityPortalConfigTraitKeys<TOptions extends CommunityPortalConfigFactoryDefineOptions<any>> = Exclude<keyof TOptions["traits"], number>;
+
+export interface CommunityPortalConfigFactoryInterfaceWithoutTraits<TTransients extends Record<string, unknown>> {
+    readonly _factoryFor: "CommunityPortalConfig";
+    build(inputData?: Partial<Prisma.CommunityPortalConfigCreateInput & TTransients>): PromiseLike<Prisma.CommunityPortalConfigCreateInput>;
+    buildCreateInput(inputData?: Partial<Prisma.CommunityPortalConfigCreateInput & TTransients>): PromiseLike<Prisma.CommunityPortalConfigCreateInput>;
+    buildList(list: readonly Partial<Prisma.CommunityPortalConfigCreateInput & TTransients>[]): PromiseLike<Prisma.CommunityPortalConfigCreateInput[]>;
+    buildList(count: number, item?: Partial<Prisma.CommunityPortalConfigCreateInput & TTransients>): PromiseLike<Prisma.CommunityPortalConfigCreateInput[]>;
+    pickForConnect(inputData: CommunityPortalConfig): Pick<CommunityPortalConfig, "id">;
+    create(inputData?: Partial<Prisma.CommunityPortalConfigCreateInput & TTransients>): PromiseLike<CommunityPortalConfig>;
+    createList(list: readonly Partial<Prisma.CommunityPortalConfigCreateInput & TTransients>[]): PromiseLike<CommunityPortalConfig[]>;
+    createList(count: number, item?: Partial<Prisma.CommunityPortalConfigCreateInput & TTransients>): PromiseLike<CommunityPortalConfig[]>;
+    createForConnect(inputData?: Partial<Prisma.CommunityPortalConfigCreateInput & TTransients>): PromiseLike<Pick<CommunityPortalConfig, "id">>;
+}
+
+export interface CommunityPortalConfigFactoryInterface<TTransients extends Record<string, unknown> = Record<string, unknown>, TTraitName extends TraitName = TraitName> extends CommunityPortalConfigFactoryInterfaceWithoutTraits<TTransients> {
+    use(name: TTraitName, ...names: readonly TTraitName[]): CommunityPortalConfigFactoryInterfaceWithoutTraits<TTransients>;
+}
+
+function autoGenerateCommunityPortalConfigScalarsOrEnums({ seq }: {
+    readonly seq: number;
+}): CommunityPortalConfigScalarOrEnumFields {
+    return {
+        tokenName: getScalarFieldValueGenerator().String({ modelName: "CommunityPortalConfig", fieldName: "tokenName", isId: false, isUnique: false, seq }),
+        title: getScalarFieldValueGenerator().String({ modelName: "CommunityPortalConfig", fieldName: "title", isId: false, isUnique: false, seq }),
+        description: getScalarFieldValueGenerator().String({ modelName: "CommunityPortalConfig", fieldName: "description", isId: false, isUnique: false, seq }),
+        domain: getScalarFieldValueGenerator().String({ modelName: "CommunityPortalConfig", fieldName: "domain", isId: false, isUnique: false, seq }),
+        faviconPrefix: getScalarFieldValueGenerator().String({ modelName: "CommunityPortalConfig", fieldName: "faviconPrefix", isId: false, isUnique: false, seq }),
+        logoPath: getScalarFieldValueGenerator().String({ modelName: "CommunityPortalConfig", fieldName: "logoPath", isId: false, isUnique: false, seq }),
+        squareLogoPath: getScalarFieldValueGenerator().String({ modelName: "CommunityPortalConfig", fieldName: "squareLogoPath", isId: false, isUnique: false, seq }),
+        ogImagePath: getScalarFieldValueGenerator().String({ modelName: "CommunityPortalConfig", fieldName: "ogImagePath", isId: false, isUnique: false, seq }),
+        enableFeatures: getScalarFieldValueGenerator().Json({ modelName: "CommunityPortalConfig", fieldName: "enableFeatures", isId: false, isUnique: false, seq })
+    };
+}
+
+function defineCommunityPortalConfigFactoryInternal<TTransients extends Record<string, unknown>, TOptions extends CommunityPortalConfigFactoryDefineOptions<TTransients>>({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }: TOptions, defaultTransientFieldValues: TTransients): CommunityPortalConfigFactoryInterface<TTransients, CommunityPortalConfigTraitKeys<TOptions>> {
+    const getFactoryWithTraits = (traitKeys: readonly CommunityPortalConfigTraitKeys<TOptions>[] = []) => {
+        const seqKey = {};
+        const getSeq = () => getSequenceCounter(seqKey);
+        const screen = createScreener("CommunityPortalConfig", modelFieldDefinitions);
+        const handleAfterBuild = createCallbackChain([
+            onAfterBuild,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterBuild),
+        ]);
+        const handleBeforeCreate = createCallbackChain([
+            ...traitKeys.slice().reverse().map(traitKey => traitsDefs[traitKey]?.onBeforeCreate),
+            onBeforeCreate,
+        ]);
+        const handleAfterCreate = createCallbackChain([
+            onAfterCreate,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterCreate),
+        ]);
+        const build = async (inputData: Partial<Prisma.CommunityPortalConfigCreateInput & TTransients> = {}) => {
+            const seq = getSeq();
+            const requiredScalarData = autoGenerateCommunityPortalConfigScalarsOrEnums({ seq });
+            const resolveValue = normalizeResolver<CommunityPortalConfigFactoryDefineInput, BuildDataOptions<any>>(defaultDataResolver);
+            const [transientFields, filteredInputData] = destructure(defaultTransientFieldValues, inputData);
+            const resolverInput = { seq, ...transientFields };
+            const defaultData = await traitKeys.reduce(async (queue, traitKey) => {
+                const acc = await queue;
+                const resolveTraitValue = normalizeResolver<Partial<CommunityPortalConfigFactoryDefineInput>, BuildDataOptions<TTransients>>(traitsDefs[traitKey]?.data ?? {});
+                const traitData = await resolveTraitValue(resolverInput);
+                return {
+                    ...acc,
+                    ...traitData,
+                };
+            }, resolveValue(resolverInput));
+            const defaultAssociations = {
+                config: isCommunityPortalConfigconfigFactory(defaultData.config) ? {
+                    create: await defaultData.config.build()
+                } : defaultData.config
+            } as Prisma.CommunityPortalConfigCreateInput;
+            const data: Prisma.CommunityPortalConfigCreateInput = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...filteredInputData };
+            await handleAfterBuild(data, transientFields);
+            return data;
+        };
+        const buildList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.CommunityPortalConfigCreateInput & TTransients>>(...args).map(data => build(data)));
+        const pickForConnect = (inputData: CommunityPortalConfig) => ({
+            id: inputData.id
+        });
+        const create = async (inputData: Partial<Prisma.CommunityPortalConfigCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
+            const [transientFields] = destructure(defaultTransientFieldValues, inputData);
+            await handleBeforeCreate(data, transientFields);
+            const createdData = await getClient<PrismaClient>().communityPortalConfig.create({ data });
+            await handleAfterCreate(createdData, transientFields);
+            return createdData;
+        };
+        const createList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.CommunityPortalConfigCreateInput & TTransients>>(...args).map(data => create(data)));
+        const createForConnect = (inputData: Partial<Prisma.CommunityPortalConfigCreateInput & TTransients> = {}) => create(inputData).then(pickForConnect);
+        return {
+            _factoryFor: "CommunityPortalConfig" as const,
+            build,
+            buildList,
+            buildCreateInput: build,
+            pickForConnect,
+            create,
+            createList,
+            createForConnect,
+        };
+    };
+    const factory = getFactoryWithTraits();
+    const useTraits = (name: CommunityPortalConfigTraitKeys<TOptions>, ...names: readonly CommunityPortalConfigTraitKeys<TOptions>[]) => {
+        return getFactoryWithTraits([name, ...names]);
+    };
+    return {
+        ...factory,
+        use: useTraits,
+    };
+}
+
+interface CommunityPortalConfigFactoryBuilder {
+    <TOptions extends CommunityPortalConfigFactoryDefineOptions>(options: TOptions): CommunityPortalConfigFactoryInterface<{}, CommunityPortalConfigTraitKeys<TOptions>>;
+    withTransientFields: <TTransients extends CommunityPortalConfigTransientFields>(defaultTransientFieldValues: TTransients) => <TOptions extends CommunityPortalConfigFactoryDefineOptions<TTransients>>(options: TOptions) => CommunityPortalConfigFactoryInterface<TTransients, CommunityPortalConfigTraitKeys<TOptions>>;
+}
+
+/**
+ * Define factory for {@link CommunityPortalConfig} model.
+ *
+ * @param options
+ * @returns factory {@link CommunityPortalConfigFactoryInterface}
+ */
+export const defineCommunityPortalConfigFactory = (<TOptions extends CommunityPortalConfigFactoryDefineOptions>(options: TOptions): CommunityPortalConfigFactoryInterface<TOptions> => {
+    return defineCommunityPortalConfigFactoryInternal(options, {});
+}) as CommunityPortalConfigFactoryBuilder;
+
+defineCommunityPortalConfigFactory.withTransientFields = defaultTransientFieldValues => options => defineCommunityPortalConfigFactoryInternal(options, defaultTransientFieldValues);
 
 type UserScalarOrEnumFields = {
     name: string;

--- a/src/infrastructure/prisma/migrations/20251214072836_add_community_portal_config/migration.sql
+++ b/src/infrastructure/prisma/migrations/20251214072836_add_community_portal_config/migration.sql
@@ -1,0 +1,31 @@
+-- CreateTable
+CREATE TABLE "t_community_portal_configs" (
+    "id" TEXT NOT NULL,
+    "config_id" TEXT NOT NULL,
+    "token_name" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "short_description" TEXT,
+    "domain" TEXT NOT NULL,
+    "favicon_prefix" TEXT NOT NULL,
+    "logo_path" TEXT NOT NULL,
+    "square_logo_path" TEXT NOT NULL,
+    "og_image_path" TEXT NOT NULL,
+    "enable_features" JSONB NOT NULL,
+    "root_path" TEXT NOT NULL DEFAULT '/',
+    "admin_root_path" TEXT NOT NULL DEFAULT '/admin',
+    "documents" JSONB,
+    "common_document_overrides" JSONB,
+    "region_name" TEXT,
+    "region_key" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3),
+
+    CONSTRAINT "t_community_portal_configs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "t_community_portal_configs_config_id_key" ON "t_community_portal_configs"("config_id");
+
+-- AddForeignKey
+ALTER TABLE "t_community_portal_configs" ADD CONSTRAINT "t_community_portal_configs_config_id_fkey" FOREIGN KEY ("config_id") REFERENCES "t_community_configs"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/src/infrastructure/prisma/migrations/20260105190540_add_liff_app_id_in_line_configs/migration.sql
+++ b/src/infrastructure/prisma/migrations/20260105190540_add_liff_app_id_in_line_configs/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "t_community_line_configs" ADD COLUMN     "liff_app_id" TEXT;
+

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -205,6 +205,7 @@ model CommunityConfig {
 
   firebaseConfig CommunityFirebaseConfig?
   lineConfig     CommunityLineConfig?
+  portalConfig   CommunityPortalConfig?
 
   createdAt DateTime  @default(now()) @map("created_at")
   updatedAt DateTime? @updatedAt @map("updated_at")
@@ -236,8 +237,9 @@ model CommunityLineConfig {
   channelSecret String @map("channel_secret")
   accessToken   String @map("access_token")
 
-  liffId      String @map("liff_id")
-  liffBaseUrl String @map("liff_base_url")
+  liffId      String  @map("liff_id")
+  liffAppId   String? @map("liff_app_id")
+  liffBaseUrl String  @map("liff_base_url")
 
   richMenus CommunityLineRichMenuConfig[]
 
@@ -266,6 +268,48 @@ enum LineRichMenuType {
   ADMIN
   USER
   PUBLIC
+}
+
+model CommunityPortalConfig {
+  id       String          @id @default(cuid())
+  configId String          @unique @map("config_id")
+  config   CommunityConfig @relation(fields: [configId], references: [id])
+
+  // 基本情報
+  tokenName        String  @map("token_name")
+  title            String
+  description      String  @db.Text
+  shortDescription String? @map("short_description")
+
+  // ドメイン・URL
+  domain String
+
+  // アセットパス
+  faviconPrefix  String @map("favicon_prefix")
+  logoPath       String @map("logo_path")
+  squareLogoPath String @map("square_logo_path")
+  ogImagePath    String @map("og_image_path")
+
+  // 機能設定
+  /// [FeaturesType]
+  enableFeatures Json   @map("enable_features") // ["opportunities", "points", ...]
+  rootPath       String @default("/") @map("root_path")
+  adminRootPath  String @default("/admin") @map("admin_root_path")
+
+  // 文書設定
+  /// [CommunityDocument]
+  documents               Json? // CommunityDocument[]
+  /// [CommonDocumentOverrides]
+  commonDocumentOverrides Json? @map("common_document_overrides")
+
+  // 地域設定
+  regionName String? @map("region_name")
+  regionKey  String? @map("region_key")
+
+  createdAt DateTime  @default(now()) @map("created_at")
+  updatedAt DateTime? @updatedAt @map("updated_at")
+
+  @@map("t_community_portal_configs")
 }
 
 // ------------------------------ User Domain ------------------------------

--- a/src/presentation/graphql/resolver.ts
+++ b/src/presentation/graphql/resolver.ts
@@ -6,6 +6,7 @@ import WalletResolver from "@/application/domain/account/wallet/controller/resol
 import NftWalletResolver from "@/application/domain/account/nft-wallet/controller/resolver";
 import MembershipResolver from "@/application/domain/account/membership/controller/resolver";
 import CommunityResolver from "@/application/domain/account/community/controller/resolver";
+import CommunityPortalConfigResolver from "@/application/domain/account/community/config/portal/controller/resolver";
 import ArticleResolver from "@/application/domain/content/article/controller/resolver";
 import OpportunityResolver from "@/application/domain/experience/opportunity/controller/resolver";
 import OpportunitySlotResolver from "@/application/domain/experience/opportunitySlot/controller/resolver";
@@ -30,6 +31,7 @@ const wallet = container.resolve(WalletResolver);
 const nftWallet = container.resolve(NftWalletResolver);
 const membership = container.resolve(MembershipResolver);
 const community = container.resolve(CommunityResolver);
+const communityPortalConfig = container.resolve(CommunityPortalConfigResolver);
 
 const article = container.resolve(ArticleResolver);
 
@@ -57,6 +59,7 @@ const resolvers = {
     ...identity.Query,
     ...user.Query,
     ...community.Query,
+    ...communityPortalConfig.Query,
     ...membership.Query,
     ...wallet.Query,
     ...article.Query,

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -206,6 +206,12 @@ export const GqlClaimLinkStatus = {
 } as const;
 
 export type GqlClaimLinkStatus = typeof GqlClaimLinkStatus[keyof typeof GqlClaimLinkStatus];
+export type GqlCommonDocumentOverrides = {
+  __typename?: 'CommonDocumentOverrides';
+  privacy?: Maybe<GqlCommunityDocument>;
+  terms?: Maybe<GqlCommunityDocument>;
+};
+
 export type GqlCommunitiesConnection = {
   __typename?: 'CommunitiesConnection';
   edges?: Maybe<Array<GqlCommunityEdge>>;
@@ -271,6 +277,15 @@ export type GqlCommunityDeleteSuccess = {
   communityId: Scalars['String']['output'];
 };
 
+export type GqlCommunityDocument = {
+  __typename?: 'CommunityDocument';
+  id: Scalars['String']['output'];
+  order?: Maybe<Scalars['Int']['output']>;
+  path: Scalars['String']['output'];
+  title: Scalars['String']['output'];
+  type: Scalars['String']['output'];
+};
+
 export type GqlCommunityEdge = GqlEdge & {
   __typename?: 'CommunityEdge';
   cursor: Scalars['String']['output'];
@@ -297,6 +312,7 @@ export type GqlCommunityLineConfig = {
   accessToken?: Maybe<Scalars['String']['output']>;
   channelId?: Maybe<Scalars['String']['output']>;
   channelSecret?: Maybe<Scalars['String']['output']>;
+  liffAppId?: Maybe<Scalars['String']['output']>;
   liffBaseUrl?: Maybe<Scalars['String']['output']>;
   liffId?: Maybe<Scalars['String']['output']>;
   richMenus?: Maybe<Array<GqlCommunityLineRichMenuConfig>>;
@@ -320,6 +336,31 @@ export type GqlCommunityLineRichMenuConfig = {
 export type GqlCommunityLineRichMenuConfigInput = {
   richMenuId: Scalars['String']['input'];
   type: GqlLineRichMenuType;
+};
+
+export type GqlCommunityPortalConfig = {
+  __typename?: 'CommunityPortalConfig';
+  adminRootPath: Scalars['String']['output'];
+  commonDocumentOverrides?: Maybe<GqlCommonDocumentOverrides>;
+  communityId: Scalars['String']['output'];
+  description: Scalars['String']['output'];
+  documents?: Maybe<Array<GqlCommunityDocument>>;
+  domain: Scalars['String']['output'];
+  enableFeatures: Array<Scalars['String']['output']>;
+  faviconPrefix: Scalars['String']['output'];
+  firebaseTenantId?: Maybe<Scalars['String']['output']>;
+  liffAppId?: Maybe<Scalars['String']['output']>;
+  liffBaseUrl?: Maybe<Scalars['String']['output']>;
+  liffId?: Maybe<Scalars['String']['output']>;
+  logoPath: Scalars['String']['output'];
+  ogImagePath: Scalars['String']['output'];
+  regionKey?: Maybe<Scalars['String']['output']>;
+  regionName?: Maybe<Scalars['String']['output']>;
+  rootPath: Scalars['String']['output'];
+  shortDescription?: Maybe<Scalars['String']['output']>;
+  squareLogoPath: Scalars['String']['output'];
+  title: Scalars['String']['output'];
+  tokenName: Scalars['String']['output'];
 };
 
 export type GqlCommunitySortInput = {
@@ -1759,6 +1800,7 @@ export type GqlQuery = {
   cities: GqlCitiesConnection;
   communities: GqlCommunitiesConnection;
   community?: Maybe<GqlCommunity>;
+  communityPortalConfig?: Maybe<GqlCommunityPortalConfig>;
   currentUser?: Maybe<GqlCurrentUserPayload>;
   echo: Scalars['String']['output'];
   evaluation?: Maybe<GqlEvaluation>;
@@ -1847,6 +1889,11 @@ export type GqlQueryCommunitiesArgs = {
 
 export type GqlQueryCommunityArgs = {
   id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryCommunityPortalConfigArgs = {
+  communityId: Scalars['String']['input'];
 };
 
 
@@ -3121,6 +3168,7 @@ export type GqlResolversTypes = ResolversObject<{
   City: ResolverTypeWrapper<City>;
   CityEdge: ResolverTypeWrapper<Omit<GqlCityEdge, 'node'> & { node?: Maybe<GqlResolversTypes['City']> }>;
   ClaimLinkStatus: GqlClaimLinkStatus;
+  CommonDocumentOverrides: ResolverTypeWrapper<GqlCommonDocumentOverrides>;
   CommunitiesConnection: ResolverTypeWrapper<Omit<GqlCommunitiesConnection, 'edges'> & { edges?: Maybe<Array<GqlResolversTypes['CommunityEdge']>> }>;
   Community: ResolverTypeWrapper<Community>;
   CommunityConfig: ResolverTypeWrapper<GqlCommunityConfig>;
@@ -3130,6 +3178,7 @@ export type GqlResolversTypes = ResolversObject<{
   CommunityCreateSuccess: ResolverTypeWrapper<Omit<GqlCommunityCreateSuccess, 'community'> & { community: GqlResolversTypes['Community'] }>;
   CommunityDeletePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['CommunityDeletePayload']>;
   CommunityDeleteSuccess: ResolverTypeWrapper<GqlCommunityDeleteSuccess>;
+  CommunityDocument: ResolverTypeWrapper<GqlCommunityDocument>;
   CommunityEdge: ResolverTypeWrapper<Omit<GqlCommunityEdge, 'node'> & { node?: Maybe<GqlResolversTypes['Community']> }>;
   CommunityFilterInput: GqlCommunityFilterInput;
   CommunityFirebaseConfig: ResolverTypeWrapper<GqlCommunityFirebaseConfig>;
@@ -3138,6 +3187,7 @@ export type GqlResolversTypes = ResolversObject<{
   CommunityLineConfigInput: GqlCommunityLineConfigInput;
   CommunityLineRichMenuConfig: ResolverTypeWrapper<GqlCommunityLineRichMenuConfig>;
   CommunityLineRichMenuConfigInput: GqlCommunityLineRichMenuConfigInput;
+  CommunityPortalConfig: ResolverTypeWrapper<GqlCommunityPortalConfig>;
   CommunitySortInput: GqlCommunitySortInput;
   CommunityUpdateProfileInput: GqlCommunityUpdateProfileInput;
   CommunityUpdateProfilePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['CommunityUpdateProfilePayload']>;
@@ -3449,6 +3499,7 @@ export type GqlResolversParentTypes = ResolversObject<{
   CitiesSortInput: GqlCitiesSortInput;
   City: City;
   CityEdge: Omit<GqlCityEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['City']> };
+  CommonDocumentOverrides: GqlCommonDocumentOverrides;
   CommunitiesConnection: Omit<GqlCommunitiesConnection, 'edges'> & { edges?: Maybe<Array<GqlResolversParentTypes['CommunityEdge']>> };
   Community: Community;
   CommunityConfig: GqlCommunityConfig;
@@ -3458,6 +3509,7 @@ export type GqlResolversParentTypes = ResolversObject<{
   CommunityCreateSuccess: Omit<GqlCommunityCreateSuccess, 'community'> & { community: GqlResolversParentTypes['Community'] };
   CommunityDeletePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['CommunityDeletePayload'];
   CommunityDeleteSuccess: GqlCommunityDeleteSuccess;
+  CommunityDocument: GqlCommunityDocument;
   CommunityEdge: Omit<GqlCommunityEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['Community']> };
   CommunityFilterInput: GqlCommunityFilterInput;
   CommunityFirebaseConfig: GqlCommunityFirebaseConfig;
@@ -3466,6 +3518,7 @@ export type GqlResolversParentTypes = ResolversObject<{
   CommunityLineConfigInput: GqlCommunityLineConfigInput;
   CommunityLineRichMenuConfig: GqlCommunityLineRichMenuConfig;
   CommunityLineRichMenuConfigInput: GqlCommunityLineRichMenuConfigInput;
+  CommunityPortalConfig: GqlCommunityPortalConfig;
   CommunitySortInput: GqlCommunitySortInput;
   CommunityUpdateProfileInput: GqlCommunityUpdateProfileInput;
   CommunityUpdateProfilePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['CommunityUpdateProfilePayload'];
@@ -3820,6 +3873,12 @@ export type GqlCityEdgeResolvers<ContextType = any, ParentType extends GqlResolv
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type GqlCommonDocumentOverridesResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CommonDocumentOverrides'] = GqlResolversParentTypes['CommonDocumentOverrides']> = ResolversObject<{
+  privacy?: Resolver<Maybe<GqlResolversTypes['CommunityDocument']>, ParentType, ContextType>;
+  terms?: Resolver<Maybe<GqlResolversTypes['CommunityDocument']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type GqlCommunitiesConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CommunitiesConnection'] = GqlResolversParentTypes['CommunitiesConnection']> = ResolversObject<{
   edges?: Resolver<Maybe<Array<GqlResolversTypes['CommunityEdge']>>, ParentType, ContextType>;
   pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
@@ -3872,6 +3931,15 @@ export type GqlCommunityDeleteSuccessResolvers<ContextType = any, ParentType ext
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type GqlCommunityDocumentResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CommunityDocument'] = GqlResolversParentTypes['CommunityDocument']> = ResolversObject<{
+  id?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  order?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  path?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  title?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  type?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type GqlCommunityEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CommunityEdge'] = GqlResolversParentTypes['CommunityEdge']> = ResolversObject<{
   cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
   node?: Resolver<Maybe<GqlResolversTypes['Community']>, ParentType, ContextType>;
@@ -3887,6 +3955,7 @@ export type GqlCommunityLineConfigResolvers<ContextType = any, ParentType extend
   accessToken?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   channelId?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   channelSecret?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  liffAppId?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   liffBaseUrl?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   liffId?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   richMenus?: Resolver<Maybe<Array<GqlResolversTypes['CommunityLineRichMenuConfig']>>, ParentType, ContextType>;
@@ -3896,6 +3965,31 @@ export type GqlCommunityLineConfigResolvers<ContextType = any, ParentType extend
 export type GqlCommunityLineRichMenuConfigResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CommunityLineRichMenuConfig'] = GqlResolversParentTypes['CommunityLineRichMenuConfig']> = ResolversObject<{
   richMenuId?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
   type?: Resolver<GqlResolversTypes['LineRichMenuType'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlCommunityPortalConfigResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CommunityPortalConfig'] = GqlResolversParentTypes['CommunityPortalConfig']> = ResolversObject<{
+  adminRootPath?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  commonDocumentOverrides?: Resolver<Maybe<GqlResolversTypes['CommonDocumentOverrides']>, ParentType, ContextType>;
+  communityId?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  description?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  documents?: Resolver<Maybe<Array<GqlResolversTypes['CommunityDocument']>>, ParentType, ContextType>;
+  domain?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  enableFeatures?: Resolver<Array<GqlResolversTypes['String']>, ParentType, ContextType>;
+  faviconPrefix?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  firebaseTenantId?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  liffAppId?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  liffBaseUrl?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  liffId?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  logoPath?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  ogImagePath?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  regionKey?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  regionName?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  rootPath?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  shortDescription?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  squareLogoPath?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  title?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  tokenName?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -4551,6 +4645,7 @@ export type GqlQueryResolvers<ContextType = any, ParentType extends GqlResolvers
   cities?: Resolver<GqlResolversTypes['CitiesConnection'], ParentType, ContextType, Partial<GqlQueryCitiesArgs>>;
   communities?: Resolver<GqlResolversTypes['CommunitiesConnection'], ParentType, ContextType, Partial<GqlQueryCommunitiesArgs>>;
   community?: Resolver<Maybe<GqlResolversTypes['Community']>, ParentType, ContextType, RequireFields<GqlQueryCommunityArgs, 'id'>>;
+  communityPortalConfig?: Resolver<Maybe<GqlResolversTypes['CommunityPortalConfig']>, ParentType, ContextType, RequireFields<GqlQueryCommunityPortalConfigArgs, 'communityId'>>;
   currentUser?: Resolver<Maybe<GqlResolversTypes['CurrentUserPayload']>, ParentType, ContextType>;
   echo?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
   evaluation?: Resolver<Maybe<GqlResolversTypes['Evaluation']>, ParentType, ContextType, RequireFields<GqlQueryEvaluationArgs, 'id'>>;
@@ -5107,6 +5202,7 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   CitiesConnection?: GqlCitiesConnectionResolvers<ContextType>;
   City?: GqlCityResolvers<ContextType>;
   CityEdge?: GqlCityEdgeResolvers<ContextType>;
+  CommonDocumentOverrides?: GqlCommonDocumentOverridesResolvers<ContextType>;
   CommunitiesConnection?: GqlCommunitiesConnectionResolvers<ContextType>;
   Community?: GqlCommunityResolvers<ContextType>;
   CommunityConfig?: GqlCommunityConfigResolvers<ContextType>;
@@ -5114,10 +5210,12 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   CommunityCreateSuccess?: GqlCommunityCreateSuccessResolvers<ContextType>;
   CommunityDeletePayload?: GqlCommunityDeletePayloadResolvers<ContextType>;
   CommunityDeleteSuccess?: GqlCommunityDeleteSuccessResolvers<ContextType>;
+  CommunityDocument?: GqlCommunityDocumentResolvers<ContextType>;
   CommunityEdge?: GqlCommunityEdgeResolvers<ContextType>;
   CommunityFirebaseConfig?: GqlCommunityFirebaseConfigResolvers<ContextType>;
   CommunityLineConfig?: GqlCommunityLineConfigResolvers<ContextType>;
   CommunityLineRichMenuConfig?: GqlCommunityLineRichMenuConfigResolvers<ContextType>;
+  CommunityPortalConfig?: GqlCommunityPortalConfigResolvers<ContextType>;
   CommunityUpdateProfilePayload?: GqlCommunityUpdateProfilePayloadResolvers<ContextType>;
   CommunityUpdateProfileSuccess?: GqlCommunityUpdateProfileSuccessResolvers<ContextType>;
   CurrentPointView?: GqlCurrentPointViewResolvers<ContextType>;


### PR DESCRIPTION
## 概要 (Summary)

このPRは、以前 Revert された「CommunityPortalConfig モデルと GraphQL API の追加 (Phase 1a)」を再適用し、コミュニティ設定のDB管理機能を実装するものです。主な変更点は以下の通りです：

* **コミュニティポータル設定**: ブランディング、機能フラグ、ドキュメントの上書き設定など、コミュニティ固有のポータル設定を管理するための `CommunityPortalConfig` モデルと、それに対応する GraphQL API を導入しました。
* **LINE設定の拡張**: `CommunityLineConfig` に `liffAppId` フィールドを追加し、コミュニティごとのLINEログインをDB上の情報を用いて行うことが可能になりました。
* その他 (今回のPRの趣旨には関係無いものの実装したもの)
   * **Prismaマイグレーションの改善**: Prisma のマイグレーション用 SQL diff の生成を効率化するためのユーティリティスクリプト `db:migrate-diff` を追加しました。
   * **APIロギングの改善**: LINE API のログに HTTP メソッド（GET, POSTなど）を含めるように変更し、エラー時の追跡可能性を向上させました。（もともとはメソッドにかかわらずPOSTと記録されていたバグを修正）

## 人間によるレビュー＆テストのチェックリスト (Review & Testing Checklist for Human)

機能の再導入およびデータレイヤーの変更が含まれるため、以下を確認してください：

* **DBマイグレーション**: 新しい `CommunityPortalConfig` テーブルおよび `liffAppId` カラムが正しく作成されることを確認してください。
* **GraphQL API**: 新しく追加された `CommunityPortalConfig` 関連のクエリが正常に動作し、期待される設定値が取得できるかテストしてください。
* **LINE連携機能**: `liffAppId` の追加により、既存のLINE連携機能やLIFFアプリの動作に退行（リグレッション）がないか確認してください。