### PR TITLE
Allow community owners to update transaction metadata

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -855,7 +855,7 @@ type Mutation {
   transactionDonateSelfPoint(input: TransactionDonateSelfPointInput!, permission: CheckIsSelfPermissionInput!): TransactionDonateSelfPointPayload
   transactionGrantCommunityPoint(input: TransactionGrantCommunityPointInput!, permission: CheckCommunityPermissionInput!): TransactionGrantCommunityPointPayload
   transactionIssueCommunityPoint(input: TransactionIssueCommunityPointInput!, permission: CheckCommunityPermissionInput!): TransactionIssueCommunityPointPayload
-  transactionUpdateMetadata(id: ID!, input: TransactionUpdateMetadataInput!, permission: CheckIsSelfPermissionInput!): TransactionUpdateMetadataPayload
+  transactionUpdateMetadata(communityPermission: CheckCommunityPermissionInput, id: ID!, input: TransactionUpdateMetadataInput!, permission: CheckIsSelfPermissionInput): TransactionUpdateMetadataPayload
   updatePortalConfig(input: CommunityPortalConfigInput!, permission: CheckCommunityPermissionInput!): CommunityPortalConfig!
   updateSignupBonusConfig(input: UpdateSignupBonusConfigInput!, permission: CheckCommunityPermissionInput!): CommunitySignupBonusConfig!
   userDeleteMe(permission: CheckIsSelfPermissionInput!): UserDeletePayload

--- a/src/application/domain/transaction/schema/mutation.graphql
+++ b/src/application/domain/transaction/schema/mutation.graphql
@@ -23,9 +23,10 @@ extend type Mutation {
     transactionUpdateMetadata(
         id: ID!
         input: TransactionUpdateMetadataInput!
-        permission: CheckIsSelfPermissionInput!
+        permission: CheckIsSelfPermissionInput
+        communityPermission: CheckCommunityPermissionInput
     ): TransactionUpdateMetadataPayload
-    @authz(rules: [IsSelf])
+    @authz(rules: [IsSelf, IsCommunityOwner])
 }
 
 # ------------------------------

--- a/src/application/domain/transaction/schema/mutation.graphql
+++ b/src/application/domain/transaction/schema/mutation.graphql
@@ -26,7 +26,7 @@ extend type Mutation {
         permission: CheckIsSelfPermissionInput
         communityPermission: CheckCommunityPermissionInput
     ): TransactionUpdateMetadataPayload
-    @authz(rules: [IsSelf, IsCommunityOwner])
+    @authz(compositeRules: [{ or: [IsSelf, IsCommunityOwner] }])
 }
 
 # ------------------------------

