### PR TITLE
fix: throw AuthenticationError for stale session cookies to trigger c…

### DIFF
--- a/src/presentation/middleware/auth/firebase-auth.ts
+++ b/src/presentation/middleware/auth/firebase-auth.ts
@@ -6,6 +6,13 @@ import { AuthHeaders, AuthResult } from "./types";
 import { AuthMeta } from "@/types/server";
 import { AuthenticationError } from "@/errors/graphql";
 
+const STALE_SESSION_ERRORS = [
+  "auth/user-not-found", // テナント移行後の残存cookie
+  "auth/session-cookie-revoked", // 明示的にrevokeされたcookie
+  "auth/session-cookie-expired", // 期限切れcookie
+  "auth/invalid-session-cookie", // 不正なcookie
+];
+
 export async function handleFirebaseAuth(
   headers: AuthHeaders,
   issuer: PrismaClientIssuer,
@@ -87,13 +94,6 @@ export async function handleFirebaseAuth(
 
     // session cookie 固有のステールエラーは throw してフロントエンドに通知
     // フロントエンドの useStaleSessionRecovery が HTTP 500 を検知して cookie をクリアする
-    const STALE_SESSION_ERRORS = [
-      "auth/user-not-found", // テナント移行後の残存cookie
-      "auth/session-cookie-revoked", // 明示的にrevokeされたcookie
-      "auth/session-cookie-expired", // 期限切れcookie
-      "auth/invalid-session-cookie", // 不正なcookie
-    ];
-
     if (authMode === "session" && STALE_SESSION_ERRORS.includes(error.code)) {
       logger.warn("🍪 Stale session cookie detected - signaling to client", {
         method: verificationMethod,


### PR DESCRIPTION
…lient-side recovery

session モードで auth/user-not-found などのステール系エラーが発生した場合、 anonymous fallback の代わりに AuthenticationError を throw する。

これにより HTTP 500 が返り、フロントエンドの useStaleSessionRecovery が 500 + __session cookie の条件で auth:token-expired を発火させ、 stale cookie を自動クリアするミッドセッションリカバリが動作する。

ページロード時の stale cookie 検出はフロントエンド（initAuthFull）が担当し、 本変更はミッドセッションのフォールバックを担う。

idToken モードや一時的ネットワーク障害は引き続き anonymous fallback を維持。

https://claude.ai/code/session_01DbpzcGtUawZ2u59uTjNDeU