### PR TITLE
feat: トランザクションチェーンビューとリフレッシュ機能の追加

### DIFF
--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -700,7 +700,7 @@ RIGHT RIGHT
   
 
   "t_transactions" {
-    String id "🗝️"
+    String transaction_id "🗝️"
     TransactionReason reason 
     String comment "❓"
     String from "❓"
@@ -883,6 +883,14 @@ RIGHT RIGHT
     Int remainingCapacity "❓"
     }
   
+
+  "mv_transaction_chains" {
+    String transactionId "🗝️"
+    Int depth 
+    String rootTxId 
+    String chainTxIds 
+    }
+  
     "t_images" o{--}o "t_users" : "users"
     "t_images" o{--}o "t_communities" : "communities"
     "t_images" o{--}o "t_articles" : "articles"
@@ -1062,6 +1070,7 @@ RIGHT RIGHT
     "t_transactions" o|--|| "TransactionReason" : "enum:reason"
     "t_transactions" o|--|o "t_wallets" : "fromWallet"
     "t_transactions" o|--|o "t_wallets" : "toWallet"
+    "t_transactions" o{--}o "mv_transaction_chains" : "chainInfo"
     "t_transactions" o|--|o "t_participations" : "participation"
     "t_transactions" o|--|o "t_reservations" : "reservation"
     "t_transactions" o{--}o "t_ticket_status_histories" : "ticketStatusHistory"
@@ -1101,4 +1110,5 @@ RIGHT RIGHT
     "v_earliest_reservable_slot" o|--|| "t_opportunities" : "opportunity"
     "v_opportunity_accumulated_participants" o|--|| "t_opportunities" : "opportunity"
     "v_slot_remaining_capacity" o|--|| "t_opportunity_slots" : "slot"
+    "mv_transaction_chains" o|--|| "t_transactions" : "transaction"
 ```

--- a/docs/schema.dbml
+++ b/docs/schema.dbml
@@ -560,6 +560,7 @@ Table t_transactions {
   to String
   toWallet t_wallets
   toPointChange Int [not null]
+  chainInfo mv_transaction_chains
   participationId String
   participation t_participations
   reservationId String
@@ -766,6 +767,14 @@ Table v_slot_remaining_capacity {
   slotId String [pk]
   slot t_opportunity_slots [not null]
   remainingCapacity Int
+}
+
+Table mv_transaction_chains {
+  transactionId String [pk]
+  transaction t_transactions [not null]
+  depth Int [not null]
+  rootTxId String [not null]
+  chainTxIds String[] [not null]
 }
 
 Table t_images_on_opportunities {
@@ -1176,3 +1185,5 @@ Ref: v_earliest_reservable_slot.opportunityId - t_opportunities.id
 Ref: v_opportunity_accumulated_participants.opportunityId - t_opportunities.id [delete: Cascade]
 
 Ref: v_slot_remaining_capacity.slotId - t_opportunity_slots.id
+
+Ref: mv_transaction_chains.transactionId - t_transactions.id

--- a/src/__tests__/helper/test-data-source-helper.ts
+++ b/src/__tests__/helper/test-data-source-helper.ts
@@ -36,6 +36,7 @@ export default class TestDataSourceHelper {
     await this.db.ticketIssuer.deleteMany();
 
     await this.db.ticket.deleteMany();
+    await this.db.incentiveGrant.deleteMany();
     await this.db.transaction.deleteMany();
 
     await this.db.nftMint.deleteMany();

--- a/src/__tests__/helper/test-data-source-helper.ts
+++ b/src/__tests__/helper/test-data-source-helper.ts
@@ -254,11 +254,21 @@ export default class TestDataSourceHelper {
     return this.db.$queryRaw`REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_current_points"`;
   }
 
+  static async refreshTransactionChains() {
+    return this.db.$queryRaw`REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_transaction_chains"`;
+  }
+
   static async getCurrentPoints(walletId: string): Promise<number | null> {
     const result = await this.db.currentPointView.findUnique({
       where: { walletId },
     });
     return result?.currentPoint ? Number(result.currentPoint) : null;
+  }
+
+  static async getTransactionChain(transactionId: string) {
+    return this.db.transactionChainView.findUnique({
+      where: { transactionId },
+    });
   }
 
   // ========== Participation関連 (不要になれば削除) =========

