### PR TITLE
Add image upload support to transaction mutations

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -1926,6 +1926,7 @@ type Transaction {
 input TransactionDonateSelfPointInput {
   comment: String
   communityId: ID!
+  images: [ImageInput!]
   toUserId: ID!
   transferPoints: Int!
 }
@@ -1961,6 +1962,7 @@ input TransactionFilterInput {
 
 input TransactionGrantCommunityPointInput {
   comment: String
+  images: [ImageInput!]
   toUserId: ID!
   transferPoints: Int!
 }
@@ -1973,6 +1975,7 @@ type TransactionGrantCommunityPointSuccess {
 
 input TransactionIssueCommunityPointInput {
   comment: String
+  images: [ImageInput!]
   transferPoints: Int!
 }
 

--- a/src/__tests__/unit/transaction.service.test.ts
+++ b/src/__tests__/unit/transaction.service.test.ts
@@ -78,7 +78,7 @@ describe("TransactionService", () => {
         comment,
       );
 
-      expect(mockConverter.issueCommunityPoint).toHaveBeenCalledWith(walletId, transferPoints, "test-user-id", comment);
+      expect(mockConverter.issueCommunityPoint).toHaveBeenCalledWith(walletId, transferPoints, "test-user-id", comment, undefined);
       expect(mockRepository.create).toHaveBeenCalledWith(mockCtx, convertedData, mockTx);
       expect(mockRepository.refreshCurrentPoints).toHaveBeenCalledWith(mockCtx, mockTx);
       expect(result).toBe(mockTransaction);
@@ -121,6 +121,7 @@ describe("TransactionService", () => {
         walletId,
         "test-user-id",
         comment,
+        undefined,
       );
       expect(mockRepository.create).toHaveBeenCalledWith(mockCtx, convertedData, mockTx);
       expect(mockRepository.refreshCurrentPoints).toHaveBeenCalledWith(mockCtx, mockTx);
@@ -164,6 +165,7 @@ describe("TransactionService", () => {
         transferPoints,
         "test-user-id",
         comment,
+        undefined,
       );
       expect(mockRepository.create).toHaveBeenCalledWith(mockCtx, convertedData, mockTx);
       expect(mockRepository.refreshCurrentPoints).toHaveBeenCalledWith(mockCtx, mockTx);

--- a/src/application/domain/transaction/data/converter.ts
+++ b/src/application/domain/transaction/data/converter.ts
@@ -33,6 +33,7 @@ export default class TransactionConverter {
     transferPoints: number,
     createdBy: string,
     comment?: string,
+    uploadedImages?: Prisma.ImageCreateWithoutTransactionsInput[],
   ): Prisma.TransactionCreateInput {
     return {
       reason: TransactionReason.POINT_ISSUED,
@@ -41,6 +42,7 @@ export default class TransactionConverter {
       toPointChange: transferPoints,
       createdByUser: { connect: { id: createdBy } },
       comment,
+      ...(uploadedImages?.length ? { images: { create: uploadedImages } } : {}),
     };
   }
 
@@ -50,6 +52,7 @@ export default class TransactionConverter {
     toWalletId: string,
     createdBy: string,
     comment?: string,
+    uploadedImages?: Prisma.ImageCreateWithoutTransactionsInput[],
   ): Prisma.TransactionCreateInput {
     return {
       reason: TransactionReason.GRANT,
@@ -59,6 +62,7 @@ export default class TransactionConverter {
       toPointChange: transferPoints,
       createdByUser: { connect: { id: createdBy } },
       comment,
+      ...(uploadedImages?.length ? { images: { create: uploadedImages } } : {}),
     };
   }
 
@@ -86,6 +90,7 @@ export default class TransactionConverter {
     transferPoints: number,
     createdBy: string,
     comment?: string,
+    uploadedImages?: Prisma.ImageCreateWithoutTransactionsInput[],
   ): Prisma.TransactionCreateInput {
     return {
       reason: TransactionReason.DONATION,
@@ -95,6 +100,7 @@ export default class TransactionConverter {
       toPointChange: transferPoints,
       createdByUser: { connect: { id: createdBy } },
       comment,
+      ...(uploadedImages?.length ? { images: { create: uploadedImages } } : {}),
     };
   }
 

--- a/src/application/domain/transaction/data/interface.ts
+++ b/src/application/domain/transaction/data/interface.ts
@@ -19,6 +19,7 @@ export interface ITransactionService {
     toWalletId: string,
     tx: Prisma.TransactionClient,
     comment?: string,
+    uploadedImages?: Prisma.ImageCreateWithoutTransactionsInput[],
   ): Promise<PrismaTransactionDetail>;
 
   grantCommunityPoint(
@@ -28,6 +29,7 @@ export interface ITransactionService {
     memberWalletId: string,
     tx: Prisma.TransactionClient,
     comment?: string,
+    uploadedImages?: Prisma.ImageCreateWithoutTransactionsInput[],
   ): Promise<PrismaTransactionDetail>;
 
   grantSignupBonus(
@@ -47,6 +49,7 @@ export interface ITransactionService {
     transferPoints: number,
     tx: Prisma.TransactionClient,
     comment?: string,
+    uploadedImages?: Prisma.ImageCreateWithoutTransactionsInput[],
   ): Promise<PrismaTransactionDetail>;
 
   reservationCreated(

--- a/src/application/domain/transaction/schema/mutation.graphql
+++ b/src/application/domain/transaction/schema/mutation.graphql
@@ -35,12 +35,14 @@ extend type Mutation {
 input TransactionIssueCommunityPointInput {
   transferPoints: Int!
   comment: String
+  images: [ImageInput!]
 }
 
 input TransactionGrantCommunityPointInput {
   toUserId: ID!
   transferPoints: Int!
   comment: String
+  images: [ImageInput!]
 }
 
 input TransactionDonateSelfPointInput {
@@ -48,6 +50,7 @@ input TransactionDonateSelfPointInput {
   toUserId: ID!
   transferPoints: Int!
   comment: String
+  images: [ImageInput!]
 }
 
 input TransactionUpdateMetadataInput {

--- a/src/application/domain/transaction/service.ts
+++ b/src/application/domain/transaction/service.ts
@@ -38,9 +38,10 @@ export default class TransactionService implements ITransactionService {
     toWalletId: string,
     tx: Prisma.TransactionClient,
     comment?: string,
+    uploadedImages?: Prisma.ImageCreateWithoutTransactionsInput[],
   ): Promise<PrismaTransactionDetail> {
     const currentUserId = getCurrentUserId(ctx);
-    const data = this.converter.issueCommunityPoint(toWalletId, transferPoints, currentUserId, comment);
+    const data = this.converter.issueCommunityPoint(toWalletId, transferPoints, currentUserId, comment, uploadedImages);
     const res = await this.repository.create(ctx, data, tx);
     return res;
   }
@@ -52,9 +53,10 @@ export default class TransactionService implements ITransactionService {
     memberWalletId: string,
     tx: Prisma.TransactionClient,
     comment?: string,
+    uploadedImages?: Prisma.ImageCreateWithoutTransactionsInput[],
   ): Promise<PrismaTransactionDetail> {
     const currentUserId = getCurrentUserId(ctx);
-    const data = this.converter.grantCommunityPoint(fromWalletId, transferPoints, memberWalletId, currentUserId, comment);
+    const data = this.converter.grantCommunityPoint(fromWalletId, transferPoints, memberWalletId, currentUserId, comment, uploadedImages);
     const res = await this.repository.create(ctx, data, tx);
     return res;
   }
@@ -80,9 +82,10 @@ export default class TransactionService implements ITransactionService {
     transferPoints: number,
     tx: Prisma.TransactionClient,
     comment?: string,
+    uploadedImages?: Prisma.ImageCreateWithoutTransactionsInput[],
   ): Promise<PrismaTransactionDetail> {
     const currentUserId = getCurrentUserId(ctx);
-    const data = this.converter.donateSelfPoint(fromWalletId, toWalletId, transferPoints, currentUserId, comment);
+    const data = this.converter.donateSelfPoint(fromWalletId, toWalletId, transferPoints, currentUserId, comment, uploadedImages);
     const transaction = await this.repository.create(ctx, data, tx);
     return transaction;
   }

--- a/src/application/domain/transaction/usecase.ts
+++ b/src/application/domain/transaction/usecase.ts
@@ -11,6 +11,7 @@ import { AuthorizationError, NotFoundError } from "@/errors/graphql";
 import ImageService from "@/application/domain/content/image/service";
 import logger from "@/infrastructure/logging";
 import {
+  GqlImageInput,
   GqlMutationTransactionDonateSelfPointArgs,
   GqlMutationTransactionGrantCommunityPointArgs,
   GqlMutationTransactionIssueCommunityPointArgs,
@@ -36,6 +37,18 @@ export default class TransactionUseCase {
     @inject("NotificationService") private readonly notificationService: NotificationService,
     @inject("ImageService") private readonly imageService: ImageService,
   ) { }
+
+  // GCSアップロードはDBトランザクション外で実行（長時間ロック防止）
+  // undefined = 変更なし（updateMetadata用）、null/[] = 画像なし
+  private async uploadTransactionImages(
+    images: GqlImageInput[] | null | undefined,
+  ): Promise<Prisma.ImageCreateWithoutTransactionsInput[] | undefined> {
+    if (images === undefined) return undefined;
+    const results = await Promise.all(
+      (images ?? []).map((img) => this.imageService.uploadPublicImage(img, "transactions")),
+    );
+    return results.filter((img): img is Prisma.ImageCreateWithoutTransactionsInput => img !== null);
+  }
 
   async visitorBrowseTransactions(
     { filter, sort, cursor, first }: GqlQueryTransactionsArgs,
@@ -74,13 +87,7 @@ export default class TransactionUseCase {
       ctx,
       permission.communityId,
     );
-
-    // GCSアップロードはDBトランザクション外で実行（長時間ロック防止）
-    const uploadedImages = input.images?.length
-      ? (await Promise.all(
-          input.images.map((img) => this.imageService.uploadPublicImage(img, "transactions")),
-        )).filter((img): img is Prisma.ImageCreateWithoutTransactionsInput => img !== null)
-      : undefined;
+    const uploadedImages = await this.uploadTransactionImages(input.images);
 
     const res = await ctx.issuer.onlyBelongingCommunity(
       ctx,
@@ -111,13 +118,7 @@ export default class TransactionUseCase {
       ctx,
       permission.communityId,
     );
-
-    // GCSアップロードはDBトランザクション外で実行（長時間ロック防止）
-    const uploadedImages = input.images?.length
-      ? (await Promise.all(
-          input.images.map((img) => this.imageService.uploadPublicImage(img, "transactions")),
-        )).filter((img): img is Prisma.ImageCreateWithoutTransactionsInput => img !== null)
-      : undefined;
+    const uploadedImages = await this.uploadTransactionImages(input.images);
 
     const transaction = await ctx.issuer.onlyBelongingCommunity(ctx, async (tx: Prisma.TransactionClient) => {
       await this.membershipService.joinIfNeeded(
@@ -142,7 +143,7 @@ export default class TransactionUseCase {
         communityWallet.id,
         toWalletId,
         tx,
-        comment,
+        comment ?? undefined,
         uploadedImages,
       );
     });
@@ -155,11 +156,11 @@ export default class TransactionUseCase {
     });
 
     const communityName = community?.name ?? "コミュニティ";
-    
+
     await ctx.issuer.internal(async (tx) => {
       await this.transactionService.refreshCurrentPoint(ctx, tx);
     });
-    
+
     this.notificationService
       .pushPointGrantReceivedMessage(
         ctx,
@@ -190,13 +191,7 @@ export default class TransactionUseCase {
       currentUserId,
       communityId,
     );
-
-    // GCSアップロードはDBトランザクション外で実行（長時間ロック防止）
-    const uploadedImages = input.images?.length
-      ? (await Promise.all(
-          input.images.map((img) => this.imageService.uploadPublicImage(img, "transactions")),
-        )).filter((img): img is Prisma.ImageCreateWithoutTransactionsInput => img !== null)
-      : undefined;
+    const uploadedImages = await this.uploadTransactionImages(input.images);
 
     const transaction = await ctx.issuer.onlyBelongingCommunity(ctx, async (tx: Prisma.TransactionClient) => {
       const toWallet = await this.walletService.findMemberWalletOrThrow(
@@ -218,7 +213,7 @@ export default class TransactionUseCase {
         toWalletId,
         transferPoints,
         tx,
-        comment,
+        comment ?? undefined,
         uploadedImages,
       );
     });
@@ -282,13 +277,8 @@ export default class TransactionUseCase {
       throw new AuthorizationError("Insufficient permissions to update transaction metadata");
     }
 
-    // GCSアップロードはDBトランザクション外で実行（長時間ロック防止）
     // undefined = 変更なし、null/[] = 画像をクリア（GraphQL慣習）
-    const uploadedImages = input.images !== undefined
-      ? (await Promise.all(
-          (input.images ?? []).map((img) => this.imageService.uploadPublicImage(img, "transactions")),
-        )).filter((img): img is Prisma.ImageCreateWithoutTransactionsInput => img !== null)
-      : undefined;
+    const uploadedImages = await this.uploadTransactionImages(input.images);
 
     const transaction = await ctx.issuer.onlyBelongingCommunity(
       ctx,

--- a/src/application/domain/transaction/usecase.ts
+++ b/src/application/domain/transaction/usecase.ts
@@ -74,6 +74,14 @@ export default class TransactionUseCase {
       ctx,
       permission.communityId,
     );
+
+    // GCSアップロードはDBトランザクション外で実行（長時間ロック防止）
+    const uploadedImages = input.images?.length
+      ? (await Promise.all(
+          input.images.map((img) => this.imageService.uploadPublicImage(img, "transactions")),
+        )).filter((img): img is Prisma.ImageCreateWithoutTransactionsInput => img !== null)
+      : undefined;
+
     const res = await ctx.issuer.onlyBelongingCommunity(
       ctx,
       async (tx: Prisma.TransactionClient) => {
@@ -82,7 +90,8 @@ export default class TransactionUseCase {
           input.transferPoints,
           communityWallet.id,
           tx,
-          input.comment,
+          input.comment ?? undefined,
+          uploadedImages,
         );
       },
     );
@@ -102,6 +111,13 @@ export default class TransactionUseCase {
       ctx,
       permission.communityId,
     );
+
+    // GCSアップロードはDBトランザクション外で実行（長時間ロック防止）
+    const uploadedImages = input.images?.length
+      ? (await Promise.all(
+          input.images.map((img) => this.imageService.uploadPublicImage(img, "transactions")),
+        )).filter((img): img is Prisma.ImageCreateWithoutTransactionsInput => img !== null)
+      : undefined;
 
     const transaction = await ctx.issuer.onlyBelongingCommunity(ctx, async (tx: Prisma.TransactionClient) => {
       await this.membershipService.joinIfNeeded(
@@ -127,6 +143,7 @@ export default class TransactionUseCase {
         toWalletId,
         tx,
         comment,
+        uploadedImages,
       );
     });
 
@@ -174,6 +191,13 @@ export default class TransactionUseCase {
       communityId,
     );
 
+    // GCSアップロードはDBトランザクション外で実行（長時間ロック防止）
+    const uploadedImages = input.images?.length
+      ? (await Promise.all(
+          input.images.map((img) => this.imageService.uploadPublicImage(img, "transactions")),
+        )).filter((img): img is Prisma.ImageCreateWithoutTransactionsInput => img !== null)
+      : undefined;
+
     const transaction = await ctx.issuer.onlyBelongingCommunity(ctx, async (tx: Prisma.TransactionClient) => {
       const toWallet = await this.walletService.findMemberWalletOrThrow(
         ctx,
@@ -195,6 +219,7 @@ export default class TransactionUseCase {
         transferPoints,
         tx,
         comment,
+        uploadedImages,
       );
     });
 

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -2777,6 +2777,7 @@ export type GqlTransaction = {
 export type GqlTransactionDonateSelfPointInput = {
   comment?: InputMaybe<Scalars['String']['input']>;
   communityId: Scalars['ID']['input'];
+  images?: InputMaybe<Array<GqlImageInput>>;
   toUserId: Scalars['ID']['input'];
   transferPoints: Scalars['Int']['input'];
 };
@@ -2814,6 +2815,7 @@ export type GqlTransactionFilterInput = {
 
 export type GqlTransactionGrantCommunityPointInput = {
   comment?: InputMaybe<Scalars['String']['input']>;
+  images?: InputMaybe<Array<GqlImageInput>>;
   toUserId: Scalars['ID']['input'];
   transferPoints: Scalars['Int']['input'];
 };
@@ -2827,6 +2829,7 @@ export type GqlTransactionGrantCommunityPointSuccess = {
 
 export type GqlTransactionIssueCommunityPointInput = {
   comment?: InputMaybe<Scalars['String']['input']>;
+  images?: InputMaybe<Array<GqlImageInput>>;
   transferPoints: Scalars['Int']['input'];
 };
 


### PR DESCRIPTION
## Summary
This PR adds support for attaching images to transactions across all transaction mutation types (issue, grant, and donate community points). Images are uploaded to Google Cloud Storage outside of the database transaction to prevent long-running locks.

## Key Changes
- **Image Upload Processing**: Added image upload logic in `TransactionUseCase` for all three transaction mutation methods (`issueCommunityPoint`, `grantCommunityPoint`, `donateSelfPoint`). Images are uploaded to GCS before the database transaction begins to avoid blocking locks.
- **Service Layer Updates**: Extended `TransactionService` methods to accept optional `uploadedImages` parameter and pass it through to the converter.
- **Data Converter Updates**: Modified `TransactionConverter` methods to include uploaded images in the Prisma transaction creation input using conditional spread syntax.
- **GraphQL Schema Updates**: Added `images: [ImageInput!]` field to all three transaction input types:
  - `TransactionIssueCommunityPointInput`
  - `TransactionGrantCommunityPointInput`
  - `TransactionDonateSelfPointInput`
- **TypeScript Types**: Updated generated GraphQL types to include the new `images` field in all transaction input types.
- **Interface Updates**: Extended `ITransactionService` interface to include `uploadedImages` parameter in all transaction creation methods.

## Implementation Details
- Images are uploaded in parallel using `Promise.all()` before entering the database transaction
- Null values are filtered out from the upload results to handle potential upload failures gracefully
- The `uploadedImages` parameter is optional and only included in the Prisma create input if images are present
- Comment parameter handling was standardized to use `?? undefined` for consistency

https://claude.ai/code/session_01Amp8xauExVEe1jcu4APrWd
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
