### PR TITLE
fix(deps): pin axios to 1.14.0 (supply chain attack mitigation)

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "@opentelemetry/semantic-conventions": "^1.37.0",
     "@prisma/instrumentation": "^6.19.0",
     "@types/graphql-upload": "^17.0.0",
-    "axios": "^1.13.5",
+    "axios": "1.14.0",
     "busboy": "^1.6.0",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,8 +113,8 @@ importers:
         specifier: ^17.0.0
         version: 17.0.0
       axios:
-        specifier: ^1.13.5
-        version: 1.13.6
+        specifier: 1.14.0
+        version: 1.14.0
       busboy:
         specifier: ^1.6.0
         version: 1.6.0
@@ -3812,8 +3812,8 @@ packages:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
     engines: {node: '>= 6.0.0'}
 
-  axios@1.13.6:
-    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
+  axios@1.14.0:
+    resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
 
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
@@ -7189,6 +7189,10 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
@@ -11635,7 +11639,7 @@ snapshots:
     dependencies:
       '@types/node': 22.16.3
     optionalDependencies:
-      axios: 1.13.6
+      axios: 1.14.0
     transitivePeerDependencies:
       - debug
 
@@ -13641,11 +13645,11 @@ snapshots:
 
   aws-ssl-profiles@1.1.2: {}
 
-  axios@1.13.6:
+  axios@1.14.0:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
@@ -14576,7 +14580,7 @@ snapshots:
       '@dbml/core': 3.9.0
       '@oclif/core': 1.12.1
       '@oclif/plugin-help': 5.1.12
-      axios: 1.13.6
+      axios: 1.14.0
       chalk: 3.0.0
       dotenv: 8.6.0
       inquirer: 7.3.3
@@ -17555,6 +17559,8 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  proxy-from-env@2.1.0: {}
+
   psl@1.15.0:
     dependencies:
       punycode: 2.3.1
@@ -18102,7 +18108,7 @@ snapshots:
       asn1.js: 5.4.1
       asn1.js-rfc2560: 5.0.1(asn1.js@5.4.1)
       asn1.js-rfc5280: 3.0.0
-      axios: 1.13.6
+      axios: 1.14.0
       big-integer: 1.6.52
       bignumber.js: 9.3.0
       binascii: 0.0.2


### PR DESCRIPTION
## 背景・目的

axiosメンテナーのnpmアカウントが侵害され、悪意あるバージョン（**1.14.1** / **0.30.4**）が公開されました。
これらのバージョンは `npm install` 実行時にマルウェアを自動実行し、環境変数・APIキー・SSHキー等を窃取する可能性があります。

参考:
- [StepSecurity — axios compromised on npm](https://step.security/blog/axios-supply-chain-attack)
- [Snyk — Axios npm Package Compromised](https://snyk.io/blog/axios-npm-package-compromised/)
- [GitHub Advisory: GHSA-fw8c-xr5c-95f9](https://github.com/advisories/GHSA-fw8c-xr5c-95f9)

## 変更内容

- `axios`: `^1.13.5` → `1.14.0`（完全固定、`^` を除去）
- `pnpm-lock.yaml`: 対応するバージョンに更新

## バージョン選定理由

| バージョン | 状態 |
|-----------|------|
| 1.14.1 | **侵害済み**（npm から削除済み） |
| 0.30.4 | **侵害済み**（npm から削除済み） |
| **1.14.0** | ✅ 正規の安定版（npm に存在確認済み） |

`^` を除去して完全固定にしたのは、将来の `pnpm install` 時に意図せず侵害バージョンを引き込まないようにするためです。

## Gemini レビューコメントへの補足

> 「1.14.0 は存在しない、最新は 1.7.9」

この指摘は誤りです。`npm view axios versions` で確認済みであり、1.14.0 は正規の npm レジストリに存在します。現在の最新版は 1.14.0 です。

https://claude.ai/code/session_01CE3FS2cK64HQ3pJVFtAUTw