### PR TITLE
Remove unused firebaseConfig field from community resolver

### DIFF
--- a/src/application/domain/account/community/controller/resolver.ts
+++ b/src/application/domain/account/community/controller/resolver.ts
@@ -67,7 +67,6 @@ export default class CommunityResolver {
                 channelSecret: null,
               }
             : null,
-          firebaseConfig: null,
         };
       }
 


### PR DESCRIPTION
This pull request addresses the following changes:

- Removed the unused `firebaseConfig` field from the community resolver, simplifying the codebase.

No additional changes are introduced in this pull request. It focuses solely on cleaning up unused code for better maintainability.