### PR TITLE
Fix MockIncentiveGrantRepository type error

### DIFF
--- a/src/__tests__/unit/transaction/incentiveGrant.service.test.ts
+++ b/src/__tests__/unit/transaction/incentiveGrant.service.test.ts
@@ -19,6 +19,10 @@ const IncentiveGrantFailureCode = {
 
 // Mock Repository
 class MockIncentiveGrantRepository implements IIncentiveGrantRepository {
+  query = jest.fn();
+  find = jest.fn();
+  findManyByIds = jest.fn();
+  count = jest.fn();
   create = jest.fn();
   markAsCompleted = jest.fn();
   markAsFailed = jest.fn();

--- a/src/application/domain/transaction/incentiveGrant/presenter.ts
+++ b/src/application/domain/transaction/incentiveGrant/presenter.ts
@@ -23,6 +23,6 @@ export default class IncentiveGrantPresenter {
     return {
       __typename: "IncentiveGrant",
       ...r,
-    };
+    } as GqlIncentiveGrant;
   }
 }

--- a/src/application/domain/transaction/incentiveGrant/usecase.ts
+++ b/src/application/domain/transaction/incentiveGrant/usecase.ts
@@ -10,6 +10,7 @@ import {
   GqlIncentiveGrant,
   GqlIncentiveGrantsConnection,
   GqlIncentiveGrantFilterInput,
+  GqlSortDirection,
 } from "@/types/graphql";
 
 @injectable()
@@ -31,10 +32,10 @@ export default class IncentiveGrantUseCase {
     // Build orderBy clause
     const orderBy: Prisma.IncentiveGrantOrderByWithRelationInput[] = [];
     if (sort?.createdAt) {
-      orderBy.push({ createdAt: sort.createdAt === "ASC" ? "asc" : "desc" });
+      orderBy.push({ createdAt: sort.createdAt === GqlSortDirection.Asc ? "asc" : "desc" });
     }
     if (sort?.updatedAt) {
-      orderBy.push({ updatedAt: sort.updatedAt === "ASC" ? "asc" : "desc" });
+      orderBy.push({ updatedAt: sort.updatedAt === GqlSortDirection.Asc ? "asc" : "desc" });
     }
     if (orderBy.length === 0) {
       orderBy.push({ createdAt: "desc" });


### PR DESCRIPTION
- Add missing methods (query, find, findManyByIds, count) to MockIncentiveGrantRepository test implementation
- Add type assertion to IncentiveGrantPresenter.get() to handle field resolver pattern where related objects (user, community) are resolved separately
- Fix sort direction comparison in usecase to use GqlSortDirection.Asc enum instead of string literal "ASC"