### PR TITLE
Add parentTx and childTxs relationships to t_wallets schema

### DIFF
--- a/docs/schema.dbml
+++ b/docs/schema.dbml
@@ -562,6 +562,8 @@ Table t_transactions {
   toWallet t_wallets
   toPointChange Int [not null]
   parentTxId String
+  parentTx t_transactions
+  childTxs t_transactions [not null]
   chainDepth Int
   participationId String
   participation t_participations


### PR DESCRIPTION
### Summary

This pull request updates the `schema.dbml` file to add `parentTx` and `childTxs` relationships to the `t_wallets` table. These relationships aim to enhance the schema by directly referencing parent-child transaction relationships, improving structural integrity and supporting better data consistency.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/814" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