--- a/src/__tests__/helper/test-data-source-helper.ts
+++ b/src/__tests__/helper/test-data-source-helper.ts
@@ -36,6 +36,7 @@ export default class TestDataSourceHelper {
     await this.db.ticketIssuer.deleteMany();
 
     await this.db.ticket.deleteMany();
+    await this.db.incentiveGrant.deleteMany();
     await this.db.transaction.deleteMany();
 
     await this.db.nftMint.deleteMany();
@@ -51,6 +52,8 @@ export default class TestDataSourceHelper {
 
     await this.db.communityFirebaseConfig.deleteMany();
     await this.db.communityLineConfig.deleteMany();
+    await this.db.communityPortalConfig.deleteMany();
+    await this.db.communitySignupBonusConfig.deleteMany();
     await this.db.communityConfig.deleteMany();
 
     await this.db.community.deleteMany();
@@ -254,11 +257,21 @@ export default class TestDataSourceHelper {
     return this.db.$queryRaw`REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_current_points"`;
   }
 
+  static async refreshTransactionChains() {
+    return this.db.$queryRaw`REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_transaction_chains"`;
+  }
+
   static async getCurrentPoints(walletId: string): Promise<number | null> {
     const result = await this.db.currentPointView.findUnique({
       where: { walletId },
     });
     return result?.currentPoint ? Number(result.currentPoint) : null;
+  }
+
+  static async getTransactionChain(transactionId: string) {
+    return this.db.transactionChainView.findUnique({
+      where: { transactionId },
+    });
   }
 
   // ========== Participation関連 (不要になれば削除) =========

--- a/src/__tests__/helper/test-data-source-helper.ts
+++ b/src/__tests__/helper/test-data-source-helper.ts
@@ -52,6 +52,8 @@ export default class TestDataSourceHelper {
 
     await this.db.communityFirebaseConfig.deleteMany();
     await this.db.communityLineConfig.deleteMany();
+    await this.db.communityPortalConfig.deleteMany();
+    await this.db.communitySignupBonusConfig.deleteMany();
     await this.db.communityConfig.deleteMany();
 
     await this.db.community.deleteMany();

--- a/src/__tests__/integration/pointTransfer/transactionChain.test.ts
+++ b/src/__tests__/integration/pointTransfer/transactionChain.test.ts
@@ -1,0 +1,313 @@
+import "reflect-metadata";
+import TestDataSourceHelper from "../../helper/test-data-source-helper";
+import { CurrentPrefecture, TransactionReason, WalletType } from "@prisma/client";
+
+describe("Transaction Chain Tests", () => {
+  beforeEach(async () => {
+    await TestDataSourceHelper.deleteAll();
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await TestDataSourceHelper.disconnect();
+  });
+
+  describe("refreshTransactionChains", () => {
+    it("should refresh without error when no transactions exist", async () => {
+      await expect(TestDataSourceHelper.refreshTransactionChains()).resolves.not.toThrow();
+    });
+
+    it("should track GRANT transaction as chain root with depth 1", async () => {
+      // Setup: Community and User
+      const user = await TestDataSourceHelper.createUser({
+        name: "User A",
+        slug: "user-a",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const community = await TestDataSourceHelper.createCommunity({
+        name: "Test Community",
+        pointName: "point",
+      });
+
+      const communityWallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.COMMUNITY,
+        community: { connect: { id: community.id } },
+      });
+
+      const userWallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.MEMBER,
+        community: { connect: { id: community.id } },
+        user: { connect: { id: user.id } },
+      });
+
+      // Create GRANT transaction
+      const grantTx = await TestDataSourceHelper.createTransaction({
+        fromWallet: { connect: { id: communityWallet.id } },
+        toWallet: { connect: { id: userWallet.id } },
+        fromPointChange: -100,
+        toPointChange: 100,
+        reason: TransactionReason.GRANT,
+      });
+
+      // Refresh materialized view
+      await TestDataSourceHelper.refreshTransactionChains();
+
+      // Verify chain info
+      const chainInfo = await TestDataSourceHelper.getTransactionChain(grantTx.id);
+
+      expect(chainInfo).not.toBeNull();
+      expect(chainInfo?.depth).toBe(1);
+      expect(chainInfo?.rootTxId).toBe(grantTx.id);
+      expect(chainInfo?.chainTxIds).toEqual([grantTx.id]);
+    });
+
+    it("should track GRANT -> DONATION chain with correct depth", async () => {
+      // Setup: Community and two Users
+      const userA = await TestDataSourceHelper.createUser({
+        name: "User A",
+        slug: "user-a",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const userB = await TestDataSourceHelper.createUser({
+        name: "User B",
+        slug: "user-b",
+        currentPrefecture: CurrentPrefecture.TOKUSHIMA,
+      });
+
+      const community = await TestDataSourceHelper.createCommunity({
+        name: "Test Community",
+        pointName: "point",
+      });
+
+      const communityWallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.COMMUNITY,
+        community: { connect: { id: community.id } },
+      });
+
+      const userAWallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.MEMBER,
+        community: { connect: { id: community.id } },
+        user: { connect: { id: userA.id } },
+      });
+
+      const userBWallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.MEMBER,
+        community: { connect: { id: community.id } },
+        user: { connect: { id: userB.id } },
+      });
+
+      // Create GRANT transaction: Community -> UserA
+      const grantTx = await TestDataSourceHelper.createTransaction({
+        fromWallet: { connect: { id: communityWallet.id } },
+        toWallet: { connect: { id: userAWallet.id } },
+        fromPointChange: -100,
+        toPointChange: 100,
+        reason: TransactionReason.GRANT,
+      });
+
+      // Wait a bit to ensure different created_at timestamps
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Create DONATION transaction: UserA -> UserB
+      const donationTx = await TestDataSourceHelper.createTransaction({
+        fromWallet: { connect: { id: userAWallet.id } },
+        toWallet: { connect: { id: userBWallet.id } },
+        fromPointChange: -50,
+        toPointChange: 50,
+        reason: TransactionReason.DONATION,
+      });
+
+      // Refresh materialized view
+      await TestDataSourceHelper.refreshTransactionChains();
+
+      // Verify GRANT chain info
+      const grantChainInfo = await TestDataSourceHelper.getTransactionChain(grantTx.id);
+      expect(grantChainInfo).not.toBeNull();
+      expect(grantChainInfo?.depth).toBe(1);
+      expect(grantChainInfo?.rootTxId).toBe(grantTx.id);
+
+      // Verify DONATION chain info (should be linked to GRANT)
+      const donationChainInfo = await TestDataSourceHelper.getTransactionChain(donationTx.id);
+      expect(donationChainInfo).not.toBeNull();
+      expect(donationChainInfo?.depth).toBe(2);
+      expect(donationChainInfo?.rootTxId).toBe(grantTx.id);
+      expect(donationChainInfo?.chainTxIds).toEqual([grantTx.id, donationTx.id]);
+    });
+
+    it("should track multiple independent chains separately", async () => {
+      // Setup
+      const user1 = await TestDataSourceHelper.createUser({
+        name: "User 1",
+        slug: "user-1",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const user2 = await TestDataSourceHelper.createUser({
+        name: "User 2",
+        slug: "user-2",
+        currentPrefecture: CurrentPrefecture.TOKUSHIMA,
+      });
+
+      const community = await TestDataSourceHelper.createCommunity({
+        name: "Test Community",
+        pointName: "point",
+      });
+
+      const communityWallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.COMMUNITY,
+        community: { connect: { id: community.id } },
+      });
+
+      const user1Wallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.MEMBER,
+        community: { connect: { id: community.id } },
+        user: { connect: { id: user1.id } },
+      });
+
+      const user2Wallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.MEMBER,
+        community: { connect: { id: community.id } },
+        user: { connect: { id: user2.id } },
+      });
+
+      // Create two independent GRANT transactions
+      const grant1 = await TestDataSourceHelper.createTransaction({
+        fromWallet: { connect: { id: communityWallet.id } },
+        toWallet: { connect: { id: user1Wallet.id } },
+        fromPointChange: -100,
+        toPointChange: 100,
+        reason: TransactionReason.GRANT,
+      });
+
+      const grant2 = await TestDataSourceHelper.createTransaction({
+        fromWallet: { connect: { id: communityWallet.id } },
+        toWallet: { connect: { id: user2Wallet.id } },
+        fromPointChange: -200,
+        toPointChange: 200,
+        reason: TransactionReason.GRANT,
+      });
+
+      // Refresh materialized view
+      await TestDataSourceHelper.refreshTransactionChains();
+
+      // Verify each GRANT has its own chain
+      const chain1 = await TestDataSourceHelper.getTransactionChain(grant1.id);
+      const chain2 = await TestDataSourceHelper.getTransactionChain(grant2.id);
+
+      expect(chain1?.rootTxId).toBe(grant1.id);
+      expect(chain2?.rootTxId).toBe(grant2.id);
+
+      // Each chain is independent
+      expect(chain1?.rootTxId).not.toBe(chain2?.rootTxId);
+    });
+
+    it("should select deeper chain when multiple paths exist to same transaction", async () => {
+      // Setup: Community and three Users
+      const userA = await TestDataSourceHelper.createUser({
+        name: "User A",
+        slug: "user-a",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const userB = await TestDataSourceHelper.createUser({
+        name: "User B",
+        slug: "user-b",
+        currentPrefecture: CurrentPrefecture.TOKUSHIMA,
+      });
+
+      const userC = await TestDataSourceHelper.createUser({
+        name: "User C",
+        slug: "user-c",
+        currentPrefecture: CurrentPrefecture.KOCHI,
+      });
+
+      const community = await TestDataSourceHelper.createCommunity({
+        name: "Test Community",
+        pointName: "point",
+      });
+
+      const communityWallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.COMMUNITY,
+        community: { connect: { id: community.id } },
+      });
+
+      const userAWallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.MEMBER,
+        community: { connect: { id: community.id } },
+        user: { connect: { id: userA.id } },
+      });
+
+      const userBWallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.MEMBER,
+        community: { connect: { id: community.id } },
+        user: { connect: { id: userB.id } },
+      });
+
+      const userCWallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.MEMBER,
+        community: { connect: { id: community.id } },
+        user: { connect: { id: userC.id } },
+      });
+
+      // Create chain: Community → UserA (GRANT, tx1)
+      const grant1 = await TestDataSourceHelper.createTransaction({
+        fromWallet: { connect: { id: communityWallet.id } },
+        toWallet: { connect: { id: userAWallet.id } },
+        fromPointChange: -100,
+        toPointChange: 100,
+        reason: TransactionReason.GRANT,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Create chain: UserA → UserB (DONATION, tx2)
+      const donation1 = await TestDataSourceHelper.createTransaction({
+        fromWallet: { connect: { id: userAWallet.id } },
+        toWallet: { connect: { id: userBWallet.id } },
+        fromPointChange: -50,
+        toPointChange: 50,
+        reason: TransactionReason.DONATION,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Create direct GRANT to UserB: Community → UserB (GRANT, tx3)
+      // This creates a shorter path (depth=1) to UserB
+      await TestDataSourceHelper.createTransaction({
+        fromWallet: { connect: { id: communityWallet.id } },
+        toWallet: { connect: { id: userBWallet.id } },
+        fromPointChange: -100,
+        toPointChange: 100,
+        reason: TransactionReason.GRANT,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Create chain: UserB → UserC (DONATION, tx4)
+      // tx4 can be reached via:
+      //   - tx1 → tx2 → tx4 (depth=3, root=tx1)
+      //   - tx3 → tx4 (depth=2, root=tx3)
+      // Should select deeper chain (depth=3)
+      const donation2 = await TestDataSourceHelper.createTransaction({
+        fromWallet: { connect: { id: userBWallet.id } },
+        toWallet: { connect: { id: userCWallet.id } },
+        fromPointChange: -25,
+        toPointChange: 25,
+        reason: TransactionReason.DONATION,
+      });
+
+      // Refresh materialized view
+      await TestDataSourceHelper.refreshTransactionChains();
+
+      // Verify tx4 selected the deeper chain (depth=3, root=tx1)
+      const donation2Chain = await TestDataSourceHelper.getTransactionChain(donation2.id);
+
+      expect(donation2Chain).not.toBeNull();
+      expect(donation2Chain?.depth).toBe(3);
+      expect(donation2Chain?.rootTxId).toBe(grant1.id);
+      expect(donation2Chain?.chainTxIds).toEqual([grant1.id, donation1.id, donation2.id]);
+    });
+  });
+});

