### PR TITLE
fix: rate limit adjustment, session cookie cleanup, and communityId validation

### DIFF
--- a/src/presentation/middleware/auth/extract-headers.ts
+++ b/src/presentation/middleware/auth/extract-headers.ts
@@ -30,10 +30,22 @@ export function extractAuthHeaders(req: http.IncomingMessage): AuthHeaders {
       .map(([k, v]) => [k, safeDecodeURIComponent(v || "")]),
   );
 
+  // Validate communityId format: allow only alphanumeric, hyphens, and underscores.
+  // Reject values like ".env" or other obviously invalid/malicious inputs.
+  const rawCommunityId = getHeader("x-community-id");
+  const isValidCommunityId = !rawCommunityId || /^[a-zA-Z0-9_-]+$/.test(rawCommunityId);
+  const communityId = isValidCommunityId ? rawCommunityId : "";
+
+  if (rawCommunityId && !isValidCommunityId) {
+    logger.warn("Invalid communityId format rejected", {
+      rawCommunityId,
+      component: "extractAuthHeaders",
+    });
+  }
+
   // Prefer community-scoped cookie, fall back to legacy "__session" / "session" for backward compatibility
-  const communityIdForCookie = getHeader("x-community-id");
-  const sessionCookie = communityIdForCookie
-    ? cookies[getSessionCookieName(communityIdForCookie)] ||
+  const sessionCookie = communityId
+    ? cookies[getSessionCookieName(communityId)] ||
       cookies[SESSION_COOKIE_NAME] ||
       cookies["session"]
     : cookies[SESSION_COOKIE_NAME] || cookies["session"];
@@ -47,7 +59,7 @@ export function extractAuthHeaders(req: http.IncomingMessage): AuthHeaders {
     authMode,
     idToken,
     adminApiKey: getHeader("x-civicship-admin-api-key"),
-    communityId: getHeader("x-community-id"),
+    communityId,
     hasCookie: !!req.headers.cookie,
   };
 

--- a/src/presentation/middleware/auth/firebase-auth.ts
+++ b/src/presentation/middleware/auth/firebase-auth.ts
@@ -7,6 +7,7 @@ import logger from "@/infrastructure/logging";
 import { AuthHeaders, AuthResult } from "./types";
 import { AuthMeta } from "@/types/server";
 import { AuthenticationError } from "@/errors/graphql";
+import { getSessionCookieName } from "@/config/constants";
 
 export async function handleFirebaseAuth(
   headers: AuthHeaders,
@@ -112,6 +113,18 @@ export async function handleFirebaseAuth(
       errorMessage: error.message,
       tokenLength: idToken.length,
     });
-    return { issuer, loaders, communityId, authMeta: { ...authMeta, authMode: "anonymous" as const, hasIdToken: false } };
+
+    // If the user was deleted from Firebase (user-not-found), clear the session
+    // cookie so the client stops sending it on every request.
+    const clearSessionCookie =
+      error.code === "auth/user-not-found" || error.code === "auth/user-disabled";
+
+    return {
+      issuer,
+      loaders,
+      communityId,
+      authMeta: { ...authMeta, authMode: "anonymous" as const, hasIdToken: false },
+      ...(clearSessionCookie ? { clearSessionCookie: getSessionCookieName(communityId) } : {}),
+    };
   }
 }

--- a/src/presentation/middleware/auth/firebase-auth.ts
+++ b/src/presentation/middleware/auth/firebase-auth.ts
@@ -7,7 +7,7 @@ import logger from "@/infrastructure/logging";
 import { AuthHeaders, AuthResult } from "./types";
 import { AuthMeta } from "@/types/server";
 import { AuthenticationError } from "@/errors/graphql";
-import { getSessionCookieName } from "@/config/constants";
+import { getSessionCookieName, SESSION_COOKIE_NAME } from "@/config/constants";
 
 export async function handleFirebaseAuth(
   headers: AuthHeaders,
@@ -124,7 +124,7 @@ export async function handleFirebaseAuth(
       loaders,
       communityId,
       authMeta: { ...authMeta, authMode: "anonymous" as const, hasIdToken: false },
-      ...(clearSessionCookie ? { clearSessionCookie: getSessionCookieName(communityId) } : {}),
+      ...(clearSessionCookie ? { clearSessionCookie: communityId ? getSessionCookieName(communityId) : SESSION_COOKIE_NAME } : {}),
     };
   }
 }

