### PR TITLE
feat(vote): add community voting domain

### DIFF
--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -277,6 +277,20 @@ FAILED FAILED
 RIGHT RIGHT
         }
     
+
+
+        vote_gate_type {
+            NFT NFT
+MEMBERSHIP MEMBERSHIP
+        }
+    
+
+
+        vote_power_policy_type {
+            FLAT FLAT
+NFT_COUNT NFT_COUNT
+        }
+    
   "t_images" {
     String id "🗝️"
     Boolean is_public 
@@ -814,6 +828,57 @@ RIGHT RIGHT
     }
   
 
+  "t_vote_gates" {
+    String id "🗝️"
+    VoteGateType type 
+    String nft_token_id "❓"
+    Role required_role "❓"
+    String topic_id 
+    }
+  
+
+  "t_vote_power_policies" {
+    String id "🗝️"
+    VotePowerPolicyType type 
+    String nft_token_id "❓"
+    String topic_id 
+    }
+  
+
+  "t_vote_topics" {
+    String id "🗝️"
+    String community_id 
+    String created_by 
+    String title 
+    String description "❓"
+    DateTime starts_at 
+    DateTime ends_at 
+    DateTime created_at 
+    DateTime updated_at "❓"
+    }
+  
+
+  "t_vote_options" {
+    String id "🗝️"
+    String topic_id 
+    String label 
+    Int order_index 
+    Int vote_count 
+    Int total_power 
+    }
+  
+
+  "t_vote_ballots" {
+    String id "🗝️"
+    String user_id 
+    String topic_id 
+    String option_id 
+    Int power 
+    DateTime created_at 
+    DateTime updated_at "❓"
+    }
+  
+
   "v_place_public_opportunity_count" {
     String placeId "🗝️"
     Int currentPublicCount 
@@ -913,6 +978,7 @@ RIGHT RIGHT
     "t_communities" o{--}o "t_participations" : "participations"
     "t_communities" o{--}o "t_articles" : "articles"
     "t_communities" o{--}o "t_nft_instances" : "nftInstance"
+    "t_communities" o{--}o "t_vote_topics" : "voteTopics"
     "t_community_configs" o|--|| "t_communities" : "community"
     "t_community_configs" o{--}o "t_community_firebase_configs" : "firebaseConfig"
     "t_community_configs" o{--}o "t_community_line_configs" : "lineConfig"
@@ -949,6 +1015,8 @@ RIGHT RIGHT
     "t_users" o{--}o "t_transactions" : "transactionsCreatedByMe"
     "t_users" o{--}o "t_articles" : "articlesWrittenByMe"
     "t_users" o{--}o "t_articles" : "articlesAboutMe"
+    "t_users" o{--}o "t_vote_ballots" : "voteBallots"
+    "t_users" o{--}o "t_vote_topics" : "createdVoteTopics"
     "t_identities" o|--|| "IdentityPlatform" : "enum:platform"
     "t_identities" o|--|| "t_users" : "user"
     "t_identities" o|--|o "t_communities" : "community"
@@ -1080,6 +1148,8 @@ RIGHT RIGHT
     "t_nft_wallets" o|--|| "t_users" : "user"
     "t_nft_wallets" o{--}o "t_nft_instances" : "nftInstances"
     "t_nft_tokens" o{--}o "t_nft_instances" : "nftInstances"
+    "t_nft_tokens" o{--}o "t_vote_gates" : "voteGates"
+    "t_nft_tokens" o{--}o "t_vote_power_policies" : "votePowerPolicies"
     "t_nft_instances" o|--|| "NftInstanceStatus" : "enum:status"
     "t_nft_instances" o|--|| "t_nft_tokens" : "nftToken"
     "t_nft_instances" o|--|o "t_nft_wallets" : "nftWallet"
@@ -1091,6 +1161,24 @@ RIGHT RIGHT
     "t_merkle_proofs" o|--|| "t_transactions" : "tx"
     "t_merkle_proofs" o|--|| "t_merkle_commits" : "commit"
     "t_merkle_proofs" o|--|| "Position" : "enum:position"
+    "t_vote_gates" o|--|| "VoteGateType" : "enum:type"
+    "t_vote_gates" o|--|o "t_nft_tokens" : "nftToken"
+    "t_vote_gates" o|--|o "Role" : "enum:required_role"
+    "t_vote_gates" o|--|| "t_vote_topics" : "topic"
+    "t_vote_power_policies" o|--|| "VotePowerPolicyType" : "enum:type"
+    "t_vote_power_policies" o|--|o "t_nft_tokens" : "nftToken"
+    "t_vote_power_policies" o|--|| "t_vote_topics" : "topic"
+    "t_vote_topics" o|--|| "t_communities" : "community"
+    "t_vote_topics" o|--|| "t_users" : "createdByUser"
+    "t_vote_topics" o{--}o "t_vote_gates" : "gate"
+    "t_vote_topics" o{--}o "t_vote_power_policies" : "powerPolicy"
+    "t_vote_topics" o{--}o "t_vote_options" : "options"
+    "t_vote_topics" o{--}o "t_vote_ballots" : "ballots"
+    "t_vote_options" o|--|| "t_vote_topics" : "topic"
+    "t_vote_options" o{--}o "t_vote_ballots" : "ballots"
+    "t_vote_ballots" o|--|| "t_users" : "user"
+    "t_vote_ballots" o|--|| "t_vote_topics" : "topic"
+    "t_vote_ballots" o|--|| "t_vote_options" : "option"
     "v_place_public_opportunity_count" o|--|| "t_places" : "place"
     "v_place_accumulated_participants" o|--|| "t_places" : "place"
     "v_membership_participation_geo" o|--|| "ParticipationType" : "enum:type"

--- a/docs/schema.dbml
+++ b/docs/schema.dbml
@@ -93,6 +93,7 @@ Table t_communities {
   participations t_participations [not null]
   articles t_articles [not null]
   nftInstance t_nft_instances [not null]
+  voteTopics t_vote_topics [not null]
   createdAt DateTime [default: `now()`, not null]
   updatedAt DateTime
 }
@@ -219,6 +220,8 @@ Table t_users {
   transactionsCreatedByMe t_transactions [not null]
   articlesWrittenByMe t_articles [not null]
   articlesAboutMe t_articles [not null]
+  voteBallots t_vote_ballots [not null]
+  createdVoteTopics t_vote_topics [not null]
   createdAt DateTime [default: `now()`, not null]
   updatedAt DateTime
 }
@@ -626,6 +629,8 @@ Table t_nft_tokens {
   symbol String
   json Json
   nftInstances t_nft_instances [not null]
+  voteGates t_vote_gates [not null]
+  votePowerPolicies t_vote_power_policies [not null]
   createdAt DateTime [default: `now()`, not null]
   updatedAt DateTime
 }
@@ -686,6 +691,75 @@ Table t_merkle_proofs {
   index Int [not null]
   sibling String [not null]
   position Position [not null]
+}
+
+Table t_vote_gates {
+  id String [pk]
+  type VoteGateType [not null]
+  nftTokenId String
+  nftToken t_nft_tokens
+  requiredRole Role
+  topicId String [unique, not null]
+  topic t_vote_topics [not null]
+}
+
+Table t_vote_power_policies {
+  id String [pk]
+  type VotePowerPolicyType [not null]
+  nftTokenId String
+  nftToken t_nft_tokens
+  topicId String [unique, not null]
+  topic t_vote_topics [not null]
+}
+
+Table t_vote_topics {
+  id String [pk]
+  communityId String [not null]
+  community t_communities [not null]
+  createdBy String [not null]
+  createdByUser t_users [not null]
+  title String [not null]
+  description String
+  startsAt DateTime [not null]
+  endsAt DateTime [not null]
+  gate t_vote_gates
+  powerPolicy t_vote_power_policies
+  options t_vote_options [not null]
+  ballots t_vote_ballots [not null]
+  createdAt DateTime [default: `now()`, not null]
+  updatedAt DateTime
+}
+
+Table t_vote_options {
+  id String [pk]
+  topicId String [not null]
+  topic t_vote_topics [not null]
+  label String [not null]
+  orderIndex Int [not null]
+  voteCount Int [not null, default: 0]
+  totalPower Int [not null, default: 0]
+  ballots t_vote_ballots [not null]
+
+  indexes {
+    (topicId, orderIndex) [unique]
+  }
+}
+
+Table t_vote_ballots {
+  id String [pk]
+  userId String [not null]
+  user t_users [not null]
+  topicId String [not null]
+  topic t_vote_topics [not null]
+  optionId String [not null]
+  option t_vote_options [not null]
+  power Int [not null]
+  createdAt DateTime [default: `now()`, not null]
+  updatedAt DateTime
+
+  indexes {
+    (userId, topicId) [unique]
+  }
 }
 
 Table v_place_public_opportunity_count {
@@ -1024,6 +1098,16 @@ Enum Position {
   RIGHT
 }
 
+Enum VoteGateType {
+  NFT
+  MEMBERSHIP
+}
+
+Enum VotePowerPolicyType {
+  FLAT
+  NFT_COUNT
+}
+
 Ref: m_cities.(stateCode, countryCode) > m_states.(code, countryCode) [delete: Restrict]
 
 Ref: t_places.imageId > t_images.id
@@ -1163,6 +1247,26 @@ Ref: t_nft_mints.nftInstanceId > t_nft_instances.id [delete: Restrict]
 Ref: t_merkle_proofs.txId > t_transactions.id [delete: Cascade]
 
 Ref: t_merkle_proofs.commitId > t_merkle_commits.id [delete: Cascade]
+
+Ref: t_vote_gates.nftTokenId > t_nft_tokens.id [delete: Restrict]
+
+Ref: t_vote_gates.topicId - t_vote_topics.id [delete: Cascade]
+
+Ref: t_vote_power_policies.nftTokenId > t_nft_tokens.id [delete: Restrict]
+
+Ref: t_vote_power_policies.topicId - t_vote_topics.id [delete: Cascade]
+
+Ref: t_vote_topics.communityId > t_communities.id [delete: Cascade]
+
+Ref: t_vote_topics.createdBy > t_users.id [delete: Restrict]
+
+Ref: t_vote_options.topicId > t_vote_topics.id [delete: Cascade]
+
+Ref: t_vote_ballots.userId > t_users.id [delete: Cascade]
+
+Ref: t_vote_ballots.topicId > t_vote_topics.id [delete: Cascade]
+
+Ref: t_vote_ballots.optionId > t_vote_options.id [delete: Cascade]
 
 Ref: v_place_public_opportunity_count.placeId - t_places.id [delete: Restrict]
 

--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -1544,7 +1544,7 @@ type Query {
   """
   verifyTransactions(txIds: [ID!]!): [TransactionVerificationResult!]
   voteTopic(id: ID!): VoteTopic
-  voteTopics(after: String, communityId: ID!, first: Int): VoteTopicsConnection!
+  voteTopics(communityId: ID!, cursor: String, first: Int): VoteTopicsConnection!
   wallet(id: ID!): Wallet
   wallets(cursor: String, filter: WalletFilterInput, first: Int, sort: WalletSortInput): WalletsConnection!
 }

--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -866,6 +866,16 @@ type Mutation {
   utilityDelete(id: ID!, permission: CheckCommunityPermissionInput!): UtilityDeletePayload
   utilitySetPublishStatus(id: ID!, input: UtilitySetPublishStatusInput!, permission: CheckCommunityPermissionInput!): UtilitySetPublishStatusPayload
   utilityUpdateInfo(id: ID!, input: UtilityUpdateInfoInput!, permission: CheckCommunityPermissionInput!): UtilityUpdateInfoPayload
+  voteCast(input: VoteCastInput!): VoteCastPayload!
+  voteTopicCreate(input: VoteTopicCreateInput!, permission: CheckCommunityPermissionInput!): VoteTopicCreatePayload!
+  voteTopicDelete(id: ID!, permission: CheckCommunityPermissionInput!): VoteTopicDeletePayload!
+}
+
+type MyVoteEligibility {
+  currentPower: Int
+  eligible: Boolean!
+  myBallot: VoteBallot
+  reason: String
 }
 
 input NestedPlaceConnectOrCreateInput {
@@ -1487,6 +1497,7 @@ type Query {
   incentiveGrants(cursor: String, filter: IncentiveGrantFilterInput, first: Int, sort: IncentiveGrantSortInput): IncentiveGrantsConnection!
   membership(communityId: ID!, userId: ID!): Membership
   memberships(cursor: MembershipCursorInput, filter: MembershipFilterInput, first: Int, sort: MembershipSortInput): MembershipsConnection!
+  myVoteEligibility(topicId: ID!): MyVoteEligibility!
   myWallet: Wallet
   nftInstance(id: ID!): NftInstance
   nftInstances(cursor: String, filter: NftInstanceFilterInput, first: Int, sort: NftInstanceSortInput): NftInstancesConnection!
@@ -1532,6 +1543,8 @@ type Query {
   - Returns data integrity verification results
   """
   verifyTransactions(txIds: [ID!]!): [TransactionVerificationResult!]
+  voteTopic(id: ID!): VoteTopic
+  voteTopics(after: String, communityId: ID!, first: Int): VoteTopicsConnection!
   wallet(id: ID!): Wallet
   wallets(cursor: String, filter: WalletFilterInput, first: Int, sort: WalletSortInput): WalletsConnection!
 }
@@ -2270,6 +2283,124 @@ enum VerificationStatus {
   NOT_VERIFIED
   PENDING
   VERIFIED
+}
+
+type VoteBallot {
+  createdAt: Datetime!
+  id: ID!
+  option: VoteOption!
+  power: Int!
+  updatedAt: Datetime
+}
+
+input VoteCastInput {
+  optionId: ID!
+  topicId: ID!
+}
+
+type VoteCastPayload {
+  ballot: VoteBallot!
+}
+
+type VoteGate {
+  id: ID!
+  nftToken: NftToken
+  requiredRole: Role
+  type: VoteGateType!
+}
+
+input VoteGateInput {
+  nftTokenId: ID
+  requiredRole: Role
+  type: VoteGateType!
+}
+
+enum VoteGateType {
+  MEMBERSHIP
+  NFT
+}
+
+type VoteOption {
+  id: ID!
+  label: String!
+  orderIndex: Int!
+  totalPower: Int
+  voteCount: Int
+}
+
+input VoteOptionInput {
+  label: String!
+  orderIndex: Int!
+}
+
+type VotePowerPolicy {
+  id: ID!
+  nftToken: NftToken
+  type: VotePowerPolicyType!
+}
+
+input VotePowerPolicyInput {
+  nftTokenId: ID
+  type: VotePowerPolicyType!
+}
+
+enum VotePowerPolicyType {
+  FLAT
+  NFT_COUNT
+}
+
+type VoteTopic {
+  community: Community!
+  createdAt: Datetime!
+  description: String
+  endsAt: Datetime!
+  gate: VoteGate!
+  id: ID!
+  myBallot: VoteBallot
+  myEligibility: MyVoteEligibility
+  options: [VoteOption!]!
+  phase: VoteTopicPhase!
+  powerPolicy: VotePowerPolicy!
+  startsAt: Datetime!
+  title: String!
+  updatedAt: Datetime
+}
+
+input VoteTopicCreateInput {
+  communityId: ID!
+  description: String
+  endsAt: Datetime!
+  gate: VoteGateInput!
+  options: [VoteOptionInput!]!
+  powerPolicy: VotePowerPolicyInput!
+  startsAt: Datetime!
+  title: String!
+}
+
+type VoteTopicCreatePayload {
+  voteTopic: VoteTopic!
+}
+
+type VoteTopicDeletePayload {
+  id: ID!
+}
+
+type VoteTopicEdge {
+  cursor: String!
+  node: VoteTopic!
+}
+
+enum VoteTopicPhase {
+  CLOSED
+  OPEN
+  UPCOMING
+}
+
+type VoteTopicsConnection {
+  edges: [VoteTopicEdge!]!
+  nodes: [VoteTopic!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
 }
 
 type Wallet {

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -32,6 +32,10 @@ module.exports = {
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
   },
-  testPathIgnorePatterns: ["<rootDir>/src/__tests__/helper/*.*", "<rootDir>/dist/"],
+  testPathIgnorePatterns: [
+    "<rootDir>/src/__tests__/helper/*.*",
+    "<rootDir>/src/__tests__/.*/helpers\\.ts",
+    "<rootDir>/dist/",
+  ],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
 };

--- a/src/__tests__/helper/test-data-source-helper.ts
+++ b/src/__tests__/helper/test-data-source-helper.ts
@@ -53,6 +53,9 @@ export default class TestDataSourceHelper {
     await this.db.communityLineConfig.deleteMany();
     await this.db.communityConfig.deleteMany();
 
+    await this.db.voteBallot.deleteMany();
+    await this.db.voteTopic.deleteMany();
+
     await this.db.community.deleteMany();
     await this.db.user.deleteMany();
     await this.db.place.deleteMany();

--- a/src/__tests__/helper/test-data-source-helper.ts
+++ b/src/__tests__/helper/test-data-source-helper.ts
@@ -55,6 +55,7 @@ export default class TestDataSourceHelper {
 
     await this.db.voteBallot.deleteMany();
     await this.db.voteTopic.deleteMany();
+    await this.db.nftToken.deleteMany();
 
     await this.db.community.deleteMany();
     await this.db.user.deleteMany();

--- a/src/__tests__/integration/vote/helpers.ts
+++ b/src/__tests__/integration/vote/helpers.ts
@@ -1,0 +1,104 @@
+import { NftInstanceStatus, NftWalletType } from "@prisma/client";
+import { prismaClient } from "@/infrastructure/prisma/client";
+
+let nftAddressCounter = 0;
+
+/**
+ * VoteTopic を gate/policy/options ごと DB に直接作成する。
+ * startsAt/endsAt を自由に制御したいケース（過去日や特定フェーズ）に使用。
+ * validateTopicInput を通さないため、業務バリデーション外の日付も設定可能。
+ */
+export async function createVoteTopic(params: {
+  communityId: string;
+  createdBy: string;
+  startsAt: Date;
+  endsAt: Date;
+  gate?: {
+    type?: "MEMBERSHIP" | "NFT";
+    requiredRole?: string | null;
+    nftTokenId?: string | null;
+  };
+  policy?: {
+    type?: "FLAT" | "NFT_COUNT";
+    nftTokenId?: string | null;
+  };
+}) {
+  const gate = params.gate ?? {};
+  const policy = params.policy ?? {};
+
+  const topic = await prismaClient.voteTopic.create({
+    data: {
+      communityId: params.communityId,
+      createdBy: params.createdBy,
+      title: "Integration Test Vote",
+      startsAt: params.startsAt,
+      endsAt: params.endsAt,
+    },
+  });
+
+  await prismaClient.voteGate.create({
+    data: {
+      type: gate.type ?? "MEMBERSHIP",
+      topicId: topic.id,
+      requiredRole: (gate.requiredRole as any) ?? null,
+      nftTokenId: gate.nftTokenId ?? null,
+    },
+  });
+
+  await prismaClient.votePowerPolicy.create({
+    data: {
+      type: policy.type ?? "FLAT",
+      topicId: topic.id,
+      nftTokenId: policy.nftTokenId ?? null,
+    },
+  });
+
+  const optionA = await prismaClient.voteOption.create({
+    data: { topicId: topic.id, label: "Option A", orderIndex: 0 },
+  });
+  const optionB = await prismaClient.voteOption.create({
+    data: { topicId: topic.id, label: "Option B", orderIndex: 1 },
+  });
+
+  return { topic, optionA, optionB };
+}
+
+/**
+ * NftToken + NftWallet（ユーザー所有） + NftInstance（OWNED）を作成する。
+ * NFT gate / NFT_COUNT policy のテストで使用。
+ */
+export async function createOwnedNft(userId: string) {
+  nftAddressCounter += 1;
+  const address = `test-nft-${Date.now()}-${nftAddressCounter}`;
+
+  const nftToken = await prismaClient.nftToken.create({
+    data: { address, type: "GOVERNANCE" },
+  });
+
+  const nftWallet = await prismaClient.nftWallet.create({
+    data: { userId, type: NftWalletType.INTERNAL, walletAddress: `wallet-${nftAddressCounter}` },
+  });
+
+  const nftInstance = await prismaClient.nftInstance.create({
+    data: {
+      instanceId: `instance-${nftAddressCounter}`,
+      nftTokenId: nftToken.id,
+      nftWalletId: nftWallet.id,
+      status: NftInstanceStatus.OWNED,
+    },
+  });
+
+  return { nftToken, nftWallet, nftInstance };
+}
+
+/**
+ * NftToken のみ作成する（NFT_COUNT policy で power=0 を再現するために使用）。
+ * ユーザーに NftInstance は与えない。
+ */
+export async function createNftToken() {
+  nftAddressCounter += 1;
+  const address = `test-nft-empty-${Date.now()}-${nftAddressCounter}`;
+  return prismaClient.nftToken.create({
+    data: { address, type: "GOVERNANCE" },
+  });
+}

--- a/src/__tests__/integration/vote/voteCast.test.ts
+++ b/src/__tests__/integration/vote/voteCast.test.ts
@@ -7,39 +7,17 @@ import { container } from "tsyringe";
 import { registerProductionDependencies } from "@/application/provider";
 import { PrismaClientIssuer, prismaClient } from "@/infrastructure/prisma/client";
 import { AuthorizationError, NotFoundError, ValidationError } from "@/errors/graphql";
+import { createVoteTopic, createOwnedNft, createNftToken } from "./helpers";
 
-async function createVoteTopic(params: {
-  communityId: string;
-  createdBy: string;
-  startsAt: Date;
-  endsAt: Date;
-  gateType?: "MEMBERSHIP" | "NFT";
-  policyType?: "FLAT" | "NFT_COUNT";
-}) {
-  const {
-    communityId,
-    createdBy,
-    startsAt,
-    endsAt,
-    gateType = "MEMBERSHIP",
-    policyType = "FLAT",
-  } = params;
+// ─── 共通セットアップ ─────────────────────────────────────────────────────────
 
-  const topic = await prismaClient.voteTopic.create({
-    data: { communityId, createdBy, title: "Integration Test Vote", startsAt, endsAt },
-  });
-
-  await prismaClient.voteGate.create({ data: { type: gateType, topicId: topic.id } });
-  await prismaClient.votePowerPolicy.create({ data: { type: policyType, topicId: topic.id } });
-
-  const optionA = await prismaClient.voteOption.create({
-    data: { topicId: topic.id, label: "Option A", orderIndex: 0 },
-  });
-  const optionB = await prismaClient.voteOption.create({
-    data: { topicId: topic.id, label: "Option B", orderIndex: 1 },
-  });
-
-  return { topic, optionA, optionB };
+/** アクティブな投票期間（1分前開始・1時間後終了）を返す */
+function activePeriod() {
+  const now = new Date();
+  return {
+    startsAt: new Date(now.getTime() - 60_000),
+    endsAt: new Date(now.getTime() + 3_600_000),
+  };
 }
 
 describe("Vote Integration: VoteCast", () => {
@@ -60,19 +38,16 @@ describe("Vote Integration: VoteCast", () => {
     await TestDataSourceHelper.disconnect();
   });
 
+  // ─── 初回投票 ─────────────────────────────────────────────────────────────
+
   describe("initial vote", () => {
-    it("should allow a community member to cast a vote", async () => {
+    it("should allow a community member to cast a vote (MEMBERSHIP/FLAT)", async () => {
       const member = await TestDataSourceHelper.createUser({
         name: "Voter",
         slug: "voter-slug",
         currentPrefecture: CurrentPrefecture.KAGAWA,
       });
-
-      const community = await TestDataSourceHelper.createCommunity({
-        name: "vote-community",
-        pointName: "pt",
-      });
-
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
       await TestDataSourceHelper.createMembership({
         user: { connect: { id: member.id } },
         community: { connect: { id: community.id } },
@@ -81,27 +56,134 @@ describe("Vote Integration: VoteCast", () => {
         role: Role.MEMBER,
       });
 
-      const now = new Date();
       const { topic, optionA } = await createVoteTopic({
         communityId: community.id,
         createdBy: member.id,
-        startsAt: new Date(now.getTime() - 60_000),
-        endsAt: new Date(now.getTime() + 3_600_000),
+        ...activePeriod(),
       });
 
       const ctx = { currentUser: { id: member.id }, issuer } as unknown as IContext;
-
       const result = await voteUseCase.userCastVote(ctx, {
         input: { topicId: topic.id, optionId: optionA.id },
       });
 
+      // 返り値の確認
       expect(result.ballot.power).toBe(1);
 
+      // DB の集計カラム確認
       const updated = await prismaClient.voteOption.findUniqueOrThrow({ where: { id: optionA.id } });
       expect(updated.voteCount).toBe(1);
       expect(updated.totalPower).toBe(1);
     });
   });
+
+  // ─── NFT ゲート ──────────────────────────────────────────────────────────
+
+  describe("gate enforcement (NFT)", () => {
+    it("should allow a vote when the user holds the required NFT", async () => {
+      const voter = await TestDataSourceHelper.createUser({
+        name: "NFT Holder",
+        slug: "nft-holder-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+
+      // NftToken + NftWallet + NftInstance(OWNED) を作成
+      const { nftToken } = await createOwnedNft(voter.id);
+
+      const { topic, optionA } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: voter.id,
+        ...activePeriod(),
+        gate: { type: "NFT", nftTokenId: nftToken.id },
+      });
+
+      const ctx = { currentUser: { id: voter.id }, issuer } as unknown as IContext;
+      const result = await voteUseCase.userCastVote(ctx, {
+        input: { topicId: topic.id, optionId: optionA.id },
+      });
+
+      expect(result.ballot.power).toBe(1);
+      const updated = await prismaClient.voteOption.findUniqueOrThrow({ where: { id: optionA.id } });
+      expect(updated.voteCount).toBe(1);
+    });
+
+    it("should reject a vote when the user does not hold the required NFT (REQUIRED_NFT_NOT_FOUND)", async () => {
+      const voter = await TestDataSourceHelper.createUser({
+        name: "No NFT",
+        slug: "no-nft-gate-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+
+      // NftToken は作成するがユーザーに NftInstance は付与しない
+      const nftToken = await createNftToken();
+
+      const { topic, optionA } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: voter.id,
+        ...activePeriod(),
+        gate: { type: "NFT", nftTokenId: nftToken.id },
+      });
+
+      const ctx = { currentUser: { id: voter.id }, issuer } as unknown as IContext;
+      await expect(
+        voteUseCase.userCastVote(ctx, { input: { topicId: topic.id, optionId: optionA.id } }),
+      ).rejects.toThrow(AuthorizationError);
+    });
+  });
+
+  // ─── NFT_COUNT policy: power > 1 ────────────────────────────────────────
+
+  describe("voting power (NFT_COUNT)", () => {
+    it("should record power=2 when the user holds 2 NFTs under NFT_COUNT policy", async () => {
+      const voter = await TestDataSourceHelper.createUser({
+        name: "Multi NFT Voter",
+        slug: "multi-nft-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+      await TestDataSourceHelper.createMembership({
+        user: { connect: { id: voter.id } },
+        community: { connect: { id: community.id } },
+        status: MembershipStatus.JOINED,
+        reason: MembershipStatusReason.INVITED,
+        role: Role.MEMBER,
+      });
+
+      // 同一 NftToken に対して 2 枚の NftInstance を付与
+      const { nftToken, nftWallet } = await createOwnedNft(voter.id);
+      await prismaClient.nftInstance.create({
+        data: {
+          instanceId: `instance-2nd-${Date.now()}`,
+          nftTokenId: nftToken.id,
+          nftWalletId: nftWallet.id,
+          status: "OWNED",
+        },
+      });
+
+      const { topic, optionA } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: voter.id,
+        ...activePeriod(),
+        gate: { type: "MEMBERSHIP" },
+        policy: { type: "NFT_COUNT", nftTokenId: nftToken.id },
+      });
+
+      const ctx = { currentUser: { id: voter.id }, issuer } as unknown as IContext;
+      const result = await voteUseCase.userCastVote(ctx, {
+        input: { topicId: topic.id, optionId: optionA.id },
+      });
+
+      // power=2 で投票が記録され、totalPower も 2 になること
+      expect(result.ballot.power).toBe(2);
+      const updated = await prismaClient.voteOption.findUniqueOrThrow({ where: { id: optionA.id } });
+      expect(updated.voteCount).toBe(1);
+      expect(updated.totalPower).toBe(2);
+    });
+  });
+
+  // ─── 再投票 ───────────────────────────────────────────────────────────────
 
   describe("revote", () => {
     it("should decrement old option and increment new option when changing option", async () => {
@@ -110,12 +192,7 @@ describe("Vote Integration: VoteCast", () => {
         slug: "revote-slug",
         currentPrefecture: CurrentPrefecture.KAGAWA,
       });
-
-      const community = await TestDataSourceHelper.createCommunity({
-        name: "revote-community",
-        pointName: "pt",
-      });
-
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
       await TestDataSourceHelper.createMembership({
         user: { connect: { id: member.id } },
         community: { connect: { id: community.id } },
@@ -124,12 +201,10 @@ describe("Vote Integration: VoteCast", () => {
         role: Role.MEMBER,
       });
 
-      const now = new Date();
       const { topic, optionA, optionB } = await createVoteTopic({
         communityId: community.id,
         createdBy: member.id,
-        startsAt: new Date(now.getTime() - 60_000),
-        endsAt: new Date(now.getTime() + 3_600_000),
+        ...activePeriod(),
       });
 
       const ctx = { currentUser: { id: member.id }, issuer } as unknown as IContext;
@@ -142,7 +217,6 @@ describe("Vote Integration: VoteCast", () => {
         prismaClient.voteOption.findUniqueOrThrow({ where: { id: optionB.id } }),
       ]);
 
-      // Option A の投票が取り消され Option B に移っていること
       expect(updatedA.voteCount).toBe(0);
       expect(updatedA.totalPower).toBe(0);
       expect(updatedB.voteCount).toBe(1);
@@ -150,19 +224,14 @@ describe("Vote Integration: VoteCast", () => {
     });
 
     it("should NOT change voteCount when re-voting for the same option (adjustOptionTotalPower path)", async () => {
-      // FLAT policy では power=1 が固定なので delta=0 となり DB 更新は何も起きない
-      // このテストは「同一選択肢への再投票でも voteCount が二重加算されない」ことを保証する
+      // FLAT policy では power=1 固定なので delta=0 → DB 更新なし
+      // このテストは voteCount が二重加算されないことを保証する
       const member = await TestDataSourceHelper.createUser({
         name: "Same Option Voter",
         slug: "same-option-slug",
         currentPrefecture: CurrentPrefecture.KAGAWA,
       });
-
-      const community = await TestDataSourceHelper.createCommunity({
-        name: "same-option-community",
-        pointName: "pt",
-      });
-
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
       await TestDataSourceHelper.createMembership({
         user: { connect: { id: member.id } },
         community: { connect: { id: community.id } },
@@ -171,75 +240,57 @@ describe("Vote Integration: VoteCast", () => {
         role: Role.MEMBER,
       });
 
-      const now = new Date();
       const { topic, optionA } = await createVoteTopic({
         communityId: community.id,
         createdBy: member.id,
-        startsAt: new Date(now.getTime() - 60_000),
-        endsAt: new Date(now.getTime() + 3_600_000),
+        ...activePeriod(),
       });
 
       const ctx = { currentUser: { id: member.id }, issuer } as unknown as IContext;
-
-      // 同じ選択肢に2回投票
       await voteUseCase.userCastVote(ctx, { input: { topicId: topic.id, optionId: optionA.id } });
       await voteUseCase.userCastVote(ctx, { input: { topicId: topic.id, optionId: optionA.id } });
 
       const updated = await prismaClient.voteOption.findUniqueOrThrow({ where: { id: optionA.id } });
-
-      // voteCount は 1 のまま（2 にならない）
-      expect(updated.voteCount).toBe(1);
+      expect(updated.voteCount).toBe(1); // 2 にならない
       expect(updated.totalPower).toBe(1);
     });
   });
 
-  describe("gate enforcement", () => {
-    it("should reject a user without community membership (MEMBERSHIP gate)", async () => {
+  // ─── ゲート強制 ───────────────────────────────────────────────────────────
+
+  describe("gate enforcement (MEMBERSHIP)", () => {
+    it("should reject a user with no membership", async () => {
       const nonMember = await TestDataSourceHelper.createUser({
         name: "NonMember",
         slug: "non-member-slug",
         currentPrefecture: CurrentPrefecture.KAGAWA,
       });
-
       const creator = await TestDataSourceHelper.createUser({
         name: "Creator",
         slug: "creator-slug",
         currentPrefecture: CurrentPrefecture.KAGAWA,
       });
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
 
-      const community = await TestDataSourceHelper.createCommunity({
-        name: "gate-community",
-        pointName: "pt",
-      });
-
-      const now = new Date();
       const { topic, optionA } = await createVoteTopic({
         communityId: community.id,
         createdBy: creator.id,
-        startsAt: new Date(now.getTime() - 60_000),
-        endsAt: new Date(now.getTime() + 3_600_000),
+        ...activePeriod(),
       });
 
       const ctx = { currentUser: { id: nonMember.id }, issuer } as unknown as IContext;
-
       await expect(
         voteUseCase.userCastVote(ctx, { input: { topicId: topic.id, optionId: optionA.id } }),
       ).rejects.toThrow(AuthorizationError);
     });
 
-    it("should reject a user whose membership status is not JOINED", async () => {
+    it("should reject a user whose membership status is PENDING", async () => {
       const pendingUser = await TestDataSourceHelper.createUser({
-        name: "Pending User",
+        name: "Pending",
         slug: "pending-slug",
         currentPrefecture: CurrentPrefecture.KAGAWA,
       });
-
-      const community = await TestDataSourceHelper.createCommunity({
-        name: "pending-community",
-        pointName: "pt",
-      });
-
-      // PENDING（未承認）状態のメンバーシップ
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
       await TestDataSourceHelper.createMembership({
         user: { connect: { id: pendingUser.id } },
         community: { connect: { id: community.id } },
@@ -248,35 +299,114 @@ describe("Vote Integration: VoteCast", () => {
         role: Role.MEMBER,
       });
 
-      const now = new Date();
       const { topic, optionA } = await createVoteTopic({
         communityId: community.id,
         createdBy: pendingUser.id,
-        startsAt: new Date(now.getTime() - 60_000),
-        endsAt: new Date(now.getTime() + 3_600_000),
+        ...activePeriod(),
       });
 
       const ctx = { currentUser: { id: pendingUser.id }, issuer } as unknown as IContext;
-
       await expect(
         voteUseCase.userCastVote(ctx, { input: { topicId: topic.id, optionId: optionA.id } }),
       ).rejects.toThrow(AuthorizationError);
     });
+
+    it("should reject a user whose membership status is LEFT", async () => {
+      const leftUser = await TestDataSourceHelper.createUser({
+        name: "Left User",
+        slug: "left-user-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+      await TestDataSourceHelper.createMembership({
+        user: { connect: { id: leftUser.id } },
+        community: { connect: { id: community.id } },
+        status: MembershipStatus.LEFT,
+        reason: MembershipStatusReason.INVITED,
+        role: Role.MEMBER,
+      });
+
+      const { topic, optionA } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: leftUser.id,
+        ...activePeriod(),
+      });
+
+      const ctx = { currentUser: { id: leftUser.id }, issuer } as unknown as IContext;
+      await expect(
+        voteUseCase.userCastVote(ctx, { input: { topicId: topic.id, optionId: optionA.id } }),
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it("should reject a MEMBER when requiredRole is MANAGER", async () => {
+      // requiredRole=MANAGER に対して MEMBER ロールでは INSUFFICIENT_ROLE
+      const member = await TestDataSourceHelper.createUser({
+        name: "Member",
+        slug: "member-role-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+      await TestDataSourceHelper.createMembership({
+        user: { connect: { id: member.id } },
+        community: { connect: { id: community.id } },
+        status: MembershipStatus.JOINED,
+        reason: MembershipStatusReason.INVITED,
+        role: Role.MEMBER,
+      });
+
+      const { topic, optionA } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: member.id,
+        ...activePeriod(),
+        gate: { type: "MEMBERSHIP", requiredRole: "MANAGER" },
+      });
+
+      const ctx = { currentUser: { id: member.id }, issuer } as unknown as IContext;
+      await expect(
+        voteUseCase.userCastVote(ctx, { input: { topicId: topic.id, optionId: optionA.id } }),
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it("should allow a MANAGER when requiredRole is MANAGER", async () => {
+      const manager = await TestDataSourceHelper.createUser({
+        name: "Manager",
+        slug: "manager-role-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+      await TestDataSourceHelper.createMembership({
+        user: { connect: { id: manager.id } },
+        community: { connect: { id: community.id } },
+        status: MembershipStatus.JOINED,
+        reason: MembershipStatusReason.INVITED,
+        role: Role.MANAGER,
+      });
+
+      const { topic, optionA } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: manager.id,
+        ...activePeriod(),
+        gate: { type: "MEMBERSHIP", requiredRole: "MANAGER" },
+      });
+
+      const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+      const result = await voteUseCase.userCastVote(ctx, {
+        input: { topicId: topic.id, optionId: optionA.id },
+      });
+      expect(result.ballot.power).toBe(1);
+    });
   });
+
+  // ─── 投票期間外 ────────────────────────────────────────────────────────────
 
   describe("voting period enforcement", () => {
     it("should reject votes before voting period starts", async () => {
       const member = await TestDataSourceHelper.createUser({
-        name: "EarlyVoter",
-        slug: "early-voter-slug",
+        name: "Early",
+        slug: "early-slug",
         currentPrefecture: CurrentPrefecture.KAGAWA,
       });
-
-      const community = await TestDataSourceHelper.createCommunity({
-        name: "early-vote-community",
-        pointName: "pt",
-      });
-
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
       await TestDataSourceHelper.createMembership({
         user: { connect: { id: member.id } },
         community: { connect: { id: community.id } },
@@ -289,12 +419,11 @@ describe("Vote Integration: VoteCast", () => {
       const { topic, optionA } = await createVoteTopic({
         communityId: community.id,
         createdBy: member.id,
-        startsAt: new Date(now.getTime() + 3_600_000),
+        startsAt: new Date(now.getTime() + 3_600_000), // 1時間後に開始
         endsAt: new Date(now.getTime() + 7_200_000),
       });
 
       const ctx = { currentUser: { id: member.id }, issuer } as unknown as IContext;
-
       await expect(
         voteUseCase.userCastVote(ctx, { input: { topicId: topic.id, optionId: optionA.id } }),
       ).rejects.toThrow(ValidationError);
@@ -302,16 +431,11 @@ describe("Vote Integration: VoteCast", () => {
 
     it("should reject votes after voting period ends", async () => {
       const member = await TestDataSourceHelper.createUser({
-        name: "LateVoter",
-        slug: "late-voter-slug",
+        name: "Late",
+        slug: "late-slug",
         currentPrefecture: CurrentPrefecture.KAGAWA,
       });
-
-      const community = await TestDataSourceHelper.createCommunity({
-        name: "late-vote-community",
-        pointName: "pt",
-      });
-
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
       await TestDataSourceHelper.createMembership({
         user: { connect: { id: member.id } },
         community: { connect: { id: community.id } },
@@ -325,30 +449,26 @@ describe("Vote Integration: VoteCast", () => {
         communityId: community.id,
         createdBy: member.id,
         startsAt: new Date(now.getTime() - 7_200_000),
-        endsAt: new Date(now.getTime() - 3_600_000),
+        endsAt: new Date(now.getTime() - 3_600_000), // 1時間前に終了
       });
 
       const ctx = { currentUser: { id: member.id }, issuer } as unknown as IContext;
-
       await expect(
         voteUseCase.userCastVote(ctx, { input: { topicId: topic.id, optionId: optionA.id } }),
       ).rejects.toThrow(ValidationError);
     });
   });
 
+  // ─── 選択肢バリデーション ──────────────────────────────────────────────────
+
   describe("option validation", () => {
     it("should reject a vote for an optionId that does not belong to the topic", async () => {
       const member = await TestDataSourceHelper.createUser({
-        name: "WrongOption Voter",
-        slug: "wrong-option-slug",
+        name: "Voter",
+        slug: "wrong-opt-slug",
         currentPrefecture: CurrentPrefecture.KAGAWA,
       });
-
-      const community = await TestDataSourceHelper.createCommunity({
-        name: "wrong-option-community",
-        pointName: "pt",
-      });
-
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
       await TestDataSourceHelper.createMembership({
         user: { connect: { id: member.id } },
         community: { connect: { id: community.id } },
@@ -357,16 +477,13 @@ describe("Vote Integration: VoteCast", () => {
         role: Role.MEMBER,
       });
 
-      const now = new Date();
       const { topic } = await createVoteTopic({
         communityId: community.id,
         createdBy: member.id,
-        startsAt: new Date(now.getTime() - 60_000),
-        endsAt: new Date(now.getTime() + 3_600_000),
+        ...activePeriod(),
       });
 
       const ctx = { currentUser: { id: member.id }, issuer } as unknown as IContext;
-
       await expect(
         voteUseCase.userCastVote(ctx, {
           input: { topicId: topic.id, optionId: "nonexistent-option-id" },
@@ -375,6 +492,45 @@ describe("Vote Integration: VoteCast", () => {
     });
   });
 
+  // ─── power=0 ──────────────────────────────────────────────────────────────
+
+  describe("voting power enforcement", () => {
+    it("should reject a vote when calculated power is 0 (NFT_COUNT policy, no NFTs owned)", async () => {
+      // MEMBERSHIP gate（資格あり） + NFT_COUNT policy（NFT 未保有 → power=0）
+      const member = await TestDataSourceHelper.createUser({
+        name: "No NFT Voter",
+        slug: "no-nft-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+      await TestDataSourceHelper.createMembership({
+        user: { connect: { id: member.id } },
+        community: { connect: { id: community.id } },
+        status: MembershipStatus.JOINED,
+        reason: MembershipStatusReason.INVITED,
+        role: Role.MEMBER,
+      });
+
+      // ユーザーには NftInstance を与えない
+      const nftToken = await createNftToken();
+
+      const { topic, optionA } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: member.id,
+        ...activePeriod(),
+        gate: { type: "MEMBERSHIP" },
+        policy: { type: "NFT_COUNT", nftTokenId: nftToken.id },
+      });
+
+      const ctx = { currentUser: { id: member.id }, issuer } as unknown as IContext;
+      await expect(
+        voteUseCase.userCastVote(ctx, { input: { topicId: topic.id, optionId: optionA.id } }),
+      ).rejects.toThrow(ValidationError);
+    });
+  });
+
+  // ─── 集計値マスキング ────────────────────────────────────────────────────
+
   describe("result masking", () => {
     it("should hide voteCount/totalPower from a regular member during active voting period", async () => {
       const manager = await TestDataSourceHelper.createUser({
@@ -382,18 +538,12 @@ describe("Vote Integration: VoteCast", () => {
         slug: "manager-masking-slug",
         currentPrefecture: CurrentPrefecture.KAGAWA,
       });
-
       const member = await TestDataSourceHelper.createUser({
         name: "Member",
         slug: "member-masking-slug",
         currentPrefecture: CurrentPrefecture.KAGAWA,
       });
-
-      const community = await TestDataSourceHelper.createCommunity({
-        name: "masking-community",
-        pointName: "pt",
-      });
-
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
       await Promise.all([
         TestDataSourceHelper.createMembership({
           user: { connect: { id: manager.id } },
@@ -411,18 +561,16 @@ describe("Vote Integration: VoteCast", () => {
         }),
       ]);
 
-      const now = new Date();
       const { topic, optionA } = await createVoteTopic({
         communityId: community.id,
         createdBy: manager.id,
-        startsAt: new Date(now.getTime() - 60_000),
-        endsAt: new Date(now.getTime() + 3_600_000),
+        ...activePeriod(),
       });
 
       const memberCtx = {
         currentUser: {
           id: member.id,
-          memberships: [{ communityId: community.id, role: Role.MEMBER, status: MembershipStatus.JOINED }],
+          memberships: [{ communityId: community.id, role: Role.MEMBER }],
         },
         issuer,
       } as unknown as IContext;
@@ -437,24 +585,17 @@ describe("Vote Integration: VoteCast", () => {
       });
 
       const optionNode = result.nodes[0].options.find((o) => o.orderIndex === 0);
-      // 投票期間中は一般メンバーには集計値が隠される
       expect(optionNode?.voteCount).toBeNull();
       expect(optionNode?.totalPower).toBeNull();
     });
 
     it("should show voteCount/totalPower to a manager during active voting period", async () => {
-      // マネージャーは投票期間中でも集計値を参照できる（isResultVisible = true）
       const manager = await TestDataSourceHelper.createUser({
         name: "Manager Visible",
         slug: "manager-visible-slug",
         currentPrefecture: CurrentPrefecture.KAGAWA,
       });
-
-      const community = await TestDataSourceHelper.createCommunity({
-        name: "manager-visible-community",
-        pointName: "pt",
-      });
-
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
       await TestDataSourceHelper.createMembership({
         user: { connect: { id: manager.id } },
         community: { connect: { id: community.id } },
@@ -463,18 +604,16 @@ describe("Vote Integration: VoteCast", () => {
         role: Role.MANAGER,
       });
 
-      const now = new Date();
       const { topic, optionA } = await createVoteTopic({
         communityId: community.id,
         createdBy: manager.id,
-        startsAt: new Date(now.getTime() - 60_000),
-        endsAt: new Date(now.getTime() + 3_600_000), // 投票期間中
+        ...activePeriod(),
       });
 
       const managerCtx = {
         currentUser: {
           id: manager.id,
-          memberships: [{ communityId: community.id, role: Role.MANAGER, status: MembershipStatus.JOINED }],
+          memberships: [{ communityId: community.id, role: Role.MANAGER }],
         },
         issuer,
       } as unknown as IContext;
@@ -489,23 +628,17 @@ describe("Vote Integration: VoteCast", () => {
       });
 
       const optionNode = result.nodes[0].options.find((o) => o.orderIndex === 0);
-      // マネージャーは投票期間中でも集計値が見える
       expect(optionNode?.voteCount).toBe(1);
       expect(optionNode?.totalPower).toBe(1);
     });
 
     it("should show voteCount/totalPower to any user after voting period ends", async () => {
       const user = await TestDataSourceHelper.createUser({
-        name: "Regular User",
-        slug: "regular-user-slug",
+        name: "Regular",
+        slug: "regular-ended-slug",
         currentPrefecture: CurrentPrefecture.KAGAWA,
       });
-
-      const community = await TestDataSourceHelper.createCommunity({
-        name: "ended-community",
-        pointName: "pt",
-      });
-
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
       await TestDataSourceHelper.createMembership({
         user: { connect: { id: user.id } },
         community: { connect: { id: community.id } },
@@ -522,27 +655,25 @@ describe("Vote Integration: VoteCast", () => {
         endsAt: new Date(now.getTime() - 3_600_000), // 終了済み
       });
 
-      // 集計カラムを直接設定（終了済みトピックには投票できないため）
       await prismaClient.voteOption.update({
         where: { id: optionA.id },
         data: { voteCount: 3, totalPower: 5 },
       });
 
-      const memberCtx = {
+      const ctx = {
         currentUser: {
           id: user.id,
-          memberships: [{ communityId: community.id, role: Role.MEMBER, status: MembershipStatus.JOINED }],
+          memberships: [{ communityId: community.id, role: Role.MEMBER }],
         },
         issuer,
       } as unknown as IContext;
 
-      const result = await voteUseCase.anyoneBrowseVoteTopics(memberCtx, {
+      const result = await voteUseCase.anyoneBrowseVoteTopics(ctx, {
         communityId: community.id,
         first: 10,
       });
 
       const optionNode = result.nodes[0].options.find((o) => o.orderIndex === 0);
-      // endsAt 後は一般ユーザーにも集計値が公開される
       expect(optionNode?.voteCount).toBe(3);
       expect(optionNode?.totalPower).toBe(5);
     });

--- a/src/__tests__/integration/vote/voteCast.test.ts
+++ b/src/__tests__/integration/vote/voteCast.test.ts
@@ -6,11 +6,8 @@ import VoteUseCase from "@/application/domain/vote/usecase";
 import { container } from "tsyringe";
 import { registerProductionDependencies } from "@/application/provider";
 import { PrismaClientIssuer, prismaClient } from "@/infrastructure/prisma/client";
-import { AuthorizationError, ValidationError } from "@/errors/graphql";
+import { AuthorizationError, NotFoundError, ValidationError } from "@/errors/graphql";
 
-// topicId の DB レコードを直接作成するユーティリティ
-// (vote topic は usecase 経由で作成するので不要だが、
-//  startsAt/endsAt を任意に制御したいケースでは直接 Prisma 操作を使う)
 async function createVoteTopic(params: {
   communityId: string;
   createdBy: string;
@@ -29,27 +26,15 @@ async function createVoteTopic(params: {
   } = params;
 
   const topic = await prismaClient.voteTopic.create({
-    data: {
-      communityId,
-      createdBy,
-      title: "Integration Test Vote",
-      startsAt,
-      endsAt,
-    },
+    data: { communityId, createdBy, title: "Integration Test Vote", startsAt, endsAt },
   });
 
-  await prismaClient.voteGate.create({
-    data: { type: gateType, topicId: topic.id },
-  });
-
-  await prismaClient.votePowerPolicy.create({
-    data: { type: policyType, topicId: topic.id },
-  });
+  await prismaClient.voteGate.create({ data: { type: gateType, topicId: topic.id } });
+  await prismaClient.votePowerPolicy.create({ data: { type: policyType, topicId: topic.id } });
 
   const optionA = await prismaClient.voteOption.create({
     data: { topicId: topic.id, label: "Option A", orderIndex: 0 },
   });
-
   const optionB = await prismaClient.voteOption.create({
     data: { topicId: topic.id, label: "Option B", orderIndex: 1 },
   });
@@ -100,33 +85,26 @@ describe("Vote Integration: VoteCast", () => {
       const { topic, optionA } = await createVoteTopic({
         communityId: community.id,
         createdBy: member.id,
-        startsAt: new Date(now.getTime() - 60_000), // 1 min ago
-        endsAt: new Date(now.getTime() + 3_600_000), // 1 hour from now
+        startsAt: new Date(now.getTime() - 60_000),
+        endsAt: new Date(now.getTime() + 3_600_000),
       });
 
-      const ctx = {
-        currentUser: { id: member.id },
-        issuer,
-      } as unknown as IContext;
+      const ctx = { currentUser: { id: member.id }, issuer } as unknown as IContext;
 
       const result = await voteUseCase.userCastVote(ctx, {
         input: { topicId: topic.id, optionId: optionA.id },
       });
 
-      expect(result.ballot).toBeDefined();
       expect(result.ballot.power).toBe(1);
 
-      // VoteOption の集計カラムが更新されているかを確認
-      const updatedOption = await prismaClient.voteOption.findUniqueOrThrow({
-        where: { id: optionA.id },
-      });
-      expect(updatedOption.voteCount).toBe(1);
-      expect(updatedOption.totalPower).toBe(1);
+      const updated = await prismaClient.voteOption.findUniqueOrThrow({ where: { id: optionA.id } });
+      expect(updated.voteCount).toBe(1);
+      expect(updated.totalPower).toBe(1);
     });
   });
 
-  describe("revote (changing option)", () => {
-    it("should update ballot and adjust option counts correctly on revote", async () => {
+  describe("revote", () => {
+    it("should decrement old option and increment new option when changing option", async () => {
       const member = await TestDataSourceHelper.createUser({
         name: "Revote User",
         slug: "revote-slug",
@@ -154,33 +132,64 @@ describe("Vote Integration: VoteCast", () => {
         endsAt: new Date(now.getTime() + 3_600_000),
       });
 
-      const ctx = {
-        currentUser: { id: member.id },
-        issuer,
-      } as unknown as IContext;
+      const ctx = { currentUser: { id: member.id }, issuer } as unknown as IContext;
 
-      // 1st vote: Option A
-      await voteUseCase.userCastVote(ctx, {
-        input: { topicId: topic.id, optionId: optionA.id },
-      });
+      await voteUseCase.userCastVote(ctx, { input: { topicId: topic.id, optionId: optionA.id } });
+      await voteUseCase.userCastVote(ctx, { input: { topicId: topic.id, optionId: optionB.id } });
 
-      // 2nd vote: Option B (revote)
-      const revoteResult = await voteUseCase.userCastVote(ctx, {
-        input: { topicId: topic.id, optionId: optionB.id },
-      });
-
-      expect(revoteResult.ballot).toBeDefined();
-
-      // Option A の count が 0 に戻り、Option B が 1 になっているかを確認
       const [updatedA, updatedB] = await Promise.all([
         prismaClient.voteOption.findUniqueOrThrow({ where: { id: optionA.id } }),
         prismaClient.voteOption.findUniqueOrThrow({ where: { id: optionB.id } }),
       ]);
 
+      // Option A の投票が取り消され Option B に移っていること
       expect(updatedA.voteCount).toBe(0);
       expect(updatedA.totalPower).toBe(0);
       expect(updatedB.voteCount).toBe(1);
       expect(updatedB.totalPower).toBe(1);
+    });
+
+    it("should NOT change voteCount when re-voting for the same option (adjustOptionTotalPower path)", async () => {
+      // FLAT policy では power=1 が固定なので delta=0 となり DB 更新は何も起きない
+      // このテストは「同一選択肢への再投票でも voteCount が二重加算されない」ことを保証する
+      const member = await TestDataSourceHelper.createUser({
+        name: "Same Option Voter",
+        slug: "same-option-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const community = await TestDataSourceHelper.createCommunity({
+        name: "same-option-community",
+        pointName: "pt",
+      });
+
+      await TestDataSourceHelper.createMembership({
+        user: { connect: { id: member.id } },
+        community: { connect: { id: community.id } },
+        status: MembershipStatus.JOINED,
+        reason: MembershipStatusReason.INVITED,
+        role: Role.MEMBER,
+      });
+
+      const now = new Date();
+      const { topic, optionA } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: member.id,
+        startsAt: new Date(now.getTime() - 60_000),
+        endsAt: new Date(now.getTime() + 3_600_000),
+      });
+
+      const ctx = { currentUser: { id: member.id }, issuer } as unknown as IContext;
+
+      // 同じ選択肢に2回投票
+      await voteUseCase.userCastVote(ctx, { input: { topicId: topic.id, optionId: optionA.id } });
+      await voteUseCase.userCastVote(ctx, { input: { topicId: topic.id, optionId: optionA.id } });
+
+      const updated = await prismaClient.voteOption.findUniqueOrThrow({ where: { id: optionA.id } });
+
+      // voteCount は 1 のまま（2 にならない）
+      expect(updated.voteCount).toBe(1);
+      expect(updated.totalPower).toBe(1);
     });
   });
 
@@ -203,7 +212,6 @@ describe("Vote Integration: VoteCast", () => {
         pointName: "pt",
       });
 
-      // nonMember は membership を持たない
       const now = new Date();
       const { topic, optionA } = await createVoteTopic({
         communityId: community.id,
@@ -212,15 +220,46 @@ describe("Vote Integration: VoteCast", () => {
         endsAt: new Date(now.getTime() + 3_600_000),
       });
 
-      const ctx = {
-        currentUser: { id: nonMember.id },
-        issuer,
-      } as unknown as IContext;
+      const ctx = { currentUser: { id: nonMember.id }, issuer } as unknown as IContext;
 
       await expect(
-        voteUseCase.userCastVote(ctx, {
-          input: { topicId: topic.id, optionId: optionA.id },
-        }),
+        voteUseCase.userCastVote(ctx, { input: { topicId: topic.id, optionId: optionA.id } }),
+      ).rejects.toThrow(AuthorizationError);
+    });
+
+    it("should reject a user whose membership status is not JOINED", async () => {
+      const pendingUser = await TestDataSourceHelper.createUser({
+        name: "Pending User",
+        slug: "pending-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const community = await TestDataSourceHelper.createCommunity({
+        name: "pending-community",
+        pointName: "pt",
+      });
+
+      // PENDING（未承認）状態のメンバーシップ
+      await TestDataSourceHelper.createMembership({
+        user: { connect: { id: pendingUser.id } },
+        community: { connect: { id: community.id } },
+        status: MembershipStatus.PENDING,
+        reason: MembershipStatusReason.INVITED,
+        role: Role.MEMBER,
+      });
+
+      const now = new Date();
+      const { topic, optionA } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: pendingUser.id,
+        startsAt: new Date(now.getTime() - 60_000),
+        endsAt: new Date(now.getTime() + 3_600_000),
+      });
+
+      const ctx = { currentUser: { id: pendingUser.id }, issuer } as unknown as IContext;
+
+      await expect(
+        voteUseCase.userCastVote(ctx, { input: { topicId: topic.id, optionId: optionA.id } }),
       ).rejects.toThrow(AuthorizationError);
     });
   });
@@ -250,19 +289,14 @@ describe("Vote Integration: VoteCast", () => {
       const { topic, optionA } = await createVoteTopic({
         communityId: community.id,
         createdBy: member.id,
-        startsAt: new Date(now.getTime() + 3_600_000), // starts 1 hour in the future
+        startsAt: new Date(now.getTime() + 3_600_000),
         endsAt: new Date(now.getTime() + 7_200_000),
       });
 
-      const ctx = {
-        currentUser: { id: member.id },
-        issuer,
-      } as unknown as IContext;
+      const ctx = { currentUser: { id: member.id }, issuer } as unknown as IContext;
 
       await expect(
-        voteUseCase.userCastVote(ctx, {
-          input: { topicId: topic.id, optionId: optionA.id },
-        }),
+        voteUseCase.userCastVote(ctx, { input: { topicId: topic.id, optionId: optionA.id } }),
       ).rejects.toThrow(ValidationError);
     });
 
@@ -290,39 +324,73 @@ describe("Vote Integration: VoteCast", () => {
       const { topic, optionA } = await createVoteTopic({
         communityId: community.id,
         createdBy: member.id,
-        startsAt: new Date(now.getTime() - 7_200_000), // started 2 hours ago
-        endsAt: new Date(now.getTime() - 3_600_000), // ended 1 hour ago
+        startsAt: new Date(now.getTime() - 7_200_000),
+        endsAt: new Date(now.getTime() - 3_600_000),
       });
 
-      const ctx = {
-        currentUser: { id: member.id },
-        issuer,
-      } as unknown as IContext;
+      const ctx = { currentUser: { id: member.id }, issuer } as unknown as IContext;
 
       await expect(
-        voteUseCase.userCastVote(ctx, {
-          input: { topicId: topic.id, optionId: optionA.id },
-        }),
+        voteUseCase.userCastVote(ctx, { input: { topicId: topic.id, optionId: optionA.id } }),
       ).rejects.toThrow(ValidationError);
     });
   });
 
-  describe("result masking", () => {
-    it("should hide voteCount/totalPower during active voting period when browsing topics", async () => {
-      const manager = await TestDataSourceHelper.createUser({
-        name: "Manager Result",
-        slug: "manager-result-slug",
-        currentPrefecture: CurrentPrefecture.KAGAWA,
-      });
-
+  describe("option validation", () => {
+    it("should reject a vote for an optionId that does not belong to the topic", async () => {
       const member = await TestDataSourceHelper.createUser({
-        name: "Member Result",
-        slug: "member-result-slug",
+        name: "WrongOption Voter",
+        slug: "wrong-option-slug",
         currentPrefecture: CurrentPrefecture.KAGAWA,
       });
 
       const community = await TestDataSourceHelper.createCommunity({
-        name: "result-community",
+        name: "wrong-option-community",
+        pointName: "pt",
+      });
+
+      await TestDataSourceHelper.createMembership({
+        user: { connect: { id: member.id } },
+        community: { connect: { id: community.id } },
+        status: MembershipStatus.JOINED,
+        reason: MembershipStatusReason.INVITED,
+        role: Role.MEMBER,
+      });
+
+      const now = new Date();
+      const { topic } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: member.id,
+        startsAt: new Date(now.getTime() - 60_000),
+        endsAt: new Date(now.getTime() + 3_600_000),
+      });
+
+      const ctx = { currentUser: { id: member.id }, issuer } as unknown as IContext;
+
+      await expect(
+        voteUseCase.userCastVote(ctx, {
+          input: { topicId: topic.id, optionId: "nonexistent-option-id" },
+        }),
+      ).rejects.toThrow(NotFoundError);
+    });
+  });
+
+  describe("result masking", () => {
+    it("should hide voteCount/totalPower from a regular member during active voting period", async () => {
+      const manager = await TestDataSourceHelper.createUser({
+        name: "Manager",
+        slug: "manager-masking-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const member = await TestDataSourceHelper.createUser({
+        name: "Member",
+        slug: "member-masking-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const community = await TestDataSourceHelper.createCommunity({
+        name: "masking-community",
         pointName: "pt",
       });
 
@@ -348,7 +416,7 @@ describe("Vote Integration: VoteCast", () => {
         communityId: community.id,
         createdBy: manager.id,
         startsAt: new Date(now.getTime() - 60_000),
-        endsAt: new Date(now.getTime() + 3_600_000), // still active
+        endsAt: new Date(now.getTime() + 3_600_000),
       });
 
       const memberCtx = {
@@ -359,33 +427,31 @@ describe("Vote Integration: VoteCast", () => {
         issuer,
       } as unknown as IContext;
 
-      // 投票を実施
       await voteUseCase.userCastVote(memberCtx, {
         input: { topicId: topic.id, optionId: optionA.id },
       });
 
-      // 一般ユーザー（非マネージャー）として一覧取得 → 集計値は null であるべき
-      const browseResult = await voteUseCase.anyoneBrowseVoteTopics(memberCtx, {
+      const result = await voteUseCase.anyoneBrowseVoteTopics(memberCtx, {
         communityId: community.id,
         first: 10,
       });
 
-      expect(browseResult.nodes).toHaveLength(1);
-      const topicNode = browseResult.nodes[0];
-      const optionANode = topicNode.options.find((o) => o.orderIndex === 0);
-      expect(optionANode?.voteCount).toBeNull();
-      expect(optionANode?.totalPower).toBeNull();
+      const optionNode = result.nodes[0].options.find((o) => o.orderIndex === 0);
+      // 投票期間中は一般メンバーには集計値が隠される
+      expect(optionNode?.voteCount).toBeNull();
+      expect(optionNode?.totalPower).toBeNull();
     });
 
-    it("should show voteCount/totalPower after voting period ends", async () => {
+    it("should show voteCount/totalPower to a manager during active voting period", async () => {
+      // マネージャーは投票期間中でも集計値を参照できる（isResultVisible = true）
       const manager = await TestDataSourceHelper.createUser({
-        name: "Manager Ended",
-        slug: "manager-ended-slug",
+        name: "Manager Visible",
+        slug: "manager-visible-slug",
         currentPrefecture: CurrentPrefecture.KAGAWA,
       });
 
       const community = await TestDataSourceHelper.createCommunity({
-        name: "ended-community",
+        name: "manager-visible-community",
         pointName: "pt",
       });
 
@@ -398,36 +464,85 @@ describe("Vote Integration: VoteCast", () => {
       });
 
       const now = new Date();
-      // 終了済みトピックを直接 DB に作成（usecase を使うと startsAt バリデーションが通らないため）
-      const { optionA } = await createVoteTopic({
+      const { topic, optionA } = await createVoteTopic({
         communityId: community.id,
         createdBy: manager.id,
-        startsAt: new Date(now.getTime() - 7_200_000), // 2 hours ago
-        endsAt: new Date(now.getTime() - 3_600_000), // ended 1 hour ago
+        startsAt: new Date(now.getTime() - 60_000),
+        endsAt: new Date(now.getTime() + 3_600_000), // 投票期間中
       });
 
-      // 集計カラムを直接更新して「投票済み」状態を再現
+      const managerCtx = {
+        currentUser: {
+          id: manager.id,
+          memberships: [{ communityId: community.id, role: Role.MANAGER, status: MembershipStatus.JOINED }],
+        },
+        issuer,
+      } as unknown as IContext;
+
+      await voteUseCase.userCastVote(managerCtx, {
+        input: { topicId: topic.id, optionId: optionA.id },
+      });
+
+      const result = await voteUseCase.anyoneBrowseVoteTopics(managerCtx, {
+        communityId: community.id,
+        first: 10,
+      });
+
+      const optionNode = result.nodes[0].options.find((o) => o.orderIndex === 0);
+      // マネージャーは投票期間中でも集計値が見える
+      expect(optionNode?.voteCount).toBe(1);
+      expect(optionNode?.totalPower).toBe(1);
+    });
+
+    it("should show voteCount/totalPower to any user after voting period ends", async () => {
+      const user = await TestDataSourceHelper.createUser({
+        name: "Regular User",
+        slug: "regular-user-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const community = await TestDataSourceHelper.createCommunity({
+        name: "ended-community",
+        pointName: "pt",
+      });
+
+      await TestDataSourceHelper.createMembership({
+        user: { connect: { id: user.id } },
+        community: { connect: { id: community.id } },
+        status: MembershipStatus.JOINED,
+        reason: MembershipStatusReason.INVITED,
+        role: Role.MEMBER,
+      });
+
+      const now = new Date();
+      const { optionA } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: user.id,
+        startsAt: new Date(now.getTime() - 7_200_000),
+        endsAt: new Date(now.getTime() - 3_600_000), // 終了済み
+      });
+
+      // 集計カラムを直接設定（終了済みトピックには投票できないため）
       await prismaClient.voteOption.update({
         where: { id: optionA.id },
         data: { voteCount: 3, totalPower: 5 },
       });
 
-      // 非マネージャーとして閲覧 → endsAt 経過後は集計値が見えるべき
-      const ctx = {
+      const memberCtx = {
         currentUser: {
-          id: manager.id,
+          id: user.id,
           memberships: [{ communityId: community.id, role: Role.MEMBER, status: MembershipStatus.JOINED }],
         },
         issuer,
       } as unknown as IContext;
 
-      const browseResult = await voteUseCase.anyoneBrowseVoteTopics(ctx, {
+      const result = await voteUseCase.anyoneBrowseVoteTopics(memberCtx, {
         communityId: community.id,
         first: 10,
       });
 
-      expect(browseResult.nodes).toHaveLength(1);
-      const optionNode = browseResult.nodes[0].options.find((o) => o.orderIndex === 0);
+      const optionNode = result.nodes[0].options.find((o) => o.orderIndex === 0);
+      // endsAt 後は一般ユーザーにも集計値が公開される
       expect(optionNode?.voteCount).toBe(3);
       expect(optionNode?.totalPower).toBe(5);
     });

--- a/src/__tests__/integration/vote/voteCast.test.ts
+++ b/src/__tests__/integration/vote/voteCast.test.ts
@@ -240,6 +240,60 @@ describe("Vote Integration: VoteCast", () => {
       expect(after2nd.voteCount).toBe(1); // voteCount は変化しない
       expect(after2nd.totalPower).toBe(1); // 2 → 1 に減少
     });
+
+    it("should increase totalPower (delta>0) when re-voting same option after gaining an NFT", async () => {
+      // adjustOptionTotalPower の delta>0 パス（増加方向）を検証する
+      // 1回目: NFT 1枚保有 → power=1 で option A に投票 (voteCount=1, totalPower=1)
+      // NFT を 1 枚追加取得
+      // 2回目: 同じ option A に再投票 → power=2, delta=+1 (voteCount=1, totalPower=2)
+      const voter = await TestDataSourceHelper.createUser({
+        name: "NFT Gain Voter",
+        slug: "nft-gain-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+      await TestDataSourceHelper.createMembership({
+        user: { connect: { id: voter.id } },
+        community: { connect: { id: community.id } },
+        status: MembershipStatus.JOINED,
+        reason: MembershipStatusReason.INVITED,
+        role: Role.MEMBER,
+      });
+
+      const { nftToken, nftWallet } = await createOwnedNft(voter.id); // instance #1（1枚）
+
+      const { topic, optionA } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: voter.id,
+        ...activePeriod(),
+        gate: { type: "MEMBERSHIP" },
+        policy: { type: "NFT_COUNT", nftTokenId: nftToken.id },
+      });
+
+      const ctx = { currentUser: { id: voter.id }, issuer } as unknown as IContext;
+
+      // 1回目: power=1
+      await voteUseCase.userCastVote(ctx, { input: { topicId: topic.id, optionId: optionA.id } });
+      const after1st = await prismaClient.voteOption.findUniqueOrThrow({ where: { id: optionA.id } });
+      expect(after1st.voteCount).toBe(1);
+      expect(after1st.totalPower).toBe(1);
+
+      // NFT を 1 枚追加取得（同一ウォレットに instance を追加）
+      await prismaClient.nftInstance.create({
+        data: {
+          instanceId: `gain-instance-${Date.now()}`,
+          nftTokenId: nftToken.id,
+          nftWalletId: nftWallet.id,
+          status: NftInstanceStatus.OWNED,
+        },
+      });
+
+      // 2回目: 同じ optionA に再投票 → power=2, delta=+1
+      await voteUseCase.userCastVote(ctx, { input: { topicId: topic.id, optionId: optionA.id } });
+      const after2nd = await prismaClient.voteOption.findUniqueOrThrow({ where: { id: optionA.id } });
+      expect(after2nd.voteCount).toBe(1); // voteCount は変化しない
+      expect(after2nd.totalPower).toBe(2); // 1 → 2 に増加
+    });
   });
 
   // ─── 再投票 ───────────────────────────────────────────────────────────────

--- a/src/__tests__/integration/vote/voteCast.test.ts
+++ b/src/__tests__/integration/vote/voteCast.test.ts
@@ -1,0 +1,435 @@
+import "reflect-metadata";
+import TestDataSourceHelper from "../../helper/test-data-source-helper";
+import { CurrentPrefecture, MembershipStatus, MembershipStatusReason, Role } from "@prisma/client";
+import { IContext } from "@/types/server";
+import VoteUseCase from "@/application/domain/vote/usecase";
+import { container } from "tsyringe";
+import { registerProductionDependencies } from "@/application/provider";
+import { PrismaClientIssuer, prismaClient } from "@/infrastructure/prisma/client";
+import { AuthorizationError, ValidationError } from "@/errors/graphql";
+
+// topicId の DB レコードを直接作成するユーティリティ
+// (vote topic は usecase 経由で作成するので不要だが、
+//  startsAt/endsAt を任意に制御したいケースでは直接 Prisma 操作を使う)
+async function createVoteTopic(params: {
+  communityId: string;
+  createdBy: string;
+  startsAt: Date;
+  endsAt: Date;
+  gateType?: "MEMBERSHIP" | "NFT";
+  policyType?: "FLAT" | "NFT_COUNT";
+}) {
+  const {
+    communityId,
+    createdBy,
+    startsAt,
+    endsAt,
+    gateType = "MEMBERSHIP",
+    policyType = "FLAT",
+  } = params;
+
+  const topic = await prismaClient.voteTopic.create({
+    data: {
+      communityId,
+      createdBy,
+      title: "Integration Test Vote",
+      startsAt,
+      endsAt,
+    },
+  });
+
+  await prismaClient.voteGate.create({
+    data: { type: gateType, topicId: topic.id },
+  });
+
+  await prismaClient.votePowerPolicy.create({
+    data: { type: policyType, topicId: topic.id },
+  });
+
+  const optionA = await prismaClient.voteOption.create({
+    data: { topicId: topic.id, label: "Option A", orderIndex: 0 },
+  });
+
+  const optionB = await prismaClient.voteOption.create({
+    data: { topicId: topic.id, label: "Option B", orderIndex: 1 },
+  });
+
+  return { topic, optionA, optionB };
+}
+
+describe("Vote Integration: VoteCast", () => {
+  let voteUseCase: VoteUseCase;
+  let issuer: PrismaClientIssuer;
+
+  beforeEach(async () => {
+    await TestDataSourceHelper.deleteAll();
+    jest.clearAllMocks();
+    container.reset();
+    registerProductionDependencies();
+
+    issuer = container.resolve(PrismaClientIssuer);
+    voteUseCase = container.resolve(VoteUseCase);
+  });
+
+  afterAll(async () => {
+    await TestDataSourceHelper.disconnect();
+  });
+
+  describe("initial vote", () => {
+    it("should allow a community member to cast a vote", async () => {
+      const member = await TestDataSourceHelper.createUser({
+        name: "Voter",
+        slug: "voter-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const community = await TestDataSourceHelper.createCommunity({
+        name: "vote-community",
+        pointName: "pt",
+      });
+
+      await TestDataSourceHelper.createMembership({
+        user: { connect: { id: member.id } },
+        community: { connect: { id: community.id } },
+        status: MembershipStatus.JOINED,
+        reason: MembershipStatusReason.INVITED,
+        role: Role.MEMBER,
+      });
+
+      const now = new Date();
+      const { topic, optionA } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: member.id,
+        startsAt: new Date(now.getTime() - 60_000), // 1 min ago
+        endsAt: new Date(now.getTime() + 3_600_000), // 1 hour from now
+      });
+
+      const ctx = {
+        currentUser: { id: member.id },
+        issuer,
+      } as unknown as IContext;
+
+      const result = await voteUseCase.userCastVote(ctx, {
+        input: { topicId: topic.id, optionId: optionA.id },
+      });
+
+      expect(result.ballot).toBeDefined();
+      expect(result.ballot.power).toBe(1);
+
+      // VoteOption の集計カラムが更新されているかを確認
+      const updatedOption = await prismaClient.voteOption.findUniqueOrThrow({
+        where: { id: optionA.id },
+      });
+      expect(updatedOption.voteCount).toBe(1);
+      expect(updatedOption.totalPower).toBe(1);
+    });
+  });
+
+  describe("revote (changing option)", () => {
+    it("should update ballot and adjust option counts correctly on revote", async () => {
+      const member = await TestDataSourceHelper.createUser({
+        name: "Revote User",
+        slug: "revote-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const community = await TestDataSourceHelper.createCommunity({
+        name: "revote-community",
+        pointName: "pt",
+      });
+
+      await TestDataSourceHelper.createMembership({
+        user: { connect: { id: member.id } },
+        community: { connect: { id: community.id } },
+        status: MembershipStatus.JOINED,
+        reason: MembershipStatusReason.INVITED,
+        role: Role.MEMBER,
+      });
+
+      const now = new Date();
+      const { topic, optionA, optionB } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: member.id,
+        startsAt: new Date(now.getTime() - 60_000),
+        endsAt: new Date(now.getTime() + 3_600_000),
+      });
+
+      const ctx = {
+        currentUser: { id: member.id },
+        issuer,
+      } as unknown as IContext;
+
+      // 1st vote: Option A
+      await voteUseCase.userCastVote(ctx, {
+        input: { topicId: topic.id, optionId: optionA.id },
+      });
+
+      // 2nd vote: Option B (revote)
+      const revoteResult = await voteUseCase.userCastVote(ctx, {
+        input: { topicId: topic.id, optionId: optionB.id },
+      });
+
+      expect(revoteResult.ballot).toBeDefined();
+
+      // Option A の count が 0 に戻り、Option B が 1 になっているかを確認
+      const [updatedA, updatedB] = await Promise.all([
+        prismaClient.voteOption.findUniqueOrThrow({ where: { id: optionA.id } }),
+        prismaClient.voteOption.findUniqueOrThrow({ where: { id: optionB.id } }),
+      ]);
+
+      expect(updatedA.voteCount).toBe(0);
+      expect(updatedA.totalPower).toBe(0);
+      expect(updatedB.voteCount).toBe(1);
+      expect(updatedB.totalPower).toBe(1);
+    });
+  });
+
+  describe("gate enforcement", () => {
+    it("should reject a user without community membership (MEMBERSHIP gate)", async () => {
+      const nonMember = await TestDataSourceHelper.createUser({
+        name: "NonMember",
+        slug: "non-member-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const creator = await TestDataSourceHelper.createUser({
+        name: "Creator",
+        slug: "creator-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const community = await TestDataSourceHelper.createCommunity({
+        name: "gate-community",
+        pointName: "pt",
+      });
+
+      // nonMember は membership を持たない
+      const now = new Date();
+      const { topic, optionA } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: creator.id,
+        startsAt: new Date(now.getTime() - 60_000),
+        endsAt: new Date(now.getTime() + 3_600_000),
+      });
+
+      const ctx = {
+        currentUser: { id: nonMember.id },
+        issuer,
+      } as unknown as IContext;
+
+      await expect(
+        voteUseCase.userCastVote(ctx, {
+          input: { topicId: topic.id, optionId: optionA.id },
+        }),
+      ).rejects.toThrow(AuthorizationError);
+    });
+  });
+
+  describe("voting period enforcement", () => {
+    it("should reject votes before voting period starts", async () => {
+      const member = await TestDataSourceHelper.createUser({
+        name: "EarlyVoter",
+        slug: "early-voter-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const community = await TestDataSourceHelper.createCommunity({
+        name: "early-vote-community",
+        pointName: "pt",
+      });
+
+      await TestDataSourceHelper.createMembership({
+        user: { connect: { id: member.id } },
+        community: { connect: { id: community.id } },
+        status: MembershipStatus.JOINED,
+        reason: MembershipStatusReason.INVITED,
+        role: Role.MEMBER,
+      });
+
+      const now = new Date();
+      const { topic, optionA } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: member.id,
+        startsAt: new Date(now.getTime() + 3_600_000), // starts 1 hour in the future
+        endsAt: new Date(now.getTime() + 7_200_000),
+      });
+
+      const ctx = {
+        currentUser: { id: member.id },
+        issuer,
+      } as unknown as IContext;
+
+      await expect(
+        voteUseCase.userCastVote(ctx, {
+          input: { topicId: topic.id, optionId: optionA.id },
+        }),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it("should reject votes after voting period ends", async () => {
+      const member = await TestDataSourceHelper.createUser({
+        name: "LateVoter",
+        slug: "late-voter-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const community = await TestDataSourceHelper.createCommunity({
+        name: "late-vote-community",
+        pointName: "pt",
+      });
+
+      await TestDataSourceHelper.createMembership({
+        user: { connect: { id: member.id } },
+        community: { connect: { id: community.id } },
+        status: MembershipStatus.JOINED,
+        reason: MembershipStatusReason.INVITED,
+        role: Role.MEMBER,
+      });
+
+      const now = new Date();
+      const { topic, optionA } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: member.id,
+        startsAt: new Date(now.getTime() - 7_200_000), // started 2 hours ago
+        endsAt: new Date(now.getTime() - 3_600_000), // ended 1 hour ago
+      });
+
+      const ctx = {
+        currentUser: { id: member.id },
+        issuer,
+      } as unknown as IContext;
+
+      await expect(
+        voteUseCase.userCastVote(ctx, {
+          input: { topicId: topic.id, optionId: optionA.id },
+        }),
+      ).rejects.toThrow(ValidationError);
+    });
+  });
+
+  describe("result masking", () => {
+    it("should hide voteCount/totalPower during active voting period when browsing topics", async () => {
+      const manager = await TestDataSourceHelper.createUser({
+        name: "Manager Result",
+        slug: "manager-result-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const member = await TestDataSourceHelper.createUser({
+        name: "Member Result",
+        slug: "member-result-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const community = await TestDataSourceHelper.createCommunity({
+        name: "result-community",
+        pointName: "pt",
+      });
+
+      await Promise.all([
+        TestDataSourceHelper.createMembership({
+          user: { connect: { id: manager.id } },
+          community: { connect: { id: community.id } },
+          status: MembershipStatus.JOINED,
+          reason: MembershipStatusReason.INVITED,
+          role: Role.MANAGER,
+        }),
+        TestDataSourceHelper.createMembership({
+          user: { connect: { id: member.id } },
+          community: { connect: { id: community.id } },
+          status: MembershipStatus.JOINED,
+          reason: MembershipStatusReason.INVITED,
+          role: Role.MEMBER,
+        }),
+      ]);
+
+      const now = new Date();
+      const { topic, optionA } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: manager.id,
+        startsAt: new Date(now.getTime() - 60_000),
+        endsAt: new Date(now.getTime() + 3_600_000), // still active
+      });
+
+      const memberCtx = {
+        currentUser: {
+          id: member.id,
+          memberships: [{ communityId: community.id, role: Role.MEMBER, status: MembershipStatus.JOINED }],
+        },
+        issuer,
+      } as unknown as IContext;
+
+      // 投票を実施
+      await voteUseCase.userCastVote(memberCtx, {
+        input: { topicId: topic.id, optionId: optionA.id },
+      });
+
+      // 一般ユーザー（非マネージャー）として一覧取得 → 集計値は null であるべき
+      const browseResult = await voteUseCase.anyoneBrowseVoteTopics(memberCtx, {
+        communityId: community.id,
+        first: 10,
+      });
+
+      expect(browseResult.nodes).toHaveLength(1);
+      const topicNode = browseResult.nodes[0];
+      const optionANode = topicNode.options.find((o) => o.orderIndex === 0);
+      expect(optionANode?.voteCount).toBeNull();
+      expect(optionANode?.totalPower).toBeNull();
+    });
+
+    it("should show voteCount/totalPower after voting period ends", async () => {
+      const manager = await TestDataSourceHelper.createUser({
+        name: "Manager Ended",
+        slug: "manager-ended-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const community = await TestDataSourceHelper.createCommunity({
+        name: "ended-community",
+        pointName: "pt",
+      });
+
+      await TestDataSourceHelper.createMembership({
+        user: { connect: { id: manager.id } },
+        community: { connect: { id: community.id } },
+        status: MembershipStatus.JOINED,
+        reason: MembershipStatusReason.INVITED,
+        role: Role.MANAGER,
+      });
+
+      const now = new Date();
+      // 終了済みトピックを直接 DB に作成（usecase を使うと startsAt バリデーションが通らないため）
+      const { optionA } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: manager.id,
+        startsAt: new Date(now.getTime() - 7_200_000), // 2 hours ago
+        endsAt: new Date(now.getTime() - 3_600_000), // ended 1 hour ago
+      });
+
+      // 集計カラムを直接更新して「投票済み」状態を再現
+      await prismaClient.voteOption.update({
+        where: { id: optionA.id },
+        data: { voteCount: 3, totalPower: 5 },
+      });
+
+      // 非マネージャーとして閲覧 → endsAt 経過後は集計値が見えるべき
+      const ctx = {
+        currentUser: {
+          id: manager.id,
+          memberships: [{ communityId: community.id, role: Role.MEMBER, status: MembershipStatus.JOINED }],
+        },
+        issuer,
+      } as unknown as IContext;
+
+      const browseResult = await voteUseCase.anyoneBrowseVoteTopics(ctx, {
+        communityId: community.id,
+        first: 10,
+      });
+
+      expect(browseResult.nodes).toHaveLength(1);
+      const optionNode = browseResult.nodes[0].options.find((o) => o.orderIndex === 0);
+      expect(optionNode?.voteCount).toBe(3);
+      expect(optionNode?.totalPower).toBe(5);
+    });
+  });
+});

--- a/src/__tests__/integration/vote/voteCast.test.ts
+++ b/src/__tests__/integration/vote/voteCast.test.ts
@@ -7,6 +7,7 @@ import { container } from "tsyringe";
 import { registerProductionDependencies } from "@/application/provider";
 import { PrismaClientIssuer, prismaClient } from "@/infrastructure/prisma/client";
 import { AuthorizationError, NotFoundError, ValidationError } from "@/errors/graphql";
+import { NftInstanceStatus } from "@prisma/client";
 import { createVoteTopic, createOwnedNft, createNftToken } from "./helpers";
 
 // ─── 共通セットアップ ─────────────────────────────────────────────────────────
@@ -158,7 +159,7 @@ describe("Vote Integration: VoteCast", () => {
           instanceId: `instance-2nd-${Date.now()}`,
           nftTokenId: nftToken.id,
           nftWalletId: nftWallet.id,
-          status: "OWNED",
+          status: NftInstanceStatus.OWNED,
         },
       });
 
@@ -180,6 +181,64 @@ describe("Vote Integration: VoteCast", () => {
       const updated = await prismaClient.voteOption.findUniqueOrThrow({ where: { id: optionA.id } });
       expect(updated.voteCount).toBe(1);
       expect(updated.totalPower).toBe(2);
+    });
+
+    it("should correctly adjust totalPower (delta≠0) when re-voting same option after NFT count changes", async () => {
+      // adjustOptionTotalPower の非ゼロ delta パスを検証する
+      // 1回目: NFT 2枚保有 → power=2 で option A に投票 (voteCount=1, totalPower=2)
+      // NFT を 1 枚売却（status=SOLD に変更）
+      // 2回目: NFT 1枚保有 → power=1 で同じ option A に再投票 (voteCount=1, totalPower=1, delta=-1)
+      const voter = await TestDataSourceHelper.createUser({
+        name: "NFT Delta Voter",
+        slug: "nft-delta-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+      await TestDataSourceHelper.createMembership({
+        user: { connect: { id: voter.id } },
+        community: { connect: { id: community.id } },
+        status: MembershipStatus.JOINED,
+        reason: MembershipStatusReason.INVITED,
+        role: Role.MEMBER,
+      });
+
+      const { nftToken, nftWallet } = await createOwnedNft(voter.id); // instance #1
+      const instance2 = await prismaClient.nftInstance.create({
+        data: {
+          instanceId: `delta-instance-2nd-${Date.now()}`,
+          nftTokenId: nftToken.id,
+          nftWalletId: nftWallet.id,
+          status: NftInstanceStatus.OWNED,
+        },
+      });
+
+      const { topic, optionA } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: voter.id,
+        ...activePeriod(),
+        gate: { type: "MEMBERSHIP" },
+        policy: { type: "NFT_COUNT", nftTokenId: nftToken.id },
+      });
+
+      const ctx = { currentUser: { id: voter.id }, issuer } as unknown as IContext;
+
+      // 1回目: power=2
+      await voteUseCase.userCastVote(ctx, { input: { topicId: topic.id, optionId: optionA.id } });
+      const after1st = await prismaClient.voteOption.findUniqueOrThrow({ where: { id: optionA.id } });
+      expect(after1st.voteCount).toBe(1);
+      expect(after1st.totalPower).toBe(2);
+
+      // NFT を 1 枚手放す（SOLD に変更）→ 保有枚数が 1 になる
+      await prismaClient.nftInstance.update({
+        where: { id: instance2.id },
+        data: { status: NftInstanceStatus.RETIRED }, // OWNED 以外にすることで保有枚数を 1 に減らす
+      });
+
+      // 2回目: 同じ optionA に再投票 → power=1, delta=-1, adjustOptionTotalPower が呼ばれる
+      await voteUseCase.userCastVote(ctx, { input: { topicId: topic.id, optionId: optionA.id } });
+      const after2nd = await prismaClient.voteOption.findUniqueOrThrow({ where: { id: optionA.id } });
+      expect(after2nd.voteCount).toBe(1); // voteCount は変化しない
+      expect(after2nd.totalPower).toBe(1); // 2 → 1 に減少
     });
   });
 
@@ -221,6 +280,47 @@ describe("Vote Integration: VoteCast", () => {
       expect(updatedA.totalPower).toBe(0);
       expect(updatedB.voteCount).toBe(1);
       expect(updatedB.totalPower).toBe(1);
+    });
+
+    it("should correctly update counts when switching back from optionB to optionA (oldId > newId deadlock prevention branch)", async () => {
+      // options は orderIndex 昇順で作成されるため optionA.id < optionB.id になる
+      // B→A の再投票は oldId(B) > newId(A) → else ブランチ（increment してから decrement）を実行する
+      const member = await TestDataSourceHelper.createUser({
+        name: "B to A Voter",
+        slug: "b-to-a-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+      await TestDataSourceHelper.createMembership({
+        user: { connect: { id: member.id } },
+        community: { connect: { id: community.id } },
+        status: MembershipStatus.JOINED,
+        reason: MembershipStatusReason.INVITED,
+        role: Role.MEMBER,
+      });
+
+      const { topic, optionA, optionB } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: member.id,
+        ...activePeriod(),
+      });
+
+      const ctx = { currentUser: { id: member.id }, issuer } as unknown as IContext;
+
+      // 1回目: B に投票
+      await voteUseCase.userCastVote(ctx, { input: { topicId: topic.id, optionId: optionB.id } });
+      // 2回目: A に戻す → oldId=B.id > newId=A.id → else ブランチ
+      await voteUseCase.userCastVote(ctx, { input: { topicId: topic.id, optionId: optionA.id } });
+
+      const [updatedA, updatedB] = await Promise.all([
+        prismaClient.voteOption.findUniqueOrThrow({ where: { id: optionA.id } }),
+        prismaClient.voteOption.findUniqueOrThrow({ where: { id: optionB.id } }),
+      ]);
+
+      expect(updatedA.voteCount).toBe(1);
+      expect(updatedA.totalPower).toBe(1);
+      expect(updatedB.voteCount).toBe(0);
+      expect(updatedB.totalPower).toBe(0);
     });
 
     it("should NOT change voteCount when re-voting for the same option (adjustOptionTotalPower path)", async () => {

--- a/src/__tests__/integration/vote/voteQuery.test.ts
+++ b/src/__tests__/integration/vote/voteQuery.test.ts
@@ -1,0 +1,442 @@
+import "reflect-metadata";
+import TestDataSourceHelper from "../../helper/test-data-source-helper";
+import { CurrentPrefecture, MembershipStatus, MembershipStatusReason, Role } from "@prisma/client";
+import { IContext } from "@/types/server";
+import VoteUseCase from "@/application/domain/vote/usecase";
+import { container } from "tsyringe";
+import { registerProductionDependencies } from "@/application/provider";
+import { PrismaClientIssuer, prismaClient } from "@/infrastructure/prisma/client";
+import { createVoteTopic } from "./helpers";
+
+// ─── 共通セットアップ ─────────────────────────────────────────────────────────
+
+describe("Vote Integration: VoteQuery", () => {
+  let voteUseCase: VoteUseCase;
+  let issuer: PrismaClientIssuer;
+
+  beforeEach(async () => {
+    await TestDataSourceHelper.deleteAll();
+    jest.clearAllMocks();
+    container.reset();
+    registerProductionDependencies();
+
+    issuer = container.resolve(PrismaClientIssuer);
+    voteUseCase = container.resolve(VoteUseCase);
+  });
+
+  afterAll(async () => {
+    await TestDataSourceHelper.disconnect();
+  });
+
+  // ─── anyoneBrowseVoteTopics ───────────────────────────────────────────────
+
+  describe("anyoneBrowseVoteTopics", () => {
+    it("should return empty connection when community has no vote topics", async () => {
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+      const ctx = { issuer } as unknown as IContext;
+
+      const result = await voteUseCase.anyoneBrowseVoteTopics(ctx, { communityId: community.id });
+
+      expect(result.totalCount).toBe(0);
+      expect(result.nodes).toHaveLength(0);
+      expect(result.pageInfo.hasNextPage).toBe(false);
+    });
+
+    it("should return phase=UPCOMING for a topic whose startsAt is in the future", async () => {
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+      const user = await TestDataSourceHelper.createUser({
+        name: "User",
+        slug: "user-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const now = new Date();
+      await createVoteTopic({
+        communityId: community.id,
+        createdBy: user.id,
+        startsAt: new Date(now.getTime() + 3_600_000),
+        endsAt: new Date(now.getTime() + 7_200_000),
+      });
+
+      const ctx = { issuer } as unknown as IContext;
+      const result = await voteUseCase.anyoneBrowseVoteTopics(ctx, { communityId: community.id });
+
+      expect(result.nodes[0].phase).toBe("UPCOMING");
+    });
+
+    it("should return phase=OPEN for an active topic", async () => {
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+      const user = await TestDataSourceHelper.createUser({
+        name: "User",
+        slug: "user-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const now = new Date();
+      await createVoteTopic({
+        communityId: community.id,
+        createdBy: user.id,
+        startsAt: new Date(now.getTime() - 60_000),
+        endsAt: new Date(now.getTime() + 3_600_000),
+      });
+
+      const ctx = { issuer } as unknown as IContext;
+      const result = await voteUseCase.anyoneBrowseVoteTopics(ctx, { communityId: community.id });
+
+      expect(result.nodes[0].phase).toBe("OPEN");
+    });
+
+    it("should return phase=CLOSED for an ended topic", async () => {
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+      const user = await TestDataSourceHelper.createUser({
+        name: "User",
+        slug: "user-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const now = new Date();
+      await createVoteTopic({
+        communityId: community.id,
+        createdBy: user.id,
+        startsAt: new Date(now.getTime() - 7_200_000),
+        endsAt: new Date(now.getTime() - 60_000),
+      });
+
+      const ctx = { issuer } as unknown as IContext;
+      const result = await voteUseCase.anyoneBrowseVoteTopics(ctx, { communityId: community.id });
+
+      expect(result.nodes[0].phase).toBe("CLOSED");
+    });
+
+    it("should exclude topics belonging to other communities", async () => {
+      const communityA = await TestDataSourceHelper.createCommunity({ name: "community-a", pointName: "pt" });
+      const communityB = await TestDataSourceHelper.createCommunity({ name: "community-b", pointName: "pt" });
+      const user = await TestDataSourceHelper.createUser({
+        name: "User",
+        slug: "user-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const now = new Date();
+      const period = {
+        startsAt: new Date(now.getTime() - 60_000),
+        endsAt: new Date(now.getTime() + 3_600_000),
+      };
+      await createVoteTopic({ communityId: communityA.id, createdBy: user.id, ...period });
+      await createVoteTopic({ communityId: communityB.id, createdBy: user.id, ...period });
+
+      const ctx = { issuer } as unknown as IContext;
+      const result = await voteUseCase.anyoneBrowseVoteTopics(ctx, { communityId: communityA.id });
+
+      expect(result.totalCount).toBe(1);
+      expect(result.nodes).toHaveLength(1);
+    });
+
+    it("should return hasNextPage=true when more records exist beyond the page", async () => {
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+      const user = await TestDataSourceHelper.createUser({
+        name: "User",
+        slug: "user-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const now = new Date();
+      const period = {
+        startsAt: new Date(now.getTime() - 60_000),
+        endsAt: new Date(now.getTime() + 3_600_000),
+      };
+      // Create 3 topics; request first=2 → hasNextPage should be true
+      await createVoteTopic({ communityId: community.id, createdBy: user.id, ...period });
+      await createVoteTopic({ communityId: community.id, createdBy: user.id, ...period });
+      await createVoteTopic({ communityId: community.id, createdBy: user.id, ...period });
+
+      const ctx = { issuer } as unknown as IContext;
+      const result = await voteUseCase.anyoneBrowseVoteTopics(ctx, { communityId: community.id, first: 2 });
+
+      expect(result.totalCount).toBe(3);
+      expect(result.nodes).toHaveLength(2);
+      expect(result.pageInfo.hasNextPage).toBe(true);
+    });
+
+    it("should paginate correctly using cursor and return hasNextPage=false on last page", async () => {
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+      const user = await TestDataSourceHelper.createUser({
+        name: "User",
+        slug: "user-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const now = new Date();
+      const period = {
+        startsAt: new Date(now.getTime() - 60_000),
+        endsAt: new Date(now.getTime() + 3_600_000),
+      };
+      await createVoteTopic({ communityId: community.id, createdBy: user.id, ...period });
+      await createVoteTopic({ communityId: community.id, createdBy: user.id, ...period });
+      await createVoteTopic({ communityId: community.id, createdBy: user.id, ...period });
+
+      const ctx = { issuer } as unknown as IContext;
+
+      // Page 1: 2 records, hasNextPage=true
+      const page1 = await voteUseCase.anyoneBrowseVoteTopics(ctx, {
+        communityId: community.id,
+        first: 2,
+      });
+      expect(page1.nodes).toHaveLength(2);
+      expect(page1.pageInfo.hasNextPage).toBe(true);
+
+      // Page 2: use endCursor from page 1
+      const cursor = page1.pageInfo.endCursor ?? undefined;
+      const page2 = await voteUseCase.anyoneBrowseVoteTopics(ctx, {
+        communityId: community.id,
+        first: 2,
+        cursor,
+      });
+      expect(page2.nodes).toHaveLength(1);
+      expect(page2.pageInfo.hasNextPage).toBe(false);
+    });
+
+    it("should hide voteCount/totalPower for an active topic when user is not a manager", async () => {
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+      const user = await TestDataSourceHelper.createUser({
+        name: "User",
+        slug: "user-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const now = new Date();
+      const { optionA } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: user.id,
+        startsAt: new Date(now.getTime() - 60_000),
+        endsAt: new Date(now.getTime() + 3_600_000),
+      });
+
+      // Seed non-zero counts directly to verify they are masked
+      await prismaClient.voteOption.update({
+        where: { id: optionA.id },
+        data: { voteCount: 5, totalPower: 10 },
+      });
+
+      // Anonymous context (no currentUser) → isManagerOfCommunity = false
+      const ctx = { issuer } as unknown as IContext;
+      const result = await voteUseCase.anyoneBrowseVoteTopics(ctx, { communityId: community.id });
+
+      const opt = result.nodes[0].options.find((o) => o.id === optionA.id);
+      expect(opt?.voteCount).toBeNull();
+      expect(opt?.totalPower).toBeNull();
+    });
+
+    it("should show voteCount/totalPower for an active topic when user is a manager", async () => {
+      const manager = await TestDataSourceHelper.createUser({
+        name: "Manager",
+        slug: "manager-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+      await TestDataSourceHelper.createMembership({
+        user: { connect: { id: manager.id } },
+        community: { connect: { id: community.id } },
+        status: MembershipStatus.JOINED,
+        reason: MembershipStatusReason.INVITED,
+        role: Role.MANAGER,
+      });
+
+      const now = new Date();
+      const { optionA } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: manager.id,
+        startsAt: new Date(now.getTime() - 60_000),
+        endsAt: new Date(now.getTime() + 3_600_000),
+      });
+
+      await prismaClient.voteOption.update({
+        where: { id: optionA.id },
+        data: { voteCount: 5, totalPower: 10 },
+      });
+
+      // Manager context: memberships must include the community with MANAGER role
+      // getMembershipRolesByCtx reads ctx.currentUser.memberships to determine isManager
+      const ctx = {
+        currentUser: {
+          id: manager.id,
+          memberships: [{ communityId: community.id, role: Role.MANAGER }],
+        },
+        issuer,
+      } as unknown as IContext;
+
+      const result = await voteUseCase.anyoneBrowseVoteTopics(ctx, { communityId: community.id });
+
+      const opt = result.nodes[0].options.find((o) => o.id === optionA.id);
+      expect(opt?.voteCount).toBe(5);
+      expect(opt?.totalPower).toBe(10);
+    });
+  });
+
+  // ─── anyoneViewVoteTopic ──────────────────────────────────────────────────
+
+  describe("anyoneViewVoteTopic", () => {
+    it("should return the vote topic when it exists", async () => {
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+      const user = await TestDataSourceHelper.createUser({
+        name: "User",
+        slug: "user-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const now = new Date();
+      const { topic } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: user.id,
+        startsAt: new Date(now.getTime() - 60_000),
+        endsAt: new Date(now.getTime() + 3_600_000),
+      });
+
+      const ctx = { issuer } as unknown as IContext;
+      const result = await voteUseCase.anyoneViewVoteTopic(ctx, { id: topic.id });
+
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe(topic.id);
+      expect(result?.gate.type).toBe("MEMBERSHIP");
+      expect(result?.powerPolicy.type).toBe("FLAT");
+      expect(result?.options).toHaveLength(2);
+    });
+
+    it("should return null when the vote topic does not exist", async () => {
+      const ctx = { issuer } as unknown as IContext;
+      const result = await voteUseCase.anyoneViewVoteTopic(ctx, { id: "nonexistent-id" });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // ─── userGetMyVoteEligibility ─────────────────────────────────────────────
+
+  describe("userGetMyVoteEligibility", () => {
+    it("should return eligible=true, currentPower=1 and myBallot=null when JOINED member has not voted (FLAT policy)", async () => {
+      const user = await TestDataSourceHelper.createUser({
+        name: "User",
+        slug: "user-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+      await TestDataSourceHelper.createMembership({
+        user: { connect: { id: user.id } },
+        community: { connect: { id: community.id } },
+        status: MembershipStatus.JOINED,
+        reason: MembershipStatusReason.INVITED,
+        role: Role.MEMBER,
+      });
+
+      const now = new Date();
+      const { topic } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: user.id,
+        startsAt: new Date(now.getTime() - 60_000),
+        endsAt: new Date(now.getTime() + 3_600_000),
+      });
+
+      const ctx = { currentUser: { id: user.id }, issuer } as unknown as IContext;
+      const result = await voteUseCase.userGetMyVoteEligibility(ctx, { topicId: topic.id });
+
+      expect(result.eligible).toBe(true);
+      expect(result.currentPower).toBe(1);
+      expect(result.myBallot).toBeNull();
+    });
+
+    it("should return eligible=true with myBallot populated when user has already voted", async () => {
+      const user = await TestDataSourceHelper.createUser({
+        name: "Voter",
+        slug: "voter-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+      await TestDataSourceHelper.createMembership({
+        user: { connect: { id: user.id } },
+        community: { connect: { id: community.id } },
+        status: MembershipStatus.JOINED,
+        reason: MembershipStatusReason.INVITED,
+        role: Role.MEMBER,
+      });
+
+      const now = new Date();
+      const { topic, optionA } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: user.id,
+        startsAt: new Date(now.getTime() - 60_000),
+        endsAt: new Date(now.getTime() + 3_600_000),
+      });
+
+      const ctx = { currentUser: { id: user.id }, issuer } as unknown as IContext;
+      // Cast a vote first
+      await voteUseCase.userCastVote(ctx, { input: { topicId: topic.id, optionId: optionA.id } });
+
+      const result = await voteUseCase.userGetMyVoteEligibility(ctx, { topicId: topic.id });
+
+      expect(result.eligible).toBe(true);
+      expect(result.myBallot).not.toBeNull();
+      expect(result.myBallot?.power).toBe(1);
+    });
+
+    it("should return eligible=false with reason=NOT_A_MEMBER when user has no membership", async () => {
+      const nonMember = await TestDataSourceHelper.createUser({
+        name: "NonMember",
+        slug: "non-member-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+      const creator = await TestDataSourceHelper.createUser({
+        name: "Creator",
+        slug: "creator-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+
+      const now = new Date();
+      const { topic } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: creator.id,
+        startsAt: new Date(now.getTime() - 60_000),
+        endsAt: new Date(now.getTime() + 3_600_000),
+      });
+
+      const ctx = { currentUser: { id: nonMember.id }, issuer } as unknown as IContext;
+      const result = await voteUseCase.userGetMyVoteEligibility(ctx, { topicId: topic.id });
+
+      expect(result.eligible).toBe(false);
+      expect(result.reason).toBe("NOT_A_MEMBER");
+      expect(result.currentPower).toBeNull();
+    });
+
+    it("should return eligible=false with reason=INSUFFICIENT_ROLE when user role is below requiredRole", async () => {
+      const member = await TestDataSourceHelper.createUser({
+        name: "Member",
+        slug: "member-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+      await TestDataSourceHelper.createMembership({
+        user: { connect: { id: member.id } },
+        community: { connect: { id: community.id } },
+        status: MembershipStatus.JOINED,
+        reason: MembershipStatusReason.INVITED,
+        role: Role.MEMBER,
+      });
+
+      const now = new Date();
+      const { topic } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: member.id,
+        startsAt: new Date(now.getTime() - 60_000),
+        endsAt: new Date(now.getTime() + 3_600_000),
+        gate: { type: "MEMBERSHIP", requiredRole: "MANAGER" }, // MANAGER 以上が必要
+      });
+
+      const ctx = { currentUser: { id: member.id }, issuer } as unknown as IContext;
+      const result = await voteUseCase.userGetMyVoteEligibility(ctx, { topicId: topic.id });
+
+      expect(result.eligible).toBe(false);
+      expect(result.reason).toBe("INSUFFICIENT_ROLE");
+      expect(result.currentPower).toBeNull();
+    });
+  });
+});

--- a/src/__tests__/integration/vote/voteQuery.test.ts
+++ b/src/__tests__/integration/vote/voteQuery.test.ts
@@ -194,6 +194,10 @@ describe("Vote Integration: VoteQuery", () => {
       });
       expect(page2.nodes).toHaveLength(1);
       expect(page2.pageInfo.hasNextPage).toBe(false);
+      // cursor を指定してページ2を取得したので hasPreviousPage=true
+      expect(page2.pageInfo.hasPreviousPage).toBe(true);
+      // ページ1は cursor なしなので hasPreviousPage=false
+      expect(page1.pageInfo.hasPreviousPage).toBe(false);
     });
 
     it("should hide voteCount/totalPower for an active topic when user is not a manager", async () => {
@@ -437,6 +441,51 @@ describe("Vote Integration: VoteQuery", () => {
       expect(result.eligible).toBe(false);
       expect(result.reason).toBe("INSUFFICIENT_ROLE");
       expect(result.currentPower).toBeNull();
+    });
+
+    it("should return resultVisible=true and myBallot populated when topic has ended (CLOSED)", async () => {
+      // userGetMyVoteEligibility の resultVisible 計算は `now >= endsAt` のみで決まる
+      // checkEligibility は gate（MEMBERSHIP）を見るため、期間終了後も eligible=true になる
+      // → myBallot の resultVisible フラグが true になることで投票結果が開示される
+      const user = await TestDataSourceHelper.createUser({
+        name: "Closed Voter",
+        slug: "closed-voter-slug",
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+      const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+      await TestDataSourceHelper.createMembership({
+        user: { connect: { id: user.id } },
+        community: { connect: { id: community.id } },
+        status: MembershipStatus.JOINED,
+        reason: MembershipStatusReason.INVITED,
+        role: Role.MEMBER,
+      });
+
+      const now = new Date();
+      const { topic, optionA } = await createVoteTopic({
+        communityId: community.id,
+        createdBy: user.id,
+        // 終了済みの topic（期間は過去）
+        startsAt: new Date(now.getTime() - 7_200_000),
+        endsAt: new Date(now.getTime() - 60_000),
+      });
+
+      // ballot を直接作成（期間外なので userCastVote は使えない）
+      const { prismaClient } = await import("@/infrastructure/prisma/client");
+      await prismaClient.voteBallot.create({
+        data: { userId: user.id, topicId: topic.id, optionId: optionA.id, power: 1 },
+      });
+
+      const ctx = { currentUser: { id: user.id }, issuer } as unknown as IContext;
+      const result = await voteUseCase.userGetMyVoteEligibility(ctx, { topicId: topic.id });
+
+      // 期間終了後も MEMBERSHIP gate が JOINED を確認するため eligible=true
+      expect(result.eligible).toBe(true);
+      // myBallot が返却される
+      expect(result.myBallot).not.toBeNull();
+      expect(result.myBallot?.power).toBe(1);
+      // resultVisible フラグが true（期間終了 → 結果開示モード）
+      expect((result.myBallot as any).resultVisible).toBe(true);
     });
   });
 });

--- a/src/__tests__/integration/vote/voteTopicCreate.test.ts
+++ b/src/__tests__/integration/vote/voteTopicCreate.test.ts
@@ -97,7 +97,7 @@ describe("Vote Integration: VoteTopicCreate", () => {
     ).rejects.toThrow(ValidationError);
   });
 
-  it("should throw ValidationError when startsAt >= endsAt", async () => {
+  it("should throw ValidationError when startsAt >= endsAt (startsAt > endsAt)", async () => {
     const manager = await TestDataSourceHelper.createUser({
       name: "Manager",
       slug: "manager-slug-3",
@@ -112,6 +112,28 @@ describe("Vote Integration: VoteTopicCreate", () => {
         input: makeValidInput(community.id, {
           startsAt: new Date(now.getTime() + 3_600_000),
           endsAt: new Date(now.getTime() + 60_000), // endsAt < startsAt
+        }),
+        permission: { communityId: community.id },
+      }),
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it("should throw ValidationError when startsAt === endsAt (exact equality, boundary of >= check)", async () => {
+    // validateTopicInput の条件は `startsAt >= endsAt` なので等値も拒否される
+    const manager = await TestDataSourceHelper.createUser({
+      name: "Manager",
+      slug: "manager-slug-3b",
+      currentPrefecture: CurrentPrefecture.KAGAWA,
+    });
+    const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+
+    const sameTime = new Date(Date.now() + 3_600_000);
+    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    await expect(
+      voteUseCase.managerCreateVoteTopic(ctx, {
+        input: makeValidInput(community.id, {
+          startsAt: sameTime,
+          endsAt: sameTime, // 完全等値
         }),
         permission: { communityId: community.id },
       }),

--- a/src/__tests__/integration/vote/voteTopicCreate.test.ts
+++ b/src/__tests__/integration/vote/voteTopicCreate.test.ts
@@ -1,0 +1,171 @@
+import "reflect-metadata";
+import TestDataSourceHelper from "../../helper/test-data-source-helper";
+import { CurrentPrefecture, MembershipStatus, MembershipStatusReason, Role } from "@prisma/client";
+import { IContext } from "@/types/server";
+import VoteUseCase from "@/application/domain/vote/usecase";
+import { container } from "tsyringe";
+import { registerProductionDependencies } from "@/application/provider";
+import { PrismaClientIssuer } from "@/infrastructure/prisma/client";
+import { ValidationError } from "@/errors/graphql";
+import { GqlVoteGateType, GqlVotePowerPolicyType } from "@/types/graphql";
+
+describe("Vote Integration: VoteTopicCreate", () => {
+  let voteUseCase: VoteUseCase;
+  let issuer: PrismaClientIssuer;
+
+  beforeEach(async () => {
+    await TestDataSourceHelper.deleteAll();
+    jest.clearAllMocks();
+    container.reset();
+    registerProductionDependencies();
+
+    issuer = container.resolve(PrismaClientIssuer);
+    voteUseCase = container.resolve(VoteUseCase);
+  });
+
+  afterAll(async () => {
+    await TestDataSourceHelper.disconnect();
+  });
+
+  it("should create a vote topic with MEMBERSHIP gate and FLAT power policy", async () => {
+    const manager = await TestDataSourceHelper.createUser({
+      name: "Manager",
+      slug: "manager-slug",
+      currentPrefecture: CurrentPrefecture.KAGAWA,
+    });
+
+    const community = await TestDataSourceHelper.createCommunity({
+      name: "test-community",
+      pointName: "pt",
+    });
+
+    await TestDataSourceHelper.createMembership({
+      user: { connect: { id: manager.id } },
+      community: { connect: { id: community.id } },
+      status: MembershipStatus.JOINED,
+      reason: MembershipStatusReason.INVITED,
+      role: Role.MANAGER,
+    });
+
+    const ctx = {
+      currentUser: {
+        id: manager.id,
+        memberships: [{ communityId: community.id, role: Role.MANAGER, status: MembershipStatus.JOINED }],
+      },
+      issuer,
+    } as unknown as IContext;
+
+    const now = new Date();
+    const startsAt = new Date(now.getTime() + 60_000);
+    const endsAt = new Date(now.getTime() + 3_600_000);
+
+    const input = {
+      communityId: community.id,
+      title: "Test Vote",
+      description: "Test description",
+      startsAt,
+      endsAt,
+      gate: { type: GqlVoteGateType.Membership },
+      powerPolicy: { type: GqlVotePowerPolicyType.Flat },
+      options: [
+        { label: "Option A", orderIndex: 0 },
+        { label: "Option B", orderIndex: 1 },
+      ],
+    };
+
+    const result = await voteUseCase.managerCreateVoteTopic(ctx, {
+      input,
+      permission: { communityId: community.id },
+    });
+
+    expect(result.voteTopic).toBeDefined();
+    expect(result.voteTopic.title).toBe("Test Vote");
+    expect(result.voteTopic.gate.type).toBe("MEMBERSHIP");
+    expect(result.voteTopic.powerPolicy.type).toBe("FLAT");
+    expect(result.voteTopic.options).toHaveLength(2);
+    expect(result.voteTopic.options.map((o) => o.label).sort()).toEqual(["Option A", "Option B"]);
+  });
+
+  it("should throw ValidationError when communityId in input does not match permission", async () => {
+    const manager = await TestDataSourceHelper.createUser({
+      name: "Manager2",
+      slug: "manager-slug-2",
+      currentPrefecture: CurrentPrefecture.KAGAWA,
+    });
+
+    const communityA = await TestDataSourceHelper.createCommunity({
+      name: "community-a",
+      pointName: "pt",
+    });
+
+    const communityB = await TestDataSourceHelper.createCommunity({
+      name: "community-b",
+      pointName: "pt",
+    });
+
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+    } as unknown as IContext;
+
+    const now = new Date();
+    const input = {
+      communityId: communityA.id,
+      title: "Mismatched Topic",
+      startsAt: new Date(now.getTime() + 60_000),
+      endsAt: new Date(now.getTime() + 3_600_000),
+      gate: { type: GqlVoteGateType.Membership },
+      powerPolicy: { type: GqlVotePowerPolicyType.Flat },
+      options: [
+        { label: "Option A", orderIndex: 0 },
+        { label: "Option B", orderIndex: 1 },
+      ],
+    };
+
+    await expect(
+      voteUseCase.managerCreateVoteTopic(ctx, {
+        input,
+        permission: { communityId: communityB.id },
+      }),
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it("should throw ValidationError when startsAt is not before endsAt", async () => {
+    const manager = await TestDataSourceHelper.createUser({
+      name: "Manager3",
+      slug: "manager-slug-3",
+      currentPrefecture: CurrentPrefecture.KAGAWA,
+    });
+
+    const community = await TestDataSourceHelper.createCommunity({
+      name: "community-date-check",
+      pointName: "pt",
+    });
+
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+    } as unknown as IContext;
+
+    const now = new Date();
+    const input = {
+      communityId: community.id,
+      title: "Bad Date Topic",
+      startsAt: new Date(now.getTime() + 3_600_000),
+      endsAt: new Date(now.getTime() + 60_000), // endsAt before startsAt
+      gate: { type: GqlVoteGateType.Membership },
+      powerPolicy: { type: GqlVotePowerPolicyType.Flat },
+      options: [
+        { label: "Option A", orderIndex: 0 },
+        { label: "Option B", orderIndex: 1 },
+      ],
+    };
+
+    await expect(
+      voteUseCase.managerCreateVoteTopic(ctx, {
+        input,
+        permission: { communityId: community.id },
+      }),
+    ).rejects.toThrow(ValidationError);
+  });
+});

--- a/src/__tests__/integration/vote/voteTopicCreate.test.ts
+++ b/src/__tests__/integration/vote/voteTopicCreate.test.ts
@@ -8,6 +8,27 @@ import { registerProductionDependencies } from "@/application/provider";
 import { PrismaClientIssuer } from "@/infrastructure/prisma/client";
 import { ValidationError } from "@/errors/graphql";
 import { GqlVoteGateType, GqlVotePowerPolicyType } from "@/types/graphql";
+import { createNftToken } from "./helpers";
+
+// ─── 共通セットアップ ─────────────────────────────────────────────────────────
+
+/** テスト用の最小有効 input を生成する。各テストで必要に応じて上書きする。 */
+function makeValidInput(communityId: string, overrides: Record<string, unknown> = {}) {
+  const now = new Date();
+  return {
+    communityId,
+    title: "Test Vote",
+    startsAt: new Date(now.getTime() + 60_000),
+    endsAt: new Date(now.getTime() + 3_600_000),
+    gate: { type: GqlVoteGateType.Membership },
+    powerPolicy: { type: GqlVotePowerPolicyType.Flat },
+    options: [
+      { label: "Option A", orderIndex: 0 },
+      { label: "Option B", orderIndex: 1 },
+    ],
+    ...overrides,
+  };
+}
 
 describe("Vote Integration: VoteTopicCreate", () => {
   let voteUseCase: VoteUseCase;
@@ -27,18 +48,15 @@ describe("Vote Integration: VoteTopicCreate", () => {
     await TestDataSourceHelper.disconnect();
   });
 
+  // ─── 正常系 ──────────────────────────────────────────────────────────────────
+
   it("should create a vote topic with MEMBERSHIP gate and FLAT power policy", async () => {
     const manager = await TestDataSourceHelper.createUser({
       name: "Manager",
       slug: "manager-slug",
       currentPrefecture: CurrentPrefecture.KAGAWA,
     });
-
-    const community = await TestDataSourceHelper.createCommunity({
-      name: "test-community",
-      pointName: "pt",
-    });
-
+    const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
     await TestDataSourceHelper.createMembership({
       user: { connect: { id: manager.id } },
       community: { connect: { id: community.id } },
@@ -47,125 +65,171 @@ describe("Vote Integration: VoteTopicCreate", () => {
       role: Role.MANAGER,
     });
 
-    const ctx = {
-      currentUser: {
-        id: manager.id,
-        memberships: [{ communityId: community.id, role: Role.MANAGER, status: MembershipStatus.JOINED }],
-      },
-      issuer,
-    } as unknown as IContext;
-
-    const now = new Date();
-    const startsAt = new Date(now.getTime() + 60_000);
-    const endsAt = new Date(now.getTime() + 3_600_000);
-
-    const input = {
-      communityId: community.id,
-      title: "Test Vote",
-      description: "Test description",
-      startsAt,
-      endsAt,
-      gate: { type: GqlVoteGateType.Membership },
-      powerPolicy: { type: GqlVotePowerPolicyType.Flat },
-      options: [
-        { label: "Option A", orderIndex: 0 },
-        { label: "Option B", orderIndex: 1 },
-      ],
-    };
-
+    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
     const result = await voteUseCase.managerCreateVoteTopic(ctx, {
-      input,
+      input: makeValidInput(community.id),
       permission: { communityId: community.id },
     });
 
-    expect(result.voteTopic).toBeDefined();
     expect(result.voteTopic.title).toBe("Test Vote");
     expect(result.voteTopic.gate.type).toBe("MEMBERSHIP");
     expect(result.voteTopic.powerPolicy.type).toBe("FLAT");
     expect(result.voteTopic.options).toHaveLength(2);
-    expect(result.voteTopic.options.map((o) => o.label).sort()).toEqual(["Option A", "Option B"]);
   });
+
+  // ─── 異常系: communityId / 日付 ──────────────────────────────────────────────
 
   it("should throw ValidationError when communityId in input does not match permission", async () => {
     const manager = await TestDataSourceHelper.createUser({
-      name: "Manager2",
+      name: "Manager",
       slug: "manager-slug-2",
       currentPrefecture: CurrentPrefecture.KAGAWA,
     });
+    const communityA = await TestDataSourceHelper.createCommunity({ name: "community-a", pointName: "pt" });
+    const communityB = await TestDataSourceHelper.createCommunity({ name: "community-b", pointName: "pt" });
 
-    const communityA = await TestDataSourceHelper.createCommunity({
-      name: "community-a",
-      pointName: "pt",
-    });
-
-    const communityB = await TestDataSourceHelper.createCommunity({
-      name: "community-b",
-      pointName: "pt",
-    });
-
-    const ctx = {
-      currentUser: { id: manager.id },
-      issuer,
-    } as unknown as IContext;
-
-    const now = new Date();
-    const input = {
-      communityId: communityA.id,
-      title: "Mismatched Topic",
-      startsAt: new Date(now.getTime() + 60_000),
-      endsAt: new Date(now.getTime() + 3_600_000),
-      gate: { type: GqlVoteGateType.Membership },
-      powerPolicy: { type: GqlVotePowerPolicyType.Flat },
-      options: [
-        { label: "Option A", orderIndex: 0 },
-        { label: "Option B", orderIndex: 1 },
-      ],
-    };
-
+    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
     await expect(
       voteUseCase.managerCreateVoteTopic(ctx, {
-        input,
+        input: makeValidInput(communityA.id),
         permission: { communityId: communityB.id },
       }),
     ).rejects.toThrow(ValidationError);
   });
 
-  it("should throw ValidationError when startsAt is not before endsAt", async () => {
+  it("should throw ValidationError when startsAt >= endsAt", async () => {
     const manager = await TestDataSourceHelper.createUser({
-      name: "Manager3",
+      name: "Manager",
       slug: "manager-slug-3",
       currentPrefecture: CurrentPrefecture.KAGAWA,
     });
-
-    const community = await TestDataSourceHelper.createCommunity({
-      name: "community-date-check",
-      pointName: "pt",
-    });
-
-    const ctx = {
-      currentUser: { id: manager.id },
-      issuer,
-    } as unknown as IContext;
+    const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
 
     const now = new Date();
-    const input = {
-      communityId: community.id,
-      title: "Bad Date Topic",
-      startsAt: new Date(now.getTime() + 3_600_000),
-      endsAt: new Date(now.getTime() + 60_000), // endsAt before startsAt
-      gate: { type: GqlVoteGateType.Membership },
-      powerPolicy: { type: GqlVotePowerPolicyType.Flat },
-      options: [
-        { label: "Option A", orderIndex: 0 },
-        { label: "Option B", orderIndex: 1 },
-      ],
-    };
-
+    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
     await expect(
       voteUseCase.managerCreateVoteTopic(ctx, {
-        input,
+        input: makeValidInput(community.id, {
+          startsAt: new Date(now.getTime() + 3_600_000),
+          endsAt: new Date(now.getTime() + 60_000), // endsAt < startsAt
+        }),
         permission: { communityId: community.id },
       }),
     ).rejects.toThrow(ValidationError);
+  });
+
+  // ─── 異常系: options バリデーション ──────────────────────────────────────────
+
+  it("should throw ValidationError when options has fewer than 2 items", async () => {
+    const manager = await TestDataSourceHelper.createUser({
+      name: "Manager",
+      slug: "manager-slug-4",
+      currentPrefecture: CurrentPrefecture.KAGAWA,
+    });
+    const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+
+    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    await expect(
+      voteUseCase.managerCreateVoteTopic(ctx, {
+        input: makeValidInput(community.id, {
+          options: [{ label: "Only Option", orderIndex: 0 }], // 1 つしかない
+        }),
+        permission: { communityId: community.id },
+      }),
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it("should throw ValidationError when an option has a negative orderIndex", async () => {
+    const manager = await TestDataSourceHelper.createUser({
+      name: "Manager",
+      slug: "manager-slug-5",
+      currentPrefecture: CurrentPrefecture.KAGAWA,
+    });
+    const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+
+    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    await expect(
+      voteUseCase.managerCreateVoteTopic(ctx, {
+        input: makeValidInput(community.id, {
+          options: [
+            { label: "Option A", orderIndex: -1 }, // 負のインデックス
+            { label: "Option B", orderIndex: 1 },
+          ],
+        }),
+        permission: { communityId: community.id },
+      }),
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it("should throw ValidationError when options have duplicate orderIndex values", async () => {
+    const manager = await TestDataSourceHelper.createUser({
+      name: "Manager",
+      slug: "manager-slug-6",
+      currentPrefecture: CurrentPrefecture.KAGAWA,
+    });
+    const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+
+    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    await expect(
+      voteUseCase.managerCreateVoteTopic(ctx, {
+        input: makeValidInput(community.id, {
+          options: [
+            { label: "Option A", orderIndex: 0 },
+            { label: "Option B", orderIndex: 0 }, // 重複
+          ],
+        }),
+        permission: { communityId: community.id },
+      }),
+    ).rejects.toThrow(ValidationError);
+  });
+
+  // ─── 異常系: NFT gate / NFT_COUNT policy バリデーション ──────────────────────
+
+  it("should throw ValidationError when NFT gate is specified without nftTokenId", async () => {
+    const manager = await TestDataSourceHelper.createUser({
+      name: "Manager",
+      slug: "manager-slug-7",
+      currentPrefecture: CurrentPrefecture.KAGAWA,
+    });
+    const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+
+    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    await expect(
+      voteUseCase.managerCreateVoteTopic(ctx, {
+        input: makeValidInput(community.id, {
+          gate: { type: GqlVoteGateType.Nft }, // nftTokenId なし
+        }),
+        permission: { communityId: community.id },
+      }),
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it("should throw ValidationError when NFT_COUNT policy is specified without nftTokenId", async () => {
+    const manager = await TestDataSourceHelper.createUser({
+      name: "Manager",
+      slug: "manager-slug-8",
+      currentPrefecture: CurrentPrefecture.KAGAWA,
+    });
+    const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+
+    // NFT_COUNT policy には nftTokenId が必須だが、
+    // NFT gate ではなく MEMBERSHIP gate の場合でも policy 側は独立して検証される
+    const nftToken = await createNftToken(); // gate 用ではなく policy 検証のため
+
+    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    await expect(
+      voteUseCase.managerCreateVoteTopic(ctx, {
+        input: makeValidInput(community.id, {
+          gate: { type: GqlVoteGateType.Membership },
+          powerPolicy: {
+            type: GqlVotePowerPolicyType.NftCount,
+            // nftTokenId なし
+          },
+        }),
+        permission: { communityId: community.id },
+      }),
+    ).rejects.toThrow(ValidationError);
+
+    void nftToken; // 未使用変数の警告を抑制
   });
 });

--- a/src/__tests__/integration/vote/voteTopicCreate.test.ts
+++ b/src/__tests__/integration/vote/voteTopicCreate.test.ts
@@ -77,6 +77,37 @@ describe("Vote Integration: VoteTopicCreate", () => {
     expect(result.voteTopic.options).toHaveLength(2);
   });
 
+  it("should create a vote topic with NFT gate when a valid nftTokenId is provided", async () => {
+    // NFT gate の作成成功パス：nftTokenId が正しく DB に保存されることを確認する
+    const manager = await TestDataSourceHelper.createUser({
+      name: "Manager NFT",
+      slug: "manager-nft-slug",
+      currentPrefecture: CurrentPrefecture.KAGAWA,
+    });
+    const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+    await TestDataSourceHelper.createMembership({
+      user: { connect: { id: manager.id } },
+      community: { connect: { id: community.id } },
+      status: MembershipStatus.JOINED,
+      reason: MembershipStatusReason.INVITED,
+      role: Role.MANAGER,
+    });
+
+    const nftToken = await createNftToken();
+
+    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const result = await voteUseCase.managerCreateVoteTopic(ctx, {
+      input: makeValidInput(community.id, {
+        gate: { type: GqlVoteGateType.Nft, nftTokenId: nftToken.id },
+      }),
+      permission: { communityId: community.id },
+    });
+
+    expect(result.voteTopic.gate.type).toBe("NFT");
+    // gate の nftTokenId が DB に保存されていること（フィールドリゾルバー用メタデータ）
+    expect((result.voteTopic.gate as any).nftTokenId).toBe(nftToken.id);
+  });
+
   // ─── 異常系: communityId / 日付 ──────────────────────────────────────────────
 
   it("should throw ValidationError when communityId in input does not match permission", async () => {

--- a/src/__tests__/integration/vote/voteTopicDelete.test.ts
+++ b/src/__tests__/integration/vote/voteTopicDelete.test.ts
@@ -6,7 +6,7 @@ import VoteUseCase from "@/application/domain/vote/usecase";
 import { container } from "tsyringe";
 import { registerProductionDependencies } from "@/application/provider";
 import { PrismaClientIssuer, prismaClient } from "@/infrastructure/prisma/client";
-import { AuthorizationError } from "@/errors/graphql";
+import { AuthorizationError, NotFoundError } from "@/errors/graphql";
 import { createVoteTopic } from "./helpers";
 
 describe("Vote Integration: VoteTopicDelete", () => {
@@ -63,6 +63,32 @@ describe("Vote Integration: VoteTopicDelete", () => {
     // Verify it is no longer in the DB
     const deleted = await prismaClient.voteTopic.findUnique({ where: { id: topic.id } });
     expect(deleted).toBeNull();
+  });
+
+  // ─── 異常系: 存在しない topic ───────────────────────────────────────────────
+
+  it("should throw NotFoundError when the topic id does not exist", async () => {
+    const manager = await TestDataSourceHelper.createUser({
+      name: "Manager",
+      slug: "manager-slug-nf",
+      currentPrefecture: CurrentPrefecture.KAGAWA,
+    });
+    const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+    await TestDataSourceHelper.createMembership({
+      user: { connect: { id: manager.id } },
+      community: { connect: { id: community.id } },
+      status: MembershipStatus.JOINED,
+      reason: MembershipStatusReason.INVITED,
+      role: Role.MANAGER,
+    });
+
+    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    await expect(
+      voteUseCase.managerDeleteVoteTopic(ctx, {
+        id: "nonexistent-topic-id",
+        permission: { communityId: community.id },
+      }),
+    ).rejects.toThrow(NotFoundError);
   });
 
   // ─── 異常系: communityId ──────────────────────────────────────────────────

--- a/src/__tests__/integration/vote/voteTopicDelete.test.ts
+++ b/src/__tests__/integration/vote/voteTopicDelete.test.ts
@@ -1,0 +1,179 @@
+import "reflect-metadata";
+import TestDataSourceHelper from "../../helper/test-data-source-helper";
+import { CurrentPrefecture, MembershipStatus, MembershipStatusReason, Role } from "@prisma/client";
+import { IContext } from "@/types/server";
+import VoteUseCase from "@/application/domain/vote/usecase";
+import { container } from "tsyringe";
+import { registerProductionDependencies } from "@/application/provider";
+import { PrismaClientIssuer, prismaClient } from "@/infrastructure/prisma/client";
+import { AuthorizationError } from "@/errors/graphql";
+import { createVoteTopic } from "./helpers";
+
+describe("Vote Integration: VoteTopicDelete", () => {
+  let voteUseCase: VoteUseCase;
+  let issuer: PrismaClientIssuer;
+
+  beforeEach(async () => {
+    await TestDataSourceHelper.deleteAll();
+    jest.clearAllMocks();
+    container.reset();
+    registerProductionDependencies();
+
+    issuer = container.resolve(PrismaClientIssuer);
+    voteUseCase = container.resolve(VoteUseCase);
+  });
+
+  afterAll(async () => {
+    await TestDataSourceHelper.disconnect();
+  });
+
+  // ─── 正常系 ──────────────────────────────────────────────────────────────────
+
+  it("should delete a vote topic and return the deleted id", async () => {
+    const manager = await TestDataSourceHelper.createUser({
+      name: "Manager",
+      slug: "manager-slug",
+      currentPrefecture: CurrentPrefecture.KAGAWA,
+    });
+    const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+    await TestDataSourceHelper.createMembership({
+      user: { connect: { id: manager.id } },
+      community: { connect: { id: community.id } },
+      status: MembershipStatus.JOINED,
+      reason: MembershipStatusReason.INVITED,
+      role: Role.MANAGER,
+    });
+
+    const now = new Date();
+    const { topic } = await createVoteTopic({
+      communityId: community.id,
+      createdBy: manager.id,
+      startsAt: new Date(now.getTime() - 60_000),
+      endsAt: new Date(now.getTime() + 3_600_000),
+    });
+
+    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const result = await voteUseCase.managerDeleteVoteTopic(ctx, {
+      id: topic.id,
+      permission: { communityId: community.id },
+    });
+
+    expect(result.id).toBe(topic.id);
+
+    // Verify it is no longer in the DB
+    const deleted = await prismaClient.voteTopic.findUnique({ where: { id: topic.id } });
+    expect(deleted).toBeNull();
+  });
+
+  // ─── 異常系: communityId ──────────────────────────────────────────────────
+
+  it("should throw AuthorizationError when topic does not belong to the specified community", async () => {
+    const manager = await TestDataSourceHelper.createUser({
+      name: "Manager",
+      slug: "manager-slug-2",
+      currentPrefecture: CurrentPrefecture.KAGAWA,
+    });
+    const communityA = await TestDataSourceHelper.createCommunity({ name: "community-a", pointName: "pt" });
+    const communityB = await TestDataSourceHelper.createCommunity({ name: "community-b", pointName: "pt" });
+    await TestDataSourceHelper.createMembership({
+      user: { connect: { id: manager.id } },
+      community: { connect: { id: communityA.id } },
+      status: MembershipStatus.JOINED,
+      reason: MembershipStatusReason.INVITED,
+      role: Role.MANAGER,
+    });
+
+    const now = new Date();
+    const { topic } = await createVoteTopic({
+      communityId: communityA.id, // topic belongs to communityA
+      createdBy: manager.id,
+      startsAt: new Date(now.getTime() - 60_000),
+      endsAt: new Date(now.getTime() + 3_600_000),
+    });
+
+    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    await expect(
+      voteUseCase.managerDeleteVoteTopic(ctx, {
+        id: topic.id,
+        permission: { communityId: communityB.id }, // wrong community
+      }),
+    ).rejects.toThrow(AuthorizationError);
+  });
+
+  // ─── カスケード削除の確認 ─────────────────────────────────────────────────
+
+  it("should cascade-delete gate, powerPolicy, options and ballots when a topic is deleted", async () => {
+    const manager = await TestDataSourceHelper.createUser({
+      name: "Manager",
+      slug: "manager-slug-3",
+      currentPrefecture: CurrentPrefecture.KAGAWA,
+    });
+    const voter = await TestDataSourceHelper.createUser({
+      name: "Voter",
+      slug: "voter-slug-3",
+      currentPrefecture: CurrentPrefecture.KAGAWA,
+    });
+    const community = await TestDataSourceHelper.createCommunity({ name: "community", pointName: "pt" });
+    await TestDataSourceHelper.createMembership({
+      user: { connect: { id: manager.id } },
+      community: { connect: { id: community.id } },
+      status: MembershipStatus.JOINED,
+      reason: MembershipStatusReason.INVITED,
+      role: Role.MANAGER,
+    });
+    await TestDataSourceHelper.createMembership({
+      user: { connect: { id: voter.id } },
+      community: { connect: { id: community.id } },
+      status: MembershipStatus.JOINED,
+      reason: MembershipStatusReason.INVITED,
+      role: Role.MEMBER,
+    });
+
+    const now = new Date();
+    const { topic, optionA } = await createVoteTopic({
+      communityId: community.id,
+      createdBy: manager.id,
+      startsAt: new Date(now.getTime() - 60_000),
+      endsAt: new Date(now.getTime() + 3_600_000),
+    });
+
+    // Create a ballot directly to verify cascade deletion
+    await prismaClient.voteBallot.create({
+      data: {
+        userId: voter.id,
+        topicId: topic.id,
+        optionId: optionA.id,
+        power: 1,
+      },
+    });
+
+    // Confirm all records exist before deletion
+    const gateBefore = await prismaClient.voteGate.findFirst({ where: { topicId: topic.id } });
+    const policyBefore = await prismaClient.votePowerPolicy.findFirst({ where: { topicId: topic.id } });
+    const optionsBefore = await prismaClient.voteOption.findMany({ where: { topicId: topic.id } });
+    const ballotBefore = await prismaClient.voteBallot.findFirst({ where: { topicId: topic.id } });
+
+    expect(gateBefore).not.toBeNull();
+    expect(policyBefore).not.toBeNull();
+    expect(optionsBefore).toHaveLength(2);
+    expect(ballotBefore).not.toBeNull();
+
+    // Delete the topic
+    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    await voteUseCase.managerDeleteVoteTopic(ctx, {
+      id: topic.id,
+      permission: { communityId: community.id },
+    });
+
+    // All related records should be cascade-deleted
+    const gateAfter = await prismaClient.voteGate.findFirst({ where: { topicId: topic.id } });
+    const policyAfter = await prismaClient.votePowerPolicy.findFirst({ where: { topicId: topic.id } });
+    const optionsAfter = await prismaClient.voteOption.findMany({ where: { topicId: topic.id } });
+    const ballotAfter = await prismaClient.voteBallot.findFirst({ where: { topicId: topic.id } });
+
+    expect(gateAfter).toBeNull();
+    expect(policyAfter).toBeNull();
+    expect(optionsAfter).toHaveLength(0);
+    expect(ballotAfter).toBeNull();
+  });
+});

--- a/src/__tests__/unit/vote/vote.service.test.ts
+++ b/src/__tests__/unit/vote/vote.service.test.ts
@@ -413,3 +413,70 @@ describe("VoteService.updateOptionCounts", () => {
     expect(mockRepo.incrementOptionCount).not.toHaveBeenCalled();
   });
 });
+
+// ---- calcResultVisible ----
+
+describe("VoteService.calcResultVisible", () => {
+  it("returns true when isManager is true regardless of time", () => {
+    const futureDate = new Date(Date.now() + 1000 * 60 * 60);
+    expect(service.calcResultVisible(futureDate, true)).toBe(true);
+  });
+
+  it("returns true when endsAt is in the past and isManager is false", () => {
+    const pastDate = new Date(Date.now() - 1000);
+    expect(service.calcResultVisible(pastDate, false)).toBe(true);
+  });
+
+  it("returns true when endsAt equals now (boundary: >=)", () => {
+    // new Date() の実行タイミング次第で境界値テストは不安定になるため
+    // 確実に過去になる値（1ms前）で >= 条件を確認する
+    const slightlyPast = new Date(Date.now() - 1);
+    expect(service.calcResultVisible(slightlyPast, false)).toBe(true);
+  });
+
+  it("returns false when endsAt is in the future and isManager is false", () => {
+    const futureDate = new Date(Date.now() + 1000 * 60 * 60);
+    expect(service.calcResultVisible(futureDate, false)).toBe(false);
+  });
+});
+
+// ---- calcPhase ----
+
+describe("VoteService.calcPhase", () => {
+  it("returns UPCOMING when now < startsAt", () => {
+    const startsAt = new Date(Date.now() + 1000 * 60 * 60);
+    const endsAt = new Date(Date.now() + 1000 * 60 * 120);
+    expect(service.calcPhase(startsAt, endsAt)).toBe("UPCOMING");
+  });
+
+  it("returns OPEN when startsAt <= now < endsAt", () => {
+    const startsAt = new Date(Date.now() - 1000 * 60);
+    const endsAt = new Date(Date.now() + 1000 * 60 * 60);
+    expect(service.calcPhase(startsAt, endsAt)).toBe("OPEN");
+  });
+
+  it("returns CLOSED when now >= endsAt", () => {
+    const startsAt = new Date(Date.now() - 1000 * 60 * 120);
+    const endsAt = new Date(Date.now() - 1000);
+    expect(service.calcPhase(startsAt, endsAt)).toBe("CLOSED");
+  });
+});
+
+// ---- validateTopicRelations ----
+
+describe("VoteService.validateTopicRelations", () => {
+  it("does not throw when gate and powerPolicy are both present", () => {
+    const topic = makeTopic();
+    expect(() => service.validateTopicRelations(topic)).not.toThrow();
+  });
+
+  it("throws ValidationError when gate is missing", () => {
+    const topic = makeTopic({ gate: null } as Partial<PrismaVoteTopic>);
+    expect(() => service.validateTopicRelations(topic)).toThrow(ValidationError);
+  });
+
+  it("throws ValidationError when powerPolicy is missing", () => {
+    const topic = makeTopic({ powerPolicy: null } as Partial<PrismaVoteTopic>);
+    expect(() => service.validateTopicRelations(topic)).toThrow(ValidationError);
+  });
+});

--- a/src/__tests__/unit/vote/vote.service.test.ts
+++ b/src/__tests__/unit/vote/vote.service.test.ts
@@ -124,6 +124,73 @@ beforeEach(() => {
   service = container.resolve(VoteService);
 });
 
+// ---- validateTopicInput ----
+
+describe("VoteService.validateTopicInput", () => {
+  const baseInput = {
+    communityId,
+    title: "Test",
+    startsAt: new Date(Date.now() - 1000 * 60),
+    endsAt: new Date(Date.now() + 1000 * 60 * 60),
+    gate: { type: "MEMBERSHIP" as const },
+    powerPolicy: { type: "FLAT" as const },
+    options: [
+      { label: "A", orderIndex: 0 },
+      { label: "B", orderIndex: 1 },
+    ],
+  };
+
+  it("passes for valid input", () => {
+    expect(() => service.validateTopicInput(baseInput)).not.toThrow();
+  });
+
+  it("throws when startsAt >= endsAt", () => {
+    const input = { ...baseInput, startsAt: new Date(Date.now() + 1000), endsAt: new Date(Date.now()) };
+    expect(() => service.validateTopicInput(input)).toThrow(ValidationError);
+  });
+
+  it("throws when fewer than 2 options", () => {
+    const input = { ...baseInput, options: [{ label: "A", orderIndex: 0 }] };
+    expect(() => service.validateTopicInput(input)).toThrow(ValidationError);
+  });
+
+  it("throws when an orderIndex is negative", () => {
+    const input = {
+      ...baseInput,
+      options: [{ label: "A", orderIndex: -1 }, { label: "B", orderIndex: 1 }],
+    };
+    expect(() => service.validateTopicInput(input)).toThrow(ValidationError);
+  });
+
+  it("throws when orderIndex values are duplicated", () => {
+    const input = {
+      ...baseInput,
+      options: [{ label: "A", orderIndex: 0 }, { label: "B", orderIndex: 0 }],
+    };
+    expect(() => service.validateTopicInput(input)).toThrow(ValidationError);
+  });
+
+  it("throws when NFT gate has no nftTokenId", () => {
+    const input = { ...baseInput, gate: { type: "NFT" as const } };
+    expect(() => service.validateTopicInput(input)).toThrow(ValidationError);
+  });
+
+  it("passes when NFT gate has nftTokenId", () => {
+    const input = { ...baseInput, gate: { type: "NFT" as const, nftTokenId } };
+    expect(() => service.validateTopicInput(input)).not.toThrow();
+  });
+
+  it("throws when NFT_COUNT policy has no nftTokenId", () => {
+    const input = { ...baseInput, powerPolicy: { type: "NFT_COUNT" as const } };
+    expect(() => service.validateTopicInput(input)).toThrow(ValidationError);
+  });
+
+  it("passes when NFT_COUNT policy has nftTokenId", () => {
+    const input = { ...baseInput, powerPolicy: { type: "NFT_COUNT" as const, nftTokenId } };
+    expect(() => service.validateTopicInput(input)).not.toThrow();
+  });
+});
+
 // ---- validateVotingPeriod ----
 
 describe("VoteService.validateVotingPeriod", () => {

--- a/src/__tests__/unit/vote/vote.service.test.ts
+++ b/src/__tests__/unit/vote/vote.service.test.ts
@@ -230,7 +230,7 @@ describe("VoteService.checkEligibility", () => {
       mockNftInstanceRepo.existsByUserAndToken.mockResolvedValue(true);
       const result = await service.checkEligibility(mockCtx, userId, topicNft);
       expect(result.eligible).toBe(true);
-      expect(mockNftInstanceRepo.existsByUserAndToken).toHaveBeenCalledWith(mockCtx, userId, nftTokenId);
+      expect(mockNftInstanceRepo.existsByUserAndToken).toHaveBeenCalledWith(mockCtx, userId, nftTokenId, undefined);
     });
 
     it("returns ineligible when user does not own the required NFT", async () => {
@@ -274,7 +274,7 @@ describe("VoteService.calculatePower", () => {
     mockNftInstanceRepo.countByUserAndToken.mockResolvedValue(3);
     const power = await service.calculatePower(mockCtx, userId, topic);
     expect(power).toBe(3);
-    expect(mockNftInstanceRepo.countByUserAndToken).toHaveBeenCalledWith(mockCtx, userId, nftTokenId);
+    expect(mockNftInstanceRepo.countByUserAndToken).toHaveBeenCalledWith(mockCtx, userId, nftTokenId, undefined);
   });
 
   it("throws ValidationError when NFT_COUNT policy has no nftTokenId", async () => {

--- a/src/__tests__/unit/vote/vote.service.test.ts
+++ b/src/__tests__/unit/vote/vote.service.test.ts
@@ -1,0 +1,348 @@
+import "reflect-metadata";
+import { MembershipStatus, Prisma, Role } from "@prisma/client";
+import { container } from "tsyringe";
+import VoteService from "@/application/domain/vote/service";
+import { IVoteRepository } from "@/application/domain/vote/data/interface";
+import VoteConverter from "@/application/domain/vote/data/converter";
+import { IContext } from "@/types/server";
+import { ValidationError } from "@/errors/graphql";
+import { PrismaVoteTopic, PrismaVoteBallot } from "@/application/domain/vote/data/type";
+
+// ---- Mocks ----
+
+class MockVoteRepository implements IVoteRepository {
+  findTopic = jest.fn();
+  findTopicOrThrow = jest.fn();
+  queryTopics = jest.fn();
+  countTopics = jest.fn();
+  createGate = jest.fn();
+  createPowerPolicy = jest.fn();
+  createTopic = jest.fn();
+  createOptions = jest.fn();
+  deleteTopic = jest.fn();
+  findBallot = jest.fn();
+  upsertBallot = jest.fn();
+  incrementOptionCount = jest.fn();
+  decrementOptionCount = jest.fn();
+  adjustOptionTotalPower = jest.fn();
+}
+
+class MockMembershipService {
+  findMembership = jest.fn();
+}
+
+class MockNftInstanceRepository {
+  existsByUserAndToken = jest.fn();
+  countByUserAndToken = jest.fn();
+  // other methods not used by VoteService
+  query = jest.fn();
+  findAndReserveInstance = jest.fn();
+  releaseReservation = jest.fn();
+  updateStatus = jest.fn();
+  findById = jest.fn();
+  count = jest.fn();
+  upsert = jest.fn();
+  findReservedByProduct = jest.fn();
+  findByIdWithTransaction = jest.fn();
+}
+
+// ---- Fixtures ----
+
+const mockCtx = {} as IContext;
+const mockTx = {} as Prisma.TransactionClient;
+const userId = "user-1";
+const communityId = "community-1";
+const topicId = "topic-1";
+const optionAId = "option-a";
+const optionBId = "option-b";
+const nftTokenId = "token-1";
+
+function makeTopic(overrides: Partial<PrismaVoteTopic> = {}): PrismaVoteTopic {
+  return {
+    id: topicId,
+    communityId,
+    createdBy: "creator",
+    title: "Test Vote",
+    description: null,
+    startsAt: new Date(Date.now() - 1000 * 60),  // 1 minute ago
+    endsAt: new Date(Date.now() + 1000 * 60 * 60), // 1 hour from now
+    createdAt: new Date(),
+    updatedAt: null,
+    gate: {
+      id: "gate-1",
+      type: "MEMBERSHIP",
+      nftTokenId: null,
+      requiredRole: null,
+      topicId,
+    },
+    powerPolicy: {
+      id: "policy-1",
+      type: "FLAT",
+      nftTokenId: null,
+      topicId,
+    },
+    options: [
+      { id: optionAId, topicId, label: "Option A", orderIndex: 0, voteCount: 0, totalPower: 0 },
+      { id: optionBId, topicId, label: "Option B", orderIndex: 1, voteCount: 0, totalPower: 0 },
+    ],
+    ...overrides,
+  } as PrismaVoteTopic;
+}
+
+function makeBallot(optionId: string, power: number): PrismaVoteBallot {
+  return {
+    id: "ballot-1",
+    userId,
+    topicId,
+    optionId,
+    power,
+    createdAt: new Date(),
+    updatedAt: null,
+  };
+}
+
+// ---- Setup ----
+
+let service: VoteService;
+let mockRepo: MockVoteRepository;
+let mockMembershipService: MockMembershipService;
+let mockNftInstanceRepo: MockNftInstanceRepository;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  container.reset();
+
+  mockRepo = new MockVoteRepository();
+  mockMembershipService = new MockMembershipService();
+  mockNftInstanceRepo = new MockNftInstanceRepository();
+
+  container.register("VoteRepository", { useValue: mockRepo });
+  container.register("VoteConverter", { useClass: VoteConverter });
+  container.register("MembershipService", { useValue: mockMembershipService });
+  container.register("NftInstanceRepository", { useValue: mockNftInstanceRepo });
+
+  service = container.resolve(VoteService);
+});
+
+// ---- validateVotingPeriod ----
+
+describe("VoteService.validateVotingPeriod", () => {
+  it("passes when topic is OPEN", () => {
+    const topic = makeTopic();
+    expect(() => service.validateVotingPeriod(topic)).not.toThrow();
+  });
+
+  it("throws when voting has not started yet", () => {
+    const topic = makeTopic({
+      startsAt: new Date(Date.now() + 1000 * 60 * 60),
+      endsAt: new Date(Date.now() + 1000 * 60 * 120),
+    });
+    expect(() => service.validateVotingPeriod(topic)).toThrow(ValidationError);
+  });
+
+  it("throws when voting period has ended", () => {
+    const topic = makeTopic({
+      startsAt: new Date(Date.now() - 1000 * 60 * 120),
+      endsAt: new Date(Date.now() - 1000 * 60),
+    });
+    expect(() => service.validateVotingPeriod(topic)).toThrow(ValidationError);
+  });
+});
+
+// ---- checkEligibility ----
+
+describe("VoteService.checkEligibility", () => {
+  describe("MEMBERSHIP gate", () => {
+    const topic = makeTopic({
+      gate: { id: "gate-1", type: "MEMBERSHIP", nftTokenId: null, requiredRole: null, topicId },
+    } as Partial<PrismaVoteTopic>);
+
+    it("returns eligible when user is a JOINED MEMBER", async () => {
+      mockMembershipService.findMembership.mockResolvedValue({
+        status: MembershipStatus.JOINED,
+        role: Role.MEMBER,
+      });
+      const result = await service.checkEligibility(mockCtx, userId, topic);
+      expect(result.eligible).toBe(true);
+    });
+
+    it("returns ineligible when user has no membership", async () => {
+      mockMembershipService.findMembership.mockResolvedValue(null);
+      const result = await service.checkEligibility(mockCtx, userId, topic);
+      expect(result.eligible).toBe(false);
+      expect(result.reason).toBe("NOT_A_MEMBER");
+    });
+
+    it("returns ineligible when membership is not JOINED", async () => {
+      mockMembershipService.findMembership.mockResolvedValue({
+        status: MembershipStatus.PENDING,
+        role: Role.MEMBER,
+      });
+      const result = await service.checkEligibility(mockCtx, userId, topic);
+      expect(result.eligible).toBe(false);
+      expect(result.reason).toBe("NOT_A_MEMBER");
+    });
+
+    it("returns ineligible when user role is below requiredRole", async () => {
+      const topicWithRoleReq = makeTopic({
+        gate: { id: "gate-1", type: "MEMBERSHIP", nftTokenId: null, requiredRole: Role.MANAGER, topicId },
+      } as Partial<PrismaVoteTopic>);
+      mockMembershipService.findMembership.mockResolvedValue({
+        status: MembershipStatus.JOINED,
+        role: Role.MEMBER,
+      });
+      const result = await service.checkEligibility(mockCtx, userId, topicWithRoleReq);
+      expect(result.eligible).toBe(false);
+      expect(result.reason).toBe("INSUFFICIENT_ROLE");
+    });
+
+    it("returns eligible when user is MANAGER and requiredRole is MANAGER", async () => {
+      const topicWithRoleReq = makeTopic({
+        gate: { id: "gate-1", type: "MEMBERSHIP", nftTokenId: null, requiredRole: Role.MANAGER, topicId },
+      } as Partial<PrismaVoteTopic>);
+      mockMembershipService.findMembership.mockResolvedValue({
+        status: MembershipStatus.JOINED,
+        role: Role.MANAGER,
+      });
+      const result = await service.checkEligibility(mockCtx, userId, topicWithRoleReq);
+      expect(result.eligible).toBe(true);
+    });
+
+    it("returns eligible when user is OWNER and requiredRole is MANAGER (higher role satisfies)", async () => {
+      const topicWithRoleReq = makeTopic({
+        gate: { id: "gate-1", type: "MEMBERSHIP", nftTokenId: null, requiredRole: Role.MANAGER, topicId },
+      } as Partial<PrismaVoteTopic>);
+      mockMembershipService.findMembership.mockResolvedValue({
+        status: MembershipStatus.JOINED,
+        role: Role.OWNER,
+      });
+      const result = await service.checkEligibility(mockCtx, userId, topicWithRoleReq);
+      expect(result.eligible).toBe(true);
+    });
+  });
+
+  describe("NFT gate", () => {
+    const topicNft = makeTopic({
+      gate: { id: "gate-1", type: "NFT", nftTokenId, requiredRole: null, topicId },
+    } as Partial<PrismaVoteTopic>);
+
+    it("returns eligible when user owns the required NFT", async () => {
+      mockNftInstanceRepo.existsByUserAndToken.mockResolvedValue(true);
+      const result = await service.checkEligibility(mockCtx, userId, topicNft);
+      expect(result.eligible).toBe(true);
+      expect(mockNftInstanceRepo.existsByUserAndToken).toHaveBeenCalledWith(mockCtx, userId, nftTokenId);
+    });
+
+    it("returns ineligible when user does not own the required NFT", async () => {
+      mockNftInstanceRepo.existsByUserAndToken.mockResolvedValue(false);
+      const result = await service.checkEligibility(mockCtx, userId, topicNft);
+      expect(result.eligible).toBe(false);
+      expect(result.reason).toBe("REQUIRED_NFT_NOT_FOUND");
+    });
+
+    it("returns ineligible when NFT gate has no nftTokenId configured", async () => {
+      const topicNoToken = makeTopic({
+        gate: { id: "gate-1", type: "NFT", nftTokenId: null, requiredRole: null, topicId },
+      } as Partial<PrismaVoteTopic>);
+      const result = await service.checkEligibility(mockCtx, userId, topicNoToken);
+      expect(result.eligible).toBe(false);
+      expect(result.reason).toBe("GATE_NFT_TOKEN_NOT_CONFIGURED");
+    });
+  });
+
+  it("returns ineligible when gate is not configured", async () => {
+    const topicNoGate = makeTopic({ gate: null } as Partial<PrismaVoteTopic>);
+    const result = await service.checkEligibility(mockCtx, userId, topicNoGate);
+    expect(result.eligible).toBe(false);
+    expect(result.reason).toBe("GATE_NOT_CONFIGURED");
+  });
+});
+
+// ---- calculatePower ----
+
+describe("VoteService.calculatePower", () => {
+  it("returns 1 for FLAT policy", async () => {
+    const topic = makeTopic();
+    const power = await service.calculatePower(mockCtx, userId, topic);
+    expect(power).toBe(1);
+  });
+
+  it("returns NFT count for NFT_COUNT policy", async () => {
+    const topic = makeTopic({
+      powerPolicy: { id: "policy-1", type: "NFT_COUNT", nftTokenId, topicId },
+    } as Partial<PrismaVoteTopic>);
+    mockNftInstanceRepo.countByUserAndToken.mockResolvedValue(3);
+    const power = await service.calculatePower(mockCtx, userId, topic);
+    expect(power).toBe(3);
+    expect(mockNftInstanceRepo.countByUserAndToken).toHaveBeenCalledWith(mockCtx, userId, nftTokenId);
+  });
+
+  it("falls back to 1 when NFT_COUNT policy has no nftTokenId", async () => {
+    const topic = makeTopic({
+      powerPolicy: { id: "policy-1", type: "NFT_COUNT", nftTokenId: null, topicId },
+    } as Partial<PrismaVoteTopic>);
+    const power = await service.calculatePower(mockCtx, userId, topic);
+    expect(power).toBe(1);
+    expect(mockNftInstanceRepo.countByUserAndToken).not.toHaveBeenCalled();
+  });
+
+  it("returns 1 when powerPolicy is null", async () => {
+    const topic = makeTopic({ powerPolicy: null } as Partial<PrismaVoteTopic>);
+    const power = await service.calculatePower(mockCtx, userId, topic);
+    expect(power).toBe(1);
+  });
+});
+
+// ---- updateOptionCounts ----
+
+describe("VoteService.updateOptionCounts", () => {
+  it("increments new option on first vote", async () => {
+    const newBallot = makeBallot(optionAId, 1);
+    await service.updateOptionCounts(mockCtx, null, newBallot, 1, mockTx);
+
+    expect(mockRepo.decrementOptionCount).not.toHaveBeenCalled();
+    expect(mockRepo.adjustOptionTotalPower).not.toHaveBeenCalled();
+    expect(mockRepo.incrementOptionCount).toHaveBeenCalledWith(mockCtx, optionAId, 1, mockTx);
+  });
+
+  it("decrements old option and increments new option on different-option re-vote", async () => {
+    const existingBallot = makeBallot(optionAId, 2);
+    const newBallot = makeBallot(optionBId, 3);
+    await service.updateOptionCounts(mockCtx, existingBallot, newBallot, 3, mockTx);
+
+    expect(mockRepo.decrementOptionCount).toHaveBeenCalledWith(mockCtx, optionAId, 2, mockTx);
+    expect(mockRepo.incrementOptionCount).toHaveBeenCalledWith(mockCtx, optionBId, 3, mockTx);
+    expect(mockRepo.adjustOptionTotalPower).not.toHaveBeenCalled();
+  });
+
+  it("only adjusts totalPower delta on same-option re-vote (voteCount unchanged)", async () => {
+    const existingBallot = makeBallot(optionAId, 2);
+    const newBallot = makeBallot(optionAId, 5);
+    await service.updateOptionCounts(mockCtx, existingBallot, newBallot, 5, mockTx);
+
+    expect(mockRepo.decrementOptionCount).not.toHaveBeenCalled();
+    expect(mockRepo.incrementOptionCount).not.toHaveBeenCalled();
+    expect(mockRepo.adjustOptionTotalPower).toHaveBeenCalledWith(mockCtx, optionAId, 3, mockTx); // delta = 5 - 2
+  });
+
+  it("adjusts totalPower with negative delta on same-option re-vote after NFT sold", async () => {
+    const existingBallot = makeBallot(optionAId, 5);
+    const newBallot = makeBallot(optionAId, 2);
+    await service.updateOptionCounts(mockCtx, existingBallot, newBallot, 2, mockTx);
+
+    expect(mockRepo.adjustOptionTotalPower).toHaveBeenCalledWith(mockCtx, optionAId, -3, mockTx); // delta = 2 - 5
+    expect(mockRepo.decrementOptionCount).not.toHaveBeenCalled();
+    expect(mockRepo.incrementOptionCount).not.toHaveBeenCalled();
+  });
+
+  it("skips adjustOptionTotalPower when delta is zero on same-option re-vote", async () => {
+    const existingBallot = makeBallot(optionAId, 3);
+    const newBallot = makeBallot(optionAId, 3);
+    await service.updateOptionCounts(mockCtx, existingBallot, newBallot, 3, mockTx);
+
+    // adjustOptionTotalPower is called with delta=0, repo impl skips the update
+    expect(mockRepo.adjustOptionTotalPower).toHaveBeenCalledWith(mockCtx, optionAId, 0, mockTx);
+    expect(mockRepo.decrementOptionCount).not.toHaveBeenCalled();
+    expect(mockRepo.incrementOptionCount).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/unit/vote/vote.service.test.ts
+++ b/src/__tests__/unit/vote/vote.service.test.ts
@@ -25,6 +25,7 @@ class MockVoteRepository implements IVoteRepository {
   incrementOptionCount = jest.fn();
   decrementOptionCount = jest.fn();
   adjustOptionTotalPower = jest.fn();
+  acquireVoteLock = jest.fn();
 }
 
 class MockMembershipService {

--- a/src/__tests__/unit/vote/vote.service.test.ts
+++ b/src/__tests__/unit/vote/vote.service.test.ts
@@ -277,12 +277,11 @@ describe("VoteService.calculatePower", () => {
     expect(mockNftInstanceRepo.countByUserAndToken).toHaveBeenCalledWith(mockCtx, userId, nftTokenId);
   });
 
-  it("falls back to 1 when NFT_COUNT policy has no nftTokenId", async () => {
+  it("throws ValidationError when NFT_COUNT policy has no nftTokenId", async () => {
     const topic = makeTopic({
       powerPolicy: { id: "policy-1", type: "NFT_COUNT", nftTokenId: null, topicId },
     } as Partial<PrismaVoteTopic>);
-    const power = await service.calculatePower(mockCtx, userId, topic);
-    expect(power).toBe(1);
+    await expect(service.calculatePower(mockCtx, userId, topic)).rejects.toThrow(ValidationError);
     expect(mockNftInstanceRepo.countByUserAndToken).not.toHaveBeenCalled();
   });
 

--- a/src/__tests__/unit/vote/vote.usecase.test.ts
+++ b/src/__tests__/unit/vote/vote.usecase.test.ts
@@ -1,0 +1,219 @@
+import "reflect-metadata";
+import { Prisma } from "@prisma/client";
+import VoteUseCase from "@/application/domain/vote/usecase";
+import { IContext } from "@/types/server";
+import { AuthorizationError, ValidationError } from "@/errors/graphql";
+import { PrismaVoteTopic, PrismaVoteBallot } from "@/application/domain/vote/data/type";
+
+// ---- Mock VoteService ----
+
+const mockService = {
+  acquireVoteLock: jest.fn().mockResolvedValue(undefined),
+  getTopicWithRelations: jest.fn(),
+  validateTopicRelations: jest.fn(),
+  validateVotingPeriod: jest.fn(),
+  checkEligibility: jest.fn(),
+  validateOptionBelongsToTopic: jest.fn(),
+  calculatePower: jest.fn(),
+  findBallot: jest.fn(),
+  upsertBallot: jest.fn(),
+  updateOptionCounts: jest.fn().mockResolvedValue(undefined),
+  calcResultVisible: jest.fn().mockReturnValue(false),
+  // not called by userCastVote, included for completeness
+  calcPhase: jest.fn().mockReturnValue("OPEN"),
+  browseTopics: jest.fn(),
+  countTopics: jest.fn(),
+  findTopic: jest.fn(),
+  validateTopicInput: jest.fn(),
+  createTopicWithRelations: jest.fn(),
+  deleteTopic: jest.fn(),
+};
+
+// ---- Fixtures ----
+
+const userId = "user-1";
+const communityId = "community-1";
+const topicId = "topic-1";
+const optionAId = "option-a";
+const optionBId = "option-b";
+const mockTx = {} as Prisma.TransactionClient;
+
+function makeCtx(): IContext {
+  return {
+    currentUser: {
+      id: userId,
+      memberships: [{ communityId, role: "MEMBER" }],
+    },
+    issuer: {
+      onlyBelongingCommunity: jest.fn((_ctx: IContext, fn: (tx: Prisma.TransactionClient) => unknown) =>
+        fn(mockTx),
+      ),
+      public: jest.fn(),
+      internal: jest.fn(),
+    },
+  } as unknown as IContext;
+}
+
+function makeTopic(): PrismaVoteTopic {
+  return {
+    id: topicId,
+    communityId,
+    createdBy: "creator",
+    title: "Test Vote",
+    description: null,
+    startsAt: new Date(Date.now() - 1000 * 60),
+    endsAt: new Date(Date.now() + 1000 * 60 * 60),
+    createdAt: new Date(),
+    updatedAt: null,
+    gate: { id: "gate-1", type: "MEMBERSHIP", nftTokenId: null, requiredRole: null, topicId },
+    powerPolicy: { id: "policy-1", type: "FLAT", nftTokenId: null, topicId },
+    options: [
+      { id: optionAId, topicId, label: "Option A", orderIndex: 0, voteCount: 0, totalPower: 0 },
+      { id: optionBId, topicId, label: "Option B", orderIndex: 1, voteCount: 0, totalPower: 0 },
+    ],
+  } as PrismaVoteTopic;
+}
+
+function makeBallot(optionId: string, power: number, id = "ballot-1"): PrismaVoteBallot {
+  return {
+    id,
+    userId,
+    topicId,
+    optionId,
+    power,
+    createdAt: new Date(),
+    updatedAt: null,
+  };
+}
+
+// ---- Tests ----
+
+describe("VoteUseCase.userCastVote — 集計カラム更新の回帰テスト", () => {
+  let useCase: VoteUseCase;
+  let ctx: IContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // VoteUseCase の constructor は VoteService の 1 依存のみ
+    useCase = new VoteUseCase(mockService as unknown as InstanceType<typeof import("@/application/domain/vote/service").default>);
+    ctx = makeCtx();
+
+    // デフォルト: 資格あり・power=1
+    mockService.checkEligibility.mockResolvedValue({ eligible: true });
+    mockService.calculatePower.mockResolvedValue(1);
+  });
+
+  describe("初回投票", () => {
+    it("updateOptionCounts が existingBallot=null で呼ばれる", async () => {
+      const topic = makeTopic();
+      const newBallot = makeBallot(optionAId, 1);
+
+      mockService.getTopicWithRelations.mockResolvedValue(topic);
+      mockService.findBallot.mockResolvedValue(null);
+      mockService.upsertBallot.mockResolvedValue(newBallot);
+
+      await useCase.userCastVote(ctx, { input: { topicId, optionId: optionAId } });
+
+      expect(mockService.updateOptionCounts).toHaveBeenCalledTimes(1);
+      expect(mockService.updateOptionCounts).toHaveBeenCalledWith(ctx, null, newBallot, 1, mockTx);
+    });
+
+    it("payload に ballot が含まれる", async () => {
+      const topic = makeTopic();
+      const newBallot = makeBallot(optionAId, 1);
+
+      mockService.getTopicWithRelations.mockResolvedValue(topic);
+      mockService.findBallot.mockResolvedValue(null);
+      mockService.upsertBallot.mockResolvedValue(newBallot);
+
+      const result = await useCase.userCastVote(ctx, { input: { topicId, optionId: optionAId } });
+
+      expect(result.ballot).toBeDefined();
+      expect(result.ballot.id).toBe(newBallot.id);
+      expect(result.ballot.power).toBe(1);
+    });
+  });
+
+  describe("同一選択肢への再投票", () => {
+    it("updateOptionCounts が既存投票と同じ optionId の ballot で呼ばれる", async () => {
+      const topic = makeTopic();
+      const existingBallot = makeBallot(optionAId, 1);
+      const newBallot = makeBallot(optionAId, 1);
+
+      mockService.getTopicWithRelations.mockResolvedValue(topic);
+      mockService.findBallot.mockResolvedValue(existingBallot);
+      mockService.upsertBallot.mockResolvedValue(newBallot);
+
+      await useCase.userCastVote(ctx, { input: { topicId, optionId: optionAId } });
+
+      expect(mockService.updateOptionCounts).toHaveBeenCalledWith(
+        ctx, existingBallot, newBallot, 1, mockTx,
+      );
+      const [, existing, next] = mockService.updateOptionCounts.mock.calls[0];
+      expect(existing.optionId).toBe(next.optionId);
+    });
+
+    it("NFT 売却後の power 減少も正しく伝播する", async () => {
+      const topic = makeTopic();
+      const existingBallot = makeBallot(optionAId, 5); // 以前は 5 NFT 保有
+      const newBallot = makeBallot(optionAId, 2);      // 今は 2 NFT
+
+      mockService.calculatePower.mockResolvedValue(2);
+      mockService.getTopicWithRelations.mockResolvedValue(topic);
+      mockService.findBallot.mockResolvedValue(existingBallot);
+      mockService.upsertBallot.mockResolvedValue(newBallot);
+
+      await useCase.userCastVote(ctx, { input: { topicId, optionId: optionAId } });
+
+      // power=2 で updateOptionCounts が呼ばれることを確認
+      expect(mockService.updateOptionCounts).toHaveBeenCalledWith(
+        ctx, existingBallot, newBallot, 2, mockTx,
+      );
+    });
+  });
+
+  describe("別選択肢への再投票", () => {
+    it("updateOptionCounts が既存投票と異なる optionId の ballot で呼ばれる", async () => {
+      const topic = makeTopic();
+      const existingBallot = makeBallot(optionAId, 1);
+      const newBallot = makeBallot(optionBId, 1);
+
+      mockService.getTopicWithRelations.mockResolvedValue(topic);
+      mockService.findBallot.mockResolvedValue(existingBallot);
+      mockService.upsertBallot.mockResolvedValue(newBallot);
+
+      await useCase.userCastVote(ctx, { input: { topicId, optionId: optionBId } });
+
+      expect(mockService.updateOptionCounts).toHaveBeenCalledWith(
+        ctx, existingBallot, newBallot, 1, mockTx,
+      );
+      const [, existing, next] = mockService.updateOptionCounts.mock.calls[0];
+      expect(existing.optionId).not.toBe(next.optionId);
+    });
+  });
+
+  describe("ガード条件（updateOptionCounts が呼ばれないケース）", () => {
+    it("資格なしの場合は AuthorizationError をスローし updateOptionCounts を呼ばない", async () => {
+      const topic = makeTopic();
+      mockService.getTopicWithRelations.mockResolvedValue(topic);
+      mockService.checkEligibility.mockResolvedValue({ eligible: false, reason: "NOT_A_MEMBER" });
+
+      await expect(
+        useCase.userCastVote(ctx, { input: { topicId, optionId: optionAId } }),
+      ).rejects.toThrow(AuthorizationError);
+      expect(mockService.updateOptionCounts).not.toHaveBeenCalled();
+    });
+
+    it("power=0 の場合は ValidationError をスローし updateOptionCounts を呼ばない", async () => {
+      const topic = makeTopic();
+      mockService.getTopicWithRelations.mockResolvedValue(topic);
+      mockService.findBallot.mockResolvedValue(null);
+      mockService.calculatePower.mockResolvedValue(0);
+
+      await expect(
+        useCase.userCastVote(ctx, { input: { topicId, optionId: optionAId } }),
+      ).rejects.toThrow(ValidationError);
+      expect(mockService.updateOptionCounts).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/application/domain/account/nft-instance/data/interface.ts
+++ b/src/application/domain/account/nft-instance/data/interface.ts
@@ -62,4 +62,18 @@ export default interface INftInstanceRepository {
     instanceId: string,
     tx?: Prisma.TransactionClient,
   ): Promise<{ id: string } | null>;
+
+  existsByUserAndToken(
+    ctx: IContext,
+    userId: string,
+    nftTokenId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<boolean>;
+
+  countByUserAndToken(
+    ctx: IContext,
+    userId: string,
+    nftTokenId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<number>;
 }

--- a/src/application/domain/account/nft-instance/data/repository.ts
+++ b/src/application/domain/account/nft-instance/data/repository.ts
@@ -179,4 +179,43 @@ export default class NftInstanceRepository implements INftInstanceRepository {
       }),
     );
   }
+
+  // 投票資格ゲート用: 「保有しているか」のみ判定（EXISTS 相当、COUNT より意味が明確）
+  async existsByUserAndToken(
+    ctx: IContext,
+    userId: string,
+    nftTokenId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<boolean> {
+    const query = (t: Prisma.TransactionClient) =>
+      t.nftInstance
+        .findFirst({
+          where: {
+            nftTokenId,
+            status: NftInstanceStatus.OWNED,
+            nftWallet: { userId },
+          },
+          select: { id: true },
+        })
+        .then((r) => r !== null);
+    return tx ? query(tx) : ctx.issuer.public(ctx, query);
+  }
+
+  // 票数計算ポリシー用: 「何個保有しているか」をカウント
+  async countByUserAndToken(
+    ctx: IContext,
+    userId: string,
+    nftTokenId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<number> {
+    const query = (t: Prisma.TransactionClient) =>
+      t.nftInstance.count({
+        where: {
+          nftTokenId,
+          status: NftInstanceStatus.OWNED,
+          nftWallet: { userId },
+        },
+      });
+    return tx ? query(tx) : ctx.issuer.public(ctx, query);
+  }
 }

--- a/src/application/domain/utils.ts
+++ b/src/application/domain/utils.ts
@@ -64,6 +64,21 @@ function determineRoleForCommunity(
   };
 }
 
+// Role 階層: OWNER > MANAGER > MEMBER
+const ROLE_RANK: Record<Role, number> = {
+  [Role.OWNER]: 3,
+  [Role.MANAGER]: 2,
+  [Role.MEMBER]: 1,
+};
+
+/**
+ * Check if a user's role meets the minimum required role.
+ * Role hierarchy: OWNER > MANAGER > MEMBER
+ */
+export function isRoleAtLeast(userRole: Role, minRole: Role): boolean {
+  return ROLE_RANK[userRole] >= ROLE_RANK[minRole];
+}
+
 /**
  * Check if a user can view content based on publishStatus and their role.
  * - Admin: can view all

--- a/src/application/domain/vote/controller/dataloader.ts
+++ b/src/application/domain/vote/controller/dataloader.ts
@@ -17,7 +17,7 @@ export function createVoteOptionLoader(prisma: PrismaClient) {
 // VoteBallot を { userId, topicId } でバッチロード（VoteTopic.myBallot フィールドリゾルバー用）
 // 1リクエスト内で複数 VoteTopic を表示する場合でも、全投票をまとめて1クエリで取得する
 export function createMyVoteBallotLoader(prisma: PrismaClient) {
-  return new DataLoader<{ userId: string; topicId: string }, PrismaVoteBallot | null>(
+  return new DataLoader<{ userId: string; topicId: string }, PrismaVoteBallot | null, string>(
     async (keys) => {
       const ballots = await prisma.voteBallot.findMany({
         where: { OR: keys.map((k) => ({ userId: k.userId, topicId: k.topicId })) },

--- a/src/application/domain/vote/controller/dataloader.ts
+++ b/src/application/domain/vote/controller/dataloader.ts
@@ -1,12 +1,8 @@
-// Vote domain DataLoaders
-// 現時点では VoteOption の個別取得用ローダーを定義
-// 集計カラム（voteCount / totalPower）は VoteOption テーブルに非正規化済みのため
-// 追加の集計クエリは不要
-
-import DataLoader from "dataloader";
 import { PrismaClient } from "@prisma/client";
+import DataLoader from "dataloader";
 import { voteOptionSelect, PrismaVoteOption } from "@/application/domain/vote/data/type";
 
+// VoteOption を id でバッチロード（VoteBallot.option フィールドリゾルバー用）
 export function createVoteOptionLoader(prisma: PrismaClient) {
   return new DataLoader<string, PrismaVoteOption | null>(async (optionIds) => {
     const options = await prisma.voteOption.findMany({
@@ -18,25 +14,16 @@ export function createVoteOptionLoader(prisma: PrismaClient) {
   });
 }
 
-export function createMyVoteBallotLoader(prisma: PrismaClient, userId: string) {
-  return new DataLoader<string, { id: string; optionId: string; power: number; createdAt: Date; updatedAt: Date | null } | null>(
-    async (topicIds) => {
-      const ballots = await prisma.voteBallot.findMany({
-        where: {
-          userId,
-          topicId: { in: [...topicIds] },
-        },
-        select: {
-          id: true,
-          topicId: true,
-          optionId: true,
-          power: true,
-          createdAt: true,
-          updatedAt: true,
-        },
+// NftToken を id でバッチロード（VoteGate / VotePowerPolicy の nftToken フィールドリゾルバー用）
+export function createNftTokenLoader(prisma: PrismaClient) {
+  return new DataLoader<string, { id: string; address: string; name: string | null; symbol: string | null; type: string } | null>(
+    async (tokenIds) => {
+      const tokens = await prisma.nftToken.findMany({
+        where: { id: { in: [...tokenIds] } },
+        select: { id: true, address: true, name: true, symbol: true, type: true },
       });
-      const map = new Map(ballots.map((b) => [b.topicId, b]));
-      return topicIds.map((id) => map.get(id) ?? null);
+      const map = new Map(tokens.map((t) => [t.id, t]));
+      return tokenIds.map((id) => map.get(id) ?? null);
     },
   );
 }

--- a/src/application/domain/vote/controller/dataloader.ts
+++ b/src/application/domain/vote/controller/dataloader.ts
@@ -1,6 +1,6 @@
 import { PrismaClient } from "@prisma/client";
 import DataLoader from "dataloader";
-import { voteOptionSelect, PrismaVoteOption } from "@/application/domain/vote/data/type";
+import { voteOptionSelect, voteBallotSelect, PrismaVoteOption, PrismaVoteBallot } from "@/application/domain/vote/data/type";
 
 // VoteOption を id でバッチロード（VoteBallot.option フィールドリゾルバー用）
 export function createVoteOptionLoader(prisma: PrismaClient) {
@@ -12,6 +12,23 @@ export function createVoteOptionLoader(prisma: PrismaClient) {
     const map = new Map(options.map((o) => [o.id, o]));
     return optionIds.map((id) => map.get(id) ?? null);
   });
+}
+
+// VoteBallot を { userId, topicId } でバッチロード（VoteTopic.myBallot フィールドリゾルバー用）
+// 1リクエスト内で複数 VoteTopic を表示する場合でも、全投票をまとめて1クエリで取得する
+export function createMyVoteBallotLoader(prisma: PrismaClient) {
+  return new DataLoader<{ userId: string; topicId: string }, PrismaVoteBallot | null>(
+    async (keys) => {
+      const ballots = await prisma.voteBallot.findMany({
+        where: { OR: keys.map((k) => ({ userId: k.userId, topicId: k.topicId })) },
+        select: voteBallotSelect,
+      });
+      return keys.map(
+        (k) => ballots.find((b) => b.userId === k.userId && b.topicId === k.topicId) ?? null,
+      );
+    },
+    { cacheKeyFn: (k) => `${k.userId}:${k.topicId}` },
+  );
 }
 
 // NftToken を id でバッチロード（VoteGate / VotePowerPolicy の nftToken フィールドリゾルバー用）

--- a/src/application/domain/vote/controller/dataloader.ts
+++ b/src/application/domain/vote/controller/dataloader.ts
@@ -15,12 +15,34 @@ export function createVoteOptionLoader(prisma: PrismaClient) {
 }
 
 // NftToken を id でバッチロード（VoteGate / VotePowerPolicy の nftToken フィールドリゾルバー用）
+// GQL NftToken 型の必須フィールド（createdAt: Datetime!）を含む完全な select を使用
 export function createNftTokenLoader(prisma: PrismaClient) {
-  return new DataLoader<string, { id: string; address: string; name: string | null; symbol: string | null; type: string } | null>(
+  return new DataLoader<
+    string,
+    {
+      id: string;
+      address: string;
+      name: string | null;
+      symbol: string | null;
+      type: string;
+      json: unknown;
+      createdAt: Date;
+      updatedAt: Date | null;
+    } | null
+  >(
     async (tokenIds) => {
       const tokens = await prisma.nftToken.findMany({
         where: { id: { in: [...tokenIds] } },
-        select: { id: true, address: true, name: true, symbol: true, type: true },
+        select: {
+          id: true,
+          address: true,
+          name: true,
+          symbol: true,
+          type: true,
+          json: true,
+          createdAt: true,
+          updatedAt: true,
+        },
       });
       const map = new Map(tokens.map((t) => [t.id, t]));
       return tokenIds.map((id) => map.get(id) ?? null);

--- a/src/application/domain/vote/controller/dataloader.ts
+++ b/src/application/domain/vote/controller/dataloader.ts
@@ -1,0 +1,42 @@
+// Vote domain DataLoaders
+// 現時点では VoteOption の個別取得用ローダーを定義
+// 集計カラム（voteCount / totalPower）は VoteOption テーブルに非正規化済みのため
+// 追加の集計クエリは不要
+
+import DataLoader from "dataloader";
+import { PrismaClient } from "@prisma/client";
+import { voteOptionSelect, PrismaVoteOption } from "@/application/domain/vote/data/type";
+
+export function createVoteOptionLoader(prisma: PrismaClient) {
+  return new DataLoader<string, PrismaVoteOption | null>(async (optionIds) => {
+    const options = await prisma.voteOption.findMany({
+      where: { id: { in: [...optionIds] } },
+      select: voteOptionSelect,
+    });
+    const map = new Map(options.map((o) => [o.id, o]));
+    return optionIds.map((id) => map.get(id) ?? null);
+  });
+}
+
+export function createMyVoteBallotLoader(prisma: PrismaClient, userId: string) {
+  return new DataLoader<string, { id: string; optionId: string; power: number; createdAt: Date; updatedAt: Date | null } | null>(
+    async (topicIds) => {
+      const ballots = await prisma.voteBallot.findMany({
+        where: {
+          userId,
+          topicId: { in: [...topicIds] },
+        },
+        select: {
+          id: true,
+          topicId: true,
+          optionId: true,
+          power: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      });
+      const map = new Map(ballots.map((b) => [b.topicId, b]));
+      return topicIds.map((id) => map.get(id) ?? null);
+    },
+  );
+}

--- a/src/application/domain/vote/controller/dataloader.ts
+++ b/src/application/domain/vote/controller/dataloader.ts
@@ -1,55 +1,52 @@
 import { PrismaClient } from "@prisma/client";
-import DataLoader from "dataloader";
-import { voteOptionSelect, voteBallotSelect, PrismaVoteOption, PrismaVoteBallot } from "@/application/domain/vote/data/type";
+import {
+  voteOptionSelect,
+  voteBallotSelect,
+  PrismaVoteOption,
+  PrismaVoteBallot,
+} from "@/application/domain/vote/data/type";
+import {
+  createLoaderById,
+  createLoaderByCompositeKey,
+} from "@/presentation/graphql/dataloader/utils";
 
 // VoteOption を id でバッチロード（VoteBallot.option フィールドリゾルバー用）
 export function createVoteOptionLoader(prisma: PrismaClient) {
-  return new DataLoader<string, PrismaVoteOption | null>(async (optionIds) => {
-    const options = await prisma.voteOption.findMany({
-      where: { id: { in: [...optionIds] } },
-      select: voteOptionSelect,
-    });
-    const map = new Map(options.map((o) => [o.id, o]));
-    return optionIds.map((id) => map.get(id) ?? null);
-  });
+  return createLoaderById<PrismaVoteOption, PrismaVoteOption>(
+    async (ids) =>
+      prisma.voteOption.findMany({
+        where: { id: { in: [...ids] } },
+        select: voteOptionSelect,
+      }),
+    (record) => record,
+  );
 }
 
 // VoteBallot を { userId, topicId } でバッチロード（VoteTopic.myBallot フィールドリゾルバー用）
 // 1リクエスト内で複数 VoteTopic を表示する場合でも、全投票をまとめて1クエリで取得する
 export function createMyVoteBallotLoader(prisma: PrismaClient) {
-  return new DataLoader<{ userId: string; topicId: string }, PrismaVoteBallot | null, string>(
-    async (keys) => {
-      const ballots = await prisma.voteBallot.findMany({
+  return createLoaderByCompositeKey<
+    { userId: string; topicId: string },
+    PrismaVoteBallot,
+    PrismaVoteBallot
+  >(
+    async (keys) =>
+      prisma.voteBallot.findMany({
         where: { OR: keys.map((k) => ({ userId: k.userId, topicId: k.topicId })) },
         select: voteBallotSelect,
-      });
-      return keys.map(
-        (k) => ballots.find((b) => b.userId === k.userId && b.topicId === k.topicId) ?? null,
-      );
-    },
-    { cacheKeyFn: (k) => `${k.userId}:${k.topicId}` },
+      }),
+    (record) => ({ userId: record.userId, topicId: record.topicId }),
+    (record) => record,
   );
 }
 
 // NftToken を id でバッチロード（VoteGate / VotePowerPolicy の nftToken フィールドリゾルバー用）
 // GQL NftToken 型の必須フィールド（createdAt: Datetime!）を含む完全な select を使用
 export function createNftTokenLoader(prisma: PrismaClient) {
-  return new DataLoader<
-    string,
-    {
-      id: string;
-      address: string;
-      name: string | null;
-      symbol: string | null;
-      type: string;
-      json: unknown;
-      createdAt: Date;
-      updatedAt: Date | null;
-    } | null
-  >(
-    async (tokenIds) => {
-      const tokens = await prisma.nftToken.findMany({
-        where: { id: { in: [...tokenIds] } },
+  return createLoaderById(
+    async (ids) =>
+      prisma.nftToken.findMany({
+        where: { id: { in: [...ids] } },
         select: {
           id: true,
           address: true,
@@ -60,9 +57,7 @@ export function createNftTokenLoader(prisma: PrismaClient) {
           createdAt: true,
           updatedAt: true,
         },
-      });
-      const map = new Map(tokens.map((t) => [t.id, t]));
-      return tokenIds.map((id) => map.get(id) ?? null);
-    },
+      }),
+    (record) => record,
   );
 }

--- a/src/application/domain/vote/controller/resolver.ts
+++ b/src/application/domain/vote/controller/resolver.ts
@@ -67,7 +67,16 @@ export default class VoteResolver {
   };
 
   VoteBallot = {
-    option: (parent: PrismaVoteBallot, _: unknown, ctx: IContext) =>
-      ctx.loaders.voteOption.load(parent.optionId),
+    option: async (parent: PrismaVoteBallot & { optionId: string; resultVisible?: boolean }, _: unknown, ctx: IContext) => {
+      const option = await ctx.loaders.voteOption.load(parent.optionId);
+      if (!option) return null;
+      // 結果秘匿: 投票期間中 (resultVisible=false) は voteCount/totalPower をマスク
+      const resultVisible = parent.resultVisible ?? false;
+      return {
+        ...option,
+        voteCount: resultVisible ? option.voteCount : null,
+        totalPower: resultVisible ? option.totalPower : null,
+      };
+    },
   };
 }

--- a/src/application/domain/vote/controller/resolver.ts
+++ b/src/application/domain/vote/controller/resolver.ts
@@ -10,7 +10,7 @@ import {
   GqlMutationVoteTopicDeleteArgs,
 } from "@/types/graphql";
 import VoteUseCase from "@/application/domain/vote/usecase";
-import VotePresenter, {
+import type {
   GqlVoteTopicWithMeta,
   GqlVoteGateWithMeta,
   GqlVotePowerPolicyWithMeta,
@@ -55,7 +55,7 @@ export default class VoteResolver {
       });
       if (!ballot) return null;
       // resultVisible は VotePresenter.topic() が親オブジェクトに付加したメタデータ
-      return VotePresenter.ballot(ballot, parent.resultVisible);
+      return this.voteUseCase.resolveMyBallotField(ballot, parent.resultVisible);
     },
 
     myEligibility: (parent: GqlVoteTopicWithMeta, _: unknown, ctx: IContext) =>
@@ -81,8 +81,7 @@ export default class VoteResolver {
     option: async (parent: GqlVoteBallotWithMeta, _: unknown, ctx: IContext) => {
       const option = await ctx.loaders.voteOption.load(parent.optionId);
       if (!option) throw new NotFoundError("VoteOption", { id: parent.optionId });
-      // 結果秘匿の適用は Presenter に委譲（resolver にマスクロジックを持たない）
-      return VotePresenter.option(option, parent.resultVisible);
+      return this.voteUseCase.resolveOptionField(option, parent.resultVisible);
     },
   };
 }

--- a/src/application/domain/vote/controller/resolver.ts
+++ b/src/application/domain/vote/controller/resolver.ts
@@ -1,5 +1,7 @@
 import { injectable, inject } from "tsyringe";
 import { IContext } from "@/types/server";
+import { NotFoundError } from "@/errors/graphql";
+import { getMembershipRolesByCtx } from "@/application/domain/utils";
 import {
   GqlQueryVoteTopicsArgs,
   GqlQueryVoteTopicArgs,
@@ -15,6 +17,7 @@ import {
   PrismaVoteBallot,
 } from "@/application/domain/vote/data/type";
 import VoteUseCase from "@/application/domain/vote/usecase";
+import VotePresenter from "@/application/domain/vote/presenter";
 
 @injectable()
 export default class VoteResolver {
@@ -46,6 +49,18 @@ export default class VoteResolver {
     community: (parent: PrismaVoteTopic, _: unknown, ctx: IContext) =>
       ctx.loaders.community.load(parent.communityId),
 
+    myBallot: async (parent: PrismaVoteTopic, _: unknown, ctx: IContext) => {
+      if (!ctx.currentUser) return null;
+      const ballot = await ctx.loaders.myVoteBallot.load({
+        userId: ctx.currentUser.id,
+        topicId: parent.id,
+      });
+      if (!ballot) return null;
+      const { isManager } = getMembershipRolesByCtx(ctx, [parent.communityId], ctx.currentUser.id);
+      const resultVisible = VotePresenter.isResultVisible(parent, !!isManager[parent.communityId]);
+      return VotePresenter.ballot(ballot, resultVisible);
+    },
+
     myEligibility: (parent: PrismaVoteTopic, _: unknown, ctx: IContext) => {
       if (!ctx.currentUser) return null;
       return this.voteUseCase.userGetMyVoteEligibility(ctx, { topicId: parent.id });
@@ -69,7 +84,7 @@ export default class VoteResolver {
   VoteBallot = {
     option: async (parent: PrismaVoteBallot & { optionId: string; resultVisible?: boolean }, _: unknown, ctx: IContext) => {
       const option = await ctx.loaders.voteOption.load(parent.optionId);
-      if (!option) return null;
+      if (!option) throw new NotFoundError("VoteOption", { id: parent.optionId });
       // 結果秘匿: 投票期間中 (resultVisible=false) は voteCount/totalPower をマスク
       const resultVisible = parent.resultVisible ?? false;
       return {

--- a/src/application/domain/vote/controller/resolver.ts
+++ b/src/application/domain/vote/controller/resolver.ts
@@ -9,14 +9,13 @@ import {
   GqlMutationVoteCastArgs,
   GqlMutationVoteTopicDeleteArgs,
 } from "@/types/graphql";
-import {
-  PrismaVoteTopic,
-  PrismaVoteGate,
-  PrismaVotePowerPolicy,
-  PrismaVoteBallot,
-} from "@/application/domain/vote/data/type";
 import VoteUseCase from "@/application/domain/vote/usecase";
-import VotePresenter from "@/application/domain/vote/presenter";
+import VotePresenter, {
+  GqlVoteTopicWithMeta,
+  GqlVoteGateWithMeta,
+  GqlVotePowerPolicyWithMeta,
+  GqlVoteBallotWithMeta,
+} from "@/application/domain/vote/presenter";
 
 @injectable()
 export default class VoteResolver {
@@ -45,10 +44,10 @@ export default class VoteResolver {
   };
 
   VoteTopic = {
-    community: (parent: PrismaVoteTopic, _: unknown, ctx: IContext) =>
+    community: (parent: GqlVoteTopicWithMeta, _: unknown, ctx: IContext) =>
       ctx.loaders.community.load(parent.communityId),
 
-    myBallot: async (parent: PrismaVoteTopic & { resultVisible?: boolean }, _: unknown, ctx: IContext) => {
+    myBallot: async (parent: GqlVoteTopicWithMeta, _: unknown, ctx: IContext) => {
       if (!ctx.currentUser) return null;
       const ballot = await ctx.loaders.myVoteBallot.load({
         userId: ctx.currentUser.id,
@@ -56,35 +55,34 @@ export default class VoteResolver {
       });
       if (!ballot) return null;
       // resultVisible は VotePresenter.topic() が親オブジェクトに付加したメタデータ
-      return VotePresenter.ballot(ballot, parent.resultVisible ?? false);
+      return VotePresenter.ballot(ballot, parent.resultVisible);
     },
 
-    myEligibility: (parent: PrismaVoteTopic, _: unknown, ctx: IContext) => {
-      if (!ctx.currentUser) return null;
-      return this.voteUseCase.userGetMyVoteEligibility(ctx, { topicId: parent.id });
-    },
+    myEligibility: (parent: GqlVoteTopicWithMeta, _: unknown, ctx: IContext) =>
+      // DB 再取得を避けるため parent のメタデータを直接利用する（N+1 防止）
+      this.voteUseCase.resolveMyEligibilityForParent(ctx, parent),
   };
 
   VoteGate = {
-    nftToken: (parent: PrismaVoteGate, _: unknown, ctx: IContext) => {
+    nftToken: (parent: GqlVoteGateWithMeta, _: unknown, ctx: IContext) => {
       if (!parent.nftTokenId) return null;
       return ctx.loaders.nftToken.load(parent.nftTokenId);
     },
   };
 
   VotePowerPolicy = {
-    nftToken: (parent: PrismaVotePowerPolicy, _: unknown, ctx: IContext) => {
+    nftToken: (parent: GqlVotePowerPolicyWithMeta, _: unknown, ctx: IContext) => {
       if (!parent.nftTokenId) return null;
       return ctx.loaders.nftToken.load(parent.nftTokenId);
     },
   };
 
   VoteBallot = {
-    option: async (parent: PrismaVoteBallot & { optionId: string; resultVisible?: boolean }, _: unknown, ctx: IContext) => {
+    option: async (parent: GqlVoteBallotWithMeta, _: unknown, ctx: IContext) => {
       const option = await ctx.loaders.voteOption.load(parent.optionId);
       if (!option) throw new NotFoundError("VoteOption", { id: parent.optionId });
       // 結果秘匿の適用は Presenter に委譲（resolver にマスクロジックを持たない）
-      return VotePresenter.option(option, parent.resultVisible ?? false);
+      return VotePresenter.option(option, parent.resultVisible);
     },
   };
 }

--- a/src/application/domain/vote/controller/resolver.ts
+++ b/src/application/domain/vote/controller/resolver.ts
@@ -1,7 +1,6 @@
 import { injectable, inject } from "tsyringe";
 import { IContext } from "@/types/server";
 import { NotFoundError } from "@/errors/graphql";
-import { getMembershipRolesByCtx } from "@/application/domain/utils";
 import {
   GqlQueryVoteTopicsArgs,
   GqlQueryVoteTopicArgs,
@@ -49,16 +48,15 @@ export default class VoteResolver {
     community: (parent: PrismaVoteTopic, _: unknown, ctx: IContext) =>
       ctx.loaders.community.load(parent.communityId),
 
-    myBallot: async (parent: PrismaVoteTopic, _: unknown, ctx: IContext) => {
+    myBallot: async (parent: PrismaVoteTopic & { resultVisible?: boolean }, _: unknown, ctx: IContext) => {
       if (!ctx.currentUser) return null;
       const ballot = await ctx.loaders.myVoteBallot.load({
         userId: ctx.currentUser.id,
         topicId: parent.id,
       });
       if (!ballot) return null;
-      const { isManager } = getMembershipRolesByCtx(ctx, [parent.communityId], ctx.currentUser.id);
-      const resultVisible = VotePresenter.isResultVisible(parent, !!isManager[parent.communityId]);
-      return VotePresenter.ballot(ballot, resultVisible);
+      // resultVisible は VotePresenter.topic() が親オブジェクトに付加したメタデータ
+      return VotePresenter.ballot(ballot, parent.resultVisible ?? false);
     },
 
     myEligibility: (parent: PrismaVoteTopic, _: unknown, ctx: IContext) => {
@@ -85,13 +83,8 @@ export default class VoteResolver {
     option: async (parent: PrismaVoteBallot & { optionId: string; resultVisible?: boolean }, _: unknown, ctx: IContext) => {
       const option = await ctx.loaders.voteOption.load(parent.optionId);
       if (!option) throw new NotFoundError("VoteOption", { id: parent.optionId });
-      // 結果秘匿: 投票期間中 (resultVisible=false) は voteCount/totalPower をマスク
-      const resultVisible = parent.resultVisible ?? false;
-      return {
-        ...option,
-        voteCount: resultVisible ? option.voteCount : null,
-        totalPower: resultVisible ? option.totalPower : null,
-      };
+      // 結果秘匿の適用は Presenter に委譲（resolver にマスクロジックを持たない）
+      return VotePresenter.option(option, parent.resultVisible ?? false);
     },
   };
 }

--- a/src/application/domain/vote/controller/resolver.ts
+++ b/src/application/domain/vote/controller/resolver.ts
@@ -1,0 +1,73 @@
+import { injectable, inject } from "tsyringe";
+import { IContext } from "@/types/server";
+import {
+  GqlQueryVoteTopicsArgs,
+  GqlQueryVoteTopicArgs,
+  GqlQueryMyVoteEligibilityArgs,
+  GqlMutationVoteTopicCreateArgs,
+  GqlMutationVoteCastArgs,
+  GqlMutationVoteTopicDeleteArgs,
+} from "@/types/graphql";
+import {
+  PrismaVoteTopic,
+  PrismaVoteGate,
+  PrismaVotePowerPolicy,
+  PrismaVoteBallot,
+} from "@/application/domain/vote/data/type";
+import VoteUseCase from "@/application/domain/vote/usecase";
+
+@injectable()
+export default class VoteResolver {
+  constructor(@inject("VoteUseCase") private readonly voteUseCase: VoteUseCase) {}
+
+  Query = {
+    voteTopics: (_: unknown, args: GqlQueryVoteTopicsArgs, ctx: IContext) =>
+      this.voteUseCase.anyoneBrowseVoteTopics(ctx, args),
+
+    voteTopic: (_: unknown, args: GqlQueryVoteTopicArgs, ctx: IContext) =>
+      this.voteUseCase.anyoneViewVoteTopic(ctx, args),
+
+    myVoteEligibility: (_: unknown, args: GqlQueryMyVoteEligibilityArgs, ctx: IContext) =>
+      this.voteUseCase.userGetMyVoteEligibility(ctx, args),
+  };
+
+  Mutation = {
+    voteTopicCreate: (_: unknown, args: GqlMutationVoteTopicCreateArgs, ctx: IContext) =>
+      this.voteUseCase.managerCreateVoteTopic(ctx, args),
+
+    voteCast: (_: unknown, args: GqlMutationVoteCastArgs, ctx: IContext) =>
+      this.voteUseCase.userCastVote(ctx, args),
+
+    voteTopicDelete: (_: unknown, args: GqlMutationVoteTopicDeleteArgs, ctx: IContext) =>
+      this.voteUseCase.managerDeleteVoteTopic(ctx, args),
+  };
+
+  VoteTopic = {
+    community: (parent: PrismaVoteTopic, _: unknown, ctx: IContext) =>
+      ctx.loaders.community.load(parent.communityId),
+
+    myEligibility: (parent: PrismaVoteTopic, _: unknown, ctx: IContext) => {
+      if (!ctx.currentUser) return null;
+      return this.voteUseCase.userGetMyVoteEligibility(ctx, { topicId: parent.id });
+    },
+  };
+
+  VoteGate = {
+    nftToken: (parent: PrismaVoteGate, _: unknown, ctx: IContext) => {
+      if (!parent.nftTokenId) return null;
+      return ctx.loaders.nftToken.load(parent.nftTokenId);
+    },
+  };
+
+  VotePowerPolicy = {
+    nftToken: (parent: PrismaVotePowerPolicy, _: unknown, ctx: IContext) => {
+      if (!parent.nftTokenId) return null;
+      return ctx.loaders.nftToken.load(parent.nftTokenId);
+    },
+  };
+
+  VoteBallot = {
+    option: (parent: PrismaVoteBallot, _: unknown, ctx: IContext) =>
+      ctx.loaders.voteOption.load(parent.optionId),
+  };
+}

--- a/src/application/domain/vote/data/converter.ts
+++ b/src/application/domain/vote/data/converter.ts
@@ -1,0 +1,20 @@
+import { injectable } from "tsyringe";
+import { Prisma } from "@prisma/client";
+import { GqlVoteTopicCreateInput } from "@/types/graphql";
+
+@injectable()
+export default class VoteConverter {
+  createTopic(
+    input: GqlVoteTopicCreateInput,
+    currentUserId: string,
+  ): Prisma.VoteTopicCreateInput {
+    return {
+      title: input.title,
+      description: input.description ?? null,
+      startsAt: new Date(input.startsAt),
+      endsAt: new Date(input.endsAt),
+      community: { connect: { id: input.communityId } },
+      createdByUser: { connect: { id: currentUserId } },
+    };
+  }
+}

--- a/src/application/domain/vote/data/interface.ts
+++ b/src/application/domain/vote/data/interface.ts
@@ -95,4 +95,10 @@ export interface IVoteRepository {
     delta: number,
     tx: Prisma.TransactionClient,
   ): Promise<void>;
+
+  acquireVoteLock(
+    userId: string,
+    topicId: string,
+    tx: Prisma.TransactionClient,
+  ): Promise<void>;
 }

--- a/src/application/domain/vote/data/interface.ts
+++ b/src/application/domain/vote/data/interface.ts
@@ -1,0 +1,93 @@
+import { IContext } from "@/types/server";
+import { Prisma } from "@prisma/client";
+import {
+  PrismaVoteTopic,
+  PrismaVoteTopicBase,
+  PrismaVoteGate,
+  PrismaVotePowerPolicy,
+  PrismaVoteOption,
+  PrismaVoteBallot,
+} from "./type";
+import {
+  GqlVoteCastInput,
+  GqlVoteGateInput,
+  GqlVotePowerPolicyInput,
+  GqlVoteOptionInput,
+} from "@/types/graphql";
+
+export interface IVoteRepository {
+  findTopic(ctx: IContext, id: string): Promise<PrismaVoteTopic | null>;
+
+  findTopicOrThrow(ctx: IContext, id: string): Promise<PrismaVoteTopic>;
+
+  queryTopics(
+    ctx: IContext,
+    communityId: string,
+    take: number,
+    cursor?: string,
+  ): Promise<PrismaVoteTopicBase[]>;
+
+  countTopics(ctx: IContext, communityId: string): Promise<number>;
+
+  createGate(
+    ctx: IContext,
+    topicId: string,
+    input: GqlVoteGateInput,
+    tx: Prisma.TransactionClient,
+  ): Promise<PrismaVoteGate>;
+
+  createPowerPolicy(
+    ctx: IContext,
+    topicId: string,
+    input: GqlVotePowerPolicyInput,
+    tx: Prisma.TransactionClient,
+  ): Promise<PrismaVotePowerPolicy>;
+
+  createTopic(
+    ctx: IContext,
+    data: Prisma.VoteTopicCreateInput,
+    tx: Prisma.TransactionClient,
+  ): Promise<PrismaVoteTopicBase>;
+
+  createOptions(
+    ctx: IContext,
+    topicId: string,
+    options: GqlVoteOptionInput[],
+    tx: Prisma.TransactionClient,
+  ): Promise<PrismaVoteOption[]>;
+
+  deleteTopic(
+    ctx: IContext,
+    id: string,
+    tx: Prisma.TransactionClient,
+  ): Promise<PrismaVoteTopicBase>;
+
+  findBallot(
+    ctx: IContext,
+    userId: string,
+    topicId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<PrismaVoteBallot | null>;
+
+  upsertBallot(
+    ctx: IContext,
+    userId: string,
+    input: GqlVoteCastInput,
+    power: number,
+    tx: Prisma.TransactionClient,
+  ): Promise<PrismaVoteBallot>;
+
+  incrementOptionCount(
+    ctx: IContext,
+    optionId: string,
+    power: number,
+    tx: Prisma.TransactionClient,
+  ): Promise<void>;
+
+  decrementOptionCount(
+    ctx: IContext,
+    optionId: string,
+    power: number,
+    tx: Prisma.TransactionClient,
+  ): Promise<void>;
+}

--- a/src/application/domain/vote/data/interface.ts
+++ b/src/application/domain/vote/data/interface.ts
@@ -4,7 +4,6 @@ import {
   PrismaVoteTopic,
   PrismaVoteGate,
   PrismaVotePowerPolicy,
-  PrismaVoteOption,
   PrismaVoteBallot,
 } from "./type";
 import {
@@ -53,7 +52,7 @@ export interface IVoteRepository {
     topicId: string,
     options: GqlVoteOptionInput[],
     tx: Prisma.TransactionClient,
-  ): Promise<PrismaVoteOption[]>;
+  ): Promise<void>;
 
   deleteTopic(
     ctx: IContext,

--- a/src/application/domain/vote/data/interface.ts
+++ b/src/application/domain/vote/data/interface.ts
@@ -2,7 +2,6 @@ import { IContext } from "@/types/server";
 import { Prisma } from "@prisma/client";
 import {
   PrismaVoteTopic,
-  PrismaVoteTopicBase,
   PrismaVoteGate,
   PrismaVotePowerPolicy,
   PrismaVoteOption,
@@ -16,16 +15,16 @@ import {
 } from "@/types/graphql";
 
 export interface IVoteRepository {
-  findTopic(ctx: IContext, id: string): Promise<PrismaVoteTopic | null>;
+  findTopic(ctx: IContext, id: string, tx?: Prisma.TransactionClient): Promise<PrismaVoteTopic | null>;
 
-  findTopicOrThrow(ctx: IContext, id: string): Promise<PrismaVoteTopic>;
+  findTopicOrThrow(ctx: IContext, id: string, tx?: Prisma.TransactionClient): Promise<PrismaVoteTopic>;
 
   queryTopics(
     ctx: IContext,
     communityId: string,
     take: number,
     cursor?: string,
-  ): Promise<PrismaVoteTopicBase[]>;
+  ): Promise<PrismaVoteTopic[]>;
 
   countTopics(ctx: IContext, communityId: string): Promise<number>;
 
@@ -47,7 +46,7 @@ export interface IVoteRepository {
     ctx: IContext,
     data: Prisma.VoteTopicCreateInput,
     tx: Prisma.TransactionClient,
-  ): Promise<PrismaVoteTopicBase>;
+  ): Promise<{ id: string }>;
 
   createOptions(
     ctx: IContext,
@@ -60,7 +59,7 @@ export interface IVoteRepository {
     ctx: IContext,
     id: string,
     tx: Prisma.TransactionClient,
-  ): Promise<PrismaVoteTopicBase>;
+  ): Promise<{ id: string }>;
 
   findBallot(
     ctx: IContext,
@@ -88,6 +87,13 @@ export interface IVoteRepository {
     ctx: IContext,
     optionId: string,
     power: number,
+    tx: Prisma.TransactionClient,
+  ): Promise<void>;
+
+  adjustOptionTotalPower(
+    ctx: IContext,
+    optionId: string,
+    delta: number,
     tx: Prisma.TransactionClient,
   ): Promise<void>;
 }

--- a/src/application/domain/vote/data/repository.ts
+++ b/src/application/domain/vote/data/repository.ts
@@ -1,0 +1,209 @@
+import { injectable } from "tsyringe";
+import { Prisma } from "@prisma/client";
+import { IContext } from "@/types/server";
+import { IVoteRepository } from "./interface";
+import {
+  voteTopicWithRelationsSelect,
+  voteTopicSelect,
+  voteGateSelect,
+  votePowerPolicySelect,
+  voteOptionSelect,
+  voteBallotSelect,
+  PrismaVoteTopic,
+  PrismaVoteTopicBase,
+  PrismaVoteGate,
+  PrismaVotePowerPolicy,
+  PrismaVoteOption,
+  PrismaVoteBallot,
+} from "./type";
+import { NotFoundError } from "@/errors/graphql";
+import {
+  GqlVoteCastInput,
+  GqlVoteGateInput,
+  GqlVotePowerPolicyInput,
+  GqlVoteOptionInput,
+} from "@/types/graphql";
+
+@injectable()
+export default class VoteRepository implements IVoteRepository {
+  async findTopic(ctx: IContext, id: string): Promise<PrismaVoteTopic | null> {
+    return ctx.issuer.public(ctx, (tx) =>
+      tx.voteTopic.findUnique({
+        where: { id },
+        select: voteTopicWithRelationsSelect,
+      }),
+    );
+  }
+
+  async findTopicOrThrow(ctx: IContext, id: string): Promise<PrismaVoteTopic> {
+    const topic = await this.findTopic(ctx, id);
+    if (!topic) throw new NotFoundError("VoteTopic", { id });
+    return topic;
+  }
+
+  async queryTopics(
+    ctx: IContext,
+    communityId: string,
+    take: number,
+    cursor?: string,
+  ): Promise<PrismaVoteTopicBase[]> {
+    return ctx.issuer.public(ctx, (tx) =>
+      tx.voteTopic.findMany({
+        where: { communityId },
+        select: voteTopicSelect,
+        orderBy: { endsAt: "desc" },
+        take: take + 1,
+        skip: cursor ? 1 : 0,
+        cursor: cursor ? { id: cursor } : undefined,
+      }),
+    );
+  }
+
+  async countTopics(ctx: IContext, communityId: string): Promise<number> {
+    return ctx.issuer.public(ctx, (tx) =>
+      tx.voteTopic.count({ where: { communityId } }),
+    );
+  }
+
+  async createGate(
+    ctx: IContext,
+    topicId: string,
+    input: GqlVoteGateInput,
+    tx: Prisma.TransactionClient,
+  ): Promise<PrismaVoteGate> {
+    return tx.voteGate.create({
+      data: {
+        type: input.type,
+        nftTokenId: input.nftTokenId ?? null,
+        requiredRole: input.requiredRole ?? null,
+        topicId,
+      },
+      select: voteGateSelect,
+    });
+  }
+
+  async createPowerPolicy(
+    ctx: IContext,
+    topicId: string,
+    input: GqlVotePowerPolicyInput,
+    tx: Prisma.TransactionClient,
+  ): Promise<PrismaVotePowerPolicy> {
+    return tx.votePowerPolicy.create({
+      data: {
+        type: input.type,
+        nftTokenId: input.nftTokenId ?? null,
+        topicId,
+      },
+      select: votePowerPolicySelect,
+    });
+  }
+
+  async createTopic(
+    ctx: IContext,
+    data: Prisma.VoteTopicCreateInput,
+    tx: Prisma.TransactionClient,
+  ): Promise<PrismaVoteTopicBase> {
+    return tx.voteTopic.create({
+      data,
+      select: voteTopicSelect,
+    });
+  }
+
+  async createOptions(
+    ctx: IContext,
+    topicId: string,
+    options: GqlVoteOptionInput[],
+    tx: Prisma.TransactionClient,
+  ): Promise<PrismaVoteOption[]> {
+    return Promise.all(
+      options.map((opt) =>
+        tx.voteOption.create({
+          data: {
+            topicId,
+            label: opt.label,
+            orderIndex: opt.orderIndex,
+          },
+          select: voteOptionSelect,
+        }),
+      ),
+    );
+  }
+
+  async deleteTopic(
+    ctx: IContext,
+    id: string,
+    tx: Prisma.TransactionClient,
+  ): Promise<PrismaVoteTopicBase> {
+    return tx.voteTopic.delete({
+      where: { id },
+      select: voteTopicSelect,
+    });
+  }
+
+  async findBallot(
+    ctx: IContext,
+    userId: string,
+    topicId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<PrismaVoteBallot | null> {
+    const query = (t: Prisma.TransactionClient) =>
+      t.voteBallot.findUnique({
+        where: { userId_topicId: { userId, topicId } },
+        select: voteBallotSelect,
+      });
+    return tx ? query(tx) : ctx.issuer.public(ctx, query);
+  }
+
+  async upsertBallot(
+    ctx: IContext,
+    userId: string,
+    input: GqlVoteCastInput,
+    power: number,
+    tx: Prisma.TransactionClient,
+  ): Promise<PrismaVoteBallot> {
+    return tx.voteBallot.upsert({
+      where: { userId_topicId: { userId, topicId: input.topicId } },
+      update: {
+        optionId: input.optionId,
+        power,
+      },
+      create: {
+        userId,
+        topicId: input.topicId,
+        optionId: input.optionId,
+        power,
+      },
+      select: voteBallotSelect,
+    });
+  }
+
+  async incrementOptionCount(
+    ctx: IContext,
+    optionId: string,
+    power: number,
+    tx: Prisma.TransactionClient,
+  ): Promise<void> {
+    await tx.voteOption.update({
+      where: { id: optionId },
+      data: {
+        voteCount: { increment: 1 },
+        totalPower: { increment: power },
+      },
+    });
+  }
+
+  async decrementOptionCount(
+    ctx: IContext,
+    optionId: string,
+    power: number,
+    tx: Prisma.TransactionClient,
+  ): Promise<void> {
+    await tx.voteOption.update({
+      where: { id: optionId },
+      data: {
+        voteCount: { decrement: 1 },
+        totalPower: { decrement: power },
+      },
+    });
+  }
+}

--- a/src/application/domain/vote/data/repository.ts
+++ b/src/application/domain/vote/data/repository.ts
@@ -6,7 +6,6 @@ import {
   voteTopicWithRelationsSelect,
   voteGateSelect,
   votePowerPolicySelect,
-  voteOptionSelect,
   voteBallotSelect,
   PrismaVoteTopic,
   PrismaVoteGate,
@@ -199,6 +198,16 @@ export default class VoteRepository implements IVoteRepository {
         totalPower: { decrement: power },
       },
     });
+  }
+
+  // 同一 (userId, topicId) への並行投票を完全にシリアライズするアドバイザリーロック
+  // pg_advisory_xact_lock はトランザクション終了時に自動解放される
+  async acquireVoteLock(
+    userId: string,
+    topicId: string,
+    tx: Prisma.TransactionClient,
+  ): Promise<void> {
+    await tx.$queryRaw`SELECT pg_advisory_xact_lock(hashtext(${userId + ":" + topicId}))`;
   }
 
   // 同じ選択肢への再投票時に totalPower のみ差分更新（voteCount は変化なし）

--- a/src/application/domain/vote/data/repository.ts
+++ b/src/application/domain/vote/data/repository.ts
@@ -4,13 +4,11 @@ import { IContext } from "@/types/server";
 import { IVoteRepository } from "./interface";
 import {
   voteTopicWithRelationsSelect,
-  voteTopicSelect,
   voteGateSelect,
   votePowerPolicySelect,
   voteOptionSelect,
   voteBallotSelect,
   PrismaVoteTopic,
-  PrismaVoteTopicBase,
   PrismaVoteGate,
   PrismaVotePowerPolicy,
   PrismaVoteOption,
@@ -26,17 +24,17 @@ import {
 
 @injectable()
 export default class VoteRepository implements IVoteRepository {
-  async findTopic(ctx: IContext, id: string): Promise<PrismaVoteTopic | null> {
-    return ctx.issuer.public(ctx, (tx) =>
-      tx.voteTopic.findUnique({
+  async findTopic(ctx: IContext, id: string, tx?: Prisma.TransactionClient): Promise<PrismaVoteTopic | null> {
+    const query = (t: Prisma.TransactionClient) =>
+      t.voteTopic.findUnique({
         where: { id },
         select: voteTopicWithRelationsSelect,
-      }),
-    );
+      });
+    return tx ? query(tx) : ctx.issuer.public(ctx, query);
   }
 
-  async findTopicOrThrow(ctx: IContext, id: string): Promise<PrismaVoteTopic> {
-    const topic = await this.findTopic(ctx, id);
+  async findTopicOrThrow(ctx: IContext, id: string, tx?: Prisma.TransactionClient): Promise<PrismaVoteTopic> {
+    const topic = await this.findTopic(ctx, id, tx);
     if (!topic) throw new NotFoundError("VoteTopic", { id });
     return topic;
   }
@@ -46,12 +44,12 @@ export default class VoteRepository implements IVoteRepository {
     communityId: string,
     take: number,
     cursor?: string,
-  ): Promise<PrismaVoteTopicBase[]> {
+  ): Promise<PrismaVoteTopic[]> {
     return ctx.issuer.public(ctx, (tx) =>
       tx.voteTopic.findMany({
         where: { communityId },
-        select: voteTopicSelect,
-        orderBy: { endsAt: "desc" },
+        select: voteTopicWithRelationsSelect,
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
         take: take + 1,
         skip: cursor ? 1 : 0,
         cursor: cursor ? { id: cursor } : undefined,
@@ -102,10 +100,10 @@ export default class VoteRepository implements IVoteRepository {
     ctx: IContext,
     data: Prisma.VoteTopicCreateInput,
     tx: Prisma.TransactionClient,
-  ): Promise<PrismaVoteTopicBase> {
+  ): Promise<{ id: string }> {
     return tx.voteTopic.create({
       data,
-      select: voteTopicSelect,
+      select: { id: true },
     });
   }
 
@@ -133,10 +131,10 @@ export default class VoteRepository implements IVoteRepository {
     ctx: IContext,
     id: string,
     tx: Prisma.TransactionClient,
-  ): Promise<PrismaVoteTopicBase> {
+  ): Promise<{ id: string }> {
     return tx.voteTopic.delete({
       where: { id },
-      select: voteTopicSelect,
+      select: { id: true },
     });
   }
 
@@ -203,6 +201,22 @@ export default class VoteRepository implements IVoteRepository {
       data: {
         voteCount: { decrement: 1 },
         totalPower: { decrement: power },
+      },
+    });
+  }
+
+  // 同じ選択肢への再投票時に totalPower のみ差分更新（voteCount は変化なし）
+  async adjustOptionTotalPower(
+    ctx: IContext,
+    optionId: string,
+    delta: number,
+    tx: Prisma.TransactionClient,
+  ): Promise<void> {
+    if (delta === 0) return;
+    await tx.voteOption.update({
+      where: { id: optionId },
+      data: {
+        totalPower: delta > 0 ? { increment: delta } : { decrement: -delta },
       },
     });
   }

--- a/src/application/domain/vote/data/repository.ts
+++ b/src/application/domain/vote/data/repository.ts
@@ -207,7 +207,9 @@ export default class VoteRepository implements IVoteRepository {
     topicId: string,
     tx: Prisma.TransactionClient,
   ): Promise<void> {
-    await tx.$queryRaw`SELECT pg_advisory_xact_lock(hashtext(${userId + ":" + topicId}))`;
+    // pg_advisory_xact_lock は void を返すため $queryRaw では deserialize できない
+    // $executeRaw はクエリ実行のみ行い戻り値を無視するため void 関数に適切
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${userId + ":" + topicId}))`;
   }
 
   // 同じ選択肢への再投票時に totalPower のみ差分更新（voteCount は変化なし）

--- a/src/application/domain/vote/data/repository.ts
+++ b/src/application/domain/vote/data/repository.ts
@@ -11,7 +11,6 @@ import {
   PrismaVoteTopic,
   PrismaVoteGate,
   PrismaVotePowerPolicy,
-  PrismaVoteOption,
   PrismaVoteBallot,
 } from "./type";
 import { NotFoundError } from "@/errors/graphql";
@@ -114,19 +113,14 @@ export default class VoteRepository implements IVoteRepository {
     topicId: string,
     options: GqlVoteOptionInput[],
     tx: Prisma.TransactionClient,
-  ): Promise<PrismaVoteOption[]> {
-    return Promise.all(
-      options.map((opt) =>
-        tx.voteOption.create({
-          data: {
-            topicId,
-            label: opt.label,
-            orderIndex: opt.orderIndex,
-          },
-          select: voteOptionSelect,
-        }),
-      ),
-    );
+  ): Promise<void> {
+    await tx.voteOption.createMany({
+      data: options.map((opt) => ({
+        topicId,
+        label: opt.label,
+        orderIndex: opt.orderIndex,
+      })),
+    });
   }
 
   async deleteTopic(

--- a/src/application/domain/vote/data/repository.ts
+++ b/src/application/domain/vote/data/repository.ts
@@ -49,6 +49,8 @@ export default class VoteRepository implements IVoteRepository {
       tx.voteTopic.findMany({
         where: { communityId },
         select: voteTopicWithRelationsSelect,
+        // endsAt ではなく createdAt でソート: id カーソルと組み合わせた場合に
+        // endsAt が同値のレコードでカーソル位置が一意に定まらない問題を防ぐ
         orderBy: [{ createdAt: "desc" }, { id: "desc" }],
         take: take + 1,
         skip: cursor ? 1 : 0,

--- a/src/application/domain/vote/data/type.ts
+++ b/src/application/domain/vote/data/type.ts
@@ -1,0 +1,81 @@
+import { Prisma } from "@prisma/client";
+
+export const voteTopicSelect = Prisma.validator<Prisma.VoteTopicSelect>()({
+  id: true,
+  communityId: true,
+  createdBy: true,
+  title: true,
+  description: true,
+  startsAt: true,
+  endsAt: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
+export const voteGateSelect = Prisma.validator<Prisma.VoteGateSelect>()({
+  id: true,
+  type: true,
+  nftTokenId: true,
+  requiredRole: true,
+  topicId: true,
+});
+
+export const votePowerPolicySelect = Prisma.validator<Prisma.VotePowerPolicySelect>()({
+  id: true,
+  type: true,
+  nftTokenId: true,
+  topicId: true,
+});
+
+export const voteOptionSelect = Prisma.validator<Prisma.VoteOptionSelect>()({
+  id: true,
+  topicId: true,
+  label: true,
+  orderIndex: true,
+  voteCount: true,
+  totalPower: true,
+});
+
+export const voteBallotSelect = Prisma.validator<Prisma.VoteBallotSelect>()({
+  id: true,
+  userId: true,
+  topicId: true,
+  optionId: true,
+  power: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
+export const voteTopicWithRelationsSelect = Prisma.validator<Prisma.VoteTopicSelect>()({
+  ...voteTopicSelect,
+  gate: { select: voteGateSelect },
+  powerPolicy: { select: votePowerPolicySelect },
+  options: {
+    select: voteOptionSelect,
+    orderBy: { orderIndex: "asc" },
+  },
+});
+
+export type PrismaVoteTopicBase = Prisma.VoteTopicGetPayload<{
+  select: typeof voteTopicSelect;
+}>;
+
+export type PrismaVoteGate = Prisma.VoteGateGetPayload<{
+  select: typeof voteGateSelect;
+}>;
+
+export type PrismaVotePowerPolicy = Prisma.VotePowerPolicyGetPayload<{
+  select: typeof votePowerPolicySelect;
+}>;
+
+export type PrismaVoteOption = Prisma.VoteOptionGetPayload<{
+  select: typeof voteOptionSelect;
+}>;
+
+export type PrismaVoteBallot = Prisma.VoteBallotGetPayload<{
+  select: typeof voteBallotSelect;
+}>;
+
+export type PrismaVoteTopic = Prisma.VoteTopicGetPayload<{
+  select: typeof voteTopicWithRelationsSelect;
+}>;

--- a/src/application/domain/vote/presenter.ts
+++ b/src/application/domain/vote/presenter.ts
@@ -26,7 +26,8 @@ export default class VotePresenter {
   static phase(topic: Pick<PrismaVoteTopicBase, "startsAt" | "endsAt">): GqlVoteTopicPhase {
     const now = new Date();
     if (now < topic.startsAt) return "UPCOMING";
-    if (now > topic.endsAt) return "CLOSED";
+    // >= で validateVotingPeriod / isResultVisible の境界と統一
+    if (now >= topic.endsAt) return "CLOSED";
     return "OPEN";
   }
 

--- a/src/application/domain/vote/presenter.ts
+++ b/src/application/domain/vote/presenter.ts
@@ -40,7 +40,9 @@ export default class VotePresenter {
       type: gate.type,
       nftToken: null, // フィールドリゾルバーで解決
       requiredRole: gate.requiredRole ?? null,
-    };
+      // フィールドリゾルバー (VoteGate.nftToken) が parent.nftTokenId を参照するため保持
+      nftTokenId: gate.nftTokenId,
+    } as GqlVoteGate;
   }
 
   static powerPolicy(policy: PrismaVotePowerPolicy): GqlVotePowerPolicy {
@@ -49,7 +51,9 @@ export default class VotePresenter {
       id: policy.id,
       type: policy.type,
       nftToken: null, // フィールドリゾルバーで解決
-    };
+      // フィールドリゾルバー (VotePowerPolicy.nftToken) が parent.nftTokenId を参照するため保持
+      nftTokenId: policy.nftTokenId,
+    } as GqlVotePowerPolicy;
   }
 
   static option(option: PrismaVoteOption, resultVisible: boolean): GqlVoteOption {
@@ -71,7 +75,9 @@ export default class VotePresenter {
       power: ballot.power,
       createdAt: ballot.createdAt,
       updatedAt: ballot.updatedAt ?? null,
-    };
+      // フィールドリゾルバー (VoteBallot.option) が parent.optionId を参照するため保持
+      optionId: ballot.optionId,
+    } as GqlVoteBallot;
   }
 
   static topic(
@@ -84,6 +90,8 @@ export default class VotePresenter {
       __typename: "VoteTopic",
       id: topic.id,
       community: null as unknown as GqlVoteTopic["community"], // フィールドリゾルバーで解決
+      // フィールドリゾルバー (VoteTopic.community) が parent.communityId を参照するため保持
+      communityId: topic.communityId,
       title: topic.title,
       description: topic.description ?? null,
       startsAt: topic.startsAt,
@@ -96,7 +104,7 @@ export default class VotePresenter {
       myEligibility: null, // フィールドリゾルバーで解決
       createdAt: topic.createdAt,
       updatedAt: topic.updatedAt ?? null,
-    };
+    } as GqlVoteTopic;
   }
 
   static eligibility(result: EligibilityResult, currentPower: number | null, myBallot: PrismaVoteBallot | null): GqlMyVoteEligibility {

--- a/src/application/domain/vote/presenter.ts
+++ b/src/application/domain/vote/presenter.ts
@@ -13,7 +13,6 @@ import {
 } from "@/types/graphql";
 import {
   PrismaVoteTopic,
-  PrismaVoteTopicBase,
   PrismaVoteGate,
   PrismaVotePowerPolicy,
   PrismaVoteOption,
@@ -49,18 +48,6 @@ export type GqlVoteTopicWithMeta = Omit<GqlVoteTopic, "gate" | "powerPolicy"> & 
 // ─── Presenter ────────────────────────────────────────────────────────────────
 
 export default class VotePresenter {
-  static phase(topic: Pick<PrismaVoteTopicBase, "startsAt" | "endsAt">): GqlVoteTopicPhase {
-    const now = new Date();
-    if (now < topic.startsAt) return "UPCOMING";
-    // >= で validateVotingPeriod / isResultVisible の境界と統一
-    if (now >= topic.endsAt) return "CLOSED";
-    return "OPEN";
-  }
-
-  static isResultVisible(topic: Pick<PrismaVoteTopicBase, "endsAt">, isManager: boolean): boolean {
-    return isManager || new Date() >= topic.endsAt;
-  }
-
   static gate(gate: PrismaVoteGate): GqlVoteGateWithMeta {
     return {
       __typename: "VoteGate",
@@ -108,9 +95,9 @@ export default class VotePresenter {
 
   static topic(
     topic: PrismaVoteTopic,
-    isManager: boolean,
+    resultVisible: boolean,
+    phase: GqlVoteTopicPhase,
   ): GqlVoteTopicWithMeta {
-    const resultVisible = this.isResultVisible(topic, isManager);
     return {
       __typename: "VoteTopic",
       id: topic.id,
@@ -121,7 +108,7 @@ export default class VotePresenter {
       description: topic.description ?? null,
       startsAt: topic.startsAt,
       endsAt: topic.endsAt,
-      phase: this.phase(topic),
+      phase,
       // validateTopicRelations() がサービス層で事前に呼ばれるため null は来ない
       gate: this.gate(topic.gate!),
       powerPolicy: this.powerPolicy(topic.powerPolicy!),

--- a/src/application/domain/vote/presenter.ts
+++ b/src/application/domain/vote/presenter.ts
@@ -95,6 +95,8 @@ export default class VotePresenter {
       community: null as unknown as GqlVoteTopic["community"], // フィールドリゾルバーで解決
       // フィールドリゾルバー (VoteTopic.community) が parent.communityId を参照するため保持
       communityId: topic.communityId,
+      // フィールドリゾルバー (VoteTopic.myBallot) が parent.resultVisible を参照するため保持
+      resultVisible,
       title: topic.title,
       description: topic.description ?? null,
       startsAt: topic.startsAt,

--- a/src/application/domain/vote/presenter.ts
+++ b/src/application/domain/vote/presenter.ts
@@ -1,0 +1,155 @@
+import {
+  GqlVoteTopic,
+  GqlVoteOption,
+  GqlVoteBallot,
+  GqlVoteGate,
+  GqlVotePowerPolicy,
+  GqlVoteTopicPhase,
+  GqlMyVoteEligibility,
+  GqlVoteTopicsConnection,
+  GqlVoteTopicCreatePayload,
+  GqlVoteCastPayload,
+  GqlVoteTopicDeletePayload,
+} from "@/types/graphql";
+import {
+  PrismaVoteTopic,
+  PrismaVoteTopicBase,
+  PrismaVoteGate,
+  PrismaVotePowerPolicy,
+  PrismaVoteOption,
+  PrismaVoteBallot,
+} from "./data/type";
+import { EligibilityResult } from "./service";
+
+export default class VotePresenter {
+  static phase(topic: Pick<PrismaVoteTopicBase, "startsAt" | "endsAt">): GqlVoteTopicPhase {
+    const now = new Date();
+    if (now < topic.startsAt) return "UPCOMING";
+    if (now > topic.endsAt) return "CLOSED";
+    return "OPEN";
+  }
+
+  static isResultVisible(topic: Pick<PrismaVoteTopicBase, "endsAt">, isManager: boolean): boolean {
+    return isManager || new Date() >= topic.endsAt;
+  }
+
+  static gate(gate: PrismaVoteGate): GqlVoteGate {
+    return {
+      __typename: "VoteGate",
+      id: gate.id,
+      type: gate.type,
+      nftToken: null, // フィールドリゾルバーで解決
+      requiredRole: gate.requiredRole ?? null,
+    };
+  }
+
+  static powerPolicy(policy: PrismaVotePowerPolicy): GqlVotePowerPolicy {
+    return {
+      __typename: "VotePowerPolicy",
+      id: policy.id,
+      type: policy.type,
+      nftToken: null, // フィールドリゾルバーで解決
+    };
+  }
+
+  static option(option: PrismaVoteOption, resultVisible: boolean): GqlVoteOption {
+    return {
+      __typename: "VoteOption",
+      id: option.id,
+      label: option.label,
+      orderIndex: option.orderIndex,
+      voteCount: resultVisible ? option.voteCount : null,
+      totalPower: resultVisible ? option.totalPower : null,
+    };
+  }
+
+  static ballot(ballot: PrismaVoteBallot): GqlVoteBallot {
+    return {
+      __typename: "VoteBallot",
+      id: ballot.id,
+      option: null as unknown as GqlVoteOption, // フィールドリゾルバーで解決
+      power: ballot.power,
+      createdAt: ballot.createdAt,
+      updatedAt: ballot.updatedAt ?? null,
+    };
+  }
+
+  static topic(
+    topic: PrismaVoteTopic,
+    isManager: boolean,
+    myBallot: PrismaVoteBallot | null = null,
+  ): GqlVoteTopic {
+    const resultVisible = this.isResultVisible(topic, isManager);
+    return {
+      __typename: "VoteTopic",
+      id: topic.id,
+      community: null as unknown as GqlVoteTopic["community"], // フィールドリゾルバーで解決
+      title: topic.title,
+      description: topic.description ?? null,
+      startsAt: topic.startsAt,
+      endsAt: topic.endsAt,
+      phase: this.phase(topic),
+      gate: topic.gate ? this.gate(topic.gate) : null as unknown as GqlVoteGate,
+      powerPolicy: topic.powerPolicy ? this.powerPolicy(topic.powerPolicy) : null as unknown as GqlVotePowerPolicy,
+      options: topic.options.map((opt) => this.option(opt, resultVisible)),
+      myBallot: myBallot ? this.ballot(myBallot) : null,
+      myEligibility: null, // フィールドリゾルバーで解決
+      createdAt: topic.createdAt,
+      updatedAt: topic.updatedAt ?? null,
+    };
+  }
+
+  static eligibility(result: EligibilityResult, currentPower: number | null, myBallot: PrismaVoteBallot | null): GqlMyVoteEligibility {
+    return {
+      __typename: "MyVoteEligibility",
+      eligible: result.eligible,
+      reason: result.reason ?? null,
+      currentPower: result.eligible ? currentPower : null,
+      myBallot: myBallot ? this.ballot(myBallot) : null,
+    };
+  }
+
+  static query(
+    topics: GqlVoteTopic[],
+    totalCount: number,
+    hasNextPage: boolean,
+    cursor?: string,
+  ): GqlVoteTopicsConnection {
+    return {
+      __typename: "VoteTopicsConnection",
+      totalCount,
+      pageInfo: {
+        hasNextPage,
+        hasPreviousPage: !!cursor,
+        startCursor: topics[0]?.id,
+        endCursor: topics.length ? topics[topics.length - 1].id : undefined,
+      },
+      edges: topics.map((node) => ({
+        cursor: node.id,
+        node,
+      })),
+      nodes: topics,
+    };
+  }
+
+  static create(topic: GqlVoteTopic): GqlVoteTopicCreatePayload {
+    return {
+      __typename: "VoteTopicCreatePayload",
+      voteTopic: topic,
+    };
+  }
+
+  static castBallot(ballot: GqlVoteBallot): GqlVoteCastPayload {
+    return {
+      __typename: "VoteCastPayload",
+      ballot,
+    };
+  }
+
+  static deleteTopic(id: string): GqlVoteTopicDeletePayload {
+    return {
+      __typename: "VoteTopicDeletePayload",
+      id,
+    };
+  }
+}

--- a/src/application/domain/vote/presenter.ts
+++ b/src/application/domain/vote/presenter.ts
@@ -20,7 +20,6 @@ import {
   PrismaVoteBallot,
 } from "./data/type";
 import { EligibilityResult } from "./service";
-import { ValidationError } from "@/errors/graphql";
 
 export default class VotePresenter {
   static phase(topic: Pick<PrismaVoteTopicBase, "startsAt" | "endsAt">): GqlVoteTopicPhase {
@@ -89,15 +88,6 @@ export default class VotePresenter {
     isManager: boolean,
     myBallot: PrismaVoteBallot | null = null,
   ): GqlVoteTopic {
-    // gate と powerPolicy はスキーマ上 non-null (VoteGate! / VotePowerPolicy!) のため、
-    // 欠落は作成フローのバグを示す。GQL の non-null 違反を伝播させるより早期エラーにする。
-    if (!topic.gate) {
-      throw new ValidationError(`VoteTopic(${topic.id}) has no gate configured`, []);
-    }
-    if (!topic.powerPolicy) {
-      throw new ValidationError(`VoteTopic(${topic.id}) has no powerPolicy configured`, []);
-    }
-
     const resultVisible = this.isResultVisible(topic, isManager);
     return {
       __typename: "VoteTopic",
@@ -110,8 +100,9 @@ export default class VotePresenter {
       startsAt: topic.startsAt,
       endsAt: topic.endsAt,
       phase: this.phase(topic),
-      gate: this.gate(topic.gate),
-      powerPolicy: this.powerPolicy(topic.powerPolicy),
+      // validateTopicRelations() がサービス層で事前に呼ばれるため null は来ない
+      gate: this.gate(topic.gate!),
+      powerPolicy: this.powerPolicy(topic.powerPolicy!),
       options: topic.options.map((opt) => this.option(opt, resultVisible)),
       myBallot: myBallot ? this.ballot(myBallot, resultVisible) : null,
       myEligibility: null, // フィールドリゾルバーで解決

--- a/src/application/domain/vote/presenter.ts
+++ b/src/application/domain/vote/presenter.ts
@@ -4,7 +4,6 @@ import {
   GqlVoteBallot,
   GqlVoteGate,
   GqlVotePowerPolicy,
-  GqlVoteTopicPhase,
   GqlMyVoteEligibility,
   GqlVoteTopicsConnection,
   GqlVoteTopicCreatePayload,
@@ -18,7 +17,7 @@ import {
   PrismaVoteOption,
   PrismaVoteBallot,
 } from "./data/type";
-import { EligibilityResult } from "./service";
+import { EligibilityResult, VotePhase } from "./service";
 
 // ─── フィールドリゾルバー向けメタデータ付き GQL 型 ──────────────────────────
 // フィールドリゾルバーは parent オブジェクト経由でこれらを参照する
@@ -48,6 +47,29 @@ export type GqlVoteTopicWithMeta = Omit<GqlVoteTopic, "gate" | "powerPolicy" | "
   resultVisible: boolean;                // VoteTopic.myBallot リゾルバーが参照
   gate: GqlVoteGateWithMeta;
   powerPolicy: GqlVotePowerPolicyWithMeta;
+};
+
+// ─── WithMeta 版 Connection / Payload 型 ─────────────────────────────────────
+// Resolver 境界でキャストなしに GqlVoteTopicWithMeta / GqlVoteBallotWithMeta を
+// 保持できるよう、nodes/edges/voteTopic/ballot フィールドを上書きした型。
+// GraphQL ランタイム（Apollo）はフィールドリゾルバーで各フィールドを解決するため
+// TypeScript 型と完全一致しなくてもよい — 型安全を保ちながらキャストを排除する。
+
+export type GqlVoteTopicsConnectionWithMeta = Omit<GqlVoteTopicsConnection, "edges" | "nodes"> & {
+  edges: Array<{ cursor: string; node: GqlVoteTopicWithMeta }>;
+  nodes: GqlVoteTopicWithMeta[];
+};
+
+export type GqlMyVoteEligibilityWithMeta = Omit<GqlMyVoteEligibility, "myBallot"> & {
+  myBallot?: GqlVoteBallotWithMeta | null;
+};
+
+export type GqlVoteTopicCreatePayloadWithMeta = Omit<GqlVoteTopicCreatePayload, "voteTopic"> & {
+  voteTopic: GqlVoteTopicWithMeta;
+};
+
+export type GqlVoteCastPayloadWithMeta = Omit<GqlVoteCastPayload, "ballot"> & {
+  ballot: GqlVoteBallotWithMeta;
 };
 
 // ─── Presenter ────────────────────────────────────────────────────────────────
@@ -101,7 +123,7 @@ export default class VotePresenter {
   static topic(
     topic: PrismaVoteTopic,
     resultVisible: boolean,
-    phase: GqlVoteTopicPhase,
+    phase: VotePhase,
   ): GqlVoteTopicWithMeta {
     return {
       __typename: "VoteTopic",
@@ -130,14 +152,13 @@ export default class VotePresenter {
     currentPower: number | null,
     myBallot: PrismaVoteBallot | null,
     resultVisible: boolean = false,
-  ): GqlMyVoteEligibility {
+  ): GqlMyVoteEligibilityWithMeta {
     return {
       __typename: "MyVoteEligibility",
       eligible: result.eligible,
       reason: result.reason ?? null,
       currentPower: result.eligible ? currentPower : null,
-      // WithMeta → GQL 境界: field resolver で option が解決されることを前提とした型境界キャスト
-      myBallot: myBallot ? (this.ballot(myBallot, resultVisible) as unknown as GqlVoteBallot) : null,
+      myBallot: myBallot ? this.ballot(myBallot, resultVisible) : null,
     };
   }
 
@@ -146,9 +167,7 @@ export default class VotePresenter {
     totalCount: number,
     hasNextPage: boolean,
     cursor?: string,
-  ): GqlVoteTopicsConnection {
-    // WithMeta → GQL 境界: community/option は field resolver で解決されることを前提とした型境界キャスト
-    const gqlTopics = topics as unknown as GqlVoteTopic[];
+  ): GqlVoteTopicsConnectionWithMeta {
     return {
       __typename: "VoteTopicsConnection",
       totalCount,
@@ -158,27 +177,25 @@ export default class VotePresenter {
         startCursor: topics[0]?.id,
         endCursor: topics.length ? topics[topics.length - 1].id : undefined,
       },
-      edges: gqlTopics.map((node) => ({
+      edges: topics.map((node) => ({
         cursor: node.id,
         node,
       })),
-      nodes: gqlTopics,
+      nodes: topics,
     };
   }
 
-  static create(topic: GqlVoteTopicWithMeta): GqlVoteTopicCreatePayload {
+  static create(topic: GqlVoteTopicWithMeta): GqlVoteTopicCreatePayloadWithMeta {
     return {
       __typename: "VoteTopicCreatePayload",
-      // WithMeta → GQL 境界: field resolver で community が解決されることを前提とした型境界キャスト
-      voteTopic: topic as unknown as GqlVoteTopic,
+      voteTopic: topic,
     };
   }
 
-  static castBallot(ballot: GqlVoteBallotWithMeta): GqlVoteCastPayload {
+  static castBallot(ballot: GqlVoteBallotWithMeta): GqlVoteCastPayloadWithMeta {
     return {
       __typename: "VoteCastPayload",
-      // WithMeta → GQL 境界: field resolver で option が解決されることを前提とした型境界キャスト
-      ballot: ballot as unknown as GqlVoteBallot,
+      ballot,
     };
   }
 

--- a/src/application/domain/vote/presenter.ts
+++ b/src/application/domain/vote/presenter.ts
@@ -68,7 +68,7 @@ export default class VotePresenter {
     };
   }
 
-  static ballot(ballot: PrismaVoteBallot): GqlVoteBallot {
+  static ballot(ballot: PrismaVoteBallot, resultVisible: boolean = false): GqlVoteBallot {
     return {
       __typename: "VoteBallot",
       id: ballot.id,
@@ -76,8 +76,10 @@ export default class VotePresenter {
       power: ballot.power,
       createdAt: ballot.createdAt,
       updatedAt: ballot.updatedAt ?? null,
-      // フィールドリゾルバー (VoteBallot.option) が parent.optionId を参照するため保持
+      // フィールドリゾルバー (VoteBallot.option) が参照するメタデータ
       optionId: ballot.optionId,
+      // VoteBallot.option リゾルバーが voteCount/totalPower を秘匿するために使用
+      resultVisible,
     } as GqlVoteBallot;
   }
 
@@ -110,20 +112,25 @@ export default class VotePresenter {
       gate: this.gate(topic.gate),
       powerPolicy: this.powerPolicy(topic.powerPolicy),
       options: topic.options.map((opt) => this.option(opt, resultVisible)),
-      myBallot: myBallot ? this.ballot(myBallot) : null,
+      myBallot: myBallot ? this.ballot(myBallot, resultVisible) : null,
       myEligibility: null, // フィールドリゾルバーで解決
       createdAt: topic.createdAt,
       updatedAt: topic.updatedAt ?? null,
     } as GqlVoteTopic;
   }
 
-  static eligibility(result: EligibilityResult, currentPower: number | null, myBallot: PrismaVoteBallot | null): GqlMyVoteEligibility {
+  static eligibility(
+    result: EligibilityResult,
+    currentPower: number | null,
+    myBallot: PrismaVoteBallot | null,
+    resultVisible: boolean = false,
+  ): GqlMyVoteEligibility {
     return {
       __typename: "MyVoteEligibility",
       eligible: result.eligible,
       reason: result.reason ?? null,
       currentPower: result.eligible ? currentPower : null,
-      myBallot: myBallot ? this.ballot(myBallot) : null,
+      myBallot: myBallot ? this.ballot(myBallot, resultVisible) : null,
     };
   }
 

--- a/src/application/domain/vote/presenter.ts
+++ b/src/application/domain/vote/presenter.ts
@@ -21,6 +21,33 @@ import {
 } from "./data/type";
 import { EligibilityResult } from "./service";
 
+// ─── フィールドリゾルバー向けメタデータ付き GQL 型 ──────────────────────────
+// フィールドリゾルバーは parent オブジェクト経由でこれらを参照する
+// GQL スキーマ上には存在しないが、Presenter → Resolver 間の型安全な受け渡しに使用
+
+export type GqlVoteGateWithMeta = GqlVoteGate & {
+  nftTokenId: string | null; // VoteGate.nftToken リゾルバーが参照
+};
+
+export type GqlVotePowerPolicyWithMeta = GqlVotePowerPolicy & {
+  nftTokenId: string | null; // VotePowerPolicy.nftToken リゾルバーが参照
+};
+
+export type GqlVoteBallotWithMeta = GqlVoteBallot & {
+  optionId: string;      // VoteBallot.option リゾルバーが参照
+  resultVisible: boolean; // VoteOption の集計マスキングに使用
+};
+
+// gate/powerPolicy は実態として常に WithMeta 版が入るため Omit して上書き
+export type GqlVoteTopicWithMeta = Omit<GqlVoteTopic, "gate" | "powerPolicy"> & {
+  communityId: string;            // VoteTopic.community リゾルバーが参照
+  resultVisible: boolean;         // VoteTopic.myBallot リゾルバーが参照
+  gate: GqlVoteGateWithMeta;
+  powerPolicy: GqlVotePowerPolicyWithMeta;
+};
+
+// ─── Presenter ────────────────────────────────────────────────────────────────
+
 export default class VotePresenter {
   static phase(topic: Pick<PrismaVoteTopicBase, "startsAt" | "endsAt">): GqlVoteTopicPhase {
     const now = new Date();
@@ -34,27 +61,25 @@ export default class VotePresenter {
     return isManager || new Date() >= topic.endsAt;
   }
 
-  static gate(gate: PrismaVoteGate): GqlVoteGate {
+  static gate(gate: PrismaVoteGate): GqlVoteGateWithMeta {
     return {
       __typename: "VoteGate",
       id: gate.id,
       type: gate.type,
       nftToken: null, // フィールドリゾルバーで解決
       requiredRole: gate.requiredRole ?? null,
-      // フィールドリゾルバー (VoteGate.nftToken) が parent.nftTokenId を参照するため保持
       nftTokenId: gate.nftTokenId,
-    } as GqlVoteGate;
+    };
   }
 
-  static powerPolicy(policy: PrismaVotePowerPolicy): GqlVotePowerPolicy {
+  static powerPolicy(policy: PrismaVotePowerPolicy): GqlVotePowerPolicyWithMeta {
     return {
       __typename: "VotePowerPolicy",
       id: policy.id,
       type: policy.type,
       nftToken: null, // フィールドリゾルバーで解決
-      // フィールドリゾルバー (VotePowerPolicy.nftToken) が parent.nftTokenId を参照するため保持
       nftTokenId: policy.nftTokenId,
-    } as GqlVotePowerPolicy;
+    };
   }
 
   static option(option: PrismaVoteOption, resultVisible: boolean): GqlVoteOption {
@@ -68,7 +93,7 @@ export default class VotePresenter {
     };
   }
 
-  static ballot(ballot: PrismaVoteBallot, resultVisible: boolean = false): GqlVoteBallot {
+  static ballot(ballot: PrismaVoteBallot, resultVisible: boolean = false): GqlVoteBallotWithMeta {
     return {
       __typename: "VoteBallot",
       id: ballot.id,
@@ -76,26 +101,21 @@ export default class VotePresenter {
       power: ballot.power,
       createdAt: ballot.createdAt,
       updatedAt: ballot.updatedAt ?? null,
-      // フィールドリゾルバー (VoteBallot.option) が参照するメタデータ
       optionId: ballot.optionId,
-      // VoteBallot.option リゾルバーが voteCount/totalPower を秘匿するために使用
       resultVisible,
-    } as GqlVoteBallot;
+    };
   }
 
   static topic(
     topic: PrismaVoteTopic,
     isManager: boolean,
-    myBallot: PrismaVoteBallot | null = null,
-  ): GqlVoteTopic {
+  ): GqlVoteTopicWithMeta {
     const resultVisible = this.isResultVisible(topic, isManager);
     return {
       __typename: "VoteTopic",
       id: topic.id,
       community: null as unknown as GqlVoteTopic["community"], // フィールドリゾルバーで解決
-      // フィールドリゾルバー (VoteTopic.community) が parent.communityId を参照するため保持
       communityId: topic.communityId,
-      // フィールドリゾルバー (VoteTopic.myBallot) が parent.resultVisible を参照するため保持
       resultVisible,
       title: topic.title,
       description: topic.description ?? null,
@@ -106,11 +126,11 @@ export default class VotePresenter {
       gate: this.gate(topic.gate!),
       powerPolicy: this.powerPolicy(topic.powerPolicy!),
       options: topic.options.map((opt) => this.option(opt, resultVisible)),
-      myBallot: myBallot ? this.ballot(myBallot, resultVisible) : null,
+      myBallot: null, // フィールドリゾルバー（DataLoader）で解決
       myEligibility: null, // フィールドリゾルバーで解決
       createdAt: topic.createdAt,
       updatedAt: topic.updatedAt ?? null,
-    } as GqlVoteTopic;
+    };
   }
 
   static eligibility(
@@ -129,7 +149,7 @@ export default class VotePresenter {
   }
 
   static query(
-    topics: GqlVoteTopic[],
+    topics: GqlVoteTopicWithMeta[],
     totalCount: number,
     hasNextPage: boolean,
     cursor?: string,
@@ -151,14 +171,14 @@ export default class VotePresenter {
     };
   }
 
-  static create(topic: GqlVoteTopic): GqlVoteTopicCreatePayload {
+  static create(topic: GqlVoteTopicWithMeta): GqlVoteTopicCreatePayload {
     return {
       __typename: "VoteTopicCreatePayload",
       voteTopic: topic,
     };
   }
 
-  static castBallot(ballot: GqlVoteBallot): GqlVoteCastPayload {
+  static castBallot(ballot: GqlVoteBallotWithMeta): GqlVoteCastPayload {
     return {
       __typename: "VoteCastPayload",
       ballot,

--- a/src/application/domain/vote/presenter.ts
+++ b/src/application/domain/vote/presenter.ts
@@ -32,15 +32,20 @@ export type GqlVotePowerPolicyWithMeta = GqlVotePowerPolicy & {
   nftTokenId: string | null; // VotePowerPolicy.nftToken リゾルバーが参照
 };
 
-export type GqlVoteBallotWithMeta = GqlVoteBallot & {
-  optionId: string;      // VoteBallot.option リゾルバーが参照
-  resultVisible: boolean; // VoteOption の集計マスキングに使用
+// フィールドリゾルバーで解決するフィールド（GQL 上 non-null だが Presenter では持たない）を
+// Omit して optional に変更することで `null as unknown as ...` キャストを排除する
+
+export type GqlVoteBallotWithMeta = Omit<GqlVoteBallot, "option"> & {
+  option?: GqlVoteOption;  // VoteBallot.option フィールドリゾルバーで解決
+  optionId: string;        // VoteBallot.option リゾルバーが参照
+  resultVisible: boolean;  // VoteOption の集計マスキングに使用
 };
 
-// gate/powerPolicy は実態として常に WithMeta 版が入るため Omit して上書き
-export type GqlVoteTopicWithMeta = Omit<GqlVoteTopic, "gate" | "powerPolicy"> & {
-  communityId: string;            // VoteTopic.community リゾルバーが参照
-  resultVisible: boolean;         // VoteTopic.myBallot リゾルバーが参照
+// gate/powerPolicy/community は Omit して WithMeta 版で上書き
+export type GqlVoteTopicWithMeta = Omit<GqlVoteTopic, "gate" | "powerPolicy" | "community"> & {
+  community?: GqlVoteTopic["community"]; // VoteTopic.community フィールドリゾルバーで解決
+  communityId: string;                   // VoteTopic.community リゾルバーが参照
+  resultVisible: boolean;                // VoteTopic.myBallot リゾルバーが参照
   gate: GqlVoteGateWithMeta;
   powerPolicy: GqlVotePowerPolicyWithMeta;
 };
@@ -84,7 +89,7 @@ export default class VotePresenter {
     return {
       __typename: "VoteBallot",
       id: ballot.id,
-      option: null as unknown as GqlVoteOption, // フィールドリゾルバーで解決
+      // option はフィールドリゾルバーで解決するため省略（Omit 済み）
       power: ballot.power,
       createdAt: ballot.createdAt,
       updatedAt: ballot.updatedAt ?? null,
@@ -101,7 +106,7 @@ export default class VotePresenter {
     return {
       __typename: "VoteTopic",
       id: topic.id,
-      community: null as unknown as GqlVoteTopic["community"], // フィールドリゾルバーで解決
+      // community はフィールドリゾルバーで解決するため省略（Omit 済み）
       communityId: topic.communityId,
       resultVisible,
       title: topic.title,
@@ -131,7 +136,8 @@ export default class VotePresenter {
       eligible: result.eligible,
       reason: result.reason ?? null,
       currentPower: result.eligible ? currentPower : null,
-      myBallot: myBallot ? this.ballot(myBallot, resultVisible) : null,
+      // WithMeta → GQL 境界: field resolver で option が解決されることを前提とした型境界キャスト
+      myBallot: myBallot ? (this.ballot(myBallot, resultVisible) as unknown as GqlVoteBallot) : null,
     };
   }
 
@@ -141,6 +147,8 @@ export default class VotePresenter {
     hasNextPage: boolean,
     cursor?: string,
   ): GqlVoteTopicsConnection {
+    // WithMeta → GQL 境界: community/option は field resolver で解決されることを前提とした型境界キャスト
+    const gqlTopics = topics as unknown as GqlVoteTopic[];
     return {
       __typename: "VoteTopicsConnection",
       totalCount,
@@ -150,25 +158,27 @@ export default class VotePresenter {
         startCursor: topics[0]?.id,
         endCursor: topics.length ? topics[topics.length - 1].id : undefined,
       },
-      edges: topics.map((node) => ({
+      edges: gqlTopics.map((node) => ({
         cursor: node.id,
         node,
       })),
-      nodes: topics,
+      nodes: gqlTopics,
     };
   }
 
   static create(topic: GqlVoteTopicWithMeta): GqlVoteTopicCreatePayload {
     return {
       __typename: "VoteTopicCreatePayload",
-      voteTopic: topic,
+      // WithMeta → GQL 境界: field resolver で community が解決されることを前提とした型境界キャスト
+      voteTopic: topic as unknown as GqlVoteTopic,
     };
   }
 
   static castBallot(ballot: GqlVoteBallotWithMeta): GqlVoteCastPayload {
     return {
       __typename: "VoteCastPayload",
-      ballot,
+      // WithMeta → GQL 境界: field resolver で option が解決されることを前提とした型境界キャスト
+      ballot: ballot as unknown as GqlVoteBallot,
     };
   }
 

--- a/src/application/domain/vote/presenter.ts
+++ b/src/application/domain/vote/presenter.ts
@@ -20,6 +20,7 @@ import {
   PrismaVoteBallot,
 } from "./data/type";
 import { EligibilityResult } from "./service";
+import { ValidationError } from "@/errors/graphql";
 
 export default class VotePresenter {
   static phase(topic: Pick<PrismaVoteTopicBase, "startsAt" | "endsAt">): GqlVoteTopicPhase {
@@ -85,6 +86,15 @@ export default class VotePresenter {
     isManager: boolean,
     myBallot: PrismaVoteBallot | null = null,
   ): GqlVoteTopic {
+    // gate と powerPolicy はスキーマ上 non-null (VoteGate! / VotePowerPolicy!) のため、
+    // 欠落は作成フローのバグを示す。GQL の non-null 違反を伝播させるより早期エラーにする。
+    if (!topic.gate) {
+      throw new ValidationError(`VoteTopic(${topic.id}) has no gate configured`, []);
+    }
+    if (!topic.powerPolicy) {
+      throw new ValidationError(`VoteTopic(${topic.id}) has no powerPolicy configured`, []);
+    }
+
     const resultVisible = this.isResultVisible(topic, isManager);
     return {
       __typename: "VoteTopic",
@@ -97,8 +107,8 @@ export default class VotePresenter {
       startsAt: topic.startsAt,
       endsAt: topic.endsAt,
       phase: this.phase(topic),
-      gate: topic.gate ? this.gate(topic.gate) : null as unknown as GqlVoteGate,
-      powerPolicy: topic.powerPolicy ? this.powerPolicy(topic.powerPolicy) : null as unknown as GqlVotePowerPolicy,
+      gate: this.gate(topic.gate),
+      powerPolicy: this.powerPolicy(topic.powerPolicy),
       options: topic.options.map((opt) => this.option(opt, resultVisible)),
       myBallot: myBallot ? this.ballot(myBallot) : null,
       myEligibility: null, // フィールドリゾルバーで解決

--- a/src/application/domain/vote/schema/mutation.graphql
+++ b/src/application/domain/vote/schema/mutation.graphql
@@ -1,0 +1,55 @@
+# ------------------------------
+# Vote Domain Mutation Definitions
+# ------------------------------
+
+extend type Mutation {
+    # 管理者: 投票テーマ・ゲート・ポリシー・選択肢を一括作成
+    voteTopicCreate(
+        input: VoteTopicCreateInput!
+        permission: CheckCommunityPermissionInput!
+    ): VoteTopicCreatePayload!
+        @authz(rules: [IsCommunityManager])
+
+    # ユーザー: 投票実行（既存投票は upsert で上書き）
+    voteCast(input: VoteCastInput!): VoteCastPayload!
+        @authz(rules: [IsUser])
+
+    # 管理者: 投票テーマ削除
+    voteTopicDelete(
+        id: ID!
+        permission: CheckCommunityPermissionInput!
+    ): VoteTopicDeletePayload!
+        @authz(rules: [IsCommunityManager])
+}
+
+input VoteTopicCreateInput {
+    communityId: ID!
+    title: String!
+    description: String
+    startsAt: Datetime!
+    endsAt: Datetime!
+    gate: VoteGateInput!
+    powerPolicy: VotePowerPolicyInput!
+    options: [VoteOptionInput!]!
+}
+
+input VoteGateInput {
+    type: VoteGateType!
+    nftTokenId: ID
+    requiredRole: Role
+}
+
+input VotePowerPolicyInput {
+    type: VotePowerPolicyType!
+    nftTokenId: ID
+}
+
+input VoteOptionInput {
+    label: String!
+    orderIndex: Int!
+}
+
+input VoteCastInput {
+    topicId: ID!
+    optionId: ID!
+}

--- a/src/application/domain/vote/schema/query.graphql
+++ b/src/application/domain/vote/schema/query.graphql
@@ -7,7 +7,7 @@ extend type Query {
     voteTopics(
         communityId: ID!
         first: Int
-        after: String
+        cursor: String
     ): VoteTopicsConnection!
 
     # 投票テーマ詳細（myBallot / myEligibility はフィールドリゾルバー経由）

--- a/src/application/domain/vote/schema/query.graphql
+++ b/src/application/domain/vote/schema/query.graphql
@@ -1,0 +1,19 @@
+# ------------------------------
+# Vote Domain Query Definitions
+# ------------------------------
+
+extend type Query {
+    # コミュニティの投票テーマ一覧（カーソルページネーション付き）
+    voteTopics(
+        communityId: ID!
+        first: Int
+        after: String
+    ): VoteTopicsConnection!
+
+    # 投票テーマ詳細（myBallot / myEligibility はフィールドリゾルバー経由）
+    voteTopic(id: ID!): VoteTopic
+
+    # ログインユーザーの投票資格確認
+    myVoteEligibility(topicId: ID!): MyVoteEligibility!
+        @authz(rules: [IsUser])
+}

--- a/src/application/domain/vote/schema/type.graphql
+++ b/src/application/domain/vote/schema/type.graphql
@@ -1,0 +1,101 @@
+# ------------------------------
+# Vote Domain Type Definitions
+# ------------------------------
+
+enum VoteGateType {
+    NFT
+    MEMBERSHIP
+}
+
+enum VotePowerPolicyType {
+    FLAT
+    NFT_COUNT
+}
+
+# 投票テーマの現在フェーズ（startsAt / endsAt から計算、DB には持たない）
+enum VoteTopicPhase {
+    UPCOMING
+    OPEN
+    CLOSED
+}
+
+type VoteGate {
+    id: ID!
+    type: VoteGateType!
+    nftToken: NftToken
+    requiredRole: Role
+}
+
+type VotePowerPolicy {
+    id: ID!
+    type: VotePowerPolicyType!
+    nftToken: NftToken
+}
+
+type VoteOption {
+    id: ID!
+    label: String!
+    orderIndex: Int!
+    # 投票期間終了後のみ値を返す（期間中は null）
+    voteCount: Int
+    totalPower: Int
+}
+
+type VoteTopic {
+    id: ID!
+    community: Community!
+    title: String!
+    description: String
+    startsAt: Datetime!
+    endsAt: Datetime!
+    phase: VoteTopicPhase!
+    gate: VoteGate!
+    powerPolicy: VotePowerPolicy!
+    options: [VoteOption!]!
+    # ログインユーザーの投票（未ログイン・未投票は null）
+    myBallot: VoteBallot
+    # ログインユーザーの資格情報（未ログインは null）
+    myEligibility: MyVoteEligibility
+    createdAt: Datetime!
+    updatedAt: Datetime
+}
+
+type VoteBallot {
+    id: ID!
+    option: VoteOption!
+    power: Int!
+    createdAt: Datetime!
+    updatedAt: Datetime
+}
+
+type MyVoteEligibility {
+    eligible: Boolean!
+    reason: String
+    currentPower: Int
+    myBallot: VoteBallot
+}
+
+type VoteTopicsConnection {
+    totalCount: Int!
+    pageInfo: PageInfo!
+    edges: [VoteTopicEdge!]!
+    nodes: [VoteTopic!]!
+}
+
+type VoteTopicEdge {
+    cursor: String!
+    node: VoteTopic!
+}
+
+# Payloads
+type VoteTopicCreatePayload {
+    voteTopic: VoteTopic!
+}
+
+type VoteCastPayload {
+    ballot: VoteBallot!
+}
+
+type VoteTopicDeletePayload {
+    id: ID!
+}

--- a/src/application/domain/vote/service.ts
+++ b/src/application/domain/vote/service.ts
@@ -123,7 +123,8 @@ export default class VoteService {
     }
     // NFT_COUNT: 保有 NftInstance 数を票数とする
     if (!policy.nftTokenId) {
-      return 1; // フォールバック: nftTokenId 未設定の場合は 1 票
+      // validateTopicInput で nftTokenId を必須としているため、ここに到達するのはデータ不整合
+      throw new ValidationError("nftTokenId is required for NFT_COUNT power policy", []);
     }
     // tx を渡すことで投票トランザクション内での読み取りを保証（TOCTOU 防止）
     const count = await this.nftInstanceRepo.countByUserAndToken(ctx, userId, policy.nftTokenId, tx);

--- a/src/application/domain/vote/service.ts
+++ b/src/application/domain/vote/service.ts
@@ -67,6 +67,16 @@ export default class VoteService {
     }
   }
 
+  validateTopicRelations(topic: PrismaVoteTopic): void {
+    // gate と powerPolicy はスキーマ上 non-null のため、欠落はデータ不整合を示す
+    if (!topic.gate) {
+      throw new ValidationError(`VoteTopic(${topic.id}) has no gate configured`, []);
+    }
+    if (!topic.powerPolicy) {
+      throw new ValidationError(`VoteTopic(${topic.id}) has no powerPolicy configured`, []);
+    }
+  }
+
   validateOptionBelongsToTopic(optionId: string, topic: PrismaVoteTopic): void {
     const option = topic.options.find((o) => o.id === optionId);
     if (!option) {

--- a/src/application/domain/vote/service.ts
+++ b/src/application/domain/vote/service.ts
@@ -31,8 +31,7 @@ export default class VoteService {
   ) {}
 
   async getTopicWithRelations(ctx: IContext, id: string, tx?: Prisma.TransactionClient): Promise<PrismaVoteTopic> {
-    const topic = await this.repo.findTopicOrThrow(ctx, id);
-    return topic;
+    return this.repo.findTopicOrThrow(ctx, id, tx);
   }
 
   validateTopicInput(input: GqlVoteTopicCreateInput): void {
@@ -145,11 +144,18 @@ export default class VoteService {
     newPower: number,
     tx: Prisma.TransactionClient,
   ): Promise<void> {
+    if (existingBallot && existingBallot.optionId === newBallot.optionId) {
+      // 同じ選択肢への再投票: voteCount は変化なし、totalPower のみ差分更新
+      const delta = newPower - existingBallot.power;
+      await this.repo.adjustOptionTotalPower(ctx, newBallot.optionId, delta, tx);
+      return;
+    }
+
     if (existingBallot) {
-      // 再投票: 旧選択肢のカウントをデクリメント
+      // 別選択肢への再投票: 旧選択肢を全デクリメント
       await this.repo.decrementOptionCount(ctx, existingBallot.optionId, existingBallot.power, tx);
     }
-    // 新選択肢のカウントをインクリメント
+    // 新選択肢をインクリメント
     await this.repo.incrementOptionCount(ctx, newBallot.optionId, newPower, tx);
   }
 
@@ -172,8 +178,8 @@ export default class VoteService {
     // 4. Options を作成
     await this.repo.createOptions(ctx, topic.id, input.options, tx);
 
-    // 5. リレーション付きで再取得
-    return this.repo.findTopicOrThrow(ctx, topic.id);
+    // 5. リレーション付きで再取得（同じトランザクション内で取得）
+    return this.repo.findTopicOrThrow(ctx, topic.id, tx);
   }
 
   async deleteTopic(
@@ -181,7 +187,6 @@ export default class VoteService {
     id: string,
     tx: Prisma.TransactionClient,
   ): Promise<void> {
-    await this.repo.findTopicOrThrow(ctx, id);
     await this.repo.deleteTopic(ctx, id, tx);
   }
 }

--- a/src/application/domain/vote/service.ts
+++ b/src/application/domain/vote/service.ts
@@ -233,6 +233,10 @@ export default class VoteService {
     return this.repo.findTopicOrThrow(ctx, topic.id, tx);
   }
 
+  async acquireVoteLock(userId: string, topicId: string, tx: Prisma.TransactionClient): Promise<void> {
+    await this.repo.acquireVoteLock(userId, topicId, tx);
+  }
+
   async deleteTopic(
     ctx: IContext,
     id: string,

--- a/src/application/domain/vote/service.ts
+++ b/src/application/domain/vote/service.ts
@@ -193,10 +193,20 @@ export default class VoteService {
     }
 
     if (existingBallot) {
-      // 別選択肢への再投票: 旧選択肢を全デクリメント
-      await this.repo.decrementOptionCount(ctx, existingBallot.optionId, existingBallot.power, tx);
+      // 別選択肢への再投票: optionId 昇順でロック取得順を固定しデッドロックを防止
+      // （複数ユーザーが同時に A→B と B→A へ再投票するケースでの相互ロック待ちを回避）
+      const oldId = existingBallot.optionId;
+      const newId = newBallot.optionId;
+      if (oldId < newId) {
+        await this.repo.decrementOptionCount(ctx, oldId, existingBallot.power, tx);
+        await this.repo.incrementOptionCount(ctx, newId, newPower, tx);
+      } else {
+        await this.repo.incrementOptionCount(ctx, newId, newPower, tx);
+        await this.repo.decrementOptionCount(ctx, oldId, existingBallot.power, tx);
+      }
+      return;
     }
-    // 新選択肢をインクリメント
+    // 新選択肢をインクリメント（初回投票）
     await this.repo.incrementOptionCount(ctx, newBallot.optionId, newPower, tx);
   }
 

--- a/src/application/domain/vote/service.ts
+++ b/src/application/domain/vote/service.ts
@@ -12,8 +12,10 @@ import {
 import {
   GqlVoteTopicCreateInput,
   GqlVoteCastInput,
-  GqlVoteTopicPhase,
 } from "@/types/graphql";
+
+// Service 層はドメイン固有型のみ返す（GQL 型を漏出させない）
+export type VotePhase = "UPCOMING" | "OPEN" | "CLOSED";
 import MembershipService from "@/application/domain/account/membership/service";
 import INftInstanceRepository from "@/application/domain/account/nft-instance/data/interface";
 
@@ -251,7 +253,7 @@ export default class VoteService {
     return isManager || new Date() >= endsAt;
   }
 
-  calcPhase(startsAt: Date, endsAt: Date): GqlVoteTopicPhase {
+  calcPhase(startsAt: Date, endsAt: Date): VotePhase {
     const now = new Date();
     if (now < startsAt) return "UPCOMING";
     // >= で validateVotingPeriod の境界と統一（endsAt の瞬間に CLOSED 扱い）

--- a/src/application/domain/vote/service.ts
+++ b/src/application/domain/vote/service.ts
@@ -68,7 +68,8 @@ export default class VoteService {
   }
 
   validateTopicRelations(topic: PrismaVoteTopic): void {
-    // gate と powerPolicy はスキーマ上 non-null のため、欠落はデータ不整合を示す
+    // gate と powerPolicy は Prisma スキーマ上 optional だが、ドメイン上は必須の不変条件
+    // 欠落している場合はデータ不整合を示す
     if (!topic.gate) {
       throw new ValidationError(`VoteTopic(${topic.id}) has no gate configured`, []);
     }

--- a/src/application/domain/vote/service.ts
+++ b/src/application/domain/vote/service.ts
@@ -1,0 +1,187 @@
+import { injectable, inject } from "tsyringe";
+import { Prisma, MembershipStatus, Role } from "@prisma/client";
+import { IContext } from "@/types/server";
+import { NotFoundError, ValidationError } from "@/errors/graphql";
+import { isRoleAtLeast } from "@/application/domain/utils";
+import { IVoteRepository } from "./data/interface";
+import VoteConverter from "./data/converter";
+import {
+  PrismaVoteTopic,
+  PrismaVoteBallot,
+} from "./data/type";
+import {
+  GqlVoteTopicCreateInput,
+  GqlVoteCastInput,
+} from "@/types/graphql";
+import MembershipService from "@/application/domain/account/membership/service";
+import INftInstanceRepository from "@/application/domain/account/nft-instance/data/interface";
+
+export interface EligibilityResult {
+  eligible: boolean;
+  reason?: string;
+}
+
+@injectable()
+export default class VoteService {
+  constructor(
+    @inject("VoteRepository") private readonly repo: IVoteRepository,
+    @inject("VoteConverter") private readonly converter: VoteConverter,
+    @inject("MembershipService") private readonly membershipService: MembershipService,
+    @inject("NftInstanceRepository") private readonly nftInstanceRepo: INftInstanceRepository,
+  ) {}
+
+  async getTopicWithRelations(ctx: IContext, id: string, tx?: Prisma.TransactionClient): Promise<PrismaVoteTopic> {
+    const topic = await this.repo.findTopicOrThrow(ctx, id);
+    return topic;
+  }
+
+  validateTopicInput(input: GqlVoteTopicCreateInput): void {
+    if (new Date(input.startsAt) >= new Date(input.endsAt)) {
+      throw new ValidationError("startsAt must be before endsAt", []);
+    }
+    if (!input.options || input.options.length < 2) {
+      throw new ValidationError("At least 2 options are required", []);
+    }
+    if (input.gate.type === "NFT" && !input.gate.nftTokenId) {
+      throw new ValidationError("nftTokenId is required for NFT gate", []);
+    }
+    if (input.powerPolicy.type === "NFT_COUNT" && !input.powerPolicy.nftTokenId) {
+      throw new ValidationError("nftTokenId is required for NFT_COUNT power policy", []);
+    }
+  }
+
+  validateVotingPeriod(topic: PrismaVoteTopic): void {
+    const now = new Date();
+    if (now < topic.startsAt) {
+      throw new ValidationError("Voting has not started yet", []);
+    }
+    if (now > topic.endsAt) {
+      throw new ValidationError("Voting period has ended", []);
+    }
+  }
+
+  validateOptionBelongsToTopic(optionId: string, topic: PrismaVoteTopic): void {
+    const option = topic.options.find((o) => o.id === optionId);
+    if (!option) {
+      throw new NotFoundError("VoteOption", { id: optionId, topicId: topic.id });
+    }
+  }
+
+  async checkEligibility(
+    ctx: IContext,
+    userId: string,
+    topic: PrismaVoteTopic,
+  ): Promise<EligibilityResult> {
+    const gate = topic.gate;
+    if (!gate) {
+      return { eligible: false, reason: "GATE_NOT_CONFIGURED" };
+    }
+
+    if (gate.type === "NFT") {
+      if (!gate.nftTokenId) {
+        return { eligible: false, reason: "GATE_NFT_TOKEN_NOT_CONFIGURED" };
+      }
+      // EXISTS クエリで判定（COUNT より効率的・意味が明確）
+      const exists = await this.nftInstanceRepo.existsByUserAndToken(ctx, userId, gate.nftTokenId);
+      return exists
+        ? { eligible: true }
+        : { eligible: false, reason: "REQUIRED_NFT_NOT_FOUND" };
+    }
+
+    if (gate.type === "MEMBERSHIP") {
+      const membership = await this.membershipService.findMembership(ctx, userId, topic.communityId);
+      if (!membership || membership.status !== MembershipStatus.JOINED) {
+        return { eligible: false, reason: "NOT_A_MEMBER" };
+      }
+      const minRole = (gate.requiredRole as Role | null) ?? Role.MEMBER;
+      return isRoleAtLeast(membership.role, minRole)
+        ? { eligible: true }
+        : { eligible: false, reason: "INSUFFICIENT_ROLE" };
+    }
+
+    return { eligible: false, reason: "UNKNOWN_GATE_TYPE" };
+  }
+
+  async calculatePower(
+    ctx: IContext,
+    userId: string,
+    topic: PrismaVoteTopic,
+  ): Promise<number> {
+    const policy = topic.powerPolicy;
+    if (!policy || policy.type === "FLAT") {
+      return 1;
+    }
+    // NFT_COUNT: 保有 NftInstance 数を票数とする
+    if (!policy.nftTokenId) {
+      return 1; // フォールバック: nftTokenId 未設定の場合は 1 票
+    }
+    const count = await this.nftInstanceRepo.countByUserAndToken(ctx, userId, policy.nftTokenId);
+    return count;
+  }
+
+  async findBallot(
+    ctx: IContext,
+    userId: string,
+    topicId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<PrismaVoteBallot | null> {
+    return this.repo.findBallot(ctx, userId, topicId, tx);
+  }
+
+  async upsertBallot(
+    ctx: IContext,
+    userId: string,
+    input: GqlVoteCastInput,
+    power: number,
+    tx: Prisma.TransactionClient,
+  ): Promise<PrismaVoteBallot> {
+    return this.repo.upsertBallot(ctx, userId, input, power, tx);
+  }
+
+  async updateOptionCounts(
+    ctx: IContext,
+    existingBallot: PrismaVoteBallot | null,
+    newBallot: PrismaVoteBallot,
+    newPower: number,
+    tx: Prisma.TransactionClient,
+  ): Promise<void> {
+    if (existingBallot) {
+      // 再投票: 旧選択肢のカウントをデクリメント
+      await this.repo.decrementOptionCount(ctx, existingBallot.optionId, existingBallot.power, tx);
+    }
+    // 新選択肢のカウントをインクリメント
+    await this.repo.incrementOptionCount(ctx, newBallot.optionId, newPower, tx);
+  }
+
+  async createTopicWithRelations(
+    ctx: IContext,
+    input: GqlVoteTopicCreateInput,
+    currentUserId: string,
+    tx: Prisma.TransactionClient,
+  ): Promise<PrismaVoteTopic> {
+    // 1. Topic を作成
+    const topicData = this.converter.createTopic(input, currentUserId);
+    const topic = await this.repo.createTopic(ctx, topicData, tx);
+
+    // 2. Gate を作成（VoteTopic の後に作成: FK は gate.topicId → topic.id）
+    await this.repo.createGate(ctx, topic.id, input.gate, tx);
+
+    // 3. PowerPolicy を作成
+    await this.repo.createPowerPolicy(ctx, topic.id, input.powerPolicy, tx);
+
+    // 4. Options を作成
+    await this.repo.createOptions(ctx, topic.id, input.options, tx);
+
+    // 5. リレーション付きで再取得
+    return this.repo.findTopicOrThrow(ctx, topic.id);
+  }
+
+  async deleteTopic(
+    ctx: IContext,
+    id: string,
+    tx: Prisma.TransactionClient,
+  ): Promise<void> {
+    await this.repo.findTopicOrThrow(ctx, id);
+    await this.repo.deleteTopic(ctx, id, tx);
+  }
+}

--- a/src/application/domain/vote/service.ts
+++ b/src/application/domain/vote/service.ts
@@ -41,6 +41,13 @@ export default class VoteService {
     if (!input.options || input.options.length < 2) {
       throw new ValidationError("At least 2 options are required", []);
     }
+    const orderIndices = input.options.map((o) => o.orderIndex);
+    if (orderIndices.some((i) => i < 0)) {
+      throw new ValidationError("Option orderIndex must be non-negative", []);
+    }
+    if (new Set(orderIndices).size !== orderIndices.length) {
+      throw new ValidationError("Option orderIndex values must be unique", []);
+    }
     if (input.gate.type === "NFT" && !input.gate.nftTokenId) {
       throw new ValidationError("nftTokenId is required for NFT gate", []);
     }
@@ -54,7 +61,8 @@ export default class VoteService {
     if (now < topic.startsAt) {
       throw new ValidationError("Voting has not started yet", []);
     }
-    if (now > topic.endsAt) {
+    // >= で isResultVisible の境界と一致させる（endsAt の瞬間に結果が見えてから投票できる抜け穴を防ぐ）
+    if (now >= topic.endsAt) {
       throw new ValidationError("Voting period has ended", []);
     }
   }
@@ -70,6 +78,7 @@ export default class VoteService {
     ctx: IContext,
     userId: string,
     topic: PrismaVoteTopic,
+    tx?: Prisma.TransactionClient,
   ): Promise<EligibilityResult> {
     const gate = topic.gate;
     if (!gate) {
@@ -81,14 +90,15 @@ export default class VoteService {
         return { eligible: false, reason: "GATE_NFT_TOKEN_NOT_CONFIGURED" };
       }
       // EXISTS クエリで判定（COUNT より効率的・意味が明確）
-      const exists = await this.nftInstanceRepo.existsByUserAndToken(ctx, userId, gate.nftTokenId);
+      // tx を渡すことで投票トランザクション内での読み取りを保証（TOCTOU 防止）
+      const exists = await this.nftInstanceRepo.existsByUserAndToken(ctx, userId, gate.nftTokenId, tx);
       return exists
         ? { eligible: true }
         : { eligible: false, reason: "REQUIRED_NFT_NOT_FOUND" };
     }
 
     if (gate.type === "MEMBERSHIP") {
-      const membership = await this.membershipService.findMembership(ctx, userId, topic.communityId);
+      const membership = await this.membershipService.findMembership(ctx, userId, topic.communityId, tx);
       if (!membership || membership.status !== MembershipStatus.JOINED) {
         return { eligible: false, reason: "NOT_A_MEMBER" };
       }
@@ -105,6 +115,7 @@ export default class VoteService {
     ctx: IContext,
     userId: string,
     topic: PrismaVoteTopic,
+    tx?: Prisma.TransactionClient,
   ): Promise<number> {
     const policy = topic.powerPolicy;
     if (!policy || policy.type === "FLAT") {
@@ -114,7 +125,8 @@ export default class VoteService {
     if (!policy.nftTokenId) {
       return 1; // フォールバック: nftTokenId 未設定の場合は 1 票
     }
-    const count = await this.nftInstanceRepo.countByUserAndToken(ctx, userId, policy.nftTokenId);
+    // tx を渡すことで投票トランザクション内での読み取りを保証（TOCTOU 防止）
+    const count = await this.nftInstanceRepo.countByUserAndToken(ctx, userId, policy.nftTokenId, tx);
     return count;
   }
 

--- a/src/application/domain/vote/service.ts
+++ b/src/application/domain/vote/service.ts
@@ -21,6 +21,17 @@ export interface EligibilityResult {
   reason?: string;
 }
 
+// checkEligibility / calculatePower が実際に参照するフィールドのみを定義した最小インターフェース
+// PrismaVoteTopic / GqlVoteTopicWithMeta どちらも構造的に満たすため、型アサーション不要
+export interface TopicForEligibilityCheck {
+  communityId: string;
+  gate: { type: string; nftTokenId: string | null; requiredRole?: string | null } | null;
+}
+
+export interface TopicForPowerCalculation {
+  powerPolicy: { type: string; nftTokenId: string | null } | null;
+}
+
 @injectable()
 export default class VoteService {
   constructor(
@@ -105,7 +116,7 @@ export default class VoteService {
   async checkEligibility(
     ctx: IContext,
     userId: string,
-    topic: PrismaVoteTopic,
+    topic: TopicForEligibilityCheck,
     tx?: Prisma.TransactionClient,
   ): Promise<EligibilityResult> {
     const gate = topic.gate;
@@ -142,7 +153,7 @@ export default class VoteService {
   async calculatePower(
     ctx: IContext,
     userId: string,
-    topic: PrismaVoteTopic,
+    topic: TopicForPowerCalculation,
     tx?: Prisma.TransactionClient,
   ): Promise<number> {
     const policy = topic.powerPolicy;

--- a/src/application/domain/vote/service.ts
+++ b/src/application/domain/vote/service.ts
@@ -34,6 +34,23 @@ export default class VoteService {
     return this.repo.findTopicOrThrow(ctx, id, tx);
   }
 
+  async findTopic(ctx: IContext, id: string): Promise<PrismaVoteTopic | null> {
+    return this.repo.findTopic(ctx, id);
+  }
+
+  async browseTopics(
+    ctx: IContext,
+    communityId: string,
+    take: number,
+    cursor?: string,
+  ): Promise<PrismaVoteTopic[]> {
+    return this.repo.queryTopics(ctx, communityId, take, cursor);
+  }
+
+  async countTopics(ctx: IContext, communityId: string): Promise<number> {
+    return this.repo.countTopics(ctx, communityId);
+  }
+
   validateTopicInput(input: GqlVoteTopicCreateInput): void {
     if (new Date(input.startsAt) >= new Date(input.endsAt)) {
       throw new ValidationError("startsAt must be before endsAt", []);

--- a/src/application/domain/vote/service.ts
+++ b/src/application/domain/vote/service.ts
@@ -12,6 +12,7 @@ import {
 import {
   GqlVoteTopicCreateInput,
   GqlVoteCastInput,
+  GqlVoteTopicPhase,
 } from "@/types/graphql";
 import MembershipService from "@/application/domain/account/membership/service";
 import INftInstanceRepository from "@/application/domain/account/nft-instance/data/interface";
@@ -242,6 +243,20 @@ export default class VoteService {
 
     // 5. リレーション付きで再取得（同じトランザクション内で取得）
     return this.repo.findTopicOrThrow(ctx, topic.id, tx);
+  }
+
+  // ─── 表示ロジック計算（Presenter に渡す前にサービスで算出）───────────────────
+
+  calcResultVisible(endsAt: Date, isManager: boolean): boolean {
+    return isManager || new Date() >= endsAt;
+  }
+
+  calcPhase(startsAt: Date, endsAt: Date): GqlVoteTopicPhase {
+    const now = new Date();
+    if (now < startsAt) return "UPCOMING";
+    // >= で validateVotingPeriod の境界と統一（endsAt の瞬間に CLOSED 扱い）
+    if (now >= endsAt) return "CLOSED";
+    return "OPEN";
   }
 
   async acquireVoteLock(userId: string, topicId: string, tx: Prisma.TransactionClient): Promise<void> {

--- a/src/application/domain/vote/usecase.ts
+++ b/src/application/domain/vote/usecase.ts
@@ -1,0 +1,160 @@
+import { injectable, inject } from "tsyringe";
+import {
+  GqlQueryVoteTopicsArgs,
+  GqlQueryVoteTopicArgs,
+  GqlQueryMyVoteEligibilityArgs,
+  GqlMutationVoteTopicCreateArgs,
+  GqlMutationVoteCastArgs,
+  GqlMutationVoteTopicDeleteArgs,
+  GqlVoteTopicsConnection,
+  GqlVoteTopic,
+  GqlMyVoteEligibility,
+  GqlVoteTopicCreatePayload,
+  GqlVoteCastPayload,
+  GqlVoteTopicDeletePayload,
+} from "@/types/graphql";
+import { IContext } from "@/types/server";
+import { AuthorizationError } from "@/errors/graphql";
+import { clampFirst, getCurrentUserId, getMembershipRolesByCtx } from "@/application/domain/utils";
+import VoteService from "./service";
+import VotePresenter from "./presenter";
+import { IVoteRepository } from "./data/interface";
+import { PrismaVoteBallot } from "./data/type";
+
+@injectable()
+export default class VoteUseCase {
+  constructor(
+    @inject("VoteService") private readonly service: VoteService,
+    @inject("VoteRepository") private readonly repo: IVoteRepository,
+  ) {}
+
+  async anyoneBrowseVoteTopics(
+    ctx: IContext,
+    { communityId, first, after }: GqlQueryVoteTopicsArgs,
+  ): Promise<GqlVoteTopicsConnection> {
+    const take = clampFirst(first);
+    const currentUserId = ctx.currentUser?.id;
+    const { isManager } = getMembershipRolesByCtx(ctx, [communityId], currentUserId);
+    const isManagerOfCommunity = !!isManager[communityId];
+
+    const [records, totalCount] = await Promise.all([
+      this.repo.queryTopics(ctx, communityId, take, after ?? undefined),
+      this.repo.countTopics(ctx, communityId),
+    ]);
+
+    const hasNextPage = records.length > take;
+    const data = records.slice(0, take);
+
+    // 各 topic の詳細（gate/options含む）を取得してプレゼンター変換
+    const topicDetails = await Promise.all(
+      data.map((t) => this.repo.findTopicOrThrow(ctx, t.id)),
+    );
+
+    const topicGqls = topicDetails.map((topic) =>
+      VotePresenter.topic(topic, isManagerOfCommunity),
+    );
+
+    return VotePresenter.query(topicGqls, totalCount, hasNextPage, after ?? undefined);
+  }
+
+  async anyoneViewVoteTopic(
+    ctx: IContext,
+    { id }: GqlQueryVoteTopicArgs,
+  ): Promise<GqlVoteTopic | null> {
+    const topic = await this.repo.findTopic(ctx, id);
+    if (!topic) return null;
+
+    const currentUserId = ctx.currentUser?.id;
+    const { isManager } = getMembershipRolesByCtx(ctx, [topic.communityId], currentUserId);
+    const isManagerOfCommunity = !!isManager[topic.communityId];
+
+    let myBallot: PrismaVoteBallot | null = null;
+    if (currentUserId) {
+      myBallot = await this.repo.findBallot(ctx, currentUserId, topic.id);
+    }
+
+    return VotePresenter.topic(topic, isManagerOfCommunity, myBallot);
+  }
+
+  async userGetMyVoteEligibility(
+    ctx: IContext,
+    { topicId }: GqlQueryMyVoteEligibilityArgs,
+  ): Promise<GqlMyVoteEligibility> {
+    const userId = getCurrentUserId(ctx);
+    const topic = await this.service.getTopicWithRelations(ctx, topicId);
+    const eligibility = await this.service.checkEligibility(ctx, userId, topic);
+
+    let currentPower: number | null = null;
+    if (eligibility.eligible) {
+      currentPower = await this.service.calculatePower(ctx, userId, topic);
+    }
+
+    const myBallot = await this.repo.findBallot(ctx, userId, topicId);
+
+    return VotePresenter.eligibility(eligibility, currentPower, myBallot);
+  }
+
+  async managerCreateVoteTopic(
+    ctx: IContext,
+    { input, permission }: GqlMutationVoteTopicCreateArgs,
+  ): Promise<GqlVoteTopicCreatePayload> {
+    const currentUserId = getCurrentUserId(ctx);
+
+    this.service.validateTopicInput(input);
+
+    return ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
+      const topic = await this.service.createTopicWithRelations(ctx, input, currentUserId, tx);
+      const topicGql = VotePresenter.topic(topic, true);
+      return VotePresenter.create(topicGql);
+    });
+  }
+
+  async userCastVote(
+    ctx: IContext,
+    { input }: GqlMutationVoteCastArgs,
+  ): Promise<GqlVoteCastPayload> {
+    const userId = getCurrentUserId(ctx);
+
+    return ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
+      // 1. テーマ取得
+      const topic = await this.service.getTopicWithRelations(ctx, input.topicId);
+
+      // 2. 期間バリデーション
+      this.service.validateVotingPeriod(topic);
+
+      // 3. 資格チェック（初回・再投票とも必ず実行）
+      const eligibility = await this.service.checkEligibility(ctx, userId, topic);
+      if (!eligibility.eligible) {
+        throw new AuthorizationError(eligibility.reason ?? "VOTE_NOT_ELIGIBLE");
+      }
+
+      // 4. 選択肢の所属チェック
+      this.service.validateOptionBelongsToTopic(input.optionId, topic);
+
+      // 5. Power 計算（再投票時は最新保有数で再計算）
+      const power = await this.service.calculatePower(ctx, userId, topic);
+
+      // 6. 既存投票を取得（再投票のデクリメント判定用）
+      const existingBallot = await this.service.findBallot(ctx, userId, topic.id, tx);
+
+      // 7. Upsert
+      const ballot = await this.service.upsertBallot(ctx, userId, input, power, tx);
+
+      // 8. VoteOption 非正規化カラム更新（同トランザクション内）
+      await this.service.updateOptionCounts(ctx, existingBallot, ballot, power, tx);
+
+      const ballotGql = VotePresenter.ballot(ballot);
+      return VotePresenter.castBallot(ballotGql);
+    });
+  }
+
+  async managerDeleteVoteTopic(
+    ctx: IContext,
+    { id, permission }: GqlMutationVoteTopicDeleteArgs,
+  ): Promise<GqlVoteTopicDeletePayload> {
+    return ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
+      await this.service.deleteTopic(ctx, id, tx);
+      return VotePresenter.deleteTopic(id);
+    });
+  }
+}

--- a/src/application/domain/vote/usecase.ts
+++ b/src/application/domain/vote/usecase.ts
@@ -6,19 +6,21 @@ import {
   GqlMutationVoteTopicCreateArgs,
   GqlMutationVoteCastArgs,
   GqlMutationVoteTopicDeleteArgs,
-  GqlVoteTopicsConnection,
-  GqlVoteTopic,
   GqlVoteOption,
-  GqlMyVoteEligibility,
-  GqlVoteTopicCreatePayload,
-  GqlVoteCastPayload,
   GqlVoteTopicDeletePayload,
 } from "@/types/graphql";
 import { IContext } from "@/types/server";
 import { AuthorizationError, ValidationError } from "@/errors/graphql";
 import { clampFirst, getCurrentUserId, getMembershipRolesByCtx } from "@/application/domain/utils";
 import VoteService from "./service";
-import VotePresenter, { GqlVoteTopicWithMeta, GqlVoteBallotWithMeta } from "./presenter";
+import VotePresenter, {
+  GqlVoteTopicWithMeta,
+  GqlVoteBallotWithMeta,
+  GqlVoteTopicsConnectionWithMeta,
+  GqlMyVoteEligibilityWithMeta,
+  GqlVoteTopicCreatePayloadWithMeta,
+  GqlVoteCastPayloadWithMeta,
+} from "./presenter";
 import { PrismaVoteBallot, PrismaVoteOption } from "./data/type";
 
 @injectable()
@@ -30,7 +32,7 @@ export default class VoteUseCase {
   async anyoneBrowseVoteTopics(
     ctx: IContext,
     { communityId, first, cursor }: GqlQueryVoteTopicsArgs,
-  ): Promise<GqlVoteTopicsConnection> {
+  ): Promise<GqlVoteTopicsConnectionWithMeta> {
     const take = clampFirst(first);
     const currentUserId = ctx.currentUser?.id;
     const { isManager } = getMembershipRolesByCtx(ctx, [communityId], currentUserId);
@@ -59,7 +61,7 @@ export default class VoteUseCase {
   async anyoneViewVoteTopic(
     ctx: IContext,
     { id }: GqlQueryVoteTopicArgs,
-  ): Promise<GqlVoteTopic | null> {
+  ): Promise<GqlVoteTopicWithMeta | null> {
     const topic = await this.service.findTopic(ctx, id);
     if (!topic) return null;
 
@@ -73,14 +75,13 @@ export default class VoteUseCase {
     // ここで個別に findBallot を呼ばない（二重クエリを防ぐ）
     const resultVisible = this.service.calcResultVisible(topic.endsAt, isManagerOfCommunity);
     const phase = this.service.calcPhase(topic.startsAt, topic.endsAt);
-    // WithMeta → GqlVoteTopic 境界: field resolver で community が解決されることを前提とした型境界キャスト
-    return VotePresenter.topic(topic, resultVisible, phase) as unknown as GqlVoteTopic;
+    return VotePresenter.topic(topic, resultVisible, phase);
   }
 
   async userGetMyVoteEligibility(
     ctx: IContext,
     { topicId }: GqlQueryMyVoteEligibilityArgs,
-  ): Promise<GqlMyVoteEligibility> {
+  ): Promise<GqlMyVoteEligibilityWithMeta> {
     const userId = getCurrentUserId(ctx);
     const topic = await this.service.getTopicWithRelations(ctx, topicId);
     this.service.validateTopicRelations(topic);
@@ -102,7 +103,7 @@ export default class VoteUseCase {
   async managerCreateVoteTopic(
     ctx: IContext,
     { input, permission }: GqlMutationVoteTopicCreateArgs,
-  ): Promise<GqlVoteTopicCreatePayload> {
+  ): Promise<GqlVoteTopicCreatePayloadWithMeta> {
     const currentUserId = getCurrentUserId(ctx);
 
     // permission で指定されたコミュニティと input のコミュニティが一致することを確認
@@ -125,7 +126,7 @@ export default class VoteUseCase {
   async userCastVote(
     ctx: IContext,
     { input }: GqlMutationVoteCastArgs,
-  ): Promise<GqlVoteCastPayload> {
+  ): Promise<GqlVoteCastPayloadWithMeta> {
     const userId = getCurrentUserId(ctx);
 
     return ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
@@ -178,7 +179,7 @@ export default class VoteUseCase {
   async resolveMyEligibilityForParent(
     ctx: IContext,
     parent: GqlVoteTopicWithMeta,
-  ): Promise<GqlMyVoteEligibility | null> {
+  ): Promise<GqlMyVoteEligibilityWithMeta | null> {
     if (!ctx.currentUser) return null;
     const userId = ctx.currentUser.id;
 

--- a/src/application/domain/vote/usecase.ts
+++ b/src/application/domain/vote/usecase.ts
@@ -134,6 +134,10 @@ export default class VoteUseCase {
 
       // 5. Power 計算（再投票時は最新保有数で再計算、tx で TOCTOU を防止）
       const power = await this.service.calculatePower(ctx, userId, topic, tx);
+      // NFT_COUNT ポリシー + MEMBERSHIP ゲートの組み合わせ等で power=0 になる場合を防ぐ
+      if (power <= 0) {
+        throw new ValidationError("Insufficient voting power", []);
+      }
 
       // 6. 既存投票を取得（再投票のデクリメント判定用）
       const existingBallot = await this.service.findBallot(ctx, userId, topic.id, tx);

--- a/src/application/domain/vote/usecase.ts
+++ b/src/application/domain/vote/usecase.ts
@@ -85,7 +85,9 @@ export default class VoteUseCase {
 
     const myBallot = await this.repo.findBallot(ctx, userId, topicId);
 
-    return VotePresenter.eligibility(eligibility, currentPower, myBallot);
+    // endsAt を超えていれば結果を公開（myEligibility context では manager 判定は行わない）
+    const resultVisible = new Date() >= topic.endsAt;
+    return VotePresenter.eligibility(eligibility, currentPower, myBallot, resultVisible);
   }
 
   async managerCreateVoteTopic(
@@ -121,8 +123,8 @@ export default class VoteUseCase {
       // 2. 期間バリデーション
       this.service.validateVotingPeriod(topic);
 
-      // 3. 資格チェック（初回・再投票とも必ず実行）
-      const eligibility = await this.service.checkEligibility(ctx, userId, topic);
+      // 3. 資格チェック（初回・再投票とも必ず実行、tx で TOCTOU を防止）
+      const eligibility = await this.service.checkEligibility(ctx, userId, topic, tx);
       if (!eligibility.eligible) {
         throw new AuthorizationError(eligibility.reason ?? "VOTE_NOT_ELIGIBLE");
       }
@@ -130,8 +132,8 @@ export default class VoteUseCase {
       // 4. 選択肢の所属チェック
       this.service.validateOptionBelongsToTopic(input.optionId, topic);
 
-      // 5. Power 計算（再投票時は最新保有数で再計算）
-      const power = await this.service.calculatePower(ctx, userId, topic);
+      // 5. Power 計算（再投票時は最新保有数で再計算、tx で TOCTOU を防止）
+      const power = await this.service.calculatePower(ctx, userId, topic, tx);
 
       // 6. 既存投票を取得（再投票のデクリメント判定用）
       const existingBallot = await this.service.findBallot(ctx, userId, topic.id, tx);
@@ -142,7 +144,8 @@ export default class VoteUseCase {
       // 8. VoteOption 非正規化カラム更新（同トランザクション内）
       await this.service.updateOptionCounts(ctx, existingBallot, ballot, power, tx);
 
-      const ballotGql = VotePresenter.ballot(ballot);
+      // 投票期間中のため resultVisible=false（集計値は秘匿）
+      const ballotGql = VotePresenter.ballot(ballot, VotePresenter.isResultVisible(topic, false));
       return VotePresenter.castBallot(ballotGql);
     });
   }

--- a/src/application/domain/vote/usecase.ts
+++ b/src/application/domain/vote/usecase.ts
@@ -73,7 +73,8 @@ export default class VoteUseCase {
     // ここで個別に findBallot を呼ばない（二重クエリを防ぐ）
     const resultVisible = this.service.calcResultVisible(topic.endsAt, isManagerOfCommunity);
     const phase = this.service.calcPhase(topic.startsAt, topic.endsAt);
-    return VotePresenter.topic(topic, resultVisible, phase);
+    // WithMeta → GqlVoteTopic 境界: field resolver で community が解決されることを前提とした型境界キャスト
+    return VotePresenter.topic(topic, resultVisible, phase) as unknown as GqlVoteTopic;
   }
 
   async userGetMyVoteEligibility(

--- a/src/application/domain/vote/usecase.ts
+++ b/src/application/domain/vote/usecase.ts
@@ -19,7 +19,6 @@ import { clampFirst, getCurrentUserId, getMembershipRolesByCtx } from "@/applica
 import VoteService from "./service";
 import VotePresenter from "./presenter";
 import { IVoteRepository } from "./data/interface";
-import { PrismaVoteBallot } from "./data/type";
 
 @injectable()
 export default class VoteUseCase {
@@ -66,12 +65,9 @@ export default class VoteUseCase {
     const { isManager } = getMembershipRolesByCtx(ctx, [topic.communityId], currentUserId);
     const isManagerOfCommunity = !!isManager[topic.communityId];
 
-    let myBallot: PrismaVoteBallot | null = null;
-    if (currentUserId) {
-      myBallot = await this.repo.findBallot(ctx, currentUserId, topic.id);
-    }
-
-    return VotePresenter.topic(topic, isManagerOfCommunity, myBallot);
+    // myBallot は VoteTopic.myBallot フィールドリゾルバー（DataLoader）が取得するため
+    // ここで個別に findBallot を呼ばない（二重クエリを防ぐ）
+    return VotePresenter.topic(topic, isManagerOfCommunity);
   }
 
   async userGetMyVoteEligibility(

--- a/src/application/domain/vote/usecase.ts
+++ b/src/application/domain/vote/usecase.ts
@@ -16,7 +16,6 @@ import {
 import { IContext } from "@/types/server";
 import { AuthorizationError, ValidationError } from "@/errors/graphql";
 import { clampFirst, getCurrentUserId, getMembershipRolesByCtx } from "@/application/domain/utils";
-import { PrismaVoteTopic } from "./data/type";
 import VoteService from "./service";
 import VotePresenter, { GqlVoteTopicWithMeta } from "./presenter";
 
@@ -170,15 +169,13 @@ export default class VoteUseCase {
     if (!ctx.currentUser) return null;
     const userId = ctx.currentUser.id;
 
-    // GQL enum と Prisma enum は同じ文字列値を持つため as unknown as PrismaVoteTopic で変換可能
-    // checkEligibility / calculatePower が参照するのは gate, powerPolicy, communityId のみ
-    const topicLike = parent as unknown as PrismaVoteTopic;
-
-    const eligibility = await this.service.checkEligibility(ctx, userId, topicLike);
+    // GqlVoteTopicWithMeta は TopicForEligibilityCheck / TopicForPowerCalculation を
+    // 構造的に満たすため、型アサーションなしで直接渡せる
+    const eligibility = await this.service.checkEligibility(ctx, userId, parent);
 
     let currentPower: number | null = null;
     if (eligibility.eligible) {
-      currentPower = await this.service.calculatePower(ctx, userId, topicLike);
+      currentPower = await this.service.calculatePower(ctx, userId, parent);
     }
 
     const myBallot = await this.service.findBallot(ctx, userId, parent.id);

--- a/src/application/domain/vote/usecase.ts
+++ b/src/application/domain/vote/usecase.ts
@@ -8,6 +8,7 @@ import {
   GqlMutationVoteTopicDeleteArgs,
   GqlVoteTopicsConnection,
   GqlVoteTopic,
+  GqlVoteOption,
   GqlMyVoteEligibility,
   GqlVoteTopicCreatePayload,
   GqlVoteCastPayload,
@@ -17,7 +18,8 @@ import { IContext } from "@/types/server";
 import { AuthorizationError, ValidationError } from "@/errors/graphql";
 import { clampFirst, getCurrentUserId, getMembershipRolesByCtx } from "@/application/domain/utils";
 import VoteService from "./service";
-import VotePresenter, { GqlVoteTopicWithMeta } from "./presenter";
+import VotePresenter, { GqlVoteTopicWithMeta, GqlVoteBallotWithMeta } from "./presenter";
+import { PrismaVoteBallot, PrismaVoteOption } from "./data/type";
 
 @injectable()
 export default class VoteUseCase {
@@ -45,7 +47,11 @@ export default class VoteUseCase {
     // browseTopics はリレーション付きで返すので N+1 なし
     // gate/powerPolicy が欠落しているトピックはデータ不整合 → 早期エラーで一覧全体を守る
     data.forEach((topic) => this.service.validateTopicRelations(topic));
-    const topicGqls = data.map((topic) => VotePresenter.topic(topic, isManagerOfCommunity));
+    const topicGqls = data.map((topic) => {
+      const resultVisible = this.service.calcResultVisible(topic.endsAt, isManagerOfCommunity);
+      const phase = this.service.calcPhase(topic.startsAt, topic.endsAt);
+      return VotePresenter.topic(topic, resultVisible, phase);
+    });
 
     return VotePresenter.query(topicGqls, totalCount, hasNextPage, cursor ?? undefined);
   }
@@ -65,7 +71,9 @@ export default class VoteUseCase {
 
     // myBallot は VoteTopic.myBallot フィールドリゾルバー（DataLoader）が取得するため
     // ここで個別に findBallot を呼ばない（二重クエリを防ぐ）
-    return VotePresenter.topic(topic, isManagerOfCommunity);
+    const resultVisible = this.service.calcResultVisible(topic.endsAt, isManagerOfCommunity);
+    const phase = this.service.calcPhase(topic.startsAt, topic.endsAt);
+    return VotePresenter.topic(topic, resultVisible, phase);
   }
 
   async userGetMyVoteEligibility(
@@ -85,7 +93,7 @@ export default class VoteUseCase {
     const myBallot = await this.service.findBallot(ctx, userId, topicId);
 
     // endsAt を超えていれば結果を公開（myEligibility context では manager 判定は行わない）
-    const resultVisible = new Date() >= topic.endsAt;
+    const resultVisible = this.service.calcResultVisible(topic.endsAt, false);
     return VotePresenter.eligibility(eligibility, currentPower, myBallot, resultVisible);
   }
 
@@ -105,7 +113,9 @@ export default class VoteUseCase {
     return ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
       const topic = await this.service.createTopicWithRelations(ctx, input, currentUserId, tx);
       this.service.validateTopicRelations(topic);
-      const topicGql = VotePresenter.topic(topic, true);
+      const resultVisible = this.service.calcResultVisible(topic.endsAt, true);
+      const phase = this.service.calcPhase(topic.startsAt, topic.endsAt);
+      const topicGql = VotePresenter.topic(topic, resultVisible, phase);
       return VotePresenter.create(topicGql);
     });
   }
@@ -155,7 +165,7 @@ export default class VoteUseCase {
       await this.service.updateOptionCounts(ctx, existingBallot, ballot, power, tx);
 
       // 投票期間中のため resultVisible=false（集計値は秘匿）
-      const ballotGql = VotePresenter.ballot(ballot, VotePresenter.isResultVisible(topic, false));
+      const ballotGql = VotePresenter.ballot(ballot, this.service.calcResultVisible(topic.endsAt, false));
       return VotePresenter.castBallot(ballotGql);
     });
   }
@@ -181,8 +191,20 @@ export default class VoteUseCase {
     const myBallot = await this.service.findBallot(ctx, userId, parent.id);
 
     // myEligibility コンテキストでは manager 判定は行わず、時刻のみで結果公開を判定
-    const resultVisible = new Date() >= parent.endsAt;
+    const resultVisible = this.service.calcResultVisible(parent.endsAt, false);
     return VotePresenter.eligibility(eligibility, currentPower, myBallot, resultVisible);
+  }
+
+  // ─── フィールドリゾルバー向けフォーマットデリゲート ──────────────────────────
+  // Resolver から Presenter を直接呼ばず UseCase を介することで
+  // 「Resolver は UseCase メソッドのみ呼ぶ」原則を維持する
+
+  resolveMyBallotField(ballot: PrismaVoteBallot, resultVisible: boolean): GqlVoteBallotWithMeta {
+    return VotePresenter.ballot(ballot, resultVisible);
+  }
+
+  resolveOptionField(option: PrismaVoteOption, resultVisible: boolean): GqlVoteOption {
+    return VotePresenter.option(option, resultVisible);
   }
 
   async managerDeleteVoteTopic(

--- a/src/application/domain/vote/usecase.ts
+++ b/src/application/domain/vote/usecase.ts
@@ -16,8 +16,9 @@ import {
 import { IContext } from "@/types/server";
 import { AuthorizationError, ValidationError } from "@/errors/graphql";
 import { clampFirst, getCurrentUserId, getMembershipRolesByCtx } from "@/application/domain/utils";
+import { PrismaVoteTopic } from "./data/type";
 import VoteService from "./service";
-import VotePresenter from "./presenter";
+import VotePresenter, { GqlVoteTopicWithMeta } from "./presenter";
 
 @injectable()
 export default class VoteUseCase {
@@ -117,6 +118,11 @@ export default class VoteUseCase {
     const userId = getCurrentUserId(ctx);
 
     return ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
+      // 0. 同一ユーザー・同一トピックへの並行投票を TOCTOU から守るアドバイザリーロック
+      //    findBallot(null) → upsert(INSERT) の間に別トランザクションが割り込むと
+      //    voteCount が二重増分される。ロックでこのウィンドウを完全に閉じる
+      await this.service.acquireVoteLock(userId, input.topicId, tx);
+
       // 1. テーマ取得（トランザクション内）
       const topic = await this.service.getTopicWithRelations(ctx, input.topicId, tx);
       this.service.validateTopicRelations(topic);
@@ -153,6 +159,33 @@ export default class VoteUseCase {
       const ballotGql = VotePresenter.ballot(ballot, VotePresenter.isResultVisible(topic, false));
       return VotePresenter.castBallot(ballotGql);
     });
+  }
+
+  // フィールドリゾルバー専用: VoteTopic.myEligibility の N+1 を回避するため
+  // parent（既に DB から取得済みのメタ付き GQL オブジェクト）を直接使用し DB 再取得しない
+  async resolveMyEligibilityForParent(
+    ctx: IContext,
+    parent: GqlVoteTopicWithMeta,
+  ): Promise<GqlMyVoteEligibility | null> {
+    if (!ctx.currentUser) return null;
+    const userId = ctx.currentUser.id;
+
+    // GQL enum と Prisma enum は同じ文字列値を持つため as unknown as PrismaVoteTopic で変換可能
+    // checkEligibility / calculatePower が参照するのは gate, powerPolicy, communityId のみ
+    const topicLike = parent as unknown as PrismaVoteTopic;
+
+    const eligibility = await this.service.checkEligibility(ctx, userId, topicLike);
+
+    let currentPower: number | null = null;
+    if (eligibility.eligible) {
+      currentPower = await this.service.calculatePower(ctx, userId, topicLike);
+    }
+
+    const myBallot = await this.service.findBallot(ctx, userId, parent.id);
+
+    // myEligibility コンテキストでは manager 判定は行わず、時刻のみで結果公開を判定
+    const resultVisible = new Date() >= parent.endsAt;
+    return VotePresenter.eligibility(eligibility, currentPower, myBallot, resultVisible);
   }
 
   async managerDeleteVoteTopic(

--- a/src/application/domain/vote/usecase.ts
+++ b/src/application/domain/vote/usecase.ts
@@ -14,7 +14,7 @@ import {
   GqlVoteTopicDeletePayload,
 } from "@/types/graphql";
 import { IContext } from "@/types/server";
-import { AuthorizationError } from "@/errors/graphql";
+import { AuthorizationError, ValidationError } from "@/errors/graphql";
 import { clampFirst, getCurrentUserId, getMembershipRolesByCtx } from "@/application/domain/utils";
 import VoteService from "./service";
 import VotePresenter from "./presenter";
@@ -45,14 +45,8 @@ export default class VoteUseCase {
     const hasNextPage = records.length > take;
     const data = records.slice(0, take);
 
-    // 各 topic の詳細（gate/options含む）を取得してプレゼンター変換
-    const topicDetails = await Promise.all(
-      data.map((t) => this.repo.findTopicOrThrow(ctx, t.id)),
-    );
-
-    const topicGqls = topicDetails.map((topic) =>
-      VotePresenter.topic(topic, isManagerOfCommunity),
-    );
+    // queryTopics はリレーション付きで返すので N+1 なし
+    const topicGqls = data.map((topic) => VotePresenter.topic(topic, isManagerOfCommunity));
 
     return VotePresenter.query(topicGqls, totalCount, hasNextPage, after ?? undefined);
   }
@@ -100,6 +94,11 @@ export default class VoteUseCase {
   ): Promise<GqlVoteTopicCreatePayload> {
     const currentUserId = getCurrentUserId(ctx);
 
+    // permission で指定されたコミュニティと input のコミュニティが一致することを確認
+    if (permission.communityId !== input.communityId) {
+      throw new ValidationError("communityId in input does not match permission.communityId", []);
+    }
+
     this.service.validateTopicInput(input);
 
     return ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
@@ -116,8 +115,8 @@ export default class VoteUseCase {
     const userId = getCurrentUserId(ctx);
 
     return ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
-      // 1. テーマ取得
-      const topic = await this.service.getTopicWithRelations(ctx, input.topicId);
+      // 1. テーマ取得（トランザクション内）
+      const topic = await this.service.getTopicWithRelations(ctx, input.topicId, tx);
 
       // 2. 期間バリデーション
       this.service.validateVotingPeriod(topic);
@@ -153,6 +152,11 @@ export default class VoteUseCase {
     { id, permission }: GqlMutationVoteTopicDeleteArgs,
   ): Promise<GqlVoteTopicDeletePayload> {
     return ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
+      // 削除前にコミュニティ所有チェック
+      const topic = await this.repo.findTopicOrThrow(ctx, id, tx);
+      if (topic.communityId !== permission.communityId) {
+        throw new AuthorizationError("TOPIC_NOT_IN_COMMUNITY");
+      }
       await this.service.deleteTopic(ctx, id, tx);
       return VotePresenter.deleteTopic(id);
     });

--- a/src/application/domain/vote/usecase.ts
+++ b/src/application/domain/vote/usecase.ts
@@ -18,13 +18,11 @@ import { AuthorizationError, ValidationError } from "@/errors/graphql";
 import { clampFirst, getCurrentUserId, getMembershipRolesByCtx } from "@/application/domain/utils";
 import VoteService from "./service";
 import VotePresenter from "./presenter";
-import { IVoteRepository } from "./data/interface";
 
 @injectable()
 export default class VoteUseCase {
   constructor(
     @inject("VoteService") private readonly service: VoteService,
-    @inject("VoteRepository") private readonly repo: IVoteRepository,
   ) {}
 
   async anyoneBrowseVoteTopics(
@@ -37,14 +35,14 @@ export default class VoteUseCase {
     const isManagerOfCommunity = !!isManager[communityId];
 
     const [records, totalCount] = await Promise.all([
-      this.repo.queryTopics(ctx, communityId, take, cursor ?? undefined),
-      this.repo.countTopics(ctx, communityId),
+      this.service.browseTopics(ctx, communityId, take, cursor ?? undefined),
+      this.service.countTopics(ctx, communityId),
     ]);
 
     const hasNextPage = records.length > take;
     const data = records.slice(0, take);
 
-    // queryTopics はリレーション付きで返すので N+1 なし
+    // browseTopics はリレーション付きで返すので N+1 なし
     // gate/powerPolicy が欠落しているトピックはデータ不整合 → 早期エラーで一覧全体を守る
     data.forEach((topic) => this.service.validateTopicRelations(topic));
     const topicGqls = data.map((topic) => VotePresenter.topic(topic, isManagerOfCommunity));
@@ -56,7 +54,7 @@ export default class VoteUseCase {
     ctx: IContext,
     { id }: GqlQueryVoteTopicArgs,
   ): Promise<GqlVoteTopic | null> {
-    const topic = await this.repo.findTopic(ctx, id);
+    const topic = await this.service.findTopic(ctx, id);
     if (!topic) return null;
 
     this.service.validateTopicRelations(topic);
@@ -84,7 +82,7 @@ export default class VoteUseCase {
       currentPower = await this.service.calculatePower(ctx, userId, topic);
     }
 
-    const myBallot = await this.repo.findBallot(ctx, userId, topicId);
+    const myBallot = await this.service.findBallot(ctx, userId, topicId);
 
     // endsAt を超えていれば結果を公開（myEligibility context では manager 判定は行わない）
     const resultVisible = new Date() >= topic.endsAt;
@@ -163,7 +161,7 @@ export default class VoteUseCase {
   ): Promise<GqlVoteTopicDeletePayload> {
     return ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
       // 削除前にコミュニティ所有チェック
-      const topic = await this.repo.findTopicOrThrow(ctx, id, tx);
+      const topic = await this.service.getTopicWithRelations(ctx, id, tx);
       if (topic.communityId !== permission.communityId) {
         throw new AuthorizationError("TOPIC_NOT_IN_COMMUNITY");
       }

--- a/src/application/domain/vote/usecase.ts
+++ b/src/application/domain/vote/usecase.ts
@@ -30,7 +30,7 @@ export default class VoteUseCase {
 
   async anyoneBrowseVoteTopics(
     ctx: IContext,
-    { communityId, first, after }: GqlQueryVoteTopicsArgs,
+    { communityId, first, cursor }: GqlQueryVoteTopicsArgs,
   ): Promise<GqlVoteTopicsConnection> {
     const take = clampFirst(first);
     const currentUserId = ctx.currentUser?.id;
@@ -38,7 +38,7 @@ export default class VoteUseCase {
     const isManagerOfCommunity = !!isManager[communityId];
 
     const [records, totalCount] = await Promise.all([
-      this.repo.queryTopics(ctx, communityId, take, after ?? undefined),
+      this.repo.queryTopics(ctx, communityId, take, cursor ?? undefined),
       this.repo.countTopics(ctx, communityId),
     ]);
 
@@ -46,9 +46,11 @@ export default class VoteUseCase {
     const data = records.slice(0, take);
 
     // queryTopics はリレーション付きで返すので N+1 なし
+    // gate/powerPolicy が欠落しているトピックはデータ不整合 → 早期エラーで一覧全体を守る
+    data.forEach((topic) => this.service.validateTopicRelations(topic));
     const topicGqls = data.map((topic) => VotePresenter.topic(topic, isManagerOfCommunity));
 
-    return VotePresenter.query(topicGqls, totalCount, hasNextPage, after ?? undefined);
+    return VotePresenter.query(topicGqls, totalCount, hasNextPage, cursor ?? undefined);
   }
 
   async anyoneViewVoteTopic(
@@ -57,6 +59,8 @@ export default class VoteUseCase {
   ): Promise<GqlVoteTopic | null> {
     const topic = await this.repo.findTopic(ctx, id);
     if (!topic) return null;
+
+    this.service.validateTopicRelations(topic);
 
     const currentUserId = ctx.currentUser?.id;
     const { isManager } = getMembershipRolesByCtx(ctx, [topic.communityId], currentUserId);
@@ -105,6 +109,7 @@ export default class VoteUseCase {
 
     return ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
       const topic = await this.service.createTopicWithRelations(ctx, input, currentUserId, tx);
+      this.service.validateTopicRelations(topic);
       const topicGql = VotePresenter.topic(topic, true);
       return VotePresenter.create(topicGql);
     });

--- a/src/application/domain/vote/usecase.ts
+++ b/src/application/domain/vote/usecase.ts
@@ -80,6 +80,7 @@ export default class VoteUseCase {
   ): Promise<GqlMyVoteEligibility> {
     const userId = getCurrentUserId(ctx);
     const topic = await this.service.getTopicWithRelations(ctx, topicId);
+    this.service.validateTopicRelations(topic);
     const eligibility = await this.service.checkEligibility(ctx, userId, topic);
 
     let currentPower: number | null = null;
@@ -124,6 +125,7 @@ export default class VoteUseCase {
     return ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
       // 1. テーマ取得（トランザクション内）
       const topic = await this.service.getTopicWithRelations(ctx, input.topicId, tx);
+      this.service.validateTopicRelations(topic);
 
       // 2. 期間バリデーション
       this.service.validateVotingPeriod(topic);

--- a/src/application/domain/vote/usecase.ts
+++ b/src/application/domain/vote/usecase.ts
@@ -92,8 +92,9 @@ export default class VoteUseCase {
 
     const myBallot = await this.service.findBallot(ctx, userId, topicId);
 
-    // endsAt を超えていれば結果を公開（myEligibility context では manager 判定は行わない）
-    const resultVisible = this.service.calcResultVisible(topic.endsAt, false);
+    // 管理者は投票期間中も集計値を参照できる（PR設計方針と一致）
+    const { isManager } = getMembershipRolesByCtx(ctx, [topic.communityId], userId);
+    const resultVisible = this.service.calcResultVisible(topic.endsAt, !!isManager[topic.communityId]);
     return VotePresenter.eligibility(eligibility, currentPower, myBallot, resultVisible);
   }
 
@@ -164,8 +165,9 @@ export default class VoteUseCase {
       // 8. VoteOption 非正規化カラム更新（同トランザクション内）
       await this.service.updateOptionCounts(ctx, existingBallot, ballot, power, tx);
 
-      // 投票期間中のため resultVisible=false（集計値は秘匿）
-      const ballotGql = VotePresenter.ballot(ballot, this.service.calcResultVisible(topic.endsAt, false));
+      // 管理者は投票期間中も集計値を参照できる（PR設計方針と一致）
+      const { isManager } = getMembershipRolesByCtx(ctx, [topic.communityId], userId);
+      const ballotGql = VotePresenter.ballot(ballot, this.service.calcResultVisible(topic.endsAt, !!isManager[topic.communityId]));
       return VotePresenter.castBallot(ballotGql);
     });
   }
@@ -190,9 +192,9 @@ export default class VoteUseCase {
 
     const myBallot = await this.service.findBallot(ctx, userId, parent.id);
 
-    // myEligibility コンテキストでは manager 判定は行わず、時刻のみで結果公開を判定
-    const resultVisible = this.service.calcResultVisible(parent.endsAt, false);
-    return VotePresenter.eligibility(eligibility, currentPower, myBallot, resultVisible);
+    // parent.resultVisible は VotePresenter.topic() が isManager を考慮して算出済みの値
+    // ここで再計算せずそのまま使うことで、管理者判定も正しく引き継がれる
+    return VotePresenter.eligibility(eligibility, currentPower, myBallot, parent.resultVisible);
   }
 
   // ─── フィールドリゾルバー向けフォーマットデリゲート ──────────────────────────

--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -112,6 +112,10 @@ import IncentiveGrantService from "@/application/domain/transaction/incentiveGra
 import IncentiveGrantUseCase from "@/application/domain/transaction/incentiveGrant/usecase";
 import IncentiveGrantRepository from "@/application/domain/transaction/incentiveGrant/data/repository";
 import IncentiveGrantConverter from "@/application/domain/transaction/incentiveGrant/data/converter";
+import VoteUseCase from "@/application/domain/vote/usecase";
+import VoteService from "@/application/domain/vote/service";
+import VoteConverter from "@/application/domain/vote/data/converter";
+import VoteRepository from "@/application/domain/vote/data/repository";
 
 export function registerProductionDependencies() {
   // ------------------------------
@@ -329,6 +333,15 @@ export function registerProductionDependencies() {
   container.register("TransactionVerificationUseCase", {
     useClass: TransactionVerificationUseCase,
   });
+
+  // ------------------------------
+  // 🗳️ Vote
+  // ------------------------------
+
+  container.register("VoteUseCase", { useClass: VoteUseCase });
+  container.register("VoteService", { useClass: VoteService });
+  container.register("VoteConverter", { useClass: VoteConverter });
+  container.register("VoteRepository", { useClass: VoteRepository });
 
   // ------------------------------
   // 👓 View

--- a/src/infrastructure/prisma/factories/__generated__/index.ts
+++ b/src/infrastructure/prisma/factories/__generated__/index.ts
@@ -39,6 +39,11 @@ import type { NftInstance } from "@prisma/client";
 import type { NftMint } from "@prisma/client";
 import type { MerkleCommit } from "@prisma/client";
 import type { MerkleProof } from "@prisma/client";
+import type { VoteGate } from "@prisma/client";
+import type { VotePowerPolicy } from "@prisma/client";
+import type { VoteTopic } from "@prisma/client";
+import type { VoteOption } from "@prisma/client";
+import type { VoteBallot } from "@prisma/client";
 import type { PlacePublicOpportunityCountView } from "@prisma/client";
 import type { PlaceAccumulatedParticipantsView } from "@prisma/client";
 import type { MembershipParticipationGeoView } from "@prisma/client";
@@ -80,6 +85,8 @@ import type { NftWalletType } from "@prisma/client";
 import type { NftInstanceStatus } from "@prisma/client";
 import type { NftMintStatus } from "@prisma/client";
 import type { Position } from "@prisma/client";
+import type { VoteGateType } from "@prisma/client";
+import type { VotePowerPolicyType } from "@prisma/client";
 import type { ParticipationType } from "@prisma/client";
 import type { Prisma, PrismaClient } from "@prisma/client";
 import { createInitializer, createScreener, getScalarFieldValueGenerator, normalizeResolver, normalizeList, getSequenceCounter, createCallbackChain, destructure } from "@quramy/prisma-fabbrica/lib/internal";
@@ -238,6 +245,10 @@ const modelFieldDefinitions: ModelWithFields[] = [{
                 name: "nftInstance",
                 type: "NftInstance",
                 relationName: "CommunityToNftInstance"
+            }, {
+                name: "voteTopics",
+                type: "VoteTopic",
+                relationName: "CommunityToVoteTopic"
             }]
     }, {
         name: "CommunityConfig",
@@ -387,6 +398,14 @@ const modelFieldDefinitions: ModelWithFields[] = [{
                 name: "articlesAboutMe",
                 type: "Article",
                 relationName: "t_related_users_on_articles"
+            }, {
+                name: "voteBallots",
+                type: "VoteBallot",
+                relationName: "UserToVoteBallot"
+            }, {
+                name: "createdVoteTopics",
+                type: "VoteTopic",
+                relationName: "VoteTopicCreatedBy"
             }]
     }, {
         name: "Identity",
@@ -846,6 +865,14 @@ const modelFieldDefinitions: ModelWithFields[] = [{
                 name: "nftInstances",
                 type: "NftInstance",
                 relationName: "NftInstanceToNftToken"
+            }, {
+                name: "voteGates",
+                type: "VoteGate",
+                relationName: "NftTokenToVoteGate"
+            }, {
+                name: "votePowerPolicies",
+                type: "VotePowerPolicy",
+                relationName: "NftTokenToVotePowerPolicy"
             }]
     }, {
         name: "NftInstance",
@@ -890,6 +917,81 @@ const modelFieldDefinitions: ModelWithFields[] = [{
                 name: "commit",
                 type: "MerkleCommit",
                 relationName: "MerkleCommitToMerkleProof"
+            }]
+    }, {
+        name: "VoteGate",
+        fields: [{
+                name: "nftToken",
+                type: "NftToken",
+                relationName: "NftTokenToVoteGate"
+            }, {
+                name: "topic",
+                type: "VoteTopic",
+                relationName: "VoteGateToVoteTopic"
+            }]
+    }, {
+        name: "VotePowerPolicy",
+        fields: [{
+                name: "nftToken",
+                type: "NftToken",
+                relationName: "NftTokenToVotePowerPolicy"
+            }, {
+                name: "topic",
+                type: "VoteTopic",
+                relationName: "VotePowerPolicyToVoteTopic"
+            }]
+    }, {
+        name: "VoteTopic",
+        fields: [{
+                name: "community",
+                type: "Community",
+                relationName: "CommunityToVoteTopic"
+            }, {
+                name: "createdByUser",
+                type: "User",
+                relationName: "VoteTopicCreatedBy"
+            }, {
+                name: "gate",
+                type: "VoteGate",
+                relationName: "VoteGateToVoteTopic"
+            }, {
+                name: "powerPolicy",
+                type: "VotePowerPolicy",
+                relationName: "VotePowerPolicyToVoteTopic"
+            }, {
+                name: "options",
+                type: "VoteOption",
+                relationName: "VoteOptionToVoteTopic"
+            }, {
+                name: "ballots",
+                type: "VoteBallot",
+                relationName: "VoteBallotToVoteTopic"
+            }]
+    }, {
+        name: "VoteOption",
+        fields: [{
+                name: "topic",
+                type: "VoteTopic",
+                relationName: "VoteOptionToVoteTopic"
+            }, {
+                name: "ballots",
+                type: "VoteBallot",
+                relationName: "VoteBallotToVoteOption"
+            }]
+    }, {
+        name: "VoteBallot",
+        fields: [{
+                name: "user",
+                type: "User",
+                relationName: "UserToVoteBallot"
+            }, {
+                name: "topic",
+                type: "VoteTopic",
+                relationName: "VoteBallotToVoteTopic"
+            }, {
+                name: "option",
+                type: "VoteOption",
+                relationName: "VoteBallotToVoteOption"
             }]
     }, {
         name: "PlacePublicOpportunityCountView",
@@ -1699,6 +1801,7 @@ type CommunityFactoryDefineInput = {
     participations?: Prisma.ParticipationCreateNestedManyWithoutCommunityInput;
     articles?: Prisma.ArticleCreateNestedManyWithoutCommunityInput;
     nftInstance?: Prisma.NftInstanceCreateNestedManyWithoutCommunityInput;
+    voteTopics?: Prisma.VoteTopicCreateNestedManyWithoutCommunityInput;
 };
 
 type CommunityTransientFields = Record<string, unknown> & Partial<Record<keyof CommunityFactoryDefineInput, never>>;
@@ -2907,6 +3010,8 @@ type UserFactoryDefineInput = {
     transactionsCreatedByMe?: Prisma.TransactionCreateNestedManyWithoutCreatedByUserInput;
     articlesWrittenByMe?: Prisma.ArticleCreateNestedManyWithoutAuthorsInput;
     articlesAboutMe?: Prisma.ArticleCreateNestedManyWithoutRelatedUsersInput;
+    voteBallots?: Prisma.VoteBallotCreateNestedManyWithoutUserInput;
+    createdVoteTopics?: Prisma.VoteTopicCreateNestedManyWithoutCreatedByUserInput;
 };
 
 type UserTransientFields = Record<string, unknown> & Partial<Record<keyof UserFactoryDefineInput, never>>;
@@ -7365,6 +7470,8 @@ type NftTokenFactoryDefineInput = {
     createdAt?: Date;
     updatedAt?: Date | null;
     nftInstances?: Prisma.NftInstanceCreateNestedManyWithoutNftTokenInput;
+    voteGates?: Prisma.VoteGateCreateNestedManyWithoutNftTokenInput;
+    votePowerPolicies?: Prisma.VotePowerPolicyCreateNestedManyWithoutNftTokenInput;
 };
 
 type NftTokenTransientFields = Record<string, unknown> & Partial<Record<keyof NftTokenFactoryDefineInput, never>>;
@@ -8159,6 +8266,877 @@ export const defineMerkleProofFactory = (<TOptions extends MerkleProofFactoryDef
 }) as MerkleProofFactoryBuilder;
 
 defineMerkleProofFactory.withTransientFields = defaultTransientFieldValues => options => defineMerkleProofFactoryInternal(options, defaultTransientFieldValues);
+
+type VoteGateScalarOrEnumFields = {
+    type: VoteGateType;
+};
+
+type VoteGatenftTokenFactory = {
+    _factoryFor: "NftToken";
+    build: () => PromiseLike<Prisma.NftTokenCreateNestedOneWithoutVoteGatesInput["create"]>;
+};
+
+type VoteGatetopicFactory = {
+    _factoryFor: "VoteTopic";
+    build: () => PromiseLike<Prisma.VoteTopicCreateNestedOneWithoutGateInput["create"]>;
+};
+
+type VoteGateFactoryDefineInput = {
+    id?: string;
+    type?: VoteGateType;
+    requiredRole?: Role | null;
+    nftToken?: VoteGatenftTokenFactory | Prisma.NftTokenCreateNestedOneWithoutVoteGatesInput;
+    topic: VoteGatetopicFactory | Prisma.VoteTopicCreateNestedOneWithoutGateInput;
+};
+
+type VoteGateTransientFields = Record<string, unknown> & Partial<Record<keyof VoteGateFactoryDefineInput, never>>;
+
+type VoteGateFactoryTrait<TTransients extends Record<string, unknown>> = {
+    data?: Resolver<Partial<VoteGateFactoryDefineInput>, BuildDataOptions<TTransients>>;
+} & CallbackDefineOptions<VoteGate, Prisma.VoteGateCreateInput, TTransients>;
+
+type VoteGateFactoryDefineOptions<TTransients extends Record<string, unknown> = Record<string, unknown>> = {
+    defaultData: Resolver<VoteGateFactoryDefineInput, BuildDataOptions<TTransients>>;
+    traits?: {
+        [traitName: string | symbol]: VoteGateFactoryTrait<TTransients>;
+    };
+} & CallbackDefineOptions<VoteGate, Prisma.VoteGateCreateInput, TTransients>;
+
+function isVoteGatenftTokenFactory(x: VoteGatenftTokenFactory | Prisma.NftTokenCreateNestedOneWithoutVoteGatesInput | undefined): x is VoteGatenftTokenFactory {
+    return (x as any)?._factoryFor === "NftToken";
+}
+
+function isVoteGatetopicFactory(x: VoteGatetopicFactory | Prisma.VoteTopicCreateNestedOneWithoutGateInput | undefined): x is VoteGatetopicFactory {
+    return (x as any)?._factoryFor === "VoteTopic";
+}
+
+type VoteGateTraitKeys<TOptions extends VoteGateFactoryDefineOptions<any>> = Exclude<keyof TOptions["traits"], number>;
+
+export interface VoteGateFactoryInterfaceWithoutTraits<TTransients extends Record<string, unknown>> {
+    readonly _factoryFor: "VoteGate";
+    build(inputData?: Partial<Prisma.VoteGateCreateInput & TTransients>): PromiseLike<Prisma.VoteGateCreateInput>;
+    buildCreateInput(inputData?: Partial<Prisma.VoteGateCreateInput & TTransients>): PromiseLike<Prisma.VoteGateCreateInput>;
+    buildList(list: readonly Partial<Prisma.VoteGateCreateInput & TTransients>[]): PromiseLike<Prisma.VoteGateCreateInput[]>;
+    buildList(count: number, item?: Partial<Prisma.VoteGateCreateInput & TTransients>): PromiseLike<Prisma.VoteGateCreateInput[]>;
+    pickForConnect(inputData: VoteGate): Pick<VoteGate, "id">;
+    create(inputData?: Partial<Prisma.VoteGateCreateInput & TTransients>): PromiseLike<VoteGate>;
+    createList(list: readonly Partial<Prisma.VoteGateCreateInput & TTransients>[]): PromiseLike<VoteGate[]>;
+    createList(count: number, item?: Partial<Prisma.VoteGateCreateInput & TTransients>): PromiseLike<VoteGate[]>;
+    createForConnect(inputData?: Partial<Prisma.VoteGateCreateInput & TTransients>): PromiseLike<Pick<VoteGate, "id">>;
+}
+
+export interface VoteGateFactoryInterface<TTransients extends Record<string, unknown> = Record<string, unknown>, TTraitName extends TraitName = TraitName> extends VoteGateFactoryInterfaceWithoutTraits<TTransients> {
+    use(name: TTraitName, ...names: readonly TTraitName[]): VoteGateFactoryInterfaceWithoutTraits<TTransients>;
+}
+
+function autoGenerateVoteGateScalarsOrEnums({ seq }: {
+    readonly seq: number;
+}): VoteGateScalarOrEnumFields {
+    return {
+        type: "NFT"
+    };
+}
+
+function defineVoteGateFactoryInternal<TTransients extends Record<string, unknown>, TOptions extends VoteGateFactoryDefineOptions<TTransients>>({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }: TOptions, defaultTransientFieldValues: TTransients): VoteGateFactoryInterface<TTransients, VoteGateTraitKeys<TOptions>> {
+    const getFactoryWithTraits = (traitKeys: readonly VoteGateTraitKeys<TOptions>[] = []) => {
+        const seqKey = {};
+        const getSeq = () => getSequenceCounter(seqKey);
+        const screen = createScreener("VoteGate", modelFieldDefinitions);
+        const handleAfterBuild = createCallbackChain([
+            onAfterBuild,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterBuild),
+        ]);
+        const handleBeforeCreate = createCallbackChain([
+            ...traitKeys.slice().reverse().map(traitKey => traitsDefs[traitKey]?.onBeforeCreate),
+            onBeforeCreate,
+        ]);
+        const handleAfterCreate = createCallbackChain([
+            onAfterCreate,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterCreate),
+        ]);
+        const build = async (inputData: Partial<Prisma.VoteGateCreateInput & TTransients> = {}) => {
+            const seq = getSeq();
+            const requiredScalarData = autoGenerateVoteGateScalarsOrEnums({ seq });
+            const resolveValue = normalizeResolver<VoteGateFactoryDefineInput, BuildDataOptions<any>>(defaultDataResolver);
+            const [transientFields, filteredInputData] = destructure(defaultTransientFieldValues, inputData);
+            const resolverInput = { seq, ...transientFields };
+            const defaultData = await traitKeys.reduce(async (queue, traitKey) => {
+                const acc = await queue;
+                const resolveTraitValue = normalizeResolver<Partial<VoteGateFactoryDefineInput>, BuildDataOptions<TTransients>>(traitsDefs[traitKey]?.data ?? {});
+                const traitData = await resolveTraitValue(resolverInput);
+                return {
+                    ...acc,
+                    ...traitData,
+                };
+            }, resolveValue(resolverInput));
+            const defaultAssociations = {
+                nftToken: isVoteGatenftTokenFactory(defaultData.nftToken) ? {
+                    create: await defaultData.nftToken.build()
+                } : defaultData.nftToken,
+                topic: isVoteGatetopicFactory(defaultData.topic) ? {
+                    create: await defaultData.topic.build()
+                } : defaultData.topic
+            } as Prisma.VoteGateCreateInput;
+            const data: Prisma.VoteGateCreateInput = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...filteredInputData };
+            await handleAfterBuild(data, transientFields);
+            return data;
+        };
+        const buildList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.VoteGateCreateInput & TTransients>>(...args).map(data => build(data)));
+        const pickForConnect = (inputData: VoteGate) => ({
+            id: inputData.id
+        });
+        const create = async (inputData: Partial<Prisma.VoteGateCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
+            const [transientFields] = destructure(defaultTransientFieldValues, inputData);
+            await handleBeforeCreate(data, transientFields);
+            const createdData = await getClient<PrismaClient>().voteGate.create({ data });
+            await handleAfterCreate(createdData, transientFields);
+            return createdData;
+        };
+        const createList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.VoteGateCreateInput & TTransients>>(...args).map(data => create(data)));
+        const createForConnect = (inputData: Partial<Prisma.VoteGateCreateInput & TTransients> = {}) => create(inputData).then(pickForConnect);
+        return {
+            _factoryFor: "VoteGate" as const,
+            build,
+            buildList,
+            buildCreateInput: build,
+            pickForConnect,
+            create,
+            createList,
+            createForConnect,
+        };
+    };
+    const factory = getFactoryWithTraits();
+    const useTraits = (name: VoteGateTraitKeys<TOptions>, ...names: readonly VoteGateTraitKeys<TOptions>[]) => {
+        return getFactoryWithTraits([name, ...names]);
+    };
+    return {
+        ...factory,
+        use: useTraits,
+    };
+}
+
+interface VoteGateFactoryBuilder {
+    <TOptions extends VoteGateFactoryDefineOptions>(options: TOptions): VoteGateFactoryInterface<{}, VoteGateTraitKeys<TOptions>>;
+    withTransientFields: <TTransients extends VoteGateTransientFields>(defaultTransientFieldValues: TTransients) => <TOptions extends VoteGateFactoryDefineOptions<TTransients>>(options: TOptions) => VoteGateFactoryInterface<TTransients, VoteGateTraitKeys<TOptions>>;
+}
+
+/**
+ * Define factory for {@link VoteGate} model.
+ *
+ * @param options
+ * @returns factory {@link VoteGateFactoryInterface}
+ */
+export const defineVoteGateFactory = (<TOptions extends VoteGateFactoryDefineOptions>(options: TOptions): VoteGateFactoryInterface<TOptions> => {
+    return defineVoteGateFactoryInternal(options, {});
+}) as VoteGateFactoryBuilder;
+
+defineVoteGateFactory.withTransientFields = defaultTransientFieldValues => options => defineVoteGateFactoryInternal(options, defaultTransientFieldValues);
+
+type VotePowerPolicyScalarOrEnumFields = {
+    type: VotePowerPolicyType;
+};
+
+type VotePowerPolicynftTokenFactory = {
+    _factoryFor: "NftToken";
+    build: () => PromiseLike<Prisma.NftTokenCreateNestedOneWithoutVotePowerPoliciesInput["create"]>;
+};
+
+type VotePowerPolicytopicFactory = {
+    _factoryFor: "VoteTopic";
+    build: () => PromiseLike<Prisma.VoteTopicCreateNestedOneWithoutPowerPolicyInput["create"]>;
+};
+
+type VotePowerPolicyFactoryDefineInput = {
+    id?: string;
+    type?: VotePowerPolicyType;
+    nftToken?: VotePowerPolicynftTokenFactory | Prisma.NftTokenCreateNestedOneWithoutVotePowerPoliciesInput;
+    topic: VotePowerPolicytopicFactory | Prisma.VoteTopicCreateNestedOneWithoutPowerPolicyInput;
+};
+
+type VotePowerPolicyTransientFields = Record<string, unknown> & Partial<Record<keyof VotePowerPolicyFactoryDefineInput, never>>;
+
+type VotePowerPolicyFactoryTrait<TTransients extends Record<string, unknown>> = {
+    data?: Resolver<Partial<VotePowerPolicyFactoryDefineInput>, BuildDataOptions<TTransients>>;
+} & CallbackDefineOptions<VotePowerPolicy, Prisma.VotePowerPolicyCreateInput, TTransients>;
+
+type VotePowerPolicyFactoryDefineOptions<TTransients extends Record<string, unknown> = Record<string, unknown>> = {
+    defaultData: Resolver<VotePowerPolicyFactoryDefineInput, BuildDataOptions<TTransients>>;
+    traits?: {
+        [traitName: string | symbol]: VotePowerPolicyFactoryTrait<TTransients>;
+    };
+} & CallbackDefineOptions<VotePowerPolicy, Prisma.VotePowerPolicyCreateInput, TTransients>;
+
+function isVotePowerPolicynftTokenFactory(x: VotePowerPolicynftTokenFactory | Prisma.NftTokenCreateNestedOneWithoutVotePowerPoliciesInput | undefined): x is VotePowerPolicynftTokenFactory {
+    return (x as any)?._factoryFor === "NftToken";
+}
+
+function isVotePowerPolicytopicFactory(x: VotePowerPolicytopicFactory | Prisma.VoteTopicCreateNestedOneWithoutPowerPolicyInput | undefined): x is VotePowerPolicytopicFactory {
+    return (x as any)?._factoryFor === "VoteTopic";
+}
+
+type VotePowerPolicyTraitKeys<TOptions extends VotePowerPolicyFactoryDefineOptions<any>> = Exclude<keyof TOptions["traits"], number>;
+
+export interface VotePowerPolicyFactoryInterfaceWithoutTraits<TTransients extends Record<string, unknown>> {
+    readonly _factoryFor: "VotePowerPolicy";
+    build(inputData?: Partial<Prisma.VotePowerPolicyCreateInput & TTransients>): PromiseLike<Prisma.VotePowerPolicyCreateInput>;
+    buildCreateInput(inputData?: Partial<Prisma.VotePowerPolicyCreateInput & TTransients>): PromiseLike<Prisma.VotePowerPolicyCreateInput>;
+    buildList(list: readonly Partial<Prisma.VotePowerPolicyCreateInput & TTransients>[]): PromiseLike<Prisma.VotePowerPolicyCreateInput[]>;
+    buildList(count: number, item?: Partial<Prisma.VotePowerPolicyCreateInput & TTransients>): PromiseLike<Prisma.VotePowerPolicyCreateInput[]>;
+    pickForConnect(inputData: VotePowerPolicy): Pick<VotePowerPolicy, "id">;
+    create(inputData?: Partial<Prisma.VotePowerPolicyCreateInput & TTransients>): PromiseLike<VotePowerPolicy>;
+    createList(list: readonly Partial<Prisma.VotePowerPolicyCreateInput & TTransients>[]): PromiseLike<VotePowerPolicy[]>;
+    createList(count: number, item?: Partial<Prisma.VotePowerPolicyCreateInput & TTransients>): PromiseLike<VotePowerPolicy[]>;
+    createForConnect(inputData?: Partial<Prisma.VotePowerPolicyCreateInput & TTransients>): PromiseLike<Pick<VotePowerPolicy, "id">>;
+}
+
+export interface VotePowerPolicyFactoryInterface<TTransients extends Record<string, unknown> = Record<string, unknown>, TTraitName extends TraitName = TraitName> extends VotePowerPolicyFactoryInterfaceWithoutTraits<TTransients> {
+    use(name: TTraitName, ...names: readonly TTraitName[]): VotePowerPolicyFactoryInterfaceWithoutTraits<TTransients>;
+}
+
+function autoGenerateVotePowerPolicyScalarsOrEnums({ seq }: {
+    readonly seq: number;
+}): VotePowerPolicyScalarOrEnumFields {
+    return {
+        type: "FLAT"
+    };
+}
+
+function defineVotePowerPolicyFactoryInternal<TTransients extends Record<string, unknown>, TOptions extends VotePowerPolicyFactoryDefineOptions<TTransients>>({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }: TOptions, defaultTransientFieldValues: TTransients): VotePowerPolicyFactoryInterface<TTransients, VotePowerPolicyTraitKeys<TOptions>> {
+    const getFactoryWithTraits = (traitKeys: readonly VotePowerPolicyTraitKeys<TOptions>[] = []) => {
+        const seqKey = {};
+        const getSeq = () => getSequenceCounter(seqKey);
+        const screen = createScreener("VotePowerPolicy", modelFieldDefinitions);
+        const handleAfterBuild = createCallbackChain([
+            onAfterBuild,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterBuild),
+        ]);
+        const handleBeforeCreate = createCallbackChain([
+            ...traitKeys.slice().reverse().map(traitKey => traitsDefs[traitKey]?.onBeforeCreate),
+            onBeforeCreate,
+        ]);
+        const handleAfterCreate = createCallbackChain([
+            onAfterCreate,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterCreate),
+        ]);
+        const build = async (inputData: Partial<Prisma.VotePowerPolicyCreateInput & TTransients> = {}) => {
+            const seq = getSeq();
+            const requiredScalarData = autoGenerateVotePowerPolicyScalarsOrEnums({ seq });
+            const resolveValue = normalizeResolver<VotePowerPolicyFactoryDefineInput, BuildDataOptions<any>>(defaultDataResolver);
+            const [transientFields, filteredInputData] = destructure(defaultTransientFieldValues, inputData);
+            const resolverInput = { seq, ...transientFields };
+            const defaultData = await traitKeys.reduce(async (queue, traitKey) => {
+                const acc = await queue;
+                const resolveTraitValue = normalizeResolver<Partial<VotePowerPolicyFactoryDefineInput>, BuildDataOptions<TTransients>>(traitsDefs[traitKey]?.data ?? {});
+                const traitData = await resolveTraitValue(resolverInput);
+                return {
+                    ...acc,
+                    ...traitData,
+                };
+            }, resolveValue(resolverInput));
+            const defaultAssociations = {
+                nftToken: isVotePowerPolicynftTokenFactory(defaultData.nftToken) ? {
+                    create: await defaultData.nftToken.build()
+                } : defaultData.nftToken,
+                topic: isVotePowerPolicytopicFactory(defaultData.topic) ? {
+                    create: await defaultData.topic.build()
+                } : defaultData.topic
+            } as Prisma.VotePowerPolicyCreateInput;
+            const data: Prisma.VotePowerPolicyCreateInput = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...filteredInputData };
+            await handleAfterBuild(data, transientFields);
+            return data;
+        };
+        const buildList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.VotePowerPolicyCreateInput & TTransients>>(...args).map(data => build(data)));
+        const pickForConnect = (inputData: VotePowerPolicy) => ({
+            id: inputData.id
+        });
+        const create = async (inputData: Partial<Prisma.VotePowerPolicyCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
+            const [transientFields] = destructure(defaultTransientFieldValues, inputData);
+            await handleBeforeCreate(data, transientFields);
+            const createdData = await getClient<PrismaClient>().votePowerPolicy.create({ data });
+            await handleAfterCreate(createdData, transientFields);
+            return createdData;
+        };
+        const createList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.VotePowerPolicyCreateInput & TTransients>>(...args).map(data => create(data)));
+        const createForConnect = (inputData: Partial<Prisma.VotePowerPolicyCreateInput & TTransients> = {}) => create(inputData).then(pickForConnect);
+        return {
+            _factoryFor: "VotePowerPolicy" as const,
+            build,
+            buildList,
+            buildCreateInput: build,
+            pickForConnect,
+            create,
+            createList,
+            createForConnect,
+        };
+    };
+    const factory = getFactoryWithTraits();
+    const useTraits = (name: VotePowerPolicyTraitKeys<TOptions>, ...names: readonly VotePowerPolicyTraitKeys<TOptions>[]) => {
+        return getFactoryWithTraits([name, ...names]);
+    };
+    return {
+        ...factory,
+        use: useTraits,
+    };
+}
+
+interface VotePowerPolicyFactoryBuilder {
+    <TOptions extends VotePowerPolicyFactoryDefineOptions>(options: TOptions): VotePowerPolicyFactoryInterface<{}, VotePowerPolicyTraitKeys<TOptions>>;
+    withTransientFields: <TTransients extends VotePowerPolicyTransientFields>(defaultTransientFieldValues: TTransients) => <TOptions extends VotePowerPolicyFactoryDefineOptions<TTransients>>(options: TOptions) => VotePowerPolicyFactoryInterface<TTransients, VotePowerPolicyTraitKeys<TOptions>>;
+}
+
+/**
+ * Define factory for {@link VotePowerPolicy} model.
+ *
+ * @param options
+ * @returns factory {@link VotePowerPolicyFactoryInterface}
+ */
+export const defineVotePowerPolicyFactory = (<TOptions extends VotePowerPolicyFactoryDefineOptions>(options: TOptions): VotePowerPolicyFactoryInterface<TOptions> => {
+    return defineVotePowerPolicyFactoryInternal(options, {});
+}) as VotePowerPolicyFactoryBuilder;
+
+defineVotePowerPolicyFactory.withTransientFields = defaultTransientFieldValues => options => defineVotePowerPolicyFactoryInternal(options, defaultTransientFieldValues);
+
+type VoteTopicScalarOrEnumFields = {
+    title: string;
+    startsAt: Date;
+    endsAt: Date;
+};
+
+type VoteTopiccommunityFactory = {
+    _factoryFor: "Community";
+    build: () => PromiseLike<Prisma.CommunityCreateNestedOneWithoutVoteTopicsInput["create"]>;
+};
+
+type VoteTopiccreatedByUserFactory = {
+    _factoryFor: "User";
+    build: () => PromiseLike<Prisma.UserCreateNestedOneWithoutCreatedVoteTopicsInput["create"]>;
+};
+
+type VoteTopicgateFactory = {
+    _factoryFor: "VoteGate";
+    build: () => PromiseLike<Prisma.VoteGateCreateNestedOneWithoutTopicInput["create"]>;
+};
+
+type VoteTopicpowerPolicyFactory = {
+    _factoryFor: "VotePowerPolicy";
+    build: () => PromiseLike<Prisma.VotePowerPolicyCreateNestedOneWithoutTopicInput["create"]>;
+};
+
+type VoteTopicFactoryDefineInput = {
+    id?: string;
+    title?: string;
+    description?: string | null;
+    startsAt?: Date;
+    endsAt?: Date;
+    createdAt?: Date;
+    updatedAt?: Date | null;
+    community: VoteTopiccommunityFactory | Prisma.CommunityCreateNestedOneWithoutVoteTopicsInput;
+    createdByUser: VoteTopiccreatedByUserFactory | Prisma.UserCreateNestedOneWithoutCreatedVoteTopicsInput;
+    gate?: VoteTopicgateFactory | Prisma.VoteGateCreateNestedOneWithoutTopicInput;
+    powerPolicy?: VoteTopicpowerPolicyFactory | Prisma.VotePowerPolicyCreateNestedOneWithoutTopicInput;
+    options?: Prisma.VoteOptionCreateNestedManyWithoutTopicInput;
+    ballots?: Prisma.VoteBallotCreateNestedManyWithoutTopicInput;
+};
+
+type VoteTopicTransientFields = Record<string, unknown> & Partial<Record<keyof VoteTopicFactoryDefineInput, never>>;
+
+type VoteTopicFactoryTrait<TTransients extends Record<string, unknown>> = {
+    data?: Resolver<Partial<VoteTopicFactoryDefineInput>, BuildDataOptions<TTransients>>;
+} & CallbackDefineOptions<VoteTopic, Prisma.VoteTopicCreateInput, TTransients>;
+
+type VoteTopicFactoryDefineOptions<TTransients extends Record<string, unknown> = Record<string, unknown>> = {
+    defaultData: Resolver<VoteTopicFactoryDefineInput, BuildDataOptions<TTransients>>;
+    traits?: {
+        [traitName: string | symbol]: VoteTopicFactoryTrait<TTransients>;
+    };
+} & CallbackDefineOptions<VoteTopic, Prisma.VoteTopicCreateInput, TTransients>;
+
+function isVoteTopiccommunityFactory(x: VoteTopiccommunityFactory | Prisma.CommunityCreateNestedOneWithoutVoteTopicsInput | undefined): x is VoteTopiccommunityFactory {
+    return (x as any)?._factoryFor === "Community";
+}
+
+function isVoteTopiccreatedByUserFactory(x: VoteTopiccreatedByUserFactory | Prisma.UserCreateNestedOneWithoutCreatedVoteTopicsInput | undefined): x is VoteTopiccreatedByUserFactory {
+    return (x as any)?._factoryFor === "User";
+}
+
+function isVoteTopicgateFactory(x: VoteTopicgateFactory | Prisma.VoteGateCreateNestedOneWithoutTopicInput | undefined): x is VoteTopicgateFactory {
+    return (x as any)?._factoryFor === "VoteGate";
+}
+
+function isVoteTopicpowerPolicyFactory(x: VoteTopicpowerPolicyFactory | Prisma.VotePowerPolicyCreateNestedOneWithoutTopicInput | undefined): x is VoteTopicpowerPolicyFactory {
+    return (x as any)?._factoryFor === "VotePowerPolicy";
+}
+
+type VoteTopicTraitKeys<TOptions extends VoteTopicFactoryDefineOptions<any>> = Exclude<keyof TOptions["traits"], number>;
+
+export interface VoteTopicFactoryInterfaceWithoutTraits<TTransients extends Record<string, unknown>> {
+    readonly _factoryFor: "VoteTopic";
+    build(inputData?: Partial<Prisma.VoteTopicCreateInput & TTransients>): PromiseLike<Prisma.VoteTopicCreateInput>;
+    buildCreateInput(inputData?: Partial<Prisma.VoteTopicCreateInput & TTransients>): PromiseLike<Prisma.VoteTopicCreateInput>;
+    buildList(list: readonly Partial<Prisma.VoteTopicCreateInput & TTransients>[]): PromiseLike<Prisma.VoteTopicCreateInput[]>;
+    buildList(count: number, item?: Partial<Prisma.VoteTopicCreateInput & TTransients>): PromiseLike<Prisma.VoteTopicCreateInput[]>;
+    pickForConnect(inputData: VoteTopic): Pick<VoteTopic, "id">;
+    create(inputData?: Partial<Prisma.VoteTopicCreateInput & TTransients>): PromiseLike<VoteTopic>;
+    createList(list: readonly Partial<Prisma.VoteTopicCreateInput & TTransients>[]): PromiseLike<VoteTopic[]>;
+    createList(count: number, item?: Partial<Prisma.VoteTopicCreateInput & TTransients>): PromiseLike<VoteTopic[]>;
+    createForConnect(inputData?: Partial<Prisma.VoteTopicCreateInput & TTransients>): PromiseLike<Pick<VoteTopic, "id">>;
+}
+
+export interface VoteTopicFactoryInterface<TTransients extends Record<string, unknown> = Record<string, unknown>, TTraitName extends TraitName = TraitName> extends VoteTopicFactoryInterfaceWithoutTraits<TTransients> {
+    use(name: TTraitName, ...names: readonly TTraitName[]): VoteTopicFactoryInterfaceWithoutTraits<TTransients>;
+}
+
+function autoGenerateVoteTopicScalarsOrEnums({ seq }: {
+    readonly seq: number;
+}): VoteTopicScalarOrEnumFields {
+    return {
+        title: getScalarFieldValueGenerator().String({ modelName: "VoteTopic", fieldName: "title", isId: false, isUnique: false, seq }),
+        startsAt: getScalarFieldValueGenerator().DateTime({ modelName: "VoteTopic", fieldName: "startsAt", isId: false, isUnique: false, seq }),
+        endsAt: getScalarFieldValueGenerator().DateTime({ modelName: "VoteTopic", fieldName: "endsAt", isId: false, isUnique: false, seq })
+    };
+}
+
+function defineVoteTopicFactoryInternal<TTransients extends Record<string, unknown>, TOptions extends VoteTopicFactoryDefineOptions<TTransients>>({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }: TOptions, defaultTransientFieldValues: TTransients): VoteTopicFactoryInterface<TTransients, VoteTopicTraitKeys<TOptions>> {
+    const getFactoryWithTraits = (traitKeys: readonly VoteTopicTraitKeys<TOptions>[] = []) => {
+        const seqKey = {};
+        const getSeq = () => getSequenceCounter(seqKey);
+        const screen = createScreener("VoteTopic", modelFieldDefinitions);
+        const handleAfterBuild = createCallbackChain([
+            onAfterBuild,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterBuild),
+        ]);
+        const handleBeforeCreate = createCallbackChain([
+            ...traitKeys.slice().reverse().map(traitKey => traitsDefs[traitKey]?.onBeforeCreate),
+            onBeforeCreate,
+        ]);
+        const handleAfterCreate = createCallbackChain([
+            onAfterCreate,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterCreate),
+        ]);
+        const build = async (inputData: Partial<Prisma.VoteTopicCreateInput & TTransients> = {}) => {
+            const seq = getSeq();
+            const requiredScalarData = autoGenerateVoteTopicScalarsOrEnums({ seq });
+            const resolveValue = normalizeResolver<VoteTopicFactoryDefineInput, BuildDataOptions<any>>(defaultDataResolver);
+            const [transientFields, filteredInputData] = destructure(defaultTransientFieldValues, inputData);
+            const resolverInput = { seq, ...transientFields };
+            const defaultData = await traitKeys.reduce(async (queue, traitKey) => {
+                const acc = await queue;
+                const resolveTraitValue = normalizeResolver<Partial<VoteTopicFactoryDefineInput>, BuildDataOptions<TTransients>>(traitsDefs[traitKey]?.data ?? {});
+                const traitData = await resolveTraitValue(resolverInput);
+                return {
+                    ...acc,
+                    ...traitData,
+                };
+            }, resolveValue(resolverInput));
+            const defaultAssociations = {
+                community: isVoteTopiccommunityFactory(defaultData.community) ? {
+                    create: await defaultData.community.build()
+                } : defaultData.community,
+                createdByUser: isVoteTopiccreatedByUserFactory(defaultData.createdByUser) ? {
+                    create: await defaultData.createdByUser.build()
+                } : defaultData.createdByUser,
+                gate: isVoteTopicgateFactory(defaultData.gate) ? {
+                    create: await defaultData.gate.build()
+                } : defaultData.gate,
+                powerPolicy: isVoteTopicpowerPolicyFactory(defaultData.powerPolicy) ? {
+                    create: await defaultData.powerPolicy.build()
+                } : defaultData.powerPolicy
+            } as Prisma.VoteTopicCreateInput;
+            const data: Prisma.VoteTopicCreateInput = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...filteredInputData };
+            await handleAfterBuild(data, transientFields);
+            return data;
+        };
+        const buildList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.VoteTopicCreateInput & TTransients>>(...args).map(data => build(data)));
+        const pickForConnect = (inputData: VoteTopic) => ({
+            id: inputData.id
+        });
+        const create = async (inputData: Partial<Prisma.VoteTopicCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
+            const [transientFields] = destructure(defaultTransientFieldValues, inputData);
+            await handleBeforeCreate(data, transientFields);
+            const createdData = await getClient<PrismaClient>().voteTopic.create({ data });
+            await handleAfterCreate(createdData, transientFields);
+            return createdData;
+        };
+        const createList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.VoteTopicCreateInput & TTransients>>(...args).map(data => create(data)));
+        const createForConnect = (inputData: Partial<Prisma.VoteTopicCreateInput & TTransients> = {}) => create(inputData).then(pickForConnect);
+        return {
+            _factoryFor: "VoteTopic" as const,
+            build,
+            buildList,
+            buildCreateInput: build,
+            pickForConnect,
+            create,
+            createList,
+            createForConnect,
+        };
+    };
+    const factory = getFactoryWithTraits();
+    const useTraits = (name: VoteTopicTraitKeys<TOptions>, ...names: readonly VoteTopicTraitKeys<TOptions>[]) => {
+        return getFactoryWithTraits([name, ...names]);
+    };
+    return {
+        ...factory,
+        use: useTraits,
+    };
+}
+
+interface VoteTopicFactoryBuilder {
+    <TOptions extends VoteTopicFactoryDefineOptions>(options: TOptions): VoteTopicFactoryInterface<{}, VoteTopicTraitKeys<TOptions>>;
+    withTransientFields: <TTransients extends VoteTopicTransientFields>(defaultTransientFieldValues: TTransients) => <TOptions extends VoteTopicFactoryDefineOptions<TTransients>>(options: TOptions) => VoteTopicFactoryInterface<TTransients, VoteTopicTraitKeys<TOptions>>;
+}
+
+/**
+ * Define factory for {@link VoteTopic} model.
+ *
+ * @param options
+ * @returns factory {@link VoteTopicFactoryInterface}
+ */
+export const defineVoteTopicFactory = (<TOptions extends VoteTopicFactoryDefineOptions>(options: TOptions): VoteTopicFactoryInterface<TOptions> => {
+    return defineVoteTopicFactoryInternal(options, {});
+}) as VoteTopicFactoryBuilder;
+
+defineVoteTopicFactory.withTransientFields = defaultTransientFieldValues => options => defineVoteTopicFactoryInternal(options, defaultTransientFieldValues);
+
+type VoteOptionScalarOrEnumFields = {
+    label: string;
+    orderIndex: number;
+};
+
+type VoteOptiontopicFactory = {
+    _factoryFor: "VoteTopic";
+    build: () => PromiseLike<Prisma.VoteTopicCreateNestedOneWithoutOptionsInput["create"]>;
+};
+
+type VoteOptionFactoryDefineInput = {
+    id?: string;
+    label?: string;
+    orderIndex?: number;
+    voteCount?: number;
+    totalPower?: number;
+    topic: VoteOptiontopicFactory | Prisma.VoteTopicCreateNestedOneWithoutOptionsInput;
+    ballots?: Prisma.VoteBallotCreateNestedManyWithoutOptionInput;
+};
+
+type VoteOptionTransientFields = Record<string, unknown> & Partial<Record<keyof VoteOptionFactoryDefineInput, never>>;
+
+type VoteOptionFactoryTrait<TTransients extends Record<string, unknown>> = {
+    data?: Resolver<Partial<VoteOptionFactoryDefineInput>, BuildDataOptions<TTransients>>;
+} & CallbackDefineOptions<VoteOption, Prisma.VoteOptionCreateInput, TTransients>;
+
+type VoteOptionFactoryDefineOptions<TTransients extends Record<string, unknown> = Record<string, unknown>> = {
+    defaultData: Resolver<VoteOptionFactoryDefineInput, BuildDataOptions<TTransients>>;
+    traits?: {
+        [traitName: string | symbol]: VoteOptionFactoryTrait<TTransients>;
+    };
+} & CallbackDefineOptions<VoteOption, Prisma.VoteOptionCreateInput, TTransients>;
+
+function isVoteOptiontopicFactory(x: VoteOptiontopicFactory | Prisma.VoteTopicCreateNestedOneWithoutOptionsInput | undefined): x is VoteOptiontopicFactory {
+    return (x as any)?._factoryFor === "VoteTopic";
+}
+
+type VoteOptionTraitKeys<TOptions extends VoteOptionFactoryDefineOptions<any>> = Exclude<keyof TOptions["traits"], number>;
+
+export interface VoteOptionFactoryInterfaceWithoutTraits<TTransients extends Record<string, unknown>> {
+    readonly _factoryFor: "VoteOption";
+    build(inputData?: Partial<Prisma.VoteOptionCreateInput & TTransients>): PromiseLike<Prisma.VoteOptionCreateInput>;
+    buildCreateInput(inputData?: Partial<Prisma.VoteOptionCreateInput & TTransients>): PromiseLike<Prisma.VoteOptionCreateInput>;
+    buildList(list: readonly Partial<Prisma.VoteOptionCreateInput & TTransients>[]): PromiseLike<Prisma.VoteOptionCreateInput[]>;
+    buildList(count: number, item?: Partial<Prisma.VoteOptionCreateInput & TTransients>): PromiseLike<Prisma.VoteOptionCreateInput[]>;
+    pickForConnect(inputData: VoteOption): Pick<VoteOption, "id">;
+    create(inputData?: Partial<Prisma.VoteOptionCreateInput & TTransients>): PromiseLike<VoteOption>;
+    createList(list: readonly Partial<Prisma.VoteOptionCreateInput & TTransients>[]): PromiseLike<VoteOption[]>;
+    createList(count: number, item?: Partial<Prisma.VoteOptionCreateInput & TTransients>): PromiseLike<VoteOption[]>;
+    createForConnect(inputData?: Partial<Prisma.VoteOptionCreateInput & TTransients>): PromiseLike<Pick<VoteOption, "id">>;
+}
+
+export interface VoteOptionFactoryInterface<TTransients extends Record<string, unknown> = Record<string, unknown>, TTraitName extends TraitName = TraitName> extends VoteOptionFactoryInterfaceWithoutTraits<TTransients> {
+    use(name: TTraitName, ...names: readonly TTraitName[]): VoteOptionFactoryInterfaceWithoutTraits<TTransients>;
+}
+
+function autoGenerateVoteOptionScalarsOrEnums({ seq }: {
+    readonly seq: number;
+}): VoteOptionScalarOrEnumFields {
+    return {
+        label: getScalarFieldValueGenerator().String({ modelName: "VoteOption", fieldName: "label", isId: false, isUnique: false, seq }),
+        orderIndex: getScalarFieldValueGenerator().Int({ modelName: "VoteOption", fieldName: "orderIndex", isId: false, isUnique: true, seq })
+    };
+}
+
+function defineVoteOptionFactoryInternal<TTransients extends Record<string, unknown>, TOptions extends VoteOptionFactoryDefineOptions<TTransients>>({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }: TOptions, defaultTransientFieldValues: TTransients): VoteOptionFactoryInterface<TTransients, VoteOptionTraitKeys<TOptions>> {
+    const getFactoryWithTraits = (traitKeys: readonly VoteOptionTraitKeys<TOptions>[] = []) => {
+        const seqKey = {};
+        const getSeq = () => getSequenceCounter(seqKey);
+        const screen = createScreener("VoteOption", modelFieldDefinitions);
+        const handleAfterBuild = createCallbackChain([
+            onAfterBuild,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterBuild),
+        ]);
+        const handleBeforeCreate = createCallbackChain([
+            ...traitKeys.slice().reverse().map(traitKey => traitsDefs[traitKey]?.onBeforeCreate),
+            onBeforeCreate,
+        ]);
+        const handleAfterCreate = createCallbackChain([
+            onAfterCreate,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterCreate),
+        ]);
+        const build = async (inputData: Partial<Prisma.VoteOptionCreateInput & TTransients> = {}) => {
+            const seq = getSeq();
+            const requiredScalarData = autoGenerateVoteOptionScalarsOrEnums({ seq });
+            const resolveValue = normalizeResolver<VoteOptionFactoryDefineInput, BuildDataOptions<any>>(defaultDataResolver);
+            const [transientFields, filteredInputData] = destructure(defaultTransientFieldValues, inputData);
+            const resolverInput = { seq, ...transientFields };
+            const defaultData = await traitKeys.reduce(async (queue, traitKey) => {
+                const acc = await queue;
+                const resolveTraitValue = normalizeResolver<Partial<VoteOptionFactoryDefineInput>, BuildDataOptions<TTransients>>(traitsDefs[traitKey]?.data ?? {});
+                const traitData = await resolveTraitValue(resolverInput);
+                return {
+                    ...acc,
+                    ...traitData,
+                };
+            }, resolveValue(resolverInput));
+            const defaultAssociations = {
+                topic: isVoteOptiontopicFactory(defaultData.topic) ? {
+                    create: await defaultData.topic.build()
+                } : defaultData.topic
+            } as Prisma.VoteOptionCreateInput;
+            const data: Prisma.VoteOptionCreateInput = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...filteredInputData };
+            await handleAfterBuild(data, transientFields);
+            return data;
+        };
+        const buildList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.VoteOptionCreateInput & TTransients>>(...args).map(data => build(data)));
+        const pickForConnect = (inputData: VoteOption) => ({
+            id: inputData.id
+        });
+        const create = async (inputData: Partial<Prisma.VoteOptionCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
+            const [transientFields] = destructure(defaultTransientFieldValues, inputData);
+            await handleBeforeCreate(data, transientFields);
+            const createdData = await getClient<PrismaClient>().voteOption.create({ data });
+            await handleAfterCreate(createdData, transientFields);
+            return createdData;
+        };
+        const createList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.VoteOptionCreateInput & TTransients>>(...args).map(data => create(data)));
+        const createForConnect = (inputData: Partial<Prisma.VoteOptionCreateInput & TTransients> = {}) => create(inputData).then(pickForConnect);
+        return {
+            _factoryFor: "VoteOption" as const,
+            build,
+            buildList,
+            buildCreateInput: build,
+            pickForConnect,
+            create,
+            createList,
+            createForConnect,
+        };
+    };
+    const factory = getFactoryWithTraits();
+    const useTraits = (name: VoteOptionTraitKeys<TOptions>, ...names: readonly VoteOptionTraitKeys<TOptions>[]) => {
+        return getFactoryWithTraits([name, ...names]);
+    };
+    return {
+        ...factory,
+        use: useTraits,
+    };
+}
+
+interface VoteOptionFactoryBuilder {
+    <TOptions extends VoteOptionFactoryDefineOptions>(options: TOptions): VoteOptionFactoryInterface<{}, VoteOptionTraitKeys<TOptions>>;
+    withTransientFields: <TTransients extends VoteOptionTransientFields>(defaultTransientFieldValues: TTransients) => <TOptions extends VoteOptionFactoryDefineOptions<TTransients>>(options: TOptions) => VoteOptionFactoryInterface<TTransients, VoteOptionTraitKeys<TOptions>>;
+}
+
+/**
+ * Define factory for {@link VoteOption} model.
+ *
+ * @param options
+ * @returns factory {@link VoteOptionFactoryInterface}
+ */
+export const defineVoteOptionFactory = (<TOptions extends VoteOptionFactoryDefineOptions>(options: TOptions): VoteOptionFactoryInterface<TOptions> => {
+    return defineVoteOptionFactoryInternal(options, {});
+}) as VoteOptionFactoryBuilder;
+
+defineVoteOptionFactory.withTransientFields = defaultTransientFieldValues => options => defineVoteOptionFactoryInternal(options, defaultTransientFieldValues);
+
+type VoteBallotScalarOrEnumFields = {
+    power: number;
+};
+
+type VoteBallotuserFactory = {
+    _factoryFor: "User";
+    build: () => PromiseLike<Prisma.UserCreateNestedOneWithoutVoteBallotsInput["create"]>;
+};
+
+type VoteBallottopicFactory = {
+    _factoryFor: "VoteTopic";
+    build: () => PromiseLike<Prisma.VoteTopicCreateNestedOneWithoutBallotsInput["create"]>;
+};
+
+type VoteBallotoptionFactory = {
+    _factoryFor: "VoteOption";
+    build: () => PromiseLike<Prisma.VoteOptionCreateNestedOneWithoutBallotsInput["create"]>;
+};
+
+type VoteBallotFactoryDefineInput = {
+    id?: string;
+    power?: number;
+    createdAt?: Date;
+    updatedAt?: Date | null;
+    user: VoteBallotuserFactory | Prisma.UserCreateNestedOneWithoutVoteBallotsInput;
+    topic: VoteBallottopicFactory | Prisma.VoteTopicCreateNestedOneWithoutBallotsInput;
+    option: VoteBallotoptionFactory | Prisma.VoteOptionCreateNestedOneWithoutBallotsInput;
+};
+
+type VoteBallotTransientFields = Record<string, unknown> & Partial<Record<keyof VoteBallotFactoryDefineInput, never>>;
+
+type VoteBallotFactoryTrait<TTransients extends Record<string, unknown>> = {
+    data?: Resolver<Partial<VoteBallotFactoryDefineInput>, BuildDataOptions<TTransients>>;
+} & CallbackDefineOptions<VoteBallot, Prisma.VoteBallotCreateInput, TTransients>;
+
+type VoteBallotFactoryDefineOptions<TTransients extends Record<string, unknown> = Record<string, unknown>> = {
+    defaultData: Resolver<VoteBallotFactoryDefineInput, BuildDataOptions<TTransients>>;
+    traits?: {
+        [traitName: string | symbol]: VoteBallotFactoryTrait<TTransients>;
+    };
+} & CallbackDefineOptions<VoteBallot, Prisma.VoteBallotCreateInput, TTransients>;
+
+function isVoteBallotuserFactory(x: VoteBallotuserFactory | Prisma.UserCreateNestedOneWithoutVoteBallotsInput | undefined): x is VoteBallotuserFactory {
+    return (x as any)?._factoryFor === "User";
+}
+
+function isVoteBallottopicFactory(x: VoteBallottopicFactory | Prisma.VoteTopicCreateNestedOneWithoutBallotsInput | undefined): x is VoteBallottopicFactory {
+    return (x as any)?._factoryFor === "VoteTopic";
+}
+
+function isVoteBallotoptionFactory(x: VoteBallotoptionFactory | Prisma.VoteOptionCreateNestedOneWithoutBallotsInput | undefined): x is VoteBallotoptionFactory {
+    return (x as any)?._factoryFor === "VoteOption";
+}
+
+type VoteBallotTraitKeys<TOptions extends VoteBallotFactoryDefineOptions<any>> = Exclude<keyof TOptions["traits"], number>;
+
+export interface VoteBallotFactoryInterfaceWithoutTraits<TTransients extends Record<string, unknown>> {
+    readonly _factoryFor: "VoteBallot";
+    build(inputData?: Partial<Prisma.VoteBallotCreateInput & TTransients>): PromiseLike<Prisma.VoteBallotCreateInput>;
+    buildCreateInput(inputData?: Partial<Prisma.VoteBallotCreateInput & TTransients>): PromiseLike<Prisma.VoteBallotCreateInput>;
+    buildList(list: readonly Partial<Prisma.VoteBallotCreateInput & TTransients>[]): PromiseLike<Prisma.VoteBallotCreateInput[]>;
+    buildList(count: number, item?: Partial<Prisma.VoteBallotCreateInput & TTransients>): PromiseLike<Prisma.VoteBallotCreateInput[]>;
+    pickForConnect(inputData: VoteBallot): Pick<VoteBallot, "id">;
+    create(inputData?: Partial<Prisma.VoteBallotCreateInput & TTransients>): PromiseLike<VoteBallot>;
+    createList(list: readonly Partial<Prisma.VoteBallotCreateInput & TTransients>[]): PromiseLike<VoteBallot[]>;
+    createList(count: number, item?: Partial<Prisma.VoteBallotCreateInput & TTransients>): PromiseLike<VoteBallot[]>;
+    createForConnect(inputData?: Partial<Prisma.VoteBallotCreateInput & TTransients>): PromiseLike<Pick<VoteBallot, "id">>;
+}
+
+export interface VoteBallotFactoryInterface<TTransients extends Record<string, unknown> = Record<string, unknown>, TTraitName extends TraitName = TraitName> extends VoteBallotFactoryInterfaceWithoutTraits<TTransients> {
+    use(name: TTraitName, ...names: readonly TTraitName[]): VoteBallotFactoryInterfaceWithoutTraits<TTransients>;
+}
+
+function autoGenerateVoteBallotScalarsOrEnums({ seq }: {
+    readonly seq: number;
+}): VoteBallotScalarOrEnumFields {
+    return {
+        power: getScalarFieldValueGenerator().Int({ modelName: "VoteBallot", fieldName: "power", isId: false, isUnique: false, seq })
+    };
+}
+
+function defineVoteBallotFactoryInternal<TTransients extends Record<string, unknown>, TOptions extends VoteBallotFactoryDefineOptions<TTransients>>({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }: TOptions, defaultTransientFieldValues: TTransients): VoteBallotFactoryInterface<TTransients, VoteBallotTraitKeys<TOptions>> {
+    const getFactoryWithTraits = (traitKeys: readonly VoteBallotTraitKeys<TOptions>[] = []) => {
+        const seqKey = {};
+        const getSeq = () => getSequenceCounter(seqKey);
+        const screen = createScreener("VoteBallot", modelFieldDefinitions);
+        const handleAfterBuild = createCallbackChain([
+            onAfterBuild,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterBuild),
+        ]);
+        const handleBeforeCreate = createCallbackChain([
+            ...traitKeys.slice().reverse().map(traitKey => traitsDefs[traitKey]?.onBeforeCreate),
+            onBeforeCreate,
+        ]);
+        const handleAfterCreate = createCallbackChain([
+            onAfterCreate,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterCreate),
+        ]);
+        const build = async (inputData: Partial<Prisma.VoteBallotCreateInput & TTransients> = {}) => {
+            const seq = getSeq();
+            const requiredScalarData = autoGenerateVoteBallotScalarsOrEnums({ seq });
+            const resolveValue = normalizeResolver<VoteBallotFactoryDefineInput, BuildDataOptions<any>>(defaultDataResolver);
+            const [transientFields, filteredInputData] = destructure(defaultTransientFieldValues, inputData);
+            const resolverInput = { seq, ...transientFields };
+            const defaultData = await traitKeys.reduce(async (queue, traitKey) => {
+                const acc = await queue;
+                const resolveTraitValue = normalizeResolver<Partial<VoteBallotFactoryDefineInput>, BuildDataOptions<TTransients>>(traitsDefs[traitKey]?.data ?? {});
+                const traitData = await resolveTraitValue(resolverInput);
+                return {
+                    ...acc,
+                    ...traitData,
+                };
+            }, resolveValue(resolverInput));
+            const defaultAssociations = {
+                user: isVoteBallotuserFactory(defaultData.user) ? {
+                    create: await defaultData.user.build()
+                } : defaultData.user,
+                topic: isVoteBallottopicFactory(defaultData.topic) ? {
+                    create: await defaultData.topic.build()
+                } : defaultData.topic,
+                option: isVoteBallotoptionFactory(defaultData.option) ? {
+                    create: await defaultData.option.build()
+                } : defaultData.option
+            } as Prisma.VoteBallotCreateInput;
+            const data: Prisma.VoteBallotCreateInput = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...filteredInputData };
+            await handleAfterBuild(data, transientFields);
+            return data;
+        };
+        const buildList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.VoteBallotCreateInput & TTransients>>(...args).map(data => build(data)));
+        const pickForConnect = (inputData: VoteBallot) => ({
+            id: inputData.id
+        });
+        const create = async (inputData: Partial<Prisma.VoteBallotCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
+            const [transientFields] = destructure(defaultTransientFieldValues, inputData);
+            await handleBeforeCreate(data, transientFields);
+            const createdData = await getClient<PrismaClient>().voteBallot.create({ data });
+            await handleAfterCreate(createdData, transientFields);
+            return createdData;
+        };
+        const createList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.VoteBallotCreateInput & TTransients>>(...args).map(data => create(data)));
+        const createForConnect = (inputData: Partial<Prisma.VoteBallotCreateInput & TTransients> = {}) => create(inputData).then(pickForConnect);
+        return {
+            _factoryFor: "VoteBallot" as const,
+            build,
+            buildList,
+            buildCreateInput: build,
+            pickForConnect,
+            create,
+            createList,
+            createForConnect,
+        };
+    };
+    const factory = getFactoryWithTraits();
+    const useTraits = (name: VoteBallotTraitKeys<TOptions>, ...names: readonly VoteBallotTraitKeys<TOptions>[]) => {
+        return getFactoryWithTraits([name, ...names]);
+    };
+    return {
+        ...factory,
+        use: useTraits,
+    };
+}
+
+interface VoteBallotFactoryBuilder {
+    <TOptions extends VoteBallotFactoryDefineOptions>(options: TOptions): VoteBallotFactoryInterface<{}, VoteBallotTraitKeys<TOptions>>;
+    withTransientFields: <TTransients extends VoteBallotTransientFields>(defaultTransientFieldValues: TTransients) => <TOptions extends VoteBallotFactoryDefineOptions<TTransients>>(options: TOptions) => VoteBallotFactoryInterface<TTransients, VoteBallotTraitKeys<TOptions>>;
+}
+
+/**
+ * Define factory for {@link VoteBallot} model.
+ *
+ * @param options
+ * @returns factory {@link VoteBallotFactoryInterface}
+ */
+export const defineVoteBallotFactory = (<TOptions extends VoteBallotFactoryDefineOptions>(options: TOptions): VoteBallotFactoryInterface<TOptions> => {
+    return defineVoteBallotFactoryInternal(options, {});
+}) as VoteBallotFactoryBuilder;
+
+defineVoteBallotFactory.withTransientFields = defaultTransientFieldValues => options => defineVoteBallotFactoryInternal(options, defaultTransientFieldValues);
 
 type PlacePublicOpportunityCountViewScalarOrEnumFields = {
     currentPublicCount: number;

--- a/src/infrastructure/prisma/migrations/20260415000000_add_vote_domain/migration.sql
+++ b/src/infrastructure/prisma/migrations/20260415000000_add_vote_domain/migration.sql
@@ -72,7 +72,7 @@ CREATE UNIQUE INDEX "t_vote_gates_topic_id_key" ON "t_vote_gates"("topic_id");
 CREATE UNIQUE INDEX "t_vote_power_policies_topic_id_key" ON "t_vote_power_policies"("topic_id");
 
 -- CreateIndex
-CREATE INDEX "t_vote_topics_community_id_ends_at_idx" ON "t_vote_topics"("community_id", "ends_at");
+CREATE INDEX "t_vote_topics_community_id_created_at_id_idx" ON "t_vote_topics"("community_id", "created_at", "id");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "t_vote_options_topic_id_order_index_key" ON "t_vote_options"("topic_id", "order_index");

--- a/src/infrastructure/prisma/migrations/20260415000000_add_vote_domain/migration.sql
+++ b/src/infrastructure/prisma/migrations/20260415000000_add_vote_domain/migration.sql
@@ -1,0 +1,112 @@
+-- CreateEnum
+CREATE TYPE "vote_gate_type" AS ENUM ('NFT', 'MEMBERSHIP');
+
+-- CreateEnum
+CREATE TYPE "vote_power_policy_type" AS ENUM ('FLAT', 'NFT_COUNT');
+
+-- CreateTable
+CREATE TABLE "t_vote_gates" (
+    "id" TEXT NOT NULL,
+    "type" "vote_gate_type" NOT NULL,
+    "nft_token_id" TEXT,
+    "required_role" "Role",
+    "topic_id" TEXT NOT NULL,
+
+    CONSTRAINT "t_vote_gates_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "t_vote_power_policies" (
+    "id" TEXT NOT NULL,
+    "type" "vote_power_policy_type" NOT NULL,
+    "nft_token_id" TEXT,
+    "topic_id" TEXT NOT NULL,
+
+    CONSTRAINT "t_vote_power_policies_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "t_vote_topics" (
+    "id" TEXT NOT NULL,
+    "community_id" TEXT NOT NULL,
+    "created_by" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "starts_at" TIMESTAMP(3) NOT NULL,
+    "ends_at" TIMESTAMP(3) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3),
+
+    CONSTRAINT "t_vote_topics_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "t_vote_options" (
+    "id" TEXT NOT NULL,
+    "topic_id" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "order_index" INTEGER NOT NULL,
+    "vote_count" INTEGER NOT NULL DEFAULT 0,
+    "total_power" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "t_vote_options_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "t_vote_ballots" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "topic_id" TEXT NOT NULL,
+    "option_id" TEXT NOT NULL,
+    "power" INTEGER NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3),
+
+    CONSTRAINT "t_vote_ballots_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "t_vote_gates_topic_id_key" ON "t_vote_gates"("topic_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "t_vote_power_policies_topic_id_key" ON "t_vote_power_policies"("topic_id");
+
+-- CreateIndex
+CREATE INDEX "t_vote_topics_community_id_ends_at_idx" ON "t_vote_topics"("community_id", "ends_at");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "t_vote_options_topic_id_order_index_key" ON "t_vote_options"("topic_id", "order_index");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "t_vote_ballots_user_id_topic_id_key" ON "t_vote_ballots"("user_id", "topic_id");
+
+-- AddForeignKey
+ALTER TABLE "t_vote_gates" ADD CONSTRAINT "t_vote_gates_nft_token_id_fkey" FOREIGN KEY ("nft_token_id") REFERENCES "t_nft_tokens"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "t_vote_gates" ADD CONSTRAINT "t_vote_gates_topic_id_fkey" FOREIGN KEY ("topic_id") REFERENCES "t_vote_topics"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "t_vote_power_policies" ADD CONSTRAINT "t_vote_power_policies_nft_token_id_fkey" FOREIGN KEY ("nft_token_id") REFERENCES "t_nft_tokens"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "t_vote_power_policies" ADD CONSTRAINT "t_vote_power_policies_topic_id_fkey" FOREIGN KEY ("topic_id") REFERENCES "t_vote_topics"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "t_vote_topics" ADD CONSTRAINT "t_vote_topics_community_id_fkey" FOREIGN KEY ("community_id") REFERENCES "t_communities"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "t_vote_topics" ADD CONSTRAINT "t_vote_topics_created_by_fkey" FOREIGN KEY ("created_by") REFERENCES "t_users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "t_vote_options" ADD CONSTRAINT "t_vote_options_topic_id_fkey" FOREIGN KEY ("topic_id") REFERENCES "t_vote_topics"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "t_vote_ballots" ADD CONSTRAINT "t_vote_ballots_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "t_users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "t_vote_ballots" ADD CONSTRAINT "t_vote_ballots_topic_id_fkey" FOREIGN KEY ("topic_id") REFERENCES "t_vote_topics"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "t_vote_ballots" ADD CONSTRAINT "t_vote_ballots_option_id_fkey" FOREIGN KEY ("option_id") REFERENCES "t_vote_options"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -1467,7 +1467,7 @@ model VoteTopic {
   createdAt DateTime  @default(now()) @map("created_at")
   updatedAt DateTime? @updatedAt @map("updated_at")
 
-  @@index([communityId, endsAt])
+  @@index([communityId, createdAt, id])
   @@map("t_vote_topics")
 }
 

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -194,6 +194,7 @@ model Community {
   articles       Article[]
 
   nftInstance NftInstance[]
+  voteTopics  VoteTopic[]
 
   createdAt DateTime  @default(now()) @map("created_at")
   updatedAt DateTime? @updatedAt @map("updated_at")
@@ -381,6 +382,9 @@ model User {
 
   articlesWrittenByMe Article[] @relation("t_author_users_on_articles")
   articlesAboutMe     Article[] @relation("t_related_users_on_articles")
+
+  voteBallots       VoteBallot[]
+  createdVoteTopics VoteTopic[]  @relation("VoteTopicCreatedBy")
 
   createdAt DateTime  @default(now()) @map("created_at")
   updatedAt DateTime? @updatedAt @map("updated_at")
@@ -1276,7 +1280,9 @@ model NftToken {
   symbol String?
   json   Json?
 
-  nftInstances NftInstance[]
+  nftInstances      NftInstance[]
+  voteGates         VoteGate[]
+  votePowerPolicies VotePowerPolicy[]
 
   createdAt DateTime  @default(now()) @map("created_at")
   updatedAt DateTime? @updatedAt @map("updated_at")
@@ -1383,4 +1389,126 @@ model MerkleProof {
   position Position
 
   @@map("t_merkle_proofs")
+}
+
+// ------------------------------ Vote Domain ------------------------------
+
+enum VoteGateType {
+  NFT // 指定NFTを1つ以上保有するユーザーのみ投票可
+  MEMBERSHIP // コミュニティメンバー（指定ロール以上）のみ投票可
+
+  @@map("vote_gate_type")
+}
+
+enum VotePowerPolicyType {
+  FLAT // 1人1票
+  NFT_COUNT // 保有 NftInstance 数 = 票数
+
+  @@map("vote_power_policy_type")
+}
+
+// 投票資格ルール: VoteTopic に従属（topicId FK を持ち Cascade）
+model VoteGate {
+  id   String       @id @default(cuid())
+  type VoteGateType
+
+  // NFT ゲート用: 対象 NftToken.id（type = NFT の場合に必須）
+  nftTokenId String?   @map("nft_token_id")
+  nftToken   NftToken? @relation(fields: [nftTokenId], references: [id], onDelete: Restrict)
+
+  // MEMBERSHIP ゲート用: このロール以上が投票可能（null = MEMBER 以上）
+  requiredRole Role? @map("required_role")
+
+  topicId String    @unique @map("topic_id")
+  topic   VoteTopic @relation(fields: [topicId], references: [id], onDelete: Cascade)
+
+  @@map("t_vote_gates")
+}
+
+// 票数計算ルール: VoteTopic に従属（topicId FK を持ち Cascade）
+model VotePowerPolicy {
+  id   String              @id @default(cuid())
+  type VotePowerPolicyType
+
+  // NFT_COUNT 用: 対象 NftToken.id（type = NFT_COUNT の場合に必須）
+  // MEMBERSHIP gate + NFT_COUNT policy の組み合わせ時も明示が必要
+  nftTokenId String?   @map("nft_token_id")
+  nftToken   NftToken? @relation(fields: [nftTokenId], references: [id], onDelete: Restrict)
+
+  topicId String    @unique @map("topic_id")
+  topic   VoteTopic @relation(fields: [topicId], references: [id], onDelete: Cascade)
+
+  @@map("t_vote_power_policies")
+}
+
+// 投票テーマ
+model VoteTopic {
+  id String @id @default(cuid())
+
+  communityId String    @map("community_id")
+  community   Community @relation(fields: [communityId], references: [id], onDelete: Cascade)
+
+  createdBy     String @map("created_by")
+  createdByUser User   @relation("VoteTopicCreatedBy", fields: [createdBy], references: [id], onDelete: Restrict)
+
+  title       String
+  description String? // Markdown 形式を想定
+
+  startsAt DateTime @map("starts_at")
+  endsAt   DateTime @map("ends_at")
+
+  // VoteGate と VotePowerPolicy は FK 逆転で従属（back-reference）
+  gate        VoteGate?
+  powerPolicy VotePowerPolicy?
+
+  options VoteOption[]
+  ballots VoteBallot[]
+
+  createdAt DateTime  @default(now()) @map("created_at")
+  updatedAt DateTime? @updatedAt @map("updated_at")
+
+  @@index([communityId, endsAt])
+  @@map("t_vote_topics")
+}
+
+// 投票選択肢（集計カラムを非正規化してパフォーマンスを確保）
+model VoteOption {
+  id      String    @id @default(cuid())
+  topicId String    @map("topic_id")
+  topic   VoteTopic @relation(fields: [topicId], references: [id], onDelete: Cascade)
+
+  label      String
+  orderIndex Int    @map("order_index")
+
+  // 非正規化: voteCast のトランザクション内でインクリメント/デクリメント
+  voteCount  Int @default(0) @map("vote_count") // 投票者数
+  totalPower Int @default(0) @map("total_power") // 票数合計
+
+  ballots VoteBallot[]
+
+  @@unique([topicId, orderIndex])
+  @@map("t_vote_options")
+}
+
+// 投票記録（1ユーザー・1テーマに1レコード、再投票は upsert で上書き）
+model VoteBallot {
+  id String @id @default(cuid())
+
+  userId String @map("user_id")
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  topicId String    @map("topic_id")
+  topic   VoteTopic @relation(fields: [topicId], references: [id], onDelete: Cascade)
+
+  optionId String     @map("option_id")
+  option   VoteOption @relation(fields: [optionId], references: [id], onDelete: Cascade)
+
+  // 投票実行時点での計算済み票数（スナップショット）
+  power Int
+
+  createdAt DateTime  @default(now()) @map("created_at")
+  updatedAt DateTime? @updatedAt @map("updated_at")
+
+  @@unique([userId, topicId])
+  @@map("t_vote_ballots")
 }

--- a/src/presentation/graphql/dataloader/domain/vote.ts
+++ b/src/presentation/graphql/dataloader/domain/vote.ts
@@ -1,0 +1,36 @@
+import { PrismaClient } from "@prisma/client";
+import DataLoader from "dataloader";
+import { voteOptionSelect, PrismaVoteOption } from "@/application/domain/vote/data/type";
+
+// VoteOption を id でバッチロード（VoteBallot.option フィールドリゾルバー用）
+export function createVoteOptionLoader(prisma: PrismaClient) {
+  return new DataLoader<string, PrismaVoteOption | null>(async (optionIds) => {
+    const options = await prisma.voteOption.findMany({
+      where: { id: { in: [...optionIds] } },
+      select: voteOptionSelect,
+    });
+    const map = new Map(options.map((o) => [o.id, o]));
+    return optionIds.map((id) => map.get(id) ?? null);
+  });
+}
+
+// NftToken を id でバッチロード（VoteGate / VotePowerPolicy の nftToken フィールドリゾルバー用）
+export function createNftTokenLoader(prisma: PrismaClient) {
+  return new DataLoader<string, { id: string; address: string; name: string | null; symbol: string | null; type: string } | null>(
+    async (tokenIds) => {
+      const tokens = await prisma.nftToken.findMany({
+        where: { id: { in: [...tokenIds] } },
+        select: { id: true, address: true, name: true, symbol: true, type: true },
+      });
+      const map = new Map(tokens.map((t) => [t.id, t]));
+      return tokenIds.map((id) => map.get(id) ?? null);
+    },
+  );
+}
+
+export function createVoteLoaders(prisma: PrismaClient) {
+  return {
+    voteOption: createVoteOptionLoader(prisma),
+    nftToken: createNftTokenLoader(prisma),
+  };
+}

--- a/src/presentation/graphql/dataloader/domain/vote.ts
+++ b/src/presentation/graphql/dataloader/domain/vote.ts
@@ -1,32 +1,8 @@
 import { PrismaClient } from "@prisma/client";
-import DataLoader from "dataloader";
-import { voteOptionSelect, PrismaVoteOption } from "@/application/domain/vote/data/type";
-
-// VoteOption を id でバッチロード（VoteBallot.option フィールドリゾルバー用）
-export function createVoteOptionLoader(prisma: PrismaClient) {
-  return new DataLoader<string, PrismaVoteOption | null>(async (optionIds) => {
-    const options = await prisma.voteOption.findMany({
-      where: { id: { in: [...optionIds] } },
-      select: voteOptionSelect,
-    });
-    const map = new Map(options.map((o) => [o.id, o]));
-    return optionIds.map((id) => map.get(id) ?? null);
-  });
-}
-
-// NftToken を id でバッチロード（VoteGate / VotePowerPolicy の nftToken フィールドリゾルバー用）
-export function createNftTokenLoader(prisma: PrismaClient) {
-  return new DataLoader<string, { id: string; address: string; name: string | null; symbol: string | null; type: string } | null>(
-    async (tokenIds) => {
-      const tokens = await prisma.nftToken.findMany({
-        where: { id: { in: [...tokenIds] } },
-        select: { id: true, address: true, name: true, symbol: true, type: true },
-      });
-      const map = new Map(tokens.map((t) => [t.id, t]));
-      return tokenIds.map((id) => map.get(id) ?? null);
-    },
-  );
-}
+import {
+  createVoteOptionLoader,
+  createNftTokenLoader,
+} from "@/application/domain/vote/controller/dataloader";
 
 export function createVoteLoaders(prisma: PrismaClient) {
   return {

--- a/src/presentation/graphql/dataloader/domain/vote.ts
+++ b/src/presentation/graphql/dataloader/domain/vote.ts
@@ -2,11 +2,13 @@ import { PrismaClient } from "@prisma/client";
 import {
   createVoteOptionLoader,
   createNftTokenLoader,
+  createMyVoteBallotLoader,
 } from "@/application/domain/vote/controller/dataloader";
 
 export function createVoteLoaders(prisma: PrismaClient) {
   return {
     voteOption: createVoteOptionLoader(prisma),
     nftToken: createNftTokenLoader(prisma),
+    myVoteBallot: createMyVoteBallotLoader(prisma),
   };
 }

--- a/src/presentation/graphql/dataloader/index.ts
+++ b/src/presentation/graphql/dataloader/index.ts
@@ -5,6 +5,7 @@ import { createRewardLoaders } from "@/presentation/graphql/dataloader/domain/re
 import { createContentLoaders } from "@/presentation/graphql/dataloader/domain/content";
 import { createTransactionLoaders } from "@/presentation/graphql/dataloader/domain/transaction";
 import { createLocationLoaders } from "@/presentation/graphql/dataloader/domain/location";
+import { createVoteLoaders } from "@/presentation/graphql/dataloader/domain/vote";
 
 export function createLoaders(prisma: PrismaClient) {
   return {
@@ -14,6 +15,7 @@ export function createLoaders(prisma: PrismaClient) {
     ...createContentLoaders(prisma),
     ...createTransactionLoaders(prisma),
     ...createLocationLoaders(prisma),
+    ...createVoteLoaders(prisma),
   };
 }
 

--- a/src/presentation/graphql/resolver.ts
+++ b/src/presentation/graphql/resolver.ts
@@ -25,6 +25,7 @@ import TicketIssuerResolver from "@/application/domain/reward/ticketIssuer/contr
 import VCIssuanceRequestResolver from "@/application/domain/experience/evaluation/vcIssuanceRequest/controller/resolver";
 import MasterResolver from "@/application/domain/location/master/controller/resolver";
 import NftInstanceResolver from "@/application/domain/account/nft-instance/controller/resolver";
+import VoteResolver from "@/application/domain/vote/controller/resolver";
 import scalarResolvers from "@/presentation/graphql/scalar";
 
 const identity = container.resolve(IdentityResolver);
@@ -57,6 +58,7 @@ const utility = container.resolve(UtilityResolver);
 const transaction = container.resolve(TransactionResolver);
 const transactionVerification = container.resolve(TransactionVerificationResolver);
 const incentiveGrant = container.resolve(IncentiveGrantResolver);
+const vote = container.resolve(VoteResolver);
 
 const resolvers = {
   Query: {
@@ -84,6 +86,7 @@ const resolvers = {
     ...transaction.Query,
     ...transactionVerification.Query,
     ...incentiveGrant.Query,
+    ...vote.Query,
   },
   Mutation: {
     ...identity.Mutation,
@@ -101,6 +104,7 @@ const resolvers = {
     ...ticket.Mutation,
     ...transaction.Mutation,
     ...incentiveGrant.Mutation,
+    ...vote.Mutation,
   },
   Identity: identity.Identity,
   User: user.User,
@@ -129,6 +133,11 @@ const resolvers = {
 
   Transaction: transaction.Transaction,
   IncentiveGrant: incentiveGrant.IncentiveGrant,
+
+  VoteTopic: vote.VoteTopic,
+  VoteGate: vote.VoteGate,
+  VotePowerPolicy: vote.VotePowerPolicy,
+  VoteBallot: vote.VoteBallot,
 
   ...scalarResolvers,
 };

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -947,6 +947,9 @@ export type GqlMutation = {
   utilityDelete?: Maybe<GqlUtilityDeletePayload>;
   utilitySetPublishStatus?: Maybe<GqlUtilitySetPublishStatusPayload>;
   utilityUpdateInfo?: Maybe<GqlUtilityUpdateInfoPayload>;
+  voteCast: GqlVoteCastPayload;
+  voteTopicCreate: GqlVoteTopicCreatePayload;
+  voteTopicDelete: GqlVoteTopicDeletePayload;
 };
 
 
@@ -1289,6 +1292,31 @@ export type GqlMutationUtilityUpdateInfoArgs = {
   id: Scalars['ID']['input'];
   input: GqlUtilityUpdateInfoInput;
   permission: GqlCheckCommunityPermissionInput;
+};
+
+
+export type GqlMutationVoteCastArgs = {
+  input: GqlVoteCastInput;
+};
+
+
+export type GqlMutationVoteTopicCreateArgs = {
+  input: GqlVoteTopicCreateInput;
+  permission: GqlCheckCommunityPermissionInput;
+};
+
+
+export type GqlMutationVoteTopicDeleteArgs = {
+  id: Scalars['ID']['input'];
+  permission: GqlCheckCommunityPermissionInput;
+};
+
+export type GqlMyVoteEligibility = {
+  __typename?: 'MyVoteEligibility';
+  currentPower?: Maybe<Scalars['Int']['output']>;
+  eligible: Scalars['Boolean']['output'];
+  myBallot?: Maybe<GqlVoteBallot>;
+  reason?: Maybe<Scalars['String']['output']>;
 };
 
 export type GqlNestedPlaceConnectOrCreateInput = {
@@ -1964,6 +1992,7 @@ export type GqlQuery = {
   incentiveGrants: GqlIncentiveGrantsConnection;
   membership?: Maybe<GqlMembership>;
   memberships: GqlMembershipsConnection;
+  myVoteEligibility: GqlMyVoteEligibility;
   myWallet?: Maybe<GqlWallet>;
   nftInstance?: Maybe<GqlNftInstance>;
   nftInstances: GqlNftInstancesConnection;
@@ -2008,6 +2037,8 @@ export type GqlQuery = {
    * - Returns data integrity verification results
    */
   verifyTransactions?: Maybe<Array<GqlTransactionVerificationResult>>;
+  voteTopic?: Maybe<GqlVoteTopic>;
+  voteTopics: GqlVoteTopicsConnection;
   wallet?: Maybe<GqlWallet>;
   wallets: GqlWalletsConnection;
 };
@@ -2103,6 +2134,11 @@ export type GqlQueryMembershipsArgs = {
   filter?: InputMaybe<GqlMembershipFilterInput>;
   first?: InputMaybe<Scalars['Int']['input']>;
   sort?: InputMaybe<GqlMembershipSortInput>;
+};
+
+
+export type GqlQueryMyVoteEligibilityArgs = {
+  topicId: Scalars['ID']['input'];
 };
 
 
@@ -2337,6 +2373,18 @@ export type GqlQueryVcIssuanceRequestsArgs = {
 
 export type GqlQueryVerifyTransactionsArgs = {
   txIds: Array<Scalars['ID']['input']>;
+};
+
+
+export type GqlQueryVoteTopicArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryVoteTopicsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  communityId: Scalars['ID']['input'];
+  first?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -3164,6 +3212,137 @@ export const GqlVerificationStatus = {
 } as const;
 
 export type GqlVerificationStatus = typeof GqlVerificationStatus[keyof typeof GqlVerificationStatus];
+export type GqlVoteBallot = {
+  __typename?: 'VoteBallot';
+  createdAt: Scalars['Datetime']['output'];
+  id: Scalars['ID']['output'];
+  option: GqlVoteOption;
+  power: Scalars['Int']['output'];
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+};
+
+export type GqlVoteCastInput = {
+  optionId: Scalars['ID']['input'];
+  topicId: Scalars['ID']['input'];
+};
+
+export type GqlVoteCastPayload = {
+  __typename?: 'VoteCastPayload';
+  ballot: GqlVoteBallot;
+};
+
+export type GqlVoteGate = {
+  __typename?: 'VoteGate';
+  id: Scalars['ID']['output'];
+  nftToken?: Maybe<GqlNftToken>;
+  requiredRole?: Maybe<GqlRole>;
+  type: GqlVoteGateType;
+};
+
+export type GqlVoteGateInput = {
+  nftTokenId?: InputMaybe<Scalars['ID']['input']>;
+  requiredRole?: InputMaybe<GqlRole>;
+  type: GqlVoteGateType;
+};
+
+export const GqlVoteGateType = {
+  Membership: 'MEMBERSHIP',
+  Nft: 'NFT'
+} as const;
+
+export type GqlVoteGateType = typeof GqlVoteGateType[keyof typeof GqlVoteGateType];
+export type GqlVoteOption = {
+  __typename?: 'VoteOption';
+  id: Scalars['ID']['output'];
+  label: Scalars['String']['output'];
+  orderIndex: Scalars['Int']['output'];
+  totalPower?: Maybe<Scalars['Int']['output']>;
+  voteCount?: Maybe<Scalars['Int']['output']>;
+};
+
+export type GqlVoteOptionInput = {
+  label: Scalars['String']['input'];
+  orderIndex: Scalars['Int']['input'];
+};
+
+export type GqlVotePowerPolicy = {
+  __typename?: 'VotePowerPolicy';
+  id: Scalars['ID']['output'];
+  nftToken?: Maybe<GqlNftToken>;
+  type: GqlVotePowerPolicyType;
+};
+
+export type GqlVotePowerPolicyInput = {
+  nftTokenId?: InputMaybe<Scalars['ID']['input']>;
+  type: GqlVotePowerPolicyType;
+};
+
+export const GqlVotePowerPolicyType = {
+  Flat: 'FLAT',
+  NftCount: 'NFT_COUNT'
+} as const;
+
+export type GqlVotePowerPolicyType = typeof GqlVotePowerPolicyType[keyof typeof GqlVotePowerPolicyType];
+export type GqlVoteTopic = {
+  __typename?: 'VoteTopic';
+  community: GqlCommunity;
+  createdAt: Scalars['Datetime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  endsAt: Scalars['Datetime']['output'];
+  gate: GqlVoteGate;
+  id: Scalars['ID']['output'];
+  myBallot?: Maybe<GqlVoteBallot>;
+  myEligibility?: Maybe<GqlMyVoteEligibility>;
+  options: Array<GqlVoteOption>;
+  phase: GqlVoteTopicPhase;
+  powerPolicy: GqlVotePowerPolicy;
+  startsAt: Scalars['Datetime']['output'];
+  title: Scalars['String']['output'];
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+};
+
+export type GqlVoteTopicCreateInput = {
+  communityId: Scalars['ID']['input'];
+  description?: InputMaybe<Scalars['String']['input']>;
+  endsAt: Scalars['Datetime']['input'];
+  gate: GqlVoteGateInput;
+  options: Array<GqlVoteOptionInput>;
+  powerPolicy: GqlVotePowerPolicyInput;
+  startsAt: Scalars['Datetime']['input'];
+  title: Scalars['String']['input'];
+};
+
+export type GqlVoteTopicCreatePayload = {
+  __typename?: 'VoteTopicCreatePayload';
+  voteTopic: GqlVoteTopic;
+};
+
+export type GqlVoteTopicDeletePayload = {
+  __typename?: 'VoteTopicDeletePayload';
+  id: Scalars['ID']['output'];
+};
+
+export type GqlVoteTopicEdge = {
+  __typename?: 'VoteTopicEdge';
+  cursor: Scalars['String']['output'];
+  node: GqlVoteTopic;
+};
+
+export const GqlVoteTopicPhase = {
+  Closed: 'CLOSED',
+  Open: 'OPEN',
+  Upcoming: 'UPCOMING'
+} as const;
+
+export type GqlVoteTopicPhase = typeof GqlVoteTopicPhase[keyof typeof GqlVoteTopicPhase];
+export type GqlVoteTopicsConnection = {
+  __typename?: 'VoteTopicsConnection';
+  edges: Array<GqlVoteTopicEdge>;
+  nodes: Array<GqlVoteTopic>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
 export type GqlWallet = {
   __typename?: 'Wallet';
   accumulatedPointView?: Maybe<GqlAccumulatedPointView>;
@@ -3468,6 +3647,7 @@ export type GqlResolversTypes = ResolversObject<{
   MembershipWithdrawSuccess: ResolverTypeWrapper<GqlMembershipWithdrawSuccess>;
   MembershipsConnection: ResolverTypeWrapper<Omit<GqlMembershipsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['MembershipEdge']>>> }>;
   Mutation: ResolverTypeWrapper<{}>;
+  MyVoteEligibility: ResolverTypeWrapper<GqlMyVoteEligibility>;
   NestedPlaceConnectOrCreateInput: GqlNestedPlaceConnectOrCreateInput;
   NestedPlaceCreateInput: GqlNestedPlaceCreateInput;
   NestedPlacesBulkConnectOrCreateInput: GqlNestedPlacesBulkConnectOrCreateInput;
@@ -3679,6 +3859,24 @@ export type GqlResolversTypes = ResolversObject<{
   VcIssuanceRequestsConnection: ResolverTypeWrapper<Omit<GqlVcIssuanceRequestsConnection, 'edges'> & { edges: Array<GqlResolversTypes['VcIssuanceRequestEdge']> }>;
   VcIssuanceStatus: GqlVcIssuanceStatus;
   VerificationStatus: GqlVerificationStatus;
+  VoteBallot: ResolverTypeWrapper<GqlVoteBallot>;
+  VoteCastInput: GqlVoteCastInput;
+  VoteCastPayload: ResolverTypeWrapper<GqlVoteCastPayload>;
+  VoteGate: ResolverTypeWrapper<GqlVoteGate>;
+  VoteGateInput: GqlVoteGateInput;
+  VoteGateType: GqlVoteGateType;
+  VoteOption: ResolverTypeWrapper<GqlVoteOption>;
+  VoteOptionInput: GqlVoteOptionInput;
+  VotePowerPolicy: ResolverTypeWrapper<GqlVotePowerPolicy>;
+  VotePowerPolicyInput: GqlVotePowerPolicyInput;
+  VotePowerPolicyType: GqlVotePowerPolicyType;
+  VoteTopic: ResolverTypeWrapper<Omit<GqlVoteTopic, 'community'> & { community: GqlResolversTypes['Community'] }>;
+  VoteTopicCreateInput: GqlVoteTopicCreateInput;
+  VoteTopicCreatePayload: ResolverTypeWrapper<Omit<GqlVoteTopicCreatePayload, 'voteTopic'> & { voteTopic: GqlResolversTypes['VoteTopic'] }>;
+  VoteTopicDeletePayload: ResolverTypeWrapper<GqlVoteTopicDeletePayload>;
+  VoteTopicEdge: ResolverTypeWrapper<Omit<GqlVoteTopicEdge, 'node'> & { node: GqlResolversTypes['VoteTopic'] }>;
+  VoteTopicPhase: GqlVoteTopicPhase;
+  VoteTopicsConnection: ResolverTypeWrapper<Omit<GqlVoteTopicsConnection, 'edges' | 'nodes'> & { edges: Array<GqlResolversTypes['VoteTopicEdge']>, nodes: Array<GqlResolversTypes['VoteTopic']> }>;
   Wallet: ResolverTypeWrapper<Wallet>;
   WalletEdge: ResolverTypeWrapper<Omit<GqlWalletEdge, 'node'> & { node?: Maybe<GqlResolversTypes['Wallet']> }>;
   WalletFilterInput: GqlWalletFilterInput;
@@ -3805,6 +4003,7 @@ export type GqlResolversParentTypes = ResolversObject<{
   MembershipWithdrawSuccess: GqlMembershipWithdrawSuccess;
   MembershipsConnection: Omit<GqlMembershipsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['MembershipEdge']>>> };
   Mutation: {};
+  MyVoteEligibility: GqlMyVoteEligibility;
   NestedPlaceConnectOrCreateInput: GqlNestedPlaceConnectOrCreateInput;
   NestedPlaceCreateInput: GqlNestedPlaceCreateInput;
   NestedPlacesBulkConnectOrCreateInput: GqlNestedPlacesBulkConnectOrCreateInput;
@@ -3995,6 +4194,21 @@ export type GqlResolversParentTypes = ResolversObject<{
   VcIssuanceRequestFilterInput: GqlVcIssuanceRequestFilterInput;
   VcIssuanceRequestSortInput: GqlVcIssuanceRequestSortInput;
   VcIssuanceRequestsConnection: Omit<GqlVcIssuanceRequestsConnection, 'edges'> & { edges: Array<GqlResolversParentTypes['VcIssuanceRequestEdge']> };
+  VoteBallot: GqlVoteBallot;
+  VoteCastInput: GqlVoteCastInput;
+  VoteCastPayload: GqlVoteCastPayload;
+  VoteGate: GqlVoteGate;
+  VoteGateInput: GqlVoteGateInput;
+  VoteOption: GqlVoteOption;
+  VoteOptionInput: GqlVoteOptionInput;
+  VotePowerPolicy: GqlVotePowerPolicy;
+  VotePowerPolicyInput: GqlVotePowerPolicyInput;
+  VoteTopic: Omit<GqlVoteTopic, 'community'> & { community: GqlResolversParentTypes['Community'] };
+  VoteTopicCreateInput: GqlVoteTopicCreateInput;
+  VoteTopicCreatePayload: Omit<GqlVoteTopicCreatePayload, 'voteTopic'> & { voteTopic: GqlResolversParentTypes['VoteTopic'] };
+  VoteTopicDeletePayload: GqlVoteTopicDeletePayload;
+  VoteTopicEdge: Omit<GqlVoteTopicEdge, 'node'> & { node: GqlResolversParentTypes['VoteTopic'] };
+  VoteTopicsConnection: Omit<GqlVoteTopicsConnection, 'edges' | 'nodes'> & { edges: Array<GqlResolversParentTypes['VoteTopicEdge']>, nodes: Array<GqlResolversParentTypes['VoteTopic']> };
   Wallet: Wallet;
   WalletEdge: Omit<GqlWalletEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['Wallet']> };
   WalletFilterInput: GqlWalletFilterInput;
@@ -4553,6 +4767,17 @@ export type GqlMutationResolvers<ContextType = any, ParentType extends GqlResolv
   utilityDelete?: Resolver<Maybe<GqlResolversTypes['UtilityDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationUtilityDeleteArgs, 'id' | 'permission'>>;
   utilitySetPublishStatus?: Resolver<Maybe<GqlResolversTypes['UtilitySetPublishStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationUtilitySetPublishStatusArgs, 'id' | 'input' | 'permission'>>;
   utilityUpdateInfo?: Resolver<Maybe<GqlResolversTypes['UtilityUpdateInfoPayload']>, ParentType, ContextType, RequireFields<GqlMutationUtilityUpdateInfoArgs, 'id' | 'input' | 'permission'>>;
+  voteCast?: Resolver<GqlResolversTypes['VoteCastPayload'], ParentType, ContextType, RequireFields<GqlMutationVoteCastArgs, 'input'>>;
+  voteTopicCreate?: Resolver<GqlResolversTypes['VoteTopicCreatePayload'], ParentType, ContextType, RequireFields<GqlMutationVoteTopicCreateArgs, 'input' | 'permission'>>;
+  voteTopicDelete?: Resolver<GqlResolversTypes['VoteTopicDeletePayload'], ParentType, ContextType, RequireFields<GqlMutationVoteTopicDeleteArgs, 'id' | 'permission'>>;
+}>;
+
+export type GqlMyVoteEligibilityResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['MyVoteEligibility'] = GqlResolversParentTypes['MyVoteEligibility']> = ResolversObject<{
+  currentPower?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  eligible?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  myBallot?: Resolver<Maybe<GqlResolversTypes['VoteBallot']>, ParentType, ContextType>;
+  reason?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
 export type GqlNftInstanceResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['NftInstance'] = GqlResolversParentTypes['NftInstance']> = ResolversObject<{
@@ -4939,6 +5164,7 @@ export type GqlQueryResolvers<ContextType = any, ParentType extends GqlResolvers
   incentiveGrants?: Resolver<GqlResolversTypes['IncentiveGrantsConnection'], ParentType, ContextType, Partial<GqlQueryIncentiveGrantsArgs>>;
   membership?: Resolver<Maybe<GqlResolversTypes['Membership']>, ParentType, ContextType, RequireFields<GqlQueryMembershipArgs, 'communityId' | 'userId'>>;
   memberships?: Resolver<GqlResolversTypes['MembershipsConnection'], ParentType, ContextType, Partial<GqlQueryMembershipsArgs>>;
+  myVoteEligibility?: Resolver<GqlResolversTypes['MyVoteEligibility'], ParentType, ContextType, RequireFields<GqlQueryMyVoteEligibilityArgs, 'topicId'>>;
   myWallet?: Resolver<Maybe<GqlResolversTypes['Wallet']>, ParentType, ContextType>;
   nftInstance?: Resolver<Maybe<GqlResolversTypes['NftInstance']>, ParentType, ContextType, RequireFields<GqlQueryNftInstanceArgs, 'id'>>;
   nftInstances?: Resolver<GqlResolversTypes['NftInstancesConnection'], ParentType, ContextType, Partial<GqlQueryNftInstancesArgs>>;
@@ -4976,6 +5202,8 @@ export type GqlQueryResolvers<ContextType = any, ParentType extends GqlResolvers
   vcIssuanceRequest?: Resolver<Maybe<GqlResolversTypes['VcIssuanceRequest']>, ParentType, ContextType, RequireFields<GqlQueryVcIssuanceRequestArgs, 'id'>>;
   vcIssuanceRequests?: Resolver<GqlResolversTypes['VcIssuanceRequestsConnection'], ParentType, ContextType, Partial<GqlQueryVcIssuanceRequestsArgs>>;
   verifyTransactions?: Resolver<Maybe<Array<GqlResolversTypes['TransactionVerificationResult']>>, ParentType, ContextType, RequireFields<GqlQueryVerifyTransactionsArgs, 'txIds'>>;
+  voteTopic?: Resolver<Maybe<GqlResolversTypes['VoteTopic']>, ParentType, ContextType, RequireFields<GqlQueryVoteTopicArgs, 'id'>>;
+  voteTopics?: Resolver<GqlResolversTypes['VoteTopicsConnection'], ParentType, ContextType, RequireFields<GqlQueryVoteTopicsArgs, 'communityId'>>;
   wallet?: Resolver<Maybe<GqlResolversTypes['Wallet']>, ParentType, ContextType, RequireFields<GqlQueryWalletArgs, 'id'>>;
   wallets?: Resolver<GqlResolversTypes['WalletsConnection'], ParentType, ContextType, Partial<GqlQueryWalletsArgs>>;
 }>;
@@ -5455,6 +5683,86 @@ export type GqlVcIssuanceRequestsConnectionResolvers<ContextType = any, ParentTy
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type GqlVoteBallotResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VoteBallot'] = GqlResolversParentTypes['VoteBallot']> = ResolversObject<{
+  createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  option?: Resolver<GqlResolversTypes['VoteOption'], ParentType, ContextType>;
+  power?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVoteCastPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VoteCastPayload'] = GqlResolversParentTypes['VoteCastPayload']> = ResolversObject<{
+  ballot?: Resolver<GqlResolversTypes['VoteBallot'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVoteGateResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VoteGate'] = GqlResolversParentTypes['VoteGate']> = ResolversObject<{
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  nftToken?: Resolver<Maybe<GqlResolversTypes['NftToken']>, ParentType, ContextType>;
+  requiredRole?: Resolver<Maybe<GqlResolversTypes['Role']>, ParentType, ContextType>;
+  type?: Resolver<GqlResolversTypes['VoteGateType'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVoteOptionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VoteOption'] = GqlResolversParentTypes['VoteOption']> = ResolversObject<{
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  label?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  orderIndex?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  totalPower?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  voteCount?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVotePowerPolicyResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VotePowerPolicy'] = GqlResolversParentTypes['VotePowerPolicy']> = ResolversObject<{
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  nftToken?: Resolver<Maybe<GqlResolversTypes['NftToken']>, ParentType, ContextType>;
+  type?: Resolver<GqlResolversTypes['VotePowerPolicyType'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVoteTopicResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VoteTopic'] = GqlResolversParentTypes['VoteTopic']> = ResolversObject<{
+  community?: Resolver<GqlResolversTypes['Community'], ParentType, ContextType>;
+  createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  description?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  endsAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  gate?: Resolver<GqlResolversTypes['VoteGate'], ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  myBallot?: Resolver<Maybe<GqlResolversTypes['VoteBallot']>, ParentType, ContextType>;
+  myEligibility?: Resolver<Maybe<GqlResolversTypes['MyVoteEligibility']>, ParentType, ContextType>;
+  options?: Resolver<Array<GqlResolversTypes['VoteOption']>, ParentType, ContextType>;
+  phase?: Resolver<GqlResolversTypes['VoteTopicPhase'], ParentType, ContextType>;
+  powerPolicy?: Resolver<GqlResolversTypes['VotePowerPolicy'], ParentType, ContextType>;
+  startsAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  title?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVoteTopicCreatePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VoteTopicCreatePayload'] = GqlResolversParentTypes['VoteTopicCreatePayload']> = ResolversObject<{
+  voteTopic?: Resolver<GqlResolversTypes['VoteTopic'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVoteTopicDeletePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VoteTopicDeletePayload'] = GqlResolversParentTypes['VoteTopicDeletePayload']> = ResolversObject<{
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVoteTopicEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VoteTopicEdge'] = GqlResolversParentTypes['VoteTopicEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<GqlResolversTypes['VoteTopic'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVoteTopicsConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VoteTopicsConnection'] = GqlResolversParentTypes['VoteTopicsConnection']> = ResolversObject<{
+  edges?: Resolver<Array<GqlResolversTypes['VoteTopicEdge']>, ParentType, ContextType>;
+  nodes?: Resolver<Array<GqlResolversTypes['VoteTopic']>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type GqlWalletResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Wallet'] = GqlResolversParentTypes['Wallet']> = ResolversObject<{
   accumulatedPointView?: Resolver<Maybe<GqlResolversTypes['AccumulatedPointView']>, ParentType, ContextType>;
   community?: Resolver<Maybe<GqlResolversTypes['Community']>, ParentType, ContextType>;
@@ -5554,6 +5862,7 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   MembershipWithdrawSuccess?: GqlMembershipWithdrawSuccessResolvers<ContextType>;
   MembershipsConnection?: GqlMembershipsConnectionResolvers<ContextType>;
   Mutation?: GqlMutationResolvers<ContextType>;
+  MyVoteEligibility?: GqlMyVoteEligibilityResolvers<ContextType>;
   NftInstance?: GqlNftInstanceResolvers<ContextType>;
   NftInstanceEdge?: GqlNftInstanceEdgeResolvers<ContextType>;
   NftInstancesConnection?: GqlNftInstancesConnectionResolvers<ContextType>;
@@ -5675,6 +5984,16 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   VcIssuanceRequest?: GqlVcIssuanceRequestResolvers<ContextType>;
   VcIssuanceRequestEdge?: GqlVcIssuanceRequestEdgeResolvers<ContextType>;
   VcIssuanceRequestsConnection?: GqlVcIssuanceRequestsConnectionResolvers<ContextType>;
+  VoteBallot?: GqlVoteBallotResolvers<ContextType>;
+  VoteCastPayload?: GqlVoteCastPayloadResolvers<ContextType>;
+  VoteGate?: GqlVoteGateResolvers<ContextType>;
+  VoteOption?: GqlVoteOptionResolvers<ContextType>;
+  VotePowerPolicy?: GqlVotePowerPolicyResolvers<ContextType>;
+  VoteTopic?: GqlVoteTopicResolvers<ContextType>;
+  VoteTopicCreatePayload?: GqlVoteTopicCreatePayloadResolvers<ContextType>;
+  VoteTopicDeletePayload?: GqlVoteTopicDeletePayloadResolvers<ContextType>;
+  VoteTopicEdge?: GqlVoteTopicEdgeResolvers<ContextType>;
+  VoteTopicsConnection?: GqlVoteTopicsConnectionResolvers<ContextType>;
   Wallet?: GqlWalletResolvers<ContextType>;
   WalletEdge?: GqlWalletEdgeResolvers<ContextType>;
   WalletsConnection?: GqlWalletsConnectionResolvers<ContextType>;

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -2382,8 +2382,8 @@ export type GqlQueryVoteTopicArgs = {
 
 
 export type GqlQueryVoteTopicsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
   communityId: Scalars['ID']['input'];
+  cursor?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
 };
 


### PR DESCRIPTION
## 概要

コミュニティのガバナンス機能として投票ドメインを新設する。
管理者が「誰が・何票で・いつまで」投票できるかを柔軟に設定でき、
メンバーはトピックに対して投票・再投票できる。

---

## 背景・設計判断

### FK 方向（VoteGate / VotePowerPolicy）

`VoteGate.topicId → VoteTopic.id`（逆向き FK）を採用。
`onDelete: Cascade` により、VoteTopic 削除時に gate / powerPolicy / options / ballots が自動削除される。

### VoteOption への非正規化カラム（voteCount / totalPower）

集計は `GROUP BY` クエリではなく `voteOption.voteCount` / `totalPower` に直接書き込む。
投票・再投票のたびにトランザクション内でインクリメント／デクリメントし、参照コストを O(1) に抑える。

### 再投票時のレースコンディション対策

同一 `(userId, topicId)` への並行投票を `pg_advisory_xact_lock` でシリアライズ。
`@@unique([userId, topicId])` との二重防御で voteCount の二重加算を防ぐ。

### 結果公開ルール

- `endsAt` 到達前：voteCount / totalPower は `null`（一般ユーザー）
- `endsAt` 到達後 または 管理者：実値を返す

---

## API

### Queries

| クエリ | 説明 |
|---|---|
| `voteTopics(communityId, first, after)` | コミュニティの投票一覧（カーソルページネーション） |
| `voteTopic(id)` | 投票トピック単件取得 |
| `myVoteEligibility(topicId)` | ログインユーザーの投票資格・現在票数・投票済みバレット |

### Mutations

| ミューテーション | 権限 | 説明 |
|---|---|---|
| `voteTopicCreate(input, permission)` | MANAGER 以上 | トピック・ゲート・ポリシー・選択肢を一括作成 |
| `voteCast(input)` | ログイン済み | 投票（再投票は upsert で上書き、資格を毎回再チェック） |
| `voteTopicDelete(id, permission)` | MANAGER 以上 | トピックと関連レコードを cascade 削除 |

### ゲート / ポリシー

| 種別 | 説明 |
|---|---|
| Gate: `MEMBERSHIP` | 指定ロール以上の JOINED メンバーのみ投票可 |
| Gate: `NFT` | 指定 NftToken を 1 枚以上保有するユーザーのみ投票可 |
| Policy: `FLAT` | 1人1票 |
| Policy: `NFT_COUNT` | 保有 NftInstance 数 = 票数（投票時点のスナップショット） |

---

## 変更ファイル

**新設（vote ドメイン）**
- `src/application/domain/vote/` — usecase / service / presenter / converter / repository / resolver / dataloader / schema

**既存ファイルへの追加**
- `schema.prisma` — VoteTopic / VoteGate / VotePowerPolicy / VoteOption / VoteBallot の 5 モデル
- `nft-instance/data/repository.ts` — `existsByUserAndToken` / `countByUserAndToken` を追加
- `domain/utils.ts` — `isRoleAtLeast()` を追加（ロール階層判定を共有化）
- `application/provider.ts` — Vote ドメインの DI 登録
- `presentation/graphql/resolver.ts` — VoteResolver の登録

---

## テスト

設計表（ユースケース × 条件 × 期待結果）を先に作成し、全コードブランチを網羅したうえで実装。

| ファイル | テスト数 | 主なカバレッジ |
|---|---|---|
| `voteTopicCreate.test.ts` | 10 | 入力バリデーション全分岐、NFT ゲート成功ケース |
| `voteCast.test.ts` | 22 | ゲート種別・ポリシー種別・再投票分岐（A→B / B→A / delta±）・期間外・power=0 |
| `voteQuery.test.ts` | 17 | フェーズ・ページネーション・結果マスキング・eligibility |
| `voteTopicDelete.test.ts` | 4 | 成功・別コミュニティ・存在しない ID・cascade 削除確認 |
| `vote.service.test.ts` | — | サービス層ユニットテスト |

```bash
pnpm test src/__tests__/integration/vote/ --runInBand
# → 51 passed
```
