### PR TITLE
Add file upload support for community portal OG image

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -339,7 +339,8 @@ input CommunityPortalConfigInput {
   enableFeatures: [String!]
   faviconPrefix: String
   logoPath: String
-  ogImagePath: String
+  ogImage: ImageInput
+  ogImagePath: String @deprecated(reason: "Use ogImage instead")
   regionKey: String
   regionName: String
   rootPath: String

--- a/src/application/domain/account/community/config/portal/service.ts
+++ b/src/application/domain/account/community/config/portal/service.ts
@@ -5,6 +5,7 @@ import { Prisma } from "@prisma/client";
 import { GqlCommunityPortalConfigInput } from "@/types/graphql";
 import ICommunityPortalConfigRepository from "@/application/domain/account/community/config/portal/data/interface";
 import ICommunityConfigRepository from "@/application/domain/account/community/config/data/interface";
+import ImageService from "@/application/domain/content/image/service";
 
 export interface CommunityPortalConfigResult {
   communityId: string;
@@ -67,6 +68,8 @@ export default class CommunityPortalConfigService {
     private readonly portalRepository: ICommunityPortalConfigRepository,
     @inject("CommunityConfigRepository")
     private readonly configRepository: ICommunityConfigRepository,
+    @inject("ImageService")
+    private readonly imageService: ImageService,
   ) {}
 
   async update(
@@ -75,6 +78,15 @@ export default class CommunityPortalConfigService {
     input: GqlCommunityPortalConfigInput,
     tx: Prisma.TransactionClient,
   ): Promise<void> {
+    // ogImage (file upload) takes priority over ogImagePath (legacy string)
+    let resolvedOgImagePath: string | undefined;
+    if (input.ogImage != null) {
+      const result = await this.imageService.uploadPublicImage(input.ogImage, "community-portal");
+      if (result) resolvedOgImagePath = result.url;
+    } else if (input.ogImagePath != null) {
+      resolvedOgImagePath = input.ogImagePath;
+    }
+
     // Plain values only — avoids type incompatibility between UpdateInput and CreateInput
     const plainValues: Partial<Prisma.CommunityPortalConfigCreateWithoutConfigInput> = {
       ...(input.tokenName       != null && { tokenName: input.tokenName }),
@@ -85,7 +97,7 @@ export default class CommunityPortalConfigService {
       ...(input.faviconPrefix   != null && { faviconPrefix: input.faviconPrefix }),
       ...(input.logoPath        != null && { logoPath: input.logoPath }),
       ...(input.squareLogoPath  != null && { squareLogoPath: input.squareLogoPath }),
-      ...(input.ogImagePath     != null && { ogImagePath: input.ogImagePath }),
+      ...(resolvedOgImagePath   != null && { ogImagePath: resolvedOgImagePath }),
       ...(input.enableFeatures  != null && { enableFeatures: input.enableFeatures }),
       ...(input.rootPath        != null && { rootPath: input.rootPath }),
       ...(input.adminRootPath   != null && { adminRootPath: input.adminRootPath }),

--- a/src/application/domain/account/community/config/schema/mutation.graphql
+++ b/src/application/domain/account/community/config/schema/mutation.graphql
@@ -27,7 +27,8 @@ input CommunityPortalConfigInput {
     faviconPrefix: String
     logoPath: String
     squareLogoPath: String
-    ogImagePath: String
+    ogImagePath: String @deprecated(reason: "Use ogImage instead")
+    ogImage: ImageInput
     enableFeatures: [String!]
     rootPath: String
     adminRootPath: String

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -383,6 +383,8 @@ export type GqlCommunityPortalConfigInput = {
   enableFeatures?: InputMaybe<Array<Scalars['String']['input']>>;
   faviconPrefix?: InputMaybe<Scalars['String']['input']>;
   logoPath?: InputMaybe<Scalars['String']['input']>;
+  ogImage?: InputMaybe<GqlImageInput>;
+  /** @deprecated Use ogImage instead */
   ogImagePath?: InputMaybe<Scalars['String']['input']>;
   regionKey?: InputMaybe<Scalars['String']['input']>;
   regionName?: InputMaybe<Scalars['String']['input']>;


### PR DESCRIPTION
## Summary
This PR adds support for uploading OG images as files for community portal configuration, while maintaining backward compatibility with the existing string-based `ogImagePath` field.

## Key Changes
- **Service Layer**: Updated `CommunityPortalConfigService` to inject `ImageService` and handle OG image uploads
  - Implements priority logic: file upload (`ogImage`) takes precedence over legacy string path (`ogImagePath`)
  - Calls `imageService.uploadPublicImage()` to process uploaded images and retrieve the resulting URL
  
- **GraphQL Schema**: Extended `CommunityPortalConfigInput` with new `ogImage` field of type `ImageInput`
  - Deprecated `ogImagePath` field with migration guidance to use `ogImage` instead
  - Updated both the main schema and mutation schema definitions

- **TypeScript Types**: Regenerated GraphQL types to include the new `ogImage` field with deprecation notice on `ogImagePath`

## Implementation Details
- The upload logic gracefully handles both new and legacy inputs, allowing for a smooth migration path
- If `ogImage` is provided, it's uploaded and the resulting URL is used; otherwise, the legacy `ogImagePath` string is used directly
- The resolved image path is then stored in the database as before, maintaining data consistency

https://claude.ai/code/session_012Xwn4p6KAjwaSsqFsHZydj
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/806" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