--- a/src/presentation/middleware/auth/index.ts
+++ b/src/presentation/middleware/auth/index.ts
@@ -61,8 +61,10 @@ export function authHandler(server: ApolloServer<IContext>) {
     const originalEnd = res.end.bind(res);
     (res.end as any) = function (...args: any[]) {
       const cookieName = (req as any).__clearSessionCookie;
-      if (cookieName) {
+      if (cookieName && !res.headersSent) {
         res.clearCookie(cookieName, { path: "/", secure: true, sameSite: "none", httpOnly: true });
+      } else if (cookieName && res.headersSent) {
+        logger.warn("Cannot clear session cookie — headers already sent", { cookieName });
       }
       return (originalEnd as any)(...args);
     };

--- a/src/presentation/middleware/auth/index.ts
+++ b/src/presentation/middleware/auth/index.ts
@@ -8,6 +8,7 @@ import { handleFirebaseAuth } from "@/presentation/middleware/auth/firebase-auth
 import logger from "@/infrastructure/logging";
 import { trace, context } from "@opentelemetry/api";
 import { runRequestSecurityChecks } from "@/presentation/middleware/auth/security";
+import express from "express";
 
 async function createContext({ req }: { req: http.IncomingMessage }): Promise<IContext> {
   const currentSpan = trace.getSpan(context.active());
@@ -41,9 +42,32 @@ async function createContext({ req }: { req: http.IncomingMessage }): Promise<IC
   if (adminContext) return adminContext;
 
   // Use the same issuer for Firebase auth if admin auth didn't handle the request
-  return await handleFirebaseAuth(headers, issuer);
+  const result = await handleFirebaseAuth(headers, issuer);
+
+  // Store clearSessionCookie flag on req so the wrapper middleware can set the header
+  if (result.clearSessionCookie) {
+    (req as any).__clearSessionCookie = result.clearSessionCookie;
+  }
+
+  return result;
 }
 
 export function authHandler(server: ApolloServer<IContext>) {
-  return expressMiddleware(server, { context: createContext });
+  const gqlMiddleware = expressMiddleware(server, { context: createContext });
+
+  // Middleware that clears stale session cookies (e.g. deleted Firebase user)
+  // after the GraphQL response is prepared but before it's sent.
+  const clearCookieMiddleware = (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    const originalEnd = res.end.bind(res);
+    (res.end as any) = function (...args: any[]) {
+      const cookieName = (req as any).__clearSessionCookie;
+      if (cookieName) {
+        res.clearCookie(cookieName, { path: "/", secure: true, sameSite: "none", httpOnly: true });
+      }
+      return (originalEnd as any)(...args);
+    };
+    next();
+  };
+
+  return [clearCookieMiddleware, gqlMiddleware];
 }

--- a/src/presentation/middleware/auth/types.ts
+++ b/src/presentation/middleware/auth/types.ts
@@ -43,6 +43,9 @@ export interface AuthResultBase {
   refreshToken?: string;
   tokenExpiresAt?: string;
   idToken?: string;
+
+  /** Cookie name to clear (e.g. when Firebase user is deleted) */
+  clearSessionCookie?: string;
 }
 
 /**

--- a/src/presentation/middleware/rate-limit.ts
+++ b/src/presentation/middleware/rate-limit.ts
@@ -13,7 +13,7 @@ const RATE_LIMIT_CONFIG = {
   },
   SESSION_LOGIN: {
     windowMs: 15 * 60 * 1000, // 15 minutes
-    max: 10, // 10 login attempts per 15 minutes per IP
+    max: 30, // 30 login attempts per 15 minutes per IP+community
   },
 } as const;
 
@@ -55,6 +55,12 @@ export const sessionLoginRateLimit = rateLimit({
   },
   standardHeaders: true,
   legacyHeaders: false,
+  // Key by IP + communityId to avoid different communities sharing the same rate limit bucket.
+  // Cloud Run users behind the same NAT/proxy share an IP, so per-IP-only limits are too strict.
+  keyGenerator: (req: Request) => {
+    const communityId = req.headers['x-community-id'] as string | undefined;
+    return `${req.ip}:${communityId || 'unknown'}`;
+  },
 });
 
 export const apiRateLimit = rateLimit({

--- a/src/presentation/middleware/rate-limit.ts
+++ b/src/presentation/middleware/rate-limit.ts
@@ -58,7 +58,9 @@ export const sessionLoginRateLimit = rateLimit({
   // Key by IP + communityId to avoid different communities sharing the same rate limit bucket.
   // Cloud Run users behind the same NAT/proxy share an IP, so per-IP-only limits are too strict.
   keyGenerator: (req: Request) => {
-    const communityId = req.headers['x-community-id'] as string | undefined;
+    const rawCommunityId = req.headers['x-community-id'] as string | undefined;
+    const isValid = !rawCommunityId || /^[a-zA-Z0-9_-]+$/.test(rawCommunityId);
+    const communityId = isValid ? rawCommunityId : undefined;
     return `${req.ip}:${communityId || 'unknown'}`;
   },
 });


### PR DESCRIPTION
## Summary

Addresses three production log issues identified from warn/error log analysis:

1. **Rate limit relaxation** (`rate-limit.ts`): `sessionLogin` max raised from 10→30 per 15 min window, and keyed by `IP:communityId` instead of IP-only. Cloud Run users behind shared NAT/proxy were exhausting the per-IP bucket across different communities (4 × 429 errors/day). The `keyGenerator` also validates communityId format (consistent with `extractAuthHeaders`).

2. **Stale session cookie cleanup** (`firebase-auth.ts`, `index.ts`, `types.ts`): When Firebase returns `auth/user-not-found` or `auth/user-disabled`, the response now clears the session cookie via `Set-Cookie` header. Previously the client kept resending the stale cookie, causing repeated fallback-to-anonymous on every request (12 WARN/day). Falls back to legacy `SESSION_COOKIE_NAME` (`__session`) when `communityId` is empty.

3. **communityId format validation** (`extract-headers.ts`): Rejects `x-community-id` values that don't match `[a-zA-Z0-9_-]+` (e.g. `.env`), replacing with empty string and logging a warning. Prevents invalid communityId from propagating to DB queries. Validation is also applied consistently in the rate limit `keyGenerator`.

## Updates since last revision

Addressed review bot comments across three commits:

- **Empty communityId cookie fallback** (Gemini): `getSessionCookieName("")` produces `__session_` which doesn't match the actual `__session` cookie. Now uses `SESSION_COOKIE_NAME` constant when `communityId` is empty.
- **Rate limit keyGenerator validation** (Gemini): Added the same `[a-zA-Z0-9_-]+` validation to the rate limit `keyGenerator`, so invalid communityIds like `.env` map to the `unknown` bucket instead of creating a separate `<ip>:.env` bucket.
- **`res.headersSent` guard** (Copilot): Added a `res.headersSent` check before calling `res.clearCookie` inside the `res.end` monkey-patch. If headers are already flushed (e.g. streaming response), logs a warning instead of throwing `ERR_HTTP_HEADERS_SENT`.

## Review & Testing Checklist for Human

- [ ] **`res.end` monkey-patch in `authHandler`** (`index.ts` lines 60-70): The cookie-clearing middleware overrides `res.end` to call `res.clearCookie` before the original `res.end`. A `res.headersSent` guard was added, but verify that Apollo's `expressMiddleware` does not call `res.write()` before `res.end()` in normal operation — if it does, the `Set-Cookie` header will be silently lost (only logged as warning). This is the highest-risk change in this PR.
- [ ] **`authHandler` return type changed from single middleware to array**: Verify that all call sites (e.g. `app.use("/graphql", ..., authHandler(server))`) correctly handle an array of middlewares. Express `app.use()` supports this, but confirm the route registration code spreads or flattens correctly.
- [ ] **communityId validation regex** (`[a-zA-Z0-9_-]+`): Confirm all legitimate production communityIds match this pattern. If any community uses dots or other special characters, this validation would silently replace it with an empty string, breaking auth for that community.
- [ ] **Staging test**: Trigger a login flow for a community, then delete the Firebase user and verify the next request returns a `Set-Cookie` header clearing the session cookie. Also verify that sending `x-community-id: .env` returns an anonymous/empty auth result rather than a DB error.

### Notes
- ESLint is broken on `master` (pre-existing `@eslint/eslintrc` + `ajv` incompatibility), so lint could not be verified locally. CI runs CodeQL analysis only — no runtime tests.
- No unit tests added — these are middleware-level changes that are best verified via integration/staging testing.
- The `(req as any).__clearSessionCookie` pattern is a common Express idiom for passing data between middlewares, but is not type-safe.

Link to Devin session: https://app.devin.ai/sessions/734a15a5627041458db8812571d01202
Requested by: @709sakata
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