--- a/src/application/domain/transaction/usecase.ts
+++ b/src/application/domain/transaction/usecase.ts
@@ -224,7 +224,7 @@ export default class TransactionUseCase {
 
   async userUpdateTransactionMetadata(
     ctx: IContext,
-    { id, input }: GqlMutationTransactionUpdateMetadataArgs,
+    { id, input, communityPermission }: GqlMutationTransactionUpdateMetadataArgs,
   ): Promise<GqlTransactionUpdateMetadataPayload> {
     const currentUserId = getCurrentUserId(ctx);
 
@@ -232,8 +232,19 @@ export default class TransactionUseCase {
     if (!existing) {
       throw new NotFoundError(`TransactionNotFound: ID=${id}`);
     }
-    if (existing.createdBy !== currentUserId) {
-      throw new AuthorizationError("User is not the creator of this transaction");
+
+    if (communityPermission?.communityId) {
+      const communityWallet = await this.walletService.findCommunityWalletOrThrow(
+        ctx,
+        communityPermission.communityId,
+      );
+      if (existing.from !== communityWallet.id) {
+        throw new AuthorizationError("Transaction is not from the community wallet");
+      }
+    } else {
+      if (existing.createdBy !== currentUserId) {
+        throw new AuthorizationError("User is not the creator of this transaction");
+      }
     }
 
     // GCSアップロードはDBトランザクション外で実行（長時間ロック防止）

--- a/src/application/domain/transaction/usecase.ts
+++ b/src/application/domain/transaction/usecase.ts
@@ -1,4 +1,4 @@
-import { Prisma, TransactionReason } from "@prisma/client";
+import { Prisma, Role, TransactionReason } from "@prisma/client";
 import { IContext } from "@/types/server";
 import TransactionPresenter from "@/application/domain/transaction/presenter";
 import MembershipService from "@/application/domain/account/membership/service";
@@ -224,7 +224,7 @@ export default class TransactionUseCase {
 
   async userUpdateTransactionMetadata(
     ctx: IContext,
-    { id, input, communityPermission }: GqlMutationTransactionUpdateMetadataArgs,
+    { id, input, permission, communityPermission }: GqlMutationTransactionUpdateMetadataArgs,
   ): Promise<GqlTransactionUpdateMetadataPayload> {
     const currentUserId = getCurrentUserId(ctx);
 
@@ -234,6 +234,14 @@ export default class TransactionUseCase {
     }
 
     if (communityPermission?.communityId) {
+      const isOwner =
+        ctx.isAdmin ||
+        ctx.currentUser?.memberships?.some(
+          (m) => m.communityId === communityPermission.communityId && m.role === Role.OWNER,
+        ) === true;
+      if (!isOwner) {
+        throw new AuthorizationError("User must be community owner");
+      }
       const communityWallet = await this.walletService.findCommunityWalletOrThrow(
         ctx,
         communityPermission.communityId,
@@ -241,10 +249,12 @@ export default class TransactionUseCase {
       if (existing.from !== communityWallet.id) {
         throw new AuthorizationError("Transaction is not from the community wallet");
       }
-    } else {
+    } else if (permission?.userId) {
       if (existing.createdBy !== currentUserId) {
         throw new AuthorizationError("User is not the creator of this transaction");
       }
+    } else {
+      throw new AuthorizationError("Insufficient permissions to update transaction metadata");
     }
 
     // GCSアップロードはDBトランザクション外で実行（長時間ロック防止）

--- a/src/presentation/graphql/rules/index.ts
+++ b/src/presentation/graphql/rules/index.ts
@@ -78,10 +78,10 @@ const IsSelf = preExecRule({
 // 🔐 コミュニティのオーナーか
 const IsCommunityOwner = preExecRule({
   error: new AuthorizationError("User must be community owner"),
-})((context: IContext, args: { permission?: { communityId?: string } }) => {
+})((context: IContext, args: { permission?: { communityId?: string }; communityPermission?: { communityId?: string } }) => {
   if (context.isAdmin) return true;
 
-  const communityId = args.permission?.communityId;
+  const communityId = args.permission?.communityId ?? args.communityPermission?.communityId;
   if (!communityId) {
     logger.error("IsCommunityOwner authorization FAILED", {
       rule: "IsCommunityOwner",

--- a/src/presentation/graphql/rules/index.ts
+++ b/src/presentation/graphql/rules/index.ts
@@ -85,7 +85,7 @@ const IsCommunityOwner = preExecRule({
   if (!communityId) {
     logger.error("IsCommunityOwner authorization FAILED", {
       rule: "IsCommunityOwner",
-      reason: "no_community_id_in_permission",
+      reason: "no_community_id_in_args",
     });
     return false;
   }

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1229,9 +1229,10 @@ export type GqlMutationTransactionIssueCommunityPointArgs = {
 
 
 export type GqlMutationTransactionUpdateMetadataArgs = {
+  communityPermission?: InputMaybe<GqlCheckCommunityPermissionInput>;
   id: Scalars['ID']['input'];
   input: GqlTransactionUpdateMetadataInput;
-  permission: GqlCheckIsSelfPermissionInput;
+  permission?: InputMaybe<GqlCheckIsSelfPermissionInput>;
 };
 
 
@@ -4537,7 +4538,7 @@ export type GqlMutationResolvers<ContextType = any, ParentType extends GqlResolv
   transactionDonateSelfPoint?: Resolver<Maybe<GqlResolversTypes['TransactionDonateSelfPointPayload']>, ParentType, ContextType, RequireFields<GqlMutationTransactionDonateSelfPointArgs, 'input' | 'permission'>>;
   transactionGrantCommunityPoint?: Resolver<Maybe<GqlResolversTypes['TransactionGrantCommunityPointPayload']>, ParentType, ContextType, RequireFields<GqlMutationTransactionGrantCommunityPointArgs, 'input' | 'permission'>>;
   transactionIssueCommunityPoint?: Resolver<Maybe<GqlResolversTypes['TransactionIssueCommunityPointPayload']>, ParentType, ContextType, RequireFields<GqlMutationTransactionIssueCommunityPointArgs, 'input' | 'permission'>>;
-  transactionUpdateMetadata?: Resolver<Maybe<GqlResolversTypes['TransactionUpdateMetadataPayload']>, ParentType, ContextType, RequireFields<GqlMutationTransactionUpdateMetadataArgs, 'id' | 'input' | 'permission'>>;
+  transactionUpdateMetadata?: Resolver<Maybe<GqlResolversTypes['TransactionUpdateMetadataPayload']>, ParentType, ContextType, RequireFields<GqlMutationTransactionUpdateMetadataArgs, 'id' | 'input'>>;
   updatePortalConfig?: Resolver<GqlResolversTypes['CommunityPortalConfig'], ParentType, ContextType, RequireFields<GqlMutationUpdatePortalConfigArgs, 'input' | 'permission'>>;
   updateSignupBonusConfig?: Resolver<GqlResolversTypes['CommunitySignupBonusConfig'], ParentType, ContextType, RequireFields<GqlMutationUpdateSignupBonusConfigArgs, 'input' | 'permission'>>;
   userDeleteMe?: Resolver<Maybe<GqlResolversTypes['UserDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationUserDeleteMeArgs, 'permission'>>;


### PR DESCRIPTION
## Summary
Extended the `transactionUpdateMetadata` mutation to allow community owners to update metadata for transactions originating from their community wallet, in addition to the existing creator-only authorization.

## Key Changes
- **Authorization Logic**: Modified `userUpdateTransactionMetadata` to support dual authorization paths:
  - Original path: User must be the transaction creator
  - New path: User must be a community owner and the transaction must originate from the community wallet
  
- **GraphQL Schema Updates**:
  - Made `permission` parameter optional (was required)
  - Added new `communityPermission` parameter to accept community context
  - Updated authorization rules from `@authz(rules: [IsSelf])` to `@authz(rules: [IsSelf, IsCommunityOwner])`

- **Authorization Rule Enhancement**: Updated `IsCommunityOwner` rule to check both `permission.communityId` and `communityPermission.communityId` parameters

- **Type Definitions**: Updated GraphQL type definitions to reflect optional `permission` and new `communityPermission` parameters

## Implementation Details
- The authorization check validates that if `communityPermission` is provided, the transaction's `from` field matches the community wallet ID
- Falls back to the original creator check if no community permission is provided
- Maintains backward compatibility by making both permission parameters optional

https://claude.ai/code/session_014ZUK4Z6EZGMEYq1sa46fj9
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/804" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