--- a/src/__tests__/integration/pointTransfer/transactionChain.test.ts
+++ b/src/__tests__/integration/pointTransfer/transactionChain.test.ts
@@ -358,8 +358,8 @@ describe("Transaction Chain Tests", () => {
         user: { connect: { id: userC.id } },
       });
 
-      // Create older GRANT to UserA (tx1)
-      const olderGrant = await TestDataSourceHelper.createTransaction({
+      // Create older GRANT to UserA (tx1) - not used in assertion, just for setup
+      await TestDataSourceHelper.createTransaction({
         fromWallet: { connect: { id: communityWallet.id } },
         toWallet: { connect: { id: userAWallet.id } },
         fromPointChange: -100,

--- a/src/__tests__/integration/pointTransfer/transactionChain.test.ts
+++ b/src/__tests__/integration/pointTransfer/transactionChain.test.ts
@@ -1,0 +1,206 @@
+import "reflect-metadata";
+import TestDataSourceHelper from "../../helper/test-data-source-helper";
+import { CurrentPrefecture, TransactionReason, WalletType } from "@prisma/client";
+
+describe("Transaction Chain Tests", () => {
+  beforeEach(async () => {
+    await TestDataSourceHelper.deleteAll();
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await TestDataSourceHelper.disconnect();
+  });
+
+  describe("refreshTransactionChains", () => {
+    it("should refresh without error when no transactions exist", async () => {
+      await expect(TestDataSourceHelper.refreshTransactionChains()).resolves.not.toThrow();
+    });
+
+    it("should track GRANT transaction as chain root with depth 1", async () => {
+      // Setup: Community and User
+      const user = await TestDataSourceHelper.createUser({
+        name: "User A",
+        slug: "user-a",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const community = await TestDataSourceHelper.createCommunity({
+        name: "Test Community",
+        pointName: "point",
+      });
+
+      const communityWallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.COMMUNITY,
+        community: { connect: { id: community.id } },
+      });
+
+      const userWallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.MEMBER,
+        community: { connect: { id: community.id } },
+        user: { connect: { id: user.id } },
+      });
+
+      // Create GRANT transaction
+      const grantTx = await TestDataSourceHelper.createTransaction({
+        fromWallet: { connect: { id: communityWallet.id } },
+        toWallet: { connect: { id: userWallet.id } },
+        fromPointChange: -100,
+        toPointChange: 100,
+        reason: TransactionReason.GRANT,
+      });
+
+      // Refresh materialized view
+      await TestDataSourceHelper.refreshTransactionChains();
+
+      // Verify chain info
+      const chainInfo = await TestDataSourceHelper.getTransactionChain(grantTx.id);
+
+      expect(chainInfo).not.toBeNull();
+      expect(chainInfo?.depth).toBe(1);
+      expect(chainInfo?.rootTxId).toBe(grantTx.id);
+      expect(chainInfo?.chainTxIds).toEqual([grantTx.id]);
+    });
+
+    it("should track GRANT -> DONATION chain with correct depth", async () => {
+      // Setup: Community and two Users
+      const userA = await TestDataSourceHelper.createUser({
+        name: "User A",
+        slug: "user-a",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const userB = await TestDataSourceHelper.createUser({
+        name: "User B",
+        slug: "user-b",
+        currentPrefecture: CurrentPrefecture.TOKUSHIMA,
+      });
+
+      const community = await TestDataSourceHelper.createCommunity({
+        name: "Test Community",
+        pointName: "point",
+      });
+
+      const communityWallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.COMMUNITY,
+        community: { connect: { id: community.id } },
+      });
+
+      const userAWallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.MEMBER,
+        community: { connect: { id: community.id } },
+        user: { connect: { id: userA.id } },
+      });
+
+      const userBWallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.MEMBER,
+        community: { connect: { id: community.id } },
+        user: { connect: { id: userB.id } },
+      });
+
+      // Create GRANT transaction: Community -> UserA
+      const grantTx = await TestDataSourceHelper.createTransaction({
+        fromWallet: { connect: { id: communityWallet.id } },
+        toWallet: { connect: { id: userAWallet.id } },
+        fromPointChange: -100,
+        toPointChange: 100,
+        reason: TransactionReason.GRANT,
+      });
+
+      // Wait a bit to ensure different created_at timestamps
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Create DONATION transaction: UserA -> UserB
+      const donationTx = await TestDataSourceHelper.createTransaction({
+        fromWallet: { connect: { id: userAWallet.id } },
+        toWallet: { connect: { id: userBWallet.id } },
+        fromPointChange: -50,
+        toPointChange: 50,
+        reason: TransactionReason.DONATION,
+      });
+
+      // Refresh materialized view
+      await TestDataSourceHelper.refreshTransactionChains();
+
+      // Verify GRANT chain info
+      const grantChainInfo = await TestDataSourceHelper.getTransactionChain(grantTx.id);
+      expect(grantChainInfo).not.toBeNull();
+      expect(grantChainInfo?.depth).toBe(1);
+      expect(grantChainInfo?.rootTxId).toBe(grantTx.id);
+
+      // Verify DONATION chain info (should be linked to GRANT)
+      const donationChainInfo = await TestDataSourceHelper.getTransactionChain(donationTx.id);
+      expect(donationChainInfo).not.toBeNull();
+      expect(donationChainInfo?.depth).toBe(2);
+      expect(donationChainInfo?.rootTxId).toBe(grantTx.id);
+      expect(donationChainInfo?.chainTxIds).toEqual([grantTx.id, donationTx.id]);
+    });
+
+    it("should track multiple independent chains separately", async () => {
+      // Setup
+      const user1 = await TestDataSourceHelper.createUser({
+        name: "User 1",
+        slug: "user-1",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const user2 = await TestDataSourceHelper.createUser({
+        name: "User 2",
+        slug: "user-2",
+        currentPrefecture: CurrentPrefecture.TOKUSHIMA,
+      });
+
+      const community = await TestDataSourceHelper.createCommunity({
+        name: "Test Community",
+        pointName: "point",
+      });
+
+      const communityWallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.COMMUNITY,
+        community: { connect: { id: community.id } },
+      });
+
+      const user1Wallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.MEMBER,
+        community: { connect: { id: community.id } },
+        user: { connect: { id: user1.id } },
+      });
+
+      const user2Wallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.MEMBER,
+        community: { connect: { id: community.id } },
+        user: { connect: { id: user2.id } },
+      });
+
+      // Create two independent GRANT transactions
+      const grant1 = await TestDataSourceHelper.createTransaction({
+        fromWallet: { connect: { id: communityWallet.id } },
+        toWallet: { connect: { id: user1Wallet.id } },
+        fromPointChange: -100,
+        toPointChange: 100,
+        reason: TransactionReason.GRANT,
+      });
+
+      const grant2 = await TestDataSourceHelper.createTransaction({
+        fromWallet: { connect: { id: communityWallet.id } },
+        toWallet: { connect: { id: user2Wallet.id } },
+        fromPointChange: -200,
+        toPointChange: 200,
+        reason: TransactionReason.GRANT,
+      });
+
+      // Refresh materialized view
+      await TestDataSourceHelper.refreshTransactionChains();
+
+      // Verify each GRANT has its own chain
+      const chain1 = await TestDataSourceHelper.getTransactionChain(grant1.id);
+      const chain2 = await TestDataSourceHelper.getTransactionChain(grant2.id);
+
+      expect(chain1?.rootTxId).toBe(grant1.id);
+      expect(chain2?.rootTxId).toBe(grant2.id);
+
+      // Each chain is independent
+      expect(chain1?.rootTxId).not.toBe(chain2?.rootTxId);
+    });
+  });
+});

--- a/src/__tests__/integration/pointTransfer/transactionChain.test.ts
+++ b/src/__tests__/integration/pointTransfer/transactionChain.test.ts
@@ -309,5 +309,336 @@ describe("Transaction Chain Tests", () => {
       expect(donation2Chain?.rootTxId).toBe(grant1.id);
       expect(donation2Chain?.chainTxIds).toEqual([grant1.id, donation1.id, donation2.id]);
     });
+
+    it("should prefer newer GRANT when depths are equal (tiebreaker)", async () => {
+      // Setup: Two independent chains that converge
+      const userA = await TestDataSourceHelper.createUser({
+        name: "User A",
+        slug: "user-a",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const userB = await TestDataSourceHelper.createUser({
+        name: "User B",
+        slug: "user-b",
+        currentPrefecture: CurrentPrefecture.TOKUSHIMA,
+      });
+
+      const userC = await TestDataSourceHelper.createUser({
+        name: "User C",
+        slug: "user-c",
+        currentPrefecture: CurrentPrefecture.KOCHI,
+      });
+
+      const community = await TestDataSourceHelper.createCommunity({
+        name: "Test Community",
+        pointName: "point",
+      });
+
+      const communityWallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.COMMUNITY,
+        community: { connect: { id: community.id } },
+      });
+
+      const userAWallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.MEMBER,
+        community: { connect: { id: community.id } },
+        user: { connect: { id: userA.id } },
+      });
+
+      const userBWallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.MEMBER,
+        community: { connect: { id: community.id } },
+        user: { connect: { id: userB.id } },
+      });
+
+      const userCWallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.MEMBER,
+        community: { connect: { id: community.id } },
+        user: { connect: { id: userC.id } },
+      });
+
+      // Create older GRANT to UserA (tx1)
+      const olderGrant = await TestDataSourceHelper.createTransaction({
+        fromWallet: { connect: { id: communityWallet.id } },
+        toWallet: { connect: { id: userAWallet.id } },
+        fromPointChange: -100,
+        toPointChange: 100,
+        reason: TransactionReason.GRANT,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Create newer GRANT to UserB (tx2)
+      const newerGrant = await TestDataSourceHelper.createTransaction({
+        fromWallet: { connect: { id: communityWallet.id } },
+        toWallet: { connect: { id: userBWallet.id } },
+        fromPointChange: -100,
+        toPointChange: 100,
+        reason: TransactionReason.GRANT,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // UserA → UserC (tx3) - creates path depth=2 from olderGrant
+      await TestDataSourceHelper.createTransaction({
+        fromWallet: { connect: { id: userAWallet.id } },
+        toWallet: { connect: { id: userCWallet.id } },
+        fromPointChange: -50,
+        toPointChange: 50,
+        reason: TransactionReason.DONATION,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // UserB → UserC (tx4) - creates path depth=2 from newerGrant
+      // tx4 has two paths with same depth=2:
+      //   - olderGrant → tx3 → (UserC receives) but tx4 starts from UserB, not applicable
+      // Actually tx4 itself: newerGrant → tx4 (depth=2)
+      // UserC now has points from both paths, and any transfer from UserC will have both paths
+      const finalTx = await TestDataSourceHelper.createTransaction({
+        fromWallet: { connect: { id: userBWallet.id } },
+        toWallet: { connect: { id: userCWallet.id } },
+        fromPointChange: -50,
+        toPointChange: 50,
+        reason: TransactionReason.DONATION,
+      });
+
+      await TestDataSourceHelper.refreshTransactionChains();
+
+      // finalTx should have depth=2 and prefer newerGrant (larger root_tx_id)
+      const finalChain = await TestDataSourceHelper.getTransactionChain(finalTx.id);
+
+      expect(finalChain).not.toBeNull();
+      expect(finalChain?.depth).toBe(2);
+      expect(finalChain?.rootTxId).toBe(newerGrant.id);
+    });
+  });
+
+  describe("Performance Tests", () => {
+    it("should handle deep chain (20 transfers) efficiently", async () => {
+      const community = await TestDataSourceHelper.createCommunity({
+        name: "Test Community",
+        pointName: "point",
+      });
+
+      const communityWallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.COMMUNITY,
+        community: { connect: { id: community.id } },
+      });
+
+      // Create 21 users for a chain of 20 transfers
+      const users = await Promise.all(
+        Array.from({ length: 21 }, (_, i) =>
+          TestDataSourceHelper.createUser({
+            name: `User ${i}`,
+            slug: `user-${i}`,
+            currentPrefecture: CurrentPrefecture.KAGAWA,
+          })
+        )
+      );
+
+      const wallets = await Promise.all(
+        users.map((user) =>
+          TestDataSourceHelper.createWallet({
+            type: WalletType.MEMBER,
+            community: { connect: { id: community.id } },
+            user: { connect: { id: user.id } },
+          })
+        )
+      );
+
+      // Create GRANT to first user
+      let previousWalletId = communityWallet.id;
+      const grantTx = await TestDataSourceHelper.createTransaction({
+        fromWallet: { connect: { id: communityWallet.id } },
+        toWallet: { connect: { id: wallets[0].id } },
+        fromPointChange: -1000,
+        toPointChange: 1000,
+        reason: TransactionReason.GRANT,
+      });
+
+      previousWalletId = wallets[0].id;
+      let lastTxId = grantTx.id;
+
+      // Create chain of 20 donations
+      for (let i = 1; i < 21; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        const tx = await TestDataSourceHelper.createTransaction({
+          fromWallet: { connect: { id: previousWalletId } },
+          toWallet: { connect: { id: wallets[i].id } },
+          fromPointChange: -10,
+          toPointChange: 10,
+          reason: TransactionReason.DONATION,
+        });
+        previousWalletId = wallets[i].id;
+        lastTxId = tx.id;
+      }
+
+      // Measure refresh time
+      const startTime = Date.now();
+      await TestDataSourceHelper.refreshTransactionChains();
+      const refreshTime = Date.now() - startTime;
+
+      // Verify the chain depth
+      const lastChain = await TestDataSourceHelper.getTransactionChain(lastTxId);
+
+      expect(lastChain).not.toBeNull();
+      expect(lastChain?.depth).toBe(21); // GRANT + 20 donations
+      expect(lastChain?.rootTxId).toBe(grantTx.id);
+      expect(lastChain?.chainTxIds.length).toBe(21);
+
+      // Performance assertion: should complete within 5 seconds
+      expect(refreshTime).toBeLessThan(5000);
+      console.log(`Deep chain (21 depth) refresh time: ${refreshTime}ms`);
+    });
+
+    it("should handle many transactions (100 independent chains) efficiently", async () => {
+      const community = await TestDataSourceHelper.createCommunity({
+        name: "Test Community",
+        pointName: "point",
+      });
+
+      const communityWallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.COMMUNITY,
+        community: { connect: { id: community.id } },
+      });
+
+      // Create 100 users
+      const users = await Promise.all(
+        Array.from({ length: 100 }, (_, i) =>
+          TestDataSourceHelper.createUser({
+            name: `User ${i}`,
+            slug: `user-perf-${i}`,
+            currentPrefecture: CurrentPrefecture.KAGAWA,
+          })
+        )
+      );
+
+      const wallets = await Promise.all(
+        users.map((user) =>
+          TestDataSourceHelper.createWallet({
+            type: WalletType.MEMBER,
+            community: { connect: { id: community.id } },
+            user: { connect: { id: user.id } },
+          })
+        )
+      );
+
+      // Create 100 independent GRANTs
+      const grants = await Promise.all(
+        wallets.map((wallet) =>
+          TestDataSourceHelper.createTransaction({
+            fromWallet: { connect: { id: communityWallet.id } },
+            toWallet: { connect: { id: wallet.id } },
+            fromPointChange: -100,
+            toPointChange: 100,
+            reason: TransactionReason.GRANT,
+          })
+        )
+      );
+
+      // Measure refresh time
+      const startTime = Date.now();
+      await TestDataSourceHelper.refreshTransactionChains();
+      const refreshTime = Date.now() - startTime;
+
+      // Verify some chains
+      const firstChain = await TestDataSourceHelper.getTransactionChain(grants[0].id);
+      const lastChain = await TestDataSourceHelper.getTransactionChain(grants[99].id);
+
+      expect(firstChain?.depth).toBe(1);
+      expect(lastChain?.depth).toBe(1);
+
+      // Performance assertion: should complete within 5 seconds
+      expect(refreshTime).toBeLessThan(5000);
+      console.log(`100 independent chains refresh time: ${refreshTime}ms`);
+    });
+
+    it("should handle branching chains (fan-out pattern) efficiently", async () => {
+      const community = await TestDataSourceHelper.createCommunity({
+        name: "Test Community",
+        pointName: "point",
+      });
+
+      const communityWallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.COMMUNITY,
+        community: { connect: { id: community.id } },
+      });
+
+      // Create users: 1 hub + 10 receivers
+      const hubUser = await TestDataSourceHelper.createUser({
+        name: "Hub User",
+        slug: "hub-user",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const hubWallet = await TestDataSourceHelper.createWallet({
+        type: WalletType.MEMBER,
+        community: { connect: { id: community.id } },
+        user: { connect: { id: hubUser.id } },
+      });
+
+      const receiverUsers = await Promise.all(
+        Array.from({ length: 10 }, (_, i) =>
+          TestDataSourceHelper.createUser({
+            name: `Receiver ${i}`,
+            slug: `receiver-${i}`,
+            currentPrefecture: CurrentPrefecture.TOKUSHIMA,
+          })
+        )
+      );
+
+      const receiverWallets = await Promise.all(
+        receiverUsers.map((user) =>
+          TestDataSourceHelper.createWallet({
+            type: WalletType.MEMBER,
+            community: { connect: { id: community.id } },
+            user: { connect: { id: user.id } },
+          })
+        )
+      );
+
+      // GRANT to hub user
+      const grantTx = await TestDataSourceHelper.createTransaction({
+        fromWallet: { connect: { id: communityWallet.id } },
+        toWallet: { connect: { id: hubWallet.id } },
+        fromPointChange: -1000,
+        toPointChange: 1000,
+        reason: TransactionReason.GRANT,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Hub fans out to 10 receivers
+      const donations = await Promise.all(
+        receiverWallets.map(async (wallet) => {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          return TestDataSourceHelper.createTransaction({
+            fromWallet: { connect: { id: hubWallet.id } },
+            toWallet: { connect: { id: wallet.id } },
+            fromPointChange: -50,
+            toPointChange: 50,
+            reason: TransactionReason.DONATION,
+          });
+        })
+      );
+
+      // Measure refresh time
+      const startTime = Date.now();
+      await TestDataSourceHelper.refreshTransactionChains();
+      const refreshTime = Date.now() - startTime;
+
+      // Verify all donations have depth=2 and point to same root
+      for (const donation of donations) {
+        const chain = await TestDataSourceHelper.getTransactionChain(donation.id);
+        expect(chain?.depth).toBe(2);
+        expect(chain?.rootTxId).toBe(grantTx.id);
+      }
+
+      // Performance assertion
+      expect(refreshTime).toBeLessThan(5000);
+      console.log(`Fan-out pattern (1→10) refresh time: ${refreshTime}ms`);
+    });
   });
 });

--- a/src/__tests__/integration/pointTransfer/transactionChain.test.ts
+++ b/src/__tests__/integration/pointTransfer/transactionChain.test.ts
@@ -275,7 +275,7 @@ describe("Transaction Chain Tests", () => {
 
       // Create direct GRANT to UserB: Community → UserB (GRANT, tx3)
       // This creates a shorter path (depth=1) to UserB
-      const grant2 = await TestDataSourceHelper.createTransaction({
+      await TestDataSourceHelper.createTransaction({
         fromWallet: { connect: { id: communityWallet.id } },
         toWallet: { connect: { id: userBWallet.id } },
         fromPointChange: -100,

--- a/src/application/domain/transaction/data/interface.ts
+++ b/src/application/domain/transaction/data/interface.ts
@@ -1,7 +1,10 @@
 import { Prisma, TransactionReason } from "@prisma/client";
 import { IContext } from "@/types/server";
 import { PrismaTransactionDetail } from "@/application/domain/transaction/data/type";
-import { refreshMaterializedViewCurrentPoints } from "@prisma/client/sql";
+import {
+  refreshMaterializedViewCurrentPoints,
+  refreshMaterializedViewTransactionChains,
+} from "@prisma/client/sql";
 import { GqlQueryTransactionsArgs } from "@/types/graphql";
 
 export interface ITransactionService {
@@ -105,6 +108,11 @@ export interface ITransactionRepository {
     ctx: IContext,
     tx: Prisma.TransactionClient,
   ): Promise<refreshMaterializedViewCurrentPoints.Result[]>;
+
+  refreshTransactionChains(
+    ctx: IContext,
+    tx: Prisma.TransactionClient,
+  ): Promise<refreshMaterializedViewTransactionChains.Result[]>;
 
   create(
     ctx: IContext,

--- a/src/application/domain/transaction/data/repository.ts
+++ b/src/application/domain/transaction/data/repository.ts
@@ -2,7 +2,10 @@ import { Prisma } from "@prisma/client";
 import { IContext } from "@/types/server";
 import { ITransactionRepository } from "@/application/domain/transaction/data/interface";
 import { transactionSelectDetail, PrismaTransactionDetail } from "@/application/domain/transaction/data/type";
-import { refreshMaterializedViewCurrentPoints } from "@prisma/client/sql";
+import {
+  refreshMaterializedViewCurrentPoints,
+  refreshMaterializedViewTransactionChains,
+} from "@prisma/client/sql";
 import { injectable } from "tsyringe";
 
 @injectable()
@@ -40,6 +43,13 @@ export default class TransactionRepository implements ITransactionRepository {
     tx: Prisma.TransactionClient,
   ): Promise<refreshMaterializedViewCurrentPoints.Result[]> {
     return tx.$queryRawTyped(refreshMaterializedViewCurrentPoints());
+  }
+
+  async refreshTransactionChains(
+    ctx: IContext,
+    tx: Prisma.TransactionClient,
+  ): Promise<refreshMaterializedViewTransactionChains.Result[]> {
+    return tx.$queryRawTyped(refreshMaterializedViewTransactionChains());
   }
 
   async create(

--- a/src/infrastructure/prisma/factories/__generated__/index.ts
+++ b/src/infrastructure/prisma/factories/__generated__/index.ts
@@ -49,6 +49,7 @@ import type { AccumulatedPointView } from "@prisma/client";
 import type { EarliestReservableSlotView } from "@prisma/client";
 import type { OpportunityAccumulatedParticipantsView } from "@prisma/client";
 import type { RemainingCapacityView } from "@prisma/client";
+import type { TransactionChainView } from "@prisma/client";
 import type { LineRichMenuType } from "@prisma/client";
 import type { SysRole } from "@prisma/client";
 import type { CurrentPrefecture } from "@prisma/client";
@@ -779,6 +780,10 @@ const modelFieldDefinitions: ModelWithFields[] = [{
                 type: "Wallet",
                 relationName: "to_wallet"
             }, {
+                name: "chainInfo",
+                type: "TransactionChainView",
+                relationName: "TransactionToTransactionChainView"
+            }, {
                 name: "participation",
                 type: "Participation",
                 relationName: "ParticipationToTransaction"
@@ -952,6 +957,13 @@ const modelFieldDefinitions: ModelWithFields[] = [{
                 name: "slot",
                 type: "OpportunitySlot",
                 relationName: "OpportunitySlotToRemainingCapacityView"
+            }]
+    }, {
+        name: "TransactionChainView",
+        fields: [{
+                name: "transaction",
+                type: "Transaction",
+                relationName: "TransactionToTransactionChainView"
             }]
     }];
 
@@ -6628,6 +6640,11 @@ type TransactiontoWalletFactory = {
     build: () => PromiseLike<Prisma.WalletCreateNestedOneWithoutToTransactionsInput["create"]>;
 };
 
+type TransactionchainInfoFactory = {
+    _factoryFor: "TransactionChainView";
+    build: () => PromiseLike<Prisma.TransactionChainViewCreateNestedOneWithoutTransactionInput["create"]>;
+};
+
 type TransactionparticipationFactory = {
     _factoryFor: "Participation";
     build: () => PromiseLike<Prisma.ParticipationCreateNestedOneWithoutTransactionsInput["create"]>;
@@ -6663,6 +6680,7 @@ type TransactionFactoryDefineInput = {
     updatedAt?: Date | null;
     fromWallet?: TransactionfromWalletFactory | Prisma.WalletCreateNestedOneWithoutFromTransactionsInput;
     toWallet?: TransactiontoWalletFactory | Prisma.WalletCreateNestedOneWithoutToTransactionsInput;
+    chainInfo?: TransactionchainInfoFactory | Prisma.TransactionChainViewCreateNestedOneWithoutTransactionInput;
     participation?: TransactionparticipationFactory | Prisma.ParticipationCreateNestedOneWithoutTransactionsInput;
     reservation?: TransactionreservationFactory | Prisma.ReservationCreateNestedOneWithoutTransactionsInput;
     ticketStatusHistory?: TransactionticketStatusHistoryFactory | Prisma.TicketStatusHistoryCreateNestedOneWithoutTransactionInput;
@@ -6690,6 +6708,10 @@ function isTransactionfromWalletFactory(x: TransactionfromWalletFactory | Prisma
 
 function isTransactiontoWalletFactory(x: TransactiontoWalletFactory | Prisma.WalletCreateNestedOneWithoutToTransactionsInput | undefined): x is TransactiontoWalletFactory {
     return (x as any)?._factoryFor === "Wallet";
+}
+
+function isTransactionchainInfoFactory(x: TransactionchainInfoFactory | Prisma.TransactionChainViewCreateNestedOneWithoutTransactionInput | undefined): x is TransactionchainInfoFactory {
+    return (x as any)?._factoryFor === "TransactionChainView";
 }
 
 function isTransactionparticipationFactory(x: TransactionparticipationFactory | Prisma.ParticipationCreateNestedOneWithoutTransactionsInput | undefined): x is TransactionparticipationFactory {
@@ -6780,6 +6802,9 @@ function defineTransactionFactoryInternal<TTransients extends Record<string, unk
                 toWallet: isTransactiontoWalletFactory(defaultData.toWallet) ? {
                     create: await defaultData.toWallet.build()
                 } : defaultData.toWallet,
+                chainInfo: isTransactionchainInfoFactory(defaultData.chainInfo) ? {
+                    create: await defaultData.chainInfo.build()
+                } : defaultData.chainInfo,
                 participation: isTransactionparticipationFactory(defaultData.participation) ? {
                     create: await defaultData.participation.build()
                 } : defaultData.participation,
@@ -9673,3 +9698,158 @@ export const defineRemainingCapacityViewFactory = (<TOptions extends RemainingCa
 }) as RemainingCapacityViewFactoryBuilder;
 
 defineRemainingCapacityViewFactory.withTransientFields = defaultTransientFieldValues => options => defineRemainingCapacityViewFactoryInternal(options, defaultTransientFieldValues);
+
+type TransactionChainViewScalarOrEnumFields = {
+    depth: number;
+    rootTxId: string;
+};
+
+type TransactionChainViewtransactionFactory = {
+    _factoryFor: "Transaction";
+    build: () => PromiseLike<Prisma.TransactionCreateNestedOneWithoutChainInfoInput["create"]>;
+};
+
+type TransactionChainViewFactoryDefineInput = {
+    depth?: number;
+    rootTxId?: string;
+    chainTxIds?: Prisma.TransactionChainViewCreatechainTxIdsInput | Array<string>;
+    transaction: TransactionChainViewtransactionFactory | Prisma.TransactionCreateNestedOneWithoutChainInfoInput;
+};
+
+type TransactionChainViewTransientFields = Record<string, unknown> & Partial<Record<keyof TransactionChainViewFactoryDefineInput, never>>;
+
+type TransactionChainViewFactoryTrait<TTransients extends Record<string, unknown>> = {
+    data?: Resolver<Partial<TransactionChainViewFactoryDefineInput>, BuildDataOptions<TTransients>>;
+} & CallbackDefineOptions<TransactionChainView, Prisma.TransactionChainViewCreateInput, TTransients>;
+
+type TransactionChainViewFactoryDefineOptions<TTransients extends Record<string, unknown> = Record<string, unknown>> = {
+    defaultData: Resolver<TransactionChainViewFactoryDefineInput, BuildDataOptions<TTransients>>;
+    traits?: {
+        [traitName: string | symbol]: TransactionChainViewFactoryTrait<TTransients>;
+    };
+} & CallbackDefineOptions<TransactionChainView, Prisma.TransactionChainViewCreateInput, TTransients>;
+
+function isTransactionChainViewtransactionFactory(x: TransactionChainViewtransactionFactory | Prisma.TransactionCreateNestedOneWithoutChainInfoInput | undefined): x is TransactionChainViewtransactionFactory {
+    return (x as any)?._factoryFor === "Transaction";
+}
+
+type TransactionChainViewTraitKeys<TOptions extends TransactionChainViewFactoryDefineOptions<any>> = Exclude<keyof TOptions["traits"], number>;
+
+export interface TransactionChainViewFactoryInterfaceWithoutTraits<TTransients extends Record<string, unknown>> {
+    readonly _factoryFor: "TransactionChainView";
+    build(inputData?: Partial<Prisma.TransactionChainViewCreateInput & TTransients>): PromiseLike<Prisma.TransactionChainViewCreateInput>;
+    buildCreateInput(inputData?: Partial<Prisma.TransactionChainViewCreateInput & TTransients>): PromiseLike<Prisma.TransactionChainViewCreateInput>;
+    buildList(list: readonly Partial<Prisma.TransactionChainViewCreateInput & TTransients>[]): PromiseLike<Prisma.TransactionChainViewCreateInput[]>;
+    buildList(count: number, item?: Partial<Prisma.TransactionChainViewCreateInput & TTransients>): PromiseLike<Prisma.TransactionChainViewCreateInput[]>;
+    pickForConnect(inputData: TransactionChainView): Pick<TransactionChainView, "transactionId">;
+    create(inputData?: Partial<Prisma.TransactionChainViewCreateInput & TTransients>): PromiseLike<TransactionChainView>;
+    createList(list: readonly Partial<Prisma.TransactionChainViewCreateInput & TTransients>[]): PromiseLike<TransactionChainView[]>;
+    createList(count: number, item?: Partial<Prisma.TransactionChainViewCreateInput & TTransients>): PromiseLike<TransactionChainView[]>;
+    createForConnect(inputData?: Partial<Prisma.TransactionChainViewCreateInput & TTransients>): PromiseLike<Pick<TransactionChainView, "transactionId">>;
+}
+
+export interface TransactionChainViewFactoryInterface<TTransients extends Record<string, unknown> = Record<string, unknown>, TTraitName extends TraitName = TraitName> extends TransactionChainViewFactoryInterfaceWithoutTraits<TTransients> {
+    use(name: TTraitName, ...names: readonly TTraitName[]): TransactionChainViewFactoryInterfaceWithoutTraits<TTransients>;
+}
+
+function autoGenerateTransactionChainViewScalarsOrEnums({ seq }: {
+    readonly seq: number;
+}): TransactionChainViewScalarOrEnumFields {
+    return {
+        depth: getScalarFieldValueGenerator().Int({ modelName: "TransactionChainView", fieldName: "depth", isId: false, isUnique: false, seq }),
+        rootTxId: getScalarFieldValueGenerator().String({ modelName: "TransactionChainView", fieldName: "rootTxId", isId: false, isUnique: false, seq })
+    };
+}
+
+function defineTransactionChainViewFactoryInternal<TTransients extends Record<string, unknown>, TOptions extends TransactionChainViewFactoryDefineOptions<TTransients>>({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }: TOptions, defaultTransientFieldValues: TTransients): TransactionChainViewFactoryInterface<TTransients, TransactionChainViewTraitKeys<TOptions>> {
+    const getFactoryWithTraits = (traitKeys: readonly TransactionChainViewTraitKeys<TOptions>[] = []) => {
+        const seqKey = {};
+        const getSeq = () => getSequenceCounter(seqKey);
+        const screen = createScreener("TransactionChainView", modelFieldDefinitions);
+        const handleAfterBuild = createCallbackChain([
+            onAfterBuild,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterBuild),
+        ]);
+        const handleBeforeCreate = createCallbackChain([
+            ...traitKeys.slice().reverse().map(traitKey => traitsDefs[traitKey]?.onBeforeCreate),
+            onBeforeCreate,
+        ]);
+        const handleAfterCreate = createCallbackChain([
+            onAfterCreate,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterCreate),
+        ]);
+        const build = async (inputData: Partial<Prisma.TransactionChainViewCreateInput & TTransients> = {}) => {
+            const seq = getSeq();
+            const requiredScalarData = autoGenerateTransactionChainViewScalarsOrEnums({ seq });
+            const resolveValue = normalizeResolver<TransactionChainViewFactoryDefineInput, BuildDataOptions<any>>(defaultDataResolver);
+            const [transientFields, filteredInputData] = destructure(defaultTransientFieldValues, inputData);
+            const resolverInput = { seq, ...transientFields };
+            const defaultData = await traitKeys.reduce(async (queue, traitKey) => {
+                const acc = await queue;
+                const resolveTraitValue = normalizeResolver<Partial<TransactionChainViewFactoryDefineInput>, BuildDataOptions<TTransients>>(traitsDefs[traitKey]?.data ?? {});
+                const traitData = await resolveTraitValue(resolverInput);
+                return {
+                    ...acc,
+                    ...traitData,
+                };
+            }, resolveValue(resolverInput));
+            const defaultAssociations = {
+                transaction: isTransactionChainViewtransactionFactory(defaultData.transaction) ? {
+                    create: await defaultData.transaction.build()
+                } : defaultData.transaction
+            } as Prisma.TransactionChainViewCreateInput;
+            const data: Prisma.TransactionChainViewCreateInput = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...filteredInputData };
+            await handleAfterBuild(data, transientFields);
+            return data;
+        };
+        const buildList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.TransactionChainViewCreateInput & TTransients>>(...args).map(data => build(data)));
+        const pickForConnect = (inputData: TransactionChainView) => ({
+            transactionId: inputData.transactionId
+        });
+        const create = async (inputData: Partial<Prisma.TransactionChainViewCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
+            const [transientFields] = destructure(defaultTransientFieldValues, inputData);
+            await handleBeforeCreate(data, transientFields);
+            const createdData = await getClient<PrismaClient>().transactionChainView.create({ data });
+            await handleAfterCreate(createdData, transientFields);
+            return createdData;
+        };
+        const createList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.TransactionChainViewCreateInput & TTransients>>(...args).map(data => create(data)));
+        const createForConnect = (inputData: Partial<Prisma.TransactionChainViewCreateInput & TTransients> = {}) => create(inputData).then(pickForConnect);
+        return {
+            _factoryFor: "TransactionChainView" as const,
+            build,
+            buildList,
+            buildCreateInput: build,
+            pickForConnect,
+            create,
+            createList,
+            createForConnect,
+        };
+    };
+    const factory = getFactoryWithTraits();
+    const useTraits = (name: TransactionChainViewTraitKeys<TOptions>, ...names: readonly TransactionChainViewTraitKeys<TOptions>[]) => {
+        return getFactoryWithTraits([name, ...names]);
+    };
+    return {
+        ...factory,
+        use: useTraits,
+    };
+}
+
+interface TransactionChainViewFactoryBuilder {
+    <TOptions extends TransactionChainViewFactoryDefineOptions>(options: TOptions): TransactionChainViewFactoryInterface<{}, TransactionChainViewTraitKeys<TOptions>>;
+    withTransientFields: <TTransients extends TransactionChainViewTransientFields>(defaultTransientFieldValues: TTransients) => <TOptions extends TransactionChainViewFactoryDefineOptions<TTransients>>(options: TOptions) => TransactionChainViewFactoryInterface<TTransients, TransactionChainViewTraitKeys<TOptions>>;
+}
+
+/**
+ * Define factory for {@link TransactionChainView} model.
+ *
+ * @param options
+ * @returns factory {@link TransactionChainViewFactoryInterface}
+ */
+export const defineTransactionChainViewFactory = (<TOptions extends TransactionChainViewFactoryDefineOptions>(options: TOptions): TransactionChainViewFactoryInterface<TOptions> => {
+    return defineTransactionChainViewFactoryInternal(options, {});
+}) as TransactionChainViewFactoryBuilder;
+
+defineTransactionChainViewFactory.withTransientFields = defaultTransientFieldValues => options => defineTransactionChainViewFactoryInternal(options, defaultTransientFieldValues);

--- a/src/infrastructure/prisma/migrations/20260115044620_create_tx_chain/migration.sql
+++ b/src/infrastructure/prisma/migrations/20260115044620_create_tx_chain/migration.sql
@@ -1,0 +1,43 @@
+-- 1. 検索インデックス（再帰CTEで使用する列のみ）
+CREATE INDEX IF NOT EXISTS idx_t_transactions_chain_lookup ON t_transactions("from", "created_at");
+
+-- 2. Materialized View の作成
+-- 再帰の内部ではフィルタリングせず、最後に全経路の中から最適なものを選び出します
+CREATE MATERIALIZED VIEW mv_transaction_chains AS
+WITH RECURSIVE chain_evolution AS (
+    -- 【起点】GRANT を 1st Link とする
+    SELECT
+        id AS transaction_id,
+        "to" AS holder_wallet_id,
+        1 AS depth,
+        id AS root_tx_id,
+        ARRAY[id]::text[] AS chain_tx_ids,
+        created_at
+    FROM t_transactions
+    WHERE reason = 'GRANT'
+
+    UNION ALL
+
+    -- 【継承】ここでは重複を許容してすべての経路を繋ぐ（ORDER BYを使わない）
+    SELECT
+        t.id,
+        t."to",
+        ce.depth + 1,
+        ce.root_tx_id,
+        ce.chain_tx_ids || t.id,
+        t.created_at
+    FROM t_transactions t
+    JOIN chain_evolution ce ON t."from" = ce.holder_wallet_id
+    WHERE t.created_at > ce.created_at
+)
+-- 3. 最後に外側で「最も長い連鎖（depth DESC）」かつ「より新しいGRANT（root_tx_id DESC）」を優先
+SELECT DISTINCT ON (transaction_id)
+    transaction_id,
+    depth,
+    root_tx_id,
+    chain_tx_ids
+FROM chain_evolution
+ORDER BY transaction_id, depth DESC, root_tx_id DESC;
+
+-- 4. ユニークインデックス（リフレッシュに必須）
+CREATE UNIQUE INDEX idx_mv_transaction_chains_id ON mv_transaction_chains(transaction_id);

--- a/src/infrastructure/prisma/migrations/20260115044620_create_tx_chain/migration.sql
+++ b/src/infrastructure/prisma/migrations/20260115044620_create_tx_chain/migration.sql
@@ -1,0 +1,43 @@
+-- 1. 検索インデックス
+CREATE INDEX IF NOT EXISTS idx_t_transactions_chain_lookup ON t_transactions("from", "to", "created_at");
+
+-- 2. Materialized View の作成
+-- 再帰の内部ではフィルタリングせず、最後に全経路の中から最適なものを選び出します
+CREATE MATERIALIZED VIEW mv_transaction_chains AS
+WITH RECURSIVE chain_evolution AS (
+    -- 【起点】GRANT を 1st Link とする
+    SELECT
+        id AS transaction_id,
+        "to" AS holder_wallet_id,
+        1 AS depth,
+        id AS root_tx_id,
+        ARRAY[id]::text[] AS chain_tx_ids,
+        created_at
+    FROM t_transactions
+    WHERE reason = 'GRANT'
+
+    UNION ALL
+
+    -- 【継承】ここでは重複を許容してすべての経路を繋ぐ（ORDER BYを使わない）
+    SELECT
+        t.id,
+        t."to",
+        ce.depth + 1,
+        ce.root_tx_id,
+        ce.chain_tx_ids || t.id,
+        t.created_at
+    FROM t_transactions t
+    JOIN chain_evolution ce ON t."from" = ce.holder_wallet_id
+    WHERE t.created_at > ce.created_at
+)
+-- 3. 最後に外側で「最も長い連鎖（depth DESC）」かつ「最新（created_at DESC）」を抽出
+SELECT DISTINCT ON (transaction_id)
+    transaction_id,
+    depth,
+    root_tx_id,
+    chain_tx_ids
+FROM chain_evolution
+ORDER BY transaction_id, depth DESC, created_at DESC;
+
+-- 4. ユニークインデックス（リフレッシュに必須）
+CREATE UNIQUE INDEX idx_mv_transaction_chains_id ON mv_transaction_chains(transaction_id);

--- a/src/infrastructure/prisma/migrations/20260115044620_create_tx_chain/migration.sql
+++ b/src/infrastructure/prisma/migrations/20260115044620_create_tx_chain/migration.sql
@@ -1,5 +1,5 @@
--- 1. 検索インデックス
-CREATE INDEX IF NOT EXISTS idx_t_transactions_chain_lookup ON t_transactions("from", "to", "created_at");
+-- 1. 検索インデックス（再帰CTEで使用する列のみ）
+CREATE INDEX IF NOT EXISTS idx_t_transactions_chain_lookup ON t_transactions("from", "created_at");
 
 -- 2. Materialized View の作成
 -- 再帰の内部ではフィルタリングせず、最後に全経路の中から最適なものを選び出します

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -1145,6 +1145,8 @@ model Transaction {
   toWallet      Wallet? @relation("to_wallet", fields: [to], references: [id], onDelete: SetNull)
   toPointChange Int     @map("to_point_change")
 
+  chainInfo TransactionChainView?
+
   participationId String?        @map("participation_id")
   participation   Participation? @relation(fields: [participationId], references: [id], onDelete: SetNull)
 
@@ -1180,6 +1182,17 @@ enum TransactionReason {
   OPPORTUNITY_RESERVATION_CREATED
   OPPORTUNITY_RESERVATION_CANCELED
   OPPORTUNITY_RESERVATION_REJECTED
+}
+
+view TransactionChainView {
+  transactionId String      @id @map("transaction_id")
+  transaction   Transaction @relation(fields: [transactionId], references: [id])
+
+  depth      Int
+  rootTxId   String   @map("root_tx_id")
+  chainTxIds String[] @map("chain_tx_ids")
+
+  @@map("mv_transaction_chains")
 }
 
 model IncentiveGrant {

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -1145,6 +1145,8 @@ model Transaction {
   toWallet      Wallet? @relation("to_wallet", fields: [to], references: [id], onDelete: SetNull)
   toPointChange Int     @map("to_point_change")
 
+  chainInfo TransactionChainView?
+
   participationId String?        @map("participation_id")
   participation   Participation? @relation(fields: [participationId], references: [id], onDelete: SetNull)
 
@@ -1162,6 +1164,7 @@ model Transaction {
 
   merkleProofs MerkleProof[]
 
+  @@index([from, createdAt])
   @@map("t_transactions")
 }
 
@@ -1180,6 +1183,17 @@ enum TransactionReason {
   OPPORTUNITY_RESERVATION_CREATED
   OPPORTUNITY_RESERVATION_CANCELED
   OPPORTUNITY_RESERVATION_REJECTED
+}
+
+view TransactionChainView {
+  transactionId String      @id @map("transaction_id")
+  transaction   Transaction @relation(fields: [transactionId], references: [id])
+
+  depth      Int
+  rootTxId   String   @map("root_tx_id")
+  chainTxIds String[] @map("chain_tx_ids")
+
+  @@map("mv_transaction_chains")
 }
 
 model IncentiveGrant {

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -1164,6 +1164,7 @@ model Transaction {
 
   merkleProofs MerkleProof[]
 
+  @@index([from, createdAt])
   @@map("t_transactions")
 }
 

--- a/src/infrastructure/prisma/sql/refreshMaterializedViewTransactionChains.sql
+++ b/src/infrastructure/prisma/sql/refreshMaterializedViewTransactionChains.sql
@@ -1,0 +1,1 @@
+REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_transaction_chains";

--- a/src/presentation/batch/refreshPointViews.ts
+++ b/src/presentation/batch/refreshPointViews.ts
@@ -18,8 +18,13 @@ export async function refreshPointViews() {
     await issuer.internal(async (tx) => {
       logger.debug("📊 Refreshing materialized view for current points...");
       const result = await transactionRepository.refreshCurrentPoints(ctx, tx);
-      logger.debug(`✅ Successfully refreshed current points view. Processed ${result.length} records.`);
-      return result;
+      logger.debug(
+        `✅ Successfully refreshed current points view. Processed ${result.length} records.`,
+      );
+
+      logger.debug("📜 Refreshing materialized view for transaction chains...");
+      await transactionRepository.refreshTransactionChains(ctx, tx);
+      logger.debug("✅ Successfully refreshed transaction chains view.");
     });
 
     logger.debug("✅ Point views refresh batch completed successfully");


### PR DESCRIPTION
- mv_transaction_chains マテリアライズドビューを作成
- 再帰的CTEでGRANTトランザクションの連鎖を追跡
- Typed SQLを使用してrefreshTransactionChainsを実装
- refreshPointViewsバッチジョブに統合