### PR TITLE
Add portal config update mutation and LINE LIFF app ID support

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -179,6 +179,11 @@ type CommonDocumentOverrides {
   terms: CommunityDocument
 }
 
+input CommonDocumentOverridesInput {
+  privacy: CommunityDocumentInput
+  terms: CommunityDocumentInput
+}
+
 type CommunitiesConnection {
   edges: [CommunityEdge!]
   pageInfo: PageInfo!
@@ -213,6 +218,7 @@ type CommunityConfig {
 
 input CommunityConfigInput {
   lineConfig: CommunityLineConfigInput
+  portalConfig: CommunityPortalConfigInput
 }
 
 input CommunityCreateInput {
@@ -240,6 +246,14 @@ type CommunityDeleteSuccess {
 }
 
 type CommunityDocument {
+  id: String!
+  order: Int
+  path: String!
+  title: String!
+  type: String!
+}
+
+input CommunityDocumentInput {
   id: String!
   order: Int
   path: String!
@@ -276,6 +290,7 @@ input CommunityLineConfigInput {
   accessToken: String!
   channelId: String!
   channelSecret: String!
+  liffAppId: String
   liffBaseUrl: String!
   liffId: String!
   richMenus: [CommunityLineRichMenuConfigInput!]!
@@ -313,6 +328,25 @@ type CommunityPortalConfig {
   squareLogoPath: String!
   title: String!
   tokenName: String!
+}
+
+input CommunityPortalConfigInput {
+  adminRootPath: String
+  commonDocumentOverrides: CommonDocumentOverridesInput
+  description: String
+  documents: [CommunityDocumentInput!]
+  domain: String
+  enableFeatures: [String!]
+  faviconPrefix: String
+  logoPath: String
+  ogImagePath: String
+  regionKey: String
+  regionName: String
+  rootPath: String
+  shortDescription: String
+  squareLogoPath: String
+  title: String
+  tokenName: String
 }
 
 type CommunitySignupBonusConfig {
@@ -821,6 +855,7 @@ type Mutation {
   transactionDonateSelfPoint(input: TransactionDonateSelfPointInput!, permission: CheckIsSelfPermissionInput!): TransactionDonateSelfPointPayload
   transactionGrantCommunityPoint(input: TransactionGrantCommunityPointInput!, permission: CheckCommunityPermissionInput!): TransactionGrantCommunityPointPayload
   transactionIssueCommunityPoint(input: TransactionIssueCommunityPointInput!, permission: CheckCommunityPermissionInput!): TransactionIssueCommunityPointPayload
+  updatePortalConfig(input: CommunityPortalConfigInput!, permission: CheckCommunityPermissionInput!): CommunityPortalConfig!
   updateSignupBonusConfig(input: UpdateSignupBonusConfigInput!, permission: CheckCommunityPermissionInput!): CommunitySignupBonusConfig!
   userDeleteMe(permission: CheckIsSelfPermissionInput!): UserDeletePayload
   userSignUp(input: UserSignUpInput!): CurrentUserPayload

--- a/src/application/domain/account/community/config/portal/data/interface.ts
+++ b/src/application/domain/account/community/config/portal/data/interface.ts
@@ -1,6 +1,12 @@
-import { CommunityPortalConfig } from "@prisma/client";
+import { CommunityPortalConfig, Prisma } from "@prisma/client";
 import { IContext } from "@/types/server";
 
 export default interface ICommunityPortalConfigRepository {
   getPortalConfig(ctx: IContext, communityId: string): Promise<CommunityPortalConfig | null>;
+  upsert(
+    ctx: IContext,
+    communityId: string,
+    data: Prisma.CommunityPortalConfigCreateWithoutConfigInput,
+    tx: Prisma.TransactionClient,
+  ): Promise<CommunityPortalConfig>;
 }

--- a/src/application/domain/account/community/config/portal/data/interface.ts
+++ b/src/application/domain/account/community/config/portal/data/interface.ts
@@ -6,7 +6,8 @@ export default interface ICommunityPortalConfigRepository {
   upsert(
     ctx: IContext,
     communityId: string,
-    data: Prisma.CommunityPortalConfigCreateWithoutConfigInput,
+    createData: Prisma.CommunityPortalConfigCreateWithoutConfigInput,
+    updateData: Prisma.CommunityPortalConfigUpdateWithoutConfigInput,
     tx: Prisma.TransactionClient,
   ): Promise<CommunityPortalConfig>;
 }

--- a/src/application/domain/account/community/config/portal/data/repository.ts
+++ b/src/application/domain/account/community/config/portal/data/repository.ts
@@ -1,5 +1,5 @@
 import { IContext } from "@/types/server";
-import { CommunityPortalConfig } from "@prisma/client";
+import { CommunityPortalConfig, Prisma } from "@prisma/client";
 import ICommunityPortalConfigRepository from "@/application/domain/account/community/config/portal/data/interface";
 import { injectable } from "tsyringe";
 
@@ -16,5 +16,23 @@ export default class CommunityPortalConfigRepository implements ICommunityPortal
       });
       return result?.portalConfig ?? null;
     });
+  }
+
+  async upsert(
+    ctx: IContext,
+    communityId: string,
+    data: Prisma.CommunityPortalConfigCreateWithoutConfigInput,
+    tx: Prisma.TransactionClient,
+  ): Promise<CommunityPortalConfig> {
+    const result = await tx.communityConfig.update({
+      where: { communityId },
+      data: {
+        portalConfig: {
+          upsert: { create: data, update: data },
+        },
+      },
+      include: { portalConfig: true },
+    });
+    return result.portalConfig!;
   }
 }

--- a/src/application/domain/account/community/config/portal/data/repository.ts
+++ b/src/application/domain/account/community/config/portal/data/repository.ts
@@ -21,14 +21,15 @@ export default class CommunityPortalConfigRepository implements ICommunityPortal
   async upsert(
     ctx: IContext,
     communityId: string,
-    data: Prisma.CommunityPortalConfigCreateWithoutConfigInput,
+    createData: Prisma.CommunityPortalConfigCreateWithoutConfigInput,
+    updateData: Prisma.CommunityPortalConfigUpdateWithoutConfigInput,
     tx: Prisma.TransactionClient,
   ): Promise<CommunityPortalConfig> {
     const result = await tx.communityConfig.update({
       where: { communityId },
       data: {
         portalConfig: {
-          upsert: { create: data, update: data },
+          upsert: { create: createData, update: updateData },
         },
       },
       include: { portalConfig: true },

--- a/src/application/domain/account/community/config/portal/service.ts
+++ b/src/application/domain/account/community/config/portal/service.ts
@@ -43,6 +43,23 @@ export interface CommonDocumentOverrides {
   privacy?: CommunityDocument;
 }
 
+const DEFAULT_ENABLE_FEATURES = ["points", "justDaoIt", "languageSwitcher"];
+
+// Fallback defaults for the create path when no portal config exists yet
+const PORTAL_CONFIG_CREATE_DEFAULTS: Prisma.CommunityPortalConfigCreateWithoutConfigInput = {
+  tokenName: "",
+  title: "",
+  description: "",
+  domain: "",
+  faviconPrefix: "",
+  logoPath: "",
+  squareLogoPath: "",
+  ogImagePath: "",
+  enableFeatures: DEFAULT_ENABLE_FEATURES,
+  rootPath: "/",
+  adminRootPath: "/admin",
+};
+
 @injectable()
 export default class CommunityPortalConfigService {
   constructor(
@@ -57,24 +74,35 @@ export default class CommunityPortalConfigService {
     communityId: string,
     input: GqlCommunityPortalConfigInput,
     tx: Prisma.TransactionClient,
-  ): Promise<CommunityPortalConfig> {
-    const data: Prisma.CommunityPortalConfigCreateWithoutConfigInput = {
-      ...(input.tokenName      !== undefined && input.tokenName      !== null && { tokenName: input.tokenName }),
-      ...(input.title          !== undefined && input.title          !== null && { title: input.title }),
-      ...(input.description    !== undefined && input.description    !== null && { description: input.description }),
+  ): Promise<void> {
+    const updateData: Prisma.CommunityPortalConfigUpdateWithoutConfigInput = {
+      ...(input.tokenName       != null && { tokenName: input.tokenName }),
+      ...(input.title           != null && { title: input.title }),
+      ...(input.description     != null && { description: input.description }),
       ...(input.shortDescription !== undefined && { shortDescription: input.shortDescription }),
-      ...(input.domain         !== undefined && input.domain         !== null && { domain: input.domain }),
-      ...(input.faviconPrefix  !== undefined && input.faviconPrefix  !== null && { faviconPrefix: input.faviconPrefix }),
-      ...(input.logoPath       !== undefined && input.logoPath       !== null && { logoPath: input.logoPath }),
-      ...(input.squareLogoPath !== undefined && input.squareLogoPath !== null && { squareLogoPath: input.squareLogoPath }),
-      ...(input.ogImagePath    !== undefined && input.ogImagePath    !== null && { ogImagePath: input.ogImagePath }),
-      ...(input.enableFeatures !== undefined && input.enableFeatures !== null && { enableFeatures: input.enableFeatures }),
-      ...(input.rootPath       !== undefined && input.rootPath       !== null && { rootPath: input.rootPath }),
-      ...(input.adminRootPath  !== undefined && input.adminRootPath  !== null && { adminRootPath: input.adminRootPath }),
-      ...(input.regionName     !== undefined && { regionName: input.regionName }),
-      ...(input.regionKey      !== undefined && { regionKey: input.regionKey }),
+      ...(input.domain          != null && { domain: input.domain }),
+      ...(input.faviconPrefix   != null && { faviconPrefix: input.faviconPrefix }),
+      ...(input.logoPath        != null && { logoPath: input.logoPath }),
+      ...(input.squareLogoPath  != null && { squareLogoPath: input.squareLogoPath }),
+      ...(input.ogImagePath     != null && { ogImagePath: input.ogImagePath }),
+      ...(input.enableFeatures  != null && { enableFeatures: input.enableFeatures }),
+      ...(input.rootPath        != null && { rootPath: input.rootPath }),
+      ...(input.adminRootPath   != null && { adminRootPath: input.adminRootPath }),
+      ...(input.regionName      !== undefined && { regionName: input.regionName }),
+      ...(input.regionKey       !== undefined && { regionKey: input.regionKey }),
+      ...(input.documents       !== undefined && { documents: input.documents ?? Prisma.JsonNull }),
+      ...(input.commonDocumentOverrides !== undefined && {
+        commonDocumentOverrides: input.commonDocumentOverrides ?? Prisma.JsonNull,
+      }),
     };
-    return this.portalRepository.upsert(ctx, communityId, data, tx);
+
+    // create path: fill required fields with defaults so NOT NULL constraints are satisfied
+    const createData: Prisma.CommunityPortalConfigCreateWithoutConfigInput = {
+      ...PORTAL_CONFIG_CREATE_DEFAULTS,
+      ...updateData,
+    };
+
+    await this.portalRepository.upsert(ctx, communityId, createData, updateData, tx);
   }
 
   async getPortalConfig(ctx: IContext, communityId: string): Promise<CommunityPortalConfigResult> {

--- a/src/application/domain/account/community/config/portal/service.ts
+++ b/src/application/domain/account/community/config/portal/service.ts
@@ -1,6 +1,8 @@
 import { IContext } from "@/types/server";
 import { NotFoundError } from "@/errors/graphql";
 import { inject, injectable } from "tsyringe";
+import { CommunityPortalConfig, Prisma } from "@prisma/client";
+import { GqlCommunityPortalConfigInput } from "@/types/graphql";
 import ICommunityPortalConfigRepository from "@/application/domain/account/community/config/portal/data/interface";
 import ICommunityConfigRepository from "@/application/domain/account/community/config/data/interface";
 
@@ -49,6 +51,31 @@ export default class CommunityPortalConfigService {
     @inject("CommunityConfigRepository")
     private readonly configRepository: ICommunityConfigRepository,
   ) {}
+
+  async update(
+    ctx: IContext,
+    communityId: string,
+    input: GqlCommunityPortalConfigInput,
+    tx: Prisma.TransactionClient,
+  ): Promise<CommunityPortalConfig> {
+    const data: Prisma.CommunityPortalConfigCreateWithoutConfigInput = {
+      ...(input.tokenName      !== undefined && input.tokenName      !== null && { tokenName: input.tokenName }),
+      ...(input.title          !== undefined && input.title          !== null && { title: input.title }),
+      ...(input.description    !== undefined && input.description    !== null && { description: input.description }),
+      ...(input.shortDescription !== undefined && { shortDescription: input.shortDescription }),
+      ...(input.domain         !== undefined && input.domain         !== null && { domain: input.domain }),
+      ...(input.faviconPrefix  !== undefined && input.faviconPrefix  !== null && { faviconPrefix: input.faviconPrefix }),
+      ...(input.logoPath       !== undefined && input.logoPath       !== null && { logoPath: input.logoPath }),
+      ...(input.squareLogoPath !== undefined && input.squareLogoPath !== null && { squareLogoPath: input.squareLogoPath }),
+      ...(input.ogImagePath    !== undefined && input.ogImagePath    !== null && { ogImagePath: input.ogImagePath }),
+      ...(input.enableFeatures !== undefined && input.enableFeatures !== null && { enableFeatures: input.enableFeatures }),
+      ...(input.rootPath       !== undefined && input.rootPath       !== null && { rootPath: input.rootPath }),
+      ...(input.adminRootPath  !== undefined && input.adminRootPath  !== null && { adminRootPath: input.adminRootPath }),
+      ...(input.regionName     !== undefined && { regionName: input.regionName }),
+      ...(input.regionKey      !== undefined && { regionKey: input.regionKey }),
+    };
+    return this.portalRepository.upsert(ctx, communityId, data, tx);
+  }
 
   async getPortalConfig(ctx: IContext, communityId: string): Promise<CommunityPortalConfigResult> {
     const portalConfig = await this.portalRepository.getPortalConfig(ctx, communityId);

--- a/src/application/domain/account/community/config/schema/mutation.graphql
+++ b/src/application/domain/account/community/config/schema/mutation.graphql
@@ -33,6 +33,21 @@ input CommunityPortalConfigInput {
     adminRootPath: String
     regionName: String
     regionKey: String
+    documents: [CommunityDocumentInput!]
+    commonDocumentOverrides: CommonDocumentOverridesInput
+}
+
+input CommunityDocumentInput {
+    id: String!
+    title: String!
+    path: String!
+    type: String!
+    order: Int
+}
+
+input CommonDocumentOverridesInput {
+    terms: CommunityDocumentInput
+    privacy: CommunityDocumentInput
 }
 
 input UpdateSignupBonusConfigInput {

--- a/src/application/domain/account/community/config/schema/mutation.graphql
+++ b/src/application/domain/account/community/config/schema/mutation.graphql
@@ -1,5 +1,6 @@
 input CommunityConfigInput {
     lineConfig: CommunityLineConfigInput
+    portalConfig: CommunityPortalConfigInput
 }
 
 input CommunityLineConfigInput {
@@ -7,6 +8,7 @@ input CommunityLineConfigInput {
     channelSecret: String!
     accessToken: String!
     liffId: String!
+    liffAppId: String
     liffBaseUrl: String!
     richMenus: [CommunityLineRichMenuConfigInput!]!
 }
@@ -14,6 +16,23 @@ input CommunityLineConfigInput {
 input CommunityLineRichMenuConfigInput {
     type: LineRichMenuType!
     richMenuId: String!
+}
+
+input CommunityPortalConfigInput {
+    tokenName: String
+    title: String
+    description: String
+    shortDescription: String
+    domain: String
+    faviconPrefix: String
+    logoPath: String
+    squareLogoPath: String
+    ogImagePath: String
+    enableFeatures: [String!]
+    rootPath: String
+    adminRootPath: String
+    regionName: String
+    regionKey: String
 }
 
 input UpdateSignupBonusConfigInput {
@@ -27,4 +46,9 @@ extend type Mutation {
         input: UpdateSignupBonusConfigInput!,
         permission: CheckCommunityPermissionInput!
     ): CommunitySignupBonusConfig! @authz(rules: [IsCommunityManager])
+
+    updatePortalConfig(
+        input: CommunityPortalConfigInput!,
+        permission: CheckCommunityPermissionInput!
+    ): CommunityPortalConfig! @authz(rules: [IsCommunityManager])
 }

--- a/src/application/domain/account/community/controller/resolver.ts
+++ b/src/application/domain/account/community/controller/resolver.ts
@@ -5,6 +5,7 @@ import {
   GqlMutationCommunityDeleteArgs,
   GqlMutationCommunityUpdateProfileArgs,
   GqlMutationUpdateSignupBonusConfigArgs,
+  GqlMutationUpdatePortalConfigArgs,
 } from "@/types/graphql";
 import { IContext } from "@/types/server";
 import { inject, injectable } from "tsyringe";
@@ -43,6 +44,9 @@ export default class CommunityResolver {
       ctx: IContext,
     ) => {
       return this.communityUseCase.managerUpdateSignupBonusConfig(args, ctx);
+    },
+    updatePortalConfig: async (_: unknown, args: GqlMutationUpdatePortalConfigArgs, ctx: IContext) => {
+      return this.communityUseCase.managerUpdatePortalConfig(args, ctx);
     },
   };
 

--- a/src/application/domain/account/community/data/converter.ts
+++ b/src/application/domain/account/community/data/converter.ts
@@ -5,6 +5,8 @@ import {
   GqlCommunitySortInput,
   GqlImageInput,
 } from "@/types/graphql";
+
+const DEFAULT_ENABLE_FEATURES = ["points", "justDaoIt", "languageSwitcher"];
 import { MembershipStatus, MembershipStatusReason, Prisma, Role } from "@prisma/client";
 import { injectable } from "tsyringe";
 
@@ -81,6 +83,7 @@ export default class CommunityConverter {
                   channelSecret: config.lineConfig.channelSecret,
                   accessToken: config.lineConfig.accessToken,
                   liffId: config.lineConfig.liffId,
+                  liffAppId: config.lineConfig.liffAppId ?? null,
                   liffBaseUrl: config.lineConfig.liffBaseUrl,
                   richMenus: {
                     create: config.lineConfig.richMenus.map((menu) => ({
@@ -91,6 +94,24 @@ export default class CommunityConverter {
                 },
               },
             }),
+            portalConfig: {
+              create: {
+                tokenName:        config?.portalConfig?.tokenName      ?? prop.pointName,
+                title:            config?.portalConfig?.title          ?? prop.name,
+                description:      config?.portalConfig?.description    ?? "",
+                shortDescription: config?.portalConfig?.shortDescription ?? null,
+                domain:           config?.portalConfig?.domain         ?? "",
+                faviconPrefix:    config?.portalConfig?.faviconPrefix  ?? "",
+                logoPath:         config?.portalConfig?.logoPath       ?? "",
+                squareLogoPath:   config?.portalConfig?.squareLogoPath ?? "",
+                ogImagePath:      config?.portalConfig?.ogImagePath    ?? "",
+                enableFeatures:   config?.portalConfig?.enableFeatures ?? DEFAULT_ENABLE_FEATURES,
+                rootPath:         config?.portalConfig?.rootPath       ?? "/",
+                adminRootPath:    config?.portalConfig?.adminRootPath  ?? "/admin",
+                regionName:       config?.portalConfig?.regionName     ?? null,
+                regionKey:        config?.portalConfig?.regionKey      ?? null,
+              },
+            },
           },
         },
       },

--- a/src/application/domain/account/community/usecase.ts
+++ b/src/application/domain/account/community/usecase.ts
@@ -12,7 +12,8 @@ import {
   GqlMutationUpdateSignupBonusConfigArgs,
   GqlMutationUpdatePortalConfigArgs,
 } from "@/types/graphql";
-import { CommunityPortalConfig, CommunitySignupBonusConfig } from "@prisma/client";
+import { CommunitySignupBonusConfig } from "@prisma/client";
+import { CommunityPortalConfigResult } from "@/application/domain/account/community/config/portal/service";
 import { IContext } from "@/types/server";
 import CommunityService from "@/application/domain/account/community/service";
 import CommunityPresenter from "@/application/domain/account/community/presenter";
@@ -115,9 +116,10 @@ export default class CommunityUseCase {
   async managerUpdatePortalConfig(
     { input, permission }: GqlMutationUpdatePortalConfigArgs,
     ctx: IContext,
-  ): Promise<CommunityPortalConfig> {
-    return ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
-      return this.portalConfigService.update(ctx, permission.communityId, input, tx);
+  ): Promise<CommunityPortalConfigResult> {
+    await ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
+      await this.portalConfigService.update(ctx, permission.communityId, input, tx);
     });
+    return this.portalConfigService.getPortalConfig(ctx, permission.communityId);
   }
 }

--- a/src/application/domain/account/community/usecase.ts
+++ b/src/application/domain/account/community/usecase.ts
@@ -10,8 +10,9 @@ import {
   GqlMutationCommunityUpdateProfileArgs,
   GqlCommunityUpdateProfilePayload,
   GqlMutationUpdateSignupBonusConfigArgs,
+  GqlMutationUpdatePortalConfigArgs,
 } from "@/types/graphql";
-import { CommunitySignupBonusConfig } from "@prisma/client";
+import { CommunityPortalConfig, CommunitySignupBonusConfig } from "@prisma/client";
 import { IContext } from "@/types/server";
 import CommunityService from "@/application/domain/account/community/service";
 import CommunityPresenter from "@/application/domain/account/community/presenter";
@@ -19,6 +20,7 @@ import { clampFirst, getCurrentUserId } from "@/application/domain/utils";
 import WalletService from "@/application/domain/account/wallet/service";
 import { inject, injectable } from "tsyringe";
 import CommunitySignupBonusConfigService from "@/application/domain/account/community/config/incentive/signup/service";
+import CommunityPortalConfigService from "@/application/domain/account/community/config/portal/service";
 import logger from "@/infrastructure/logging";
 
 @injectable()
@@ -28,6 +30,8 @@ export default class CommunityUseCase {
     @inject("WalletService") private readonly walletService: WalletService,
     @inject("CommunitySignupBonusConfigService")
     private readonly signupBonusConfigService: CommunitySignupBonusConfigService,
+    @inject("CommunityPortalConfigService")
+    private readonly portalConfigService: CommunityPortalConfigService,
   ) {}
 
   async userBrowseCommunities(
@@ -105,6 +109,15 @@ export default class CommunityUseCase {
   ): Promise<CommunitySignupBonusConfig> {
     return ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
       return this.signupBonusConfigService.update(ctx, permission.communityId, input, tx);
+    });
+  }
+
+  async managerUpdatePortalConfig(
+    { input, permission }: GqlMutationUpdatePortalConfigArgs,
+    ctx: IContext,
+  ): Promise<CommunityPortalConfig> {
+    return ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
+      return this.portalConfigService.update(ctx, permission.communityId, input, tx);
     });
   }
 }

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -249,6 +249,7 @@ export type GqlCommunityConfig = {
 
 export type GqlCommunityConfigInput = {
   lineConfig?: InputMaybe<GqlCommunityLineConfigInput>;
+  portalConfig?: InputMaybe<GqlCommunityPortalConfigInput>;
 };
 
 export type GqlCommunityCreateInput = {
@@ -318,6 +319,7 @@ export type GqlCommunityLineConfigInput = {
   accessToken: Scalars['String']['input'];
   channelId: Scalars['String']['input'];
   channelSecret: Scalars['String']['input'];
+  liffAppId?: InputMaybe<Scalars['String']['input']>;
   liffBaseUrl: Scalars['String']['input'];
   liffId: Scalars['String']['input'];
   richMenus: Array<GqlCommunityLineRichMenuConfigInput>;
@@ -357,6 +359,23 @@ export type GqlCommunityPortalConfig = {
   squareLogoPath: Scalars['String']['output'];
   title: Scalars['String']['output'];
   tokenName: Scalars['String']['output'];
+};
+
+export type GqlCommunityPortalConfigInput = {
+  adminRootPath?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  domain?: InputMaybe<Scalars['String']['input']>;
+  enableFeatures?: InputMaybe<Array<Scalars['String']['input']>>;
+  faviconPrefix?: InputMaybe<Scalars['String']['input']>;
+  logoPath?: InputMaybe<Scalars['String']['input']>;
+  ogImagePath?: InputMaybe<Scalars['String']['input']>;
+  regionKey?: InputMaybe<Scalars['String']['input']>;
+  regionName?: InputMaybe<Scalars['String']['input']>;
+  rootPath?: InputMaybe<Scalars['String']['input']>;
+  shortDescription?: InputMaybe<Scalars['String']['input']>;
+  squareLogoPath?: InputMaybe<Scalars['String']['input']>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  tokenName?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type GqlCommunitySignupBonusConfig = {
@@ -901,6 +920,7 @@ export type GqlMutation = {
   transactionDonateSelfPoint?: Maybe<GqlTransactionDonateSelfPointPayload>;
   transactionGrantCommunityPoint?: Maybe<GqlTransactionGrantCommunityPointPayload>;
   transactionIssueCommunityPoint?: Maybe<GqlTransactionIssueCommunityPointPayload>;
+  updatePortalConfig: GqlCommunityPortalConfig;
   updateSignupBonusConfig: GqlCommunitySignupBonusConfig;
   userDeleteMe?: Maybe<GqlUserDeletePayload>;
   userSignUp?: Maybe<GqlCurrentUserPayload>;
@@ -1188,6 +1208,12 @@ export type GqlMutationTransactionGrantCommunityPointArgs = {
 
 export type GqlMutationTransactionIssueCommunityPointArgs = {
   input: GqlTransactionIssueCommunityPointInput;
+  permission: GqlCheckCommunityPermissionInput;
+};
+
+
+export type GqlMutationUpdatePortalConfigArgs = {
+  input: GqlCommunityPortalConfigInput;
   permission: GqlCheckCommunityPermissionInput;
 };
 
@@ -3316,6 +3342,7 @@ export type GqlResolversTypes = ResolversObject<{
   CommunityLineRichMenuConfig: ResolverTypeWrapper<GqlCommunityLineRichMenuConfig>;
   CommunityLineRichMenuConfigInput: GqlCommunityLineRichMenuConfigInput;
   CommunityPortalConfig: ResolverTypeWrapper<GqlCommunityPortalConfig>;
+  CommunityPortalConfigInput: GqlCommunityPortalConfigInput;
   CommunitySignupBonusConfig: ResolverTypeWrapper<GqlCommunitySignupBonusConfig>;
   CommunitySortInput: GqlCommunitySortInput;
   CommunityUpdateProfileInput: GqlCommunityUpdateProfileInput;
@@ -3659,6 +3686,7 @@ export type GqlResolversParentTypes = ResolversObject<{
   CommunityLineRichMenuConfig: GqlCommunityLineRichMenuConfig;
   CommunityLineRichMenuConfigInput: GqlCommunityLineRichMenuConfigInput;
   CommunityPortalConfig: GqlCommunityPortalConfig;
+  CommunityPortalConfigInput: GqlCommunityPortalConfigInput;
   CommunitySignupBonusConfig: GqlCommunitySignupBonusConfig;
   CommunitySortInput: GqlCommunitySortInput;
   CommunityUpdateProfileInput: GqlCommunityUpdateProfileInput;
@@ -4462,6 +4490,7 @@ export type GqlMutationResolvers<ContextType = any, ParentType extends GqlResolv
   transactionDonateSelfPoint?: Resolver<Maybe<GqlResolversTypes['TransactionDonateSelfPointPayload']>, ParentType, ContextType, RequireFields<GqlMutationTransactionDonateSelfPointArgs, 'input' | 'permission'>>;
   transactionGrantCommunityPoint?: Resolver<Maybe<GqlResolversTypes['TransactionGrantCommunityPointPayload']>, ParentType, ContextType, RequireFields<GqlMutationTransactionGrantCommunityPointArgs, 'input' | 'permission'>>;
   transactionIssueCommunityPoint?: Resolver<Maybe<GqlResolversTypes['TransactionIssueCommunityPointPayload']>, ParentType, ContextType, RequireFields<GqlMutationTransactionIssueCommunityPointArgs, 'input' | 'permission'>>;
+  updatePortalConfig?: Resolver<GqlResolversTypes['CommunityPortalConfig'], ParentType, ContextType, RequireFields<GqlMutationUpdatePortalConfigArgs, 'input' | 'permission'>>;
   updateSignupBonusConfig?: Resolver<GqlResolversTypes['CommunitySignupBonusConfig'], ParentType, ContextType, RequireFields<GqlMutationUpdateSignupBonusConfigArgs, 'input' | 'permission'>>;
   userDeleteMe?: Resolver<Maybe<GqlResolversTypes['UserDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationUserDeleteMeArgs, 'permission'>>;
   userSignUp?: Resolver<Maybe<GqlResolversTypes['CurrentUserPayload']>, ParentType, ContextType, RequireFields<GqlMutationUserSignUpArgs, 'input'>>;

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -212,6 +212,11 @@ export type GqlCommonDocumentOverrides = {
   terms?: Maybe<GqlCommunityDocument>;
 };
 
+export type GqlCommonDocumentOverridesInput = {
+  privacy?: InputMaybe<GqlCommunityDocumentInput>;
+  terms?: InputMaybe<GqlCommunityDocumentInput>;
+};
+
 export type GqlCommunitiesConnection = {
   __typename?: 'CommunitiesConnection';
   edges?: Maybe<Array<GqlCommunityEdge>>;
@@ -285,6 +290,14 @@ export type GqlCommunityDocument = {
   path: Scalars['String']['output'];
   title: Scalars['String']['output'];
   type: Scalars['String']['output'];
+};
+
+export type GqlCommunityDocumentInput = {
+  id: Scalars['String']['input'];
+  order?: InputMaybe<Scalars['Int']['input']>;
+  path: Scalars['String']['input'];
+  title: Scalars['String']['input'];
+  type: Scalars['String']['input'];
 };
 
 export type GqlCommunityEdge = GqlEdge & {
@@ -363,7 +376,9 @@ export type GqlCommunityPortalConfig = {
 
 export type GqlCommunityPortalConfigInput = {
   adminRootPath?: InputMaybe<Scalars['String']['input']>;
+  commonDocumentOverrides?: InputMaybe<GqlCommonDocumentOverridesInput>;
   description?: InputMaybe<Scalars['String']['input']>;
+  documents?: InputMaybe<Array<GqlCommunityDocumentInput>>;
   domain?: InputMaybe<Scalars['String']['input']>;
   enableFeatures?: InputMaybe<Array<Scalars['String']['input']>>;
   faviconPrefix?: InputMaybe<Scalars['String']['input']>;
@@ -3324,6 +3339,7 @@ export type GqlResolversTypes = ResolversObject<{
   CityEdge: ResolverTypeWrapper<Omit<GqlCityEdge, 'node'> & { node?: Maybe<GqlResolversTypes['City']> }>;
   ClaimLinkStatus: GqlClaimLinkStatus;
   CommonDocumentOverrides: ResolverTypeWrapper<GqlCommonDocumentOverrides>;
+  CommonDocumentOverridesInput: GqlCommonDocumentOverridesInput;
   CommunitiesConnection: ResolverTypeWrapper<Omit<GqlCommunitiesConnection, 'edges'> & { edges?: Maybe<Array<GqlResolversTypes['CommunityEdge']>> }>;
   Community: ResolverTypeWrapper<Community>;
   CommunityConfig: ResolverTypeWrapper<GqlCommunityConfig>;
@@ -3334,6 +3350,7 @@ export type GqlResolversTypes = ResolversObject<{
   CommunityDeletePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['CommunityDeletePayload']>;
   CommunityDeleteSuccess: ResolverTypeWrapper<GqlCommunityDeleteSuccess>;
   CommunityDocument: ResolverTypeWrapper<GqlCommunityDocument>;
+  CommunityDocumentInput: GqlCommunityDocumentInput;
   CommunityEdge: ResolverTypeWrapper<Omit<GqlCommunityEdge, 'node'> & { node?: Maybe<GqlResolversTypes['Community']> }>;
   CommunityFilterInput: GqlCommunityFilterInput;
   CommunityFirebaseConfig: ResolverTypeWrapper<GqlCommunityFirebaseConfig>;
@@ -3668,6 +3685,7 @@ export type GqlResolversParentTypes = ResolversObject<{
   City: City;
   CityEdge: Omit<GqlCityEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['City']> };
   CommonDocumentOverrides: GqlCommonDocumentOverrides;
+  CommonDocumentOverridesInput: GqlCommonDocumentOverridesInput;
   CommunitiesConnection: Omit<GqlCommunitiesConnection, 'edges'> & { edges?: Maybe<Array<GqlResolversParentTypes['CommunityEdge']>> };
   Community: Community;
   CommunityConfig: GqlCommunityConfig;
@@ -3678,6 +3696,7 @@ export type GqlResolversParentTypes = ResolversObject<{
   CommunityDeletePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['CommunityDeletePayload'];
   CommunityDeleteSuccess: GqlCommunityDeleteSuccess;
   CommunityDocument: GqlCommunityDocument;
+  CommunityDocumentInput: GqlCommunityDocumentInput;
   CommunityEdge: Omit<GqlCommunityEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['Community']> };
   CommunityFilterInput: GqlCommunityFilterInput;
   CommunityFirebaseConfig: GqlCommunityFirebaseConfig;


### PR DESCRIPTION
## Summary
This PR adds the ability to update community portal configuration through a new GraphQL mutation and introduces support for LINE LIFF App ID configuration.

## Key Changes

- **New GraphQL Mutation**: Added `updatePortalConfig` mutation to allow community managers to update portal configuration settings including title, description, domain, logos, and feature flags
- **Portal Config Input Type**: Created `GqlCommunityPortalConfigInput` GraphQL input type with all configurable portal properties
- **LINE LIFF App ID**: Added optional `liffAppId` field to `CommunityLineConfigInput` for LINE LIFF configuration
- **Service Layer**: Implemented `CommunityPortalConfigService.update()` method to handle portal config updates with transaction support
- **Repository Enhancement**: Added `upsert()` method to `CommunityPortalConfigRepository` for atomic portal config updates
- **Use Case Integration**: Added `managerUpdatePortalConfig()` use case method with proper permission checks
- **Resolver**: Wired up the new mutation resolver to handle incoming requests
- **Community Creation**: Updated community converter to initialize portal config with sensible defaults during community creation, including a `DEFAULT_ENABLE_FEATURES` constant with `["points", "justDaoIt", "languageSwitcher"]`

## Implementation Details

- Portal config updates use upsert semantics to handle both creation and updates
- All portal config fields are optional in the input, allowing partial updates
- Null/undefined values are conditionally spread to avoid overwriting with empty values
- Community managers are required to have proper permissions via `@authz(rules: [IsCommunityManager])` directive
- Updates are wrapped in database transactions for consistency

https://claude.ai/code/session_01YcNQMUHZ84fjCPf2jjpmvq
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
