### PR TITLE
Add bio field to TransactionChainUser type

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -1950,6 +1950,7 @@ type TransactionChainStep {
 }
 
 type TransactionChainUser {
+  bio: String
   id: ID!
   image: String
   name: String!

--- a/src/application/domain/transaction/data/repository.ts
+++ b/src/application/domain/transaction/data/repository.ts
@@ -73,9 +73,11 @@ export default class TransactionRepository implements ITransactionRepository {
           fu.id   AS from_user_id,
           fu.name AS from_user_name,
           fi.url  AS from_user_image,
+          fu.bio  AS from_user_bio,
           tu.id   AS to_user_id,
           tu.name AS to_user_name,
-          ti.url  AS to_user_image
+          ti.url  AS to_user_image,
+          tu.bio  AS to_user_bio
         FROM chain c
         LEFT JOIN t_wallets fw ON fw.id = c."from"
         LEFT JOIN t_users   fu ON fu.id = fw.user_id

--- a/src/application/domain/transaction/data/type.ts
+++ b/src/application/domain/transaction/data/type.ts
@@ -46,7 +46,9 @@ export type TransactionChainRow = {
   from_user_id: string | null;
   from_user_name: string | null;
   from_user_image: string | null;
+  from_user_bio: string | null;
   to_user_id: string | null;
   to_user_name: string | null;
   to_user_image: string | null;
+  to_user_bio: string | null;
 };

--- a/src/application/domain/transaction/presenter.ts
+++ b/src/application/domain/transaction/presenter.ts
@@ -79,6 +79,7 @@ export default class TransactionPresenter {
               id: row.from_user_id,
               name: row.from_user_name ?? "",
               image: row.from_user_image ?? null,
+              bio: row.from_user_bio ?? null,
             }
           : null,
         toUser: row.to_user_id
@@ -87,6 +88,7 @@ export default class TransactionPresenter {
               id: row.to_user_id,
               name: row.to_user_name ?? "",
               image: row.to_user_image ?? null,
+              bio: row.to_user_bio ?? null,
             }
           : null,
       })),

--- a/src/application/domain/transaction/schema/type.graphql
+++ b/src/application/domain/transaction/schema/type.graphql
@@ -52,6 +52,7 @@ type TransactionChainUser {
   id: ID!
   name: String!
   image: String
+  bio: String
 }
 
 # ------------------------------

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -2808,6 +2808,7 @@ export type GqlTransactionChainStep = {
 
 export type GqlTransactionChainUser = {
   __typename?: 'TransactionChainUser';
+  bio?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   image?: Maybe<Scalars['String']['output']>;
   name: Scalars['String']['output'];
@@ -5297,6 +5298,7 @@ export type GqlTransactionChainStepResolvers<ContextType = any, ParentType exten
 }>;
 
 export type GqlTransactionChainUserResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TransactionChainUser'] = GqlResolversParentTypes['TransactionChainUser']> = ResolversObject<{
+  bio?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
   image?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   name?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;


### PR DESCRIPTION
## Summary
This PR adds the `bio` field to the `TransactionChainUser` GraphQL type, allowing transaction chain data to include user biography information for both sender and recipient users.

## Key Changes
- **Database Query**: Updated the transaction repository SQL query to select the `bio` field from both `from_user` and `to_user` tables
- **Type Definitions**: Extended `TransactionChainRow` type to include `from_user_bio` and `to_user_bio` fields
- **Presenter Layer**: Modified the transaction presenter to map bio data from database rows to the response objects for both `fromUser` and `toUser`
- **GraphQL Schema**: 
  - Added `bio: String` field to `TransactionChainUser` type in the schema definition
  - Updated generated TypeScript types and resolvers to include the bio field

## Implementation Details
The bio field is optional (nullable) throughout the stack, maintaining backward compatibility. The field is populated from the user's bio column in the database and flows through the repository → presenter → GraphQL resolver chain.

https://claude.ai/code/session_01Q3CZ4qG6xgoTGTJVxNMa3j
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/813" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
