### PR TITLE
fix: address review comments on transaction chain

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -1909,9 +1909,9 @@ type TicketsConnection {
 
 type Transaction {
   """
-  ポイントの旅の全ステップを返します。
-  親トランザクションの探索自体は再帰CTEによる単一クエリで行われますが、
-  transactions などのリスト取得で chain を要求すると、各 Transaction ごとにこの再帰クエリが実行されるため高コストになりえます。
+  ポイントの旅のステップを返します（最大10段階）。
+  再帰CTEによる単一クエリで取得しますが、循環・異常データ対策のため深さ上限を10としています。
+  transactions などのリスト取得で chain を要求すると、各 Transaction ごとにこのクエリが実行されるため高コストになりえます。
   transaction(id) での単体取得時のみ使用し、深さだけ必要な場合は chainDepth を使用してください。
   """
   chain: TransactionChain

--- a/src/application/domain/transaction/data/repository.ts
+++ b/src/application/domain/transaction/data/repository.ts
@@ -36,7 +36,7 @@ export default class TransactionRepository implements ITransactionRepository {
   }
 
   async findLatestReceivedTx(
-    ctx: IContext,
+    _ctx: IContext,
     walletId: string,
     tx: Prisma.TransactionClient,
   ): Promise<{ id: string; chainDepth: number | null } | null> {

--- a/src/application/domain/transaction/schema/type.graphql
+++ b/src/application/domain/transaction/schema/type.graphql
@@ -21,9 +21,9 @@ type Transaction {
   createdByUser: User
 
   """
-  ポイントの旅の全ステップを返します。
-  親トランザクションの探索自体は再帰CTEによる単一クエリで行われますが、
-  transactions などのリスト取得で chain を要求すると、各 Transaction ごとにこの再帰クエリが実行されるため高コストになりえます。
+  ポイントの旅のステップを返します（最大10段階）。
+  再帰CTEによる単一クエリで取得しますが、循環・異常データ対策のため深さ上限を10としています。
+  transactions などのリスト取得で chain を要求すると、各 Transaction ごとにこのクエリが実行されるため高コストになりえます。
   transaction(id) での単体取得時のみ使用し、深さだけ必要な場合は chainDepth を使用してください。
   """
   chain: TransactionChain

--- a/src/application/domain/transaction/service.ts
+++ b/src/application/domain/transaction/service.ts
@@ -86,7 +86,7 @@ export default class TransactionService implements ITransactionService {
   ): Promise<PrismaTransactionDetail> {
     const currentUserId = getCurrentUserId(ctx);
     const parentTx = await this.repository.findLatestReceivedTx(ctx, fromWalletId, tx);
-    const chainDepth = (parentTx?.chainDepth ?? 0) + 1;
+    const chainDepth = parentTx ? (parentTx.chainDepth ?? 0) + 1 : undefined;
     const data = this.converter.donateSelfPoint(fromWalletId, toWalletId, transferPoints, currentUserId, comment, parentTx?.id, chainDepth, uploadedImages);
     return this.repository.create(ctx, data, tx);
   }
@@ -116,7 +116,7 @@ export default class TransactionService implements ITransactionService {
   ): Promise<PrismaTransactionDetail> {
     const currentUserId = getCurrentUserId(ctx);
     const parentTx = await this.repository.findLatestReceivedTx(ctx, fromWalletId, tx);
-    const chainDepth = (parentTx?.chainDepth ?? 0) + 1;
+    const chainDepth = parentTx ? (parentTx.chainDepth ?? 0) + 1 : undefined;
     const data = this.converter.giveRewardPoint(
       fromWalletId,
       toWalletId,

--- a/src/infrastructure/prisma/migrations/20260415000000_add_parent_tx_id/migration.sql
+++ b/src/infrastructure/prisma/migrations/20260415000000_add_parent_tx_id/migration.sql
@@ -25,7 +25,7 @@ ALTER TABLE "t_transactions" ADD COLUMN "chain_depth" INTEGER;
 
 -- Backfill chain_depth via recursive CTE traversal from GRANT roots
 WITH RECURSIVE depth_calc AS (
-  -- Base: GRANT (root) and any orphaned DONATION/POINT_REWARD with no parent
+  -- Base: GRANT のみをチェーンの根（depth=1）として扱う
   SELECT id, 1 AS depth
   FROM "t_transactions"
   WHERE reason = 'GRANT'

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -2761,9 +2761,9 @@ export type GqlTicketsConnection = {
 export type GqlTransaction = {
   __typename?: 'Transaction';
   /**
-   * ポイントの旅の全ステップを返します。
-   * 親トランザクションの探索自体は再帰CTEによる単一クエリで行われますが、
-   * transactions などのリスト取得で chain を要求すると、各 Transaction ごとにこの再帰クエリが実行されるため高コストになりえます。
+   * ポイントの旅のステップを返します（最大10段階）。
+   * 再帰CTEによる単一クエリで取得しますが、循環・異常データ対策のため深さ上限を10としています。
+   * transactions などのリスト取得で chain を要求すると、各 Transaction ごとにこのクエリが実行されるため高コストになりえます。
    * transaction(id) での単体取得時のみ使用し、深さだけ必要な場合は chainDepth を使用してください。
    */
   chain?: Maybe<GqlTransactionChain>;


### PR DESCRIPTION
- chainDepth: set to undefined (not 1) when parentTx not found, so DONATION/POINT_REWARD without a chain root stay NULL
- findLatestReceivedTx: rename ctx to _ctx (unused parameter)
- migration comment: remove incorrect "orphaned DONATION/POINT_REWARD" note; only GRANT is the base case in the original backfill
- chain field description: clarify 10-step depth limit and its purpose (guard against cyclic/corrupted data)

https://claude.ai/code/session_01KhjSpPLeSPAsED4MR44gdo
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
