### PR TITLE
Add dedicated signupBonusConfig query endpoint

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -1455,6 +1455,7 @@ type Query {
   reservationHistories(cursor: String, filter: ReservationHistoryFilterInput, first: Int, sort: ReservationHistorySortInput): ReservationHistoriesConnection!
   reservationHistory(id: ID!): ReservationHistory
   reservations(cursor: String, filter: ReservationFilterInput, first: Int, sort: ReservationSortInput): ReservationsConnection!
+  signupBonusConfig(communityId: ID!): CommunitySignupBonusConfig
   states(cursor: String, filter: StatesInput, first: Int): StatesConnection!
   ticket(id: ID!): Ticket
   ticketClaimLink(id: ID!): TicketClaimLink

--- a/src/application/domain/account/community/config/controller/resolver.ts
+++ b/src/application/domain/account/community/config/controller/resolver.ts
@@ -1,0 +1,22 @@
+import { GqlQuerySignupBonusConfigArgs } from "@/types/graphql";
+import { IContext } from "@/types/server";
+import { inject, injectable } from "tsyringe";
+import CommunitySignupBonusConfigService from "@/application/domain/account/community/config/incentive/signup/service";
+
+@injectable()
+export default class CommunityConfigResolver {
+  constructor(
+    @inject("CommunitySignupBonusConfigService")
+    private readonly signupBonusConfigService: CommunitySignupBonusConfigService,
+  ) {}
+
+  Query = {
+    signupBonusConfig: async (
+      _: unknown,
+      args: GqlQuerySignupBonusConfigArgs,
+      ctx: IContext,
+    ) => {
+      return this.signupBonusConfigService.get(ctx, args.communityId);
+    },
+  };
+}

--- a/src/application/domain/account/community/config/schema/query.graphql
+++ b/src/application/domain/account/community/config/schema/query.graphql
@@ -1,0 +1,6 @@
+# ------------------------------
+# CommunityConfig Query Definitions
+# ------------------------------
+extend type Query {
+  signupBonusConfig(communityId: ID!): CommunitySignupBonusConfig
+}

--- a/src/presentation/graphql/resolver.ts
+++ b/src/presentation/graphql/resolver.ts
@@ -6,6 +6,7 @@ import WalletResolver from "@/application/domain/account/wallet/controller/resol
 import NftWalletResolver from "@/application/domain/account/nft-wallet/controller/resolver";
 import MembershipResolver from "@/application/domain/account/membership/controller/resolver";
 import CommunityResolver from "@/application/domain/account/community/controller/resolver";
+import CommunityConfigResolver from "@/application/domain/account/community/config/controller/resolver";
 import CommunityPortalConfigResolver from "@/application/domain/account/community/config/portal/controller/resolver";
 import ArticleResolver from "@/application/domain/content/article/controller/resolver";
 import OpportunityResolver from "@/application/domain/experience/opportunity/controller/resolver";
@@ -32,6 +33,7 @@ const wallet = container.resolve(WalletResolver);
 const nftWallet = container.resolve(NftWalletResolver);
 const membership = container.resolve(MembershipResolver);
 const community = container.resolve(CommunityResolver);
+const communityConfig = container.resolve(CommunityConfigResolver);
 const communityPortalConfig = container.resolve(CommunityPortalConfigResolver);
 
 const article = container.resolve(ArticleResolver);
@@ -61,6 +63,7 @@ const resolvers = {
     ...identity.Query,
     ...user.Query,
     ...community.Query,
+    ...communityConfig.Query,
     ...communityPortalConfig.Query,
     ...membership.Query,
     ...wallet.Query,

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1910,6 +1910,7 @@ export type GqlQuery = {
   reservationHistories: GqlReservationHistoriesConnection;
   reservationHistory?: Maybe<GqlReservationHistory>;
   reservations: GqlReservationsConnection;
+  signupBonusConfig?: Maybe<GqlCommunitySignupBonusConfig>;
   states: GqlStatesConnection;
   ticket?: Maybe<GqlTicket>;
   ticketClaimLink?: Maybe<GqlTicketClaimLink>;
@@ -2142,6 +2143,11 @@ export type GqlQueryReservationsArgs = {
   filter?: InputMaybe<GqlReservationFilterInput>;
   first?: InputMaybe<Scalars['Int']['input']>;
   sort?: InputMaybe<GqlReservationSortInput>;
+};
+
+
+export type GqlQuerySignupBonusConfigArgs = {
+  communityId: Scalars['ID']['input'];
 };
 
 
@@ -4832,6 +4838,7 @@ export type GqlQueryResolvers<ContextType = any, ParentType extends GqlResolvers
   reservationHistories?: Resolver<GqlResolversTypes['ReservationHistoriesConnection'], ParentType, ContextType, Partial<GqlQueryReservationHistoriesArgs>>;
   reservationHistory?: Resolver<Maybe<GqlResolversTypes['ReservationHistory']>, ParentType, ContextType, RequireFields<GqlQueryReservationHistoryArgs, 'id'>>;
   reservations?: Resolver<GqlResolversTypes['ReservationsConnection'], ParentType, ContextType, Partial<GqlQueryReservationsArgs>>;
+  signupBonusConfig?: Resolver<Maybe<GqlResolversTypes['CommunitySignupBonusConfig']>, ParentType, ContextType, RequireFields<GqlQuerySignupBonusConfigArgs, 'communityId'>>;
   states?: Resolver<GqlResolversTypes['StatesConnection'], ParentType, ContextType, Partial<GqlQueryStatesArgs>>;
   ticket?: Resolver<Maybe<GqlResolversTypes['Ticket']>, ParentType, ContextType, RequireFields<GqlQueryTicketArgs, 'id'>>;
   ticketClaimLink?: Resolver<Maybe<GqlResolversTypes['TicketClaimLink']>, ParentType, ContextType, RequireFields<GqlQueryTicketClaimLinkArgs, 'id'>>;


### PR DESCRIPTION
### Description

This pull request introduces a new GraphQL query, `signupBonusConfig`, allowing direct access to signup bonus configuration without relying on the `Community.config` field resolver. This simplifies the process and improves efficiency.

### Changes
- Added new query `signupBonusConfig(communityId: ID!)` to the schema.
- Implemented `CommunityConfigResolver` to handle the new query.
- Registered the resolver in the presentation layer.
- Regenerated GraphQL types.

### Usage
Frontend developers can now use the query as follows:
```graphql
query GetSignupBonusConfig($communityId: ID!) {
  signupBonusConfig(communityId: $communityId) {
    bonusPoint
    isEnabled
    message
  }
}
```

### Checklist

- [ ] Reviewed the changes for potential impacts.
- [ ] Included tests for added functionality.
- [ ] Ensured all schema changes are documented.
- [ ] Verified backward compatibility is maintained.