### PR TITLE
Allow anonymous access when Firebase verification fails

### DIFF
--- a/src/presentation/middleware/auth/firebase-auth.ts
+++ b/src/presentation/middleware/auth/firebase-auth.ts
@@ -84,13 +84,14 @@ export async function handleFirebaseAuth(
       throw err;
     }
     const error = err as any;
-    logger.error("🔥 Firebase verification failed", {
+    logger.warn("🔥 Firebase verification failed - falling back to anonymous", {
       method: verificationMethod,
       communityId,
       errorCode: error.code || "unknown",
       errorMessage: error.message,
       tokenLength: idToken.length,
     });
-    throw new AuthenticationError("Firebase verification failed");
+    // 検証失敗時は anonymous として扱う（public クエリは引き続き動作する）
+    return { issuer, loaders, communityId, authMeta };
   }
 }


### PR DESCRIPTION
## Summary
Changed Firebase authentication error handling to gracefully fall back to anonymous access instead of throwing an error when token verification fails. This allows public queries to continue functioning even when Firebase verification encounters issues.

## Key Changes
- Changed error logging level from `error` to `warn` to reflect the non-fatal nature of verification failures
- Updated log message to indicate fallback behavior: "Firebase verification failed - falling back to anonymous"
- Replaced `throw new AuthenticationError()` with returning the auth context as anonymous, allowing requests to proceed with public access
- Added Japanese comment explaining that failed verification is treated as anonymous access, allowing public queries to continue working

## Implementation Details
- The function now returns successfully with the same `issuer`, `loaders`, and `communityId` context when Firebase verification fails
- This enables a graceful degradation pattern where public/unauthenticated queries remain functional during Firebase service issues or token problems
- The change maintains backward compatibility for authenticated requests while improving resilience for public access patterns

https://claude.ai/code/session_01DbpzcGtUawZ2u59uTjNDeU