### PR TITLE
Add transaction report views and AI-facing report generation

### DIFF
--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -948,15 +948,6 @@ NFT_COUNT NFT_COUNT
     }
   
 
-  "mv_transaction_active_users_daily" {
-    DateTime date "🗝️"
-    String communityId "🗝️"
-    Int activeUsers 
-    Int senders 
-    Int receivers 
-    }
-  
-
   "mv_user_transaction_daily" {
     DateTime date "🗝️"
     String communityId "🗝️"

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -868,6 +868,76 @@ RIGHT RIGHT
     }
   
 
+  "mv_transaction_summary_daily" {
+    DateTime date "🗝️"
+    String communityId "🗝️"
+    TransactionReason reason "🗝️"
+    Int txCount 
+    BigInt pointsSum 
+    Int chainRootCount 
+    Int chainDescendantCount 
+    Int maxChainDepth "❓"
+    Int sumChainDepth 
+    Int issuanceCount 
+    Int burnCount 
+    }
+  
+
+  "mv_transaction_active_users_daily" {
+    DateTime date "🗝️"
+    String communityId "🗝️"
+    Int activeUsers 
+    Int senders 
+    Int receivers 
+    }
+  
+
+  "mv_user_transaction_daily" {
+    DateTime date "🗝️"
+    String communityId "🗝️"
+    String userId "🗝️"
+    String walletId "🗝️"
+    Int txCountIn 
+    Int txCountOut 
+    BigInt pointsIn 
+    BigInt pointsOut 
+    Int donationOutCount 
+    BigInt donationOutPoints 
+    Int receivedDonationCount 
+    Int chainRootCount 
+    Int maxChainDepthStarted "❓"
+    Int chainDepthReachedMax "❓"
+    Int uniqueCounterparties 
+    }
+  
+
+  "v_transaction_comments" {
+    String transactionId "🗝️"
+    DateTime date 
+    DateTime createdAt 
+    String communityId 
+    String fromUserId "❓"
+    String toUserId "❓"
+    String createdByUserId "❓"
+    TransactionReason reason 
+    Int points 
+    String comment 
+    Int chainDepth "❓"
+    }
+  
+
+  "v_user_profile_for_report" {
+    String userId "🗝️"
+    String communityId "🗝️"
+    String name 
+    String userBio "❓"
+    String membershipBio "❓"
+    String headline "❓"
+    Role role 
+    DateTime joinedAt 
+    }
+  
+
   "v_earliest_reservable_slot" {
     String opportunityId "🗝️"
     DateTime earliestReservableAt "❓"
@@ -1104,6 +1174,9 @@ RIGHT RIGHT
     "v_membership_hosted_opportunity_count" o|--|| "t_memberships" : "membership"
     "mv_current_points" o|--|| "t_wallets" : "wallet"
     "mv_accumulated_points" o|--|| "t_wallets" : "wallet"
+    "mv_transaction_summary_daily" o|--|| "TransactionReason" : "enum:reason"
+    "v_transaction_comments" o|--|| "TransactionReason" : "enum:reason"
+    "v_user_profile_for_report" o|--|| "Role" : "enum:role"
     "v_earliest_reservable_slot" o|--|| "t_opportunities" : "opportunity"
     "v_opportunity_accumulated_participants" o|--|| "t_opportunities" : "opportunity"
     "v_slot_remaining_capacity" o|--|| "t_opportunity_slots" : "slot"

--- a/docs/schema.dbml
+++ b/docs/schema.dbml
@@ -848,18 +848,6 @@ Table mv_transaction_summary_daily {
   }
 }
 
-Table mv_transaction_active_users_daily {
-  date DateTime [not null]
-  communityId String [not null]
-  activeUsers Int [not null]
-  senders Int [not null]
-  receivers Int [not null]
-
-  indexes {
-    (date, communityId) [pk]
-  }
-}
-
 Table mv_user_transaction_daily {
   date DateTime [not null]
   communityId String [not null]

--- a/docs/schema.dbml
+++ b/docs/schema.dbml
@@ -562,6 +562,8 @@ Table t_transactions {
   toWallet t_wallets
   toPointChange Int [not null]
   parentTxId String
+  parentTx t_transactions
+  childTxs t_transactions [not null]
   chainDepth Int
   participationId String
   participation t_participations
@@ -752,6 +754,87 @@ Table mv_accumulated_points {
   walletId String [pk]
   wallet t_wallets [not null]
   accumulatedPoint BigInt [not null]
+}
+
+Table mv_transaction_summary_daily {
+  date DateTime [not null]
+  communityId String [not null]
+  reason TransactionReason [not null]
+  txCount Int [not null]
+  pointsSum BigInt [not null]
+  chainRootCount Int [not null]
+  chainDescendantCount Int [not null]
+  maxChainDepth Int
+  sumChainDepth Int [not null]
+  issuanceCount Int [not null]
+  burnCount Int [not null]
+
+  indexes {
+    (date, communityId, reason) [pk]
+  }
+}
+
+Table mv_transaction_active_users_daily {
+  date DateTime [not null]
+  communityId String [not null]
+  activeUsers Int [not null]
+  senders Int [not null]
+  receivers Int [not null]
+
+  indexes {
+    (date, communityId) [pk]
+  }
+}
+
+Table mv_user_transaction_daily {
+  date DateTime [not null]
+  communityId String [not null]
+  userId String [not null]
+  walletId String [not null]
+  txCountIn Int [not null]
+  txCountOut Int [not null]
+  pointsIn BigInt [not null]
+  pointsOut BigInt [not null]
+  donationOutCount Int [not null]
+  donationOutPoints BigInt [not null]
+  receivedDonationCount Int [not null]
+  chainRootCount Int [not null]
+  maxChainDepthStarted Int
+  chainDepthReachedMax Int
+  uniqueCounterparties Int [not null]
+
+  indexes {
+    (date, communityId, userId, walletId) [pk]
+  }
+}
+
+Table v_transaction_comments {
+  transactionId String [pk]
+  date DateTime [not null]
+  createdAt DateTime [not null]
+  communityId String [not null]
+  fromUserId String
+  toUserId String
+  createdByUserId String
+  reason TransactionReason [not null]
+  points Int [not null]
+  comment String [not null]
+  chainDepth Int
+}
+
+Table v_user_profile_for_report {
+  userId String [not null]
+  communityId String [not null]
+  name String [not null]
+  userBio String
+  membershipBio String
+  headline String
+  role Role [not null]
+  joinedAt DateTime [not null]
+
+  indexes {
+    (userId, communityId) [pk]
+  }
 }
 
 Table v_earliest_reservable_slot {

--- a/src/application/domain/report/data/interface.ts
+++ b/src/application/domain/report/data/interface.ts
@@ -41,6 +41,27 @@ export interface UserTransactionDailyRow {
   uniqueCounterparties: number;
 }
 
+/**
+ * Per-user aggregate across the reporting window, produced via Prisma
+ * `groupBy` on UserTransactionDailyView in the repository. BigInt sums come
+ * through unchanged from the aggregate; the presenter converts them via the
+ * safe-integer guard at the payload boundary.
+ */
+export interface UserTransactionAggregateRow {
+  userId: string;
+  txCountIn: number;
+  txCountOut: number;
+  pointsIn: bigint;
+  pointsOut: bigint;
+  donationOutCount: number;
+  donationOutPoints: bigint;
+  receivedDonationCount: number;
+  chainRootCount: number;
+  maxChainDepthStarted: number | null;
+  chainDepthReachedMax: number | null;
+  uniqueCounterpartiesSum: number;
+}
+
 export interface TransactionCommentRow {
   transactionId: string;
   date: Date;
@@ -84,11 +105,11 @@ export interface IReportRepository {
     range: DateRange,
   ): Promise<TransactionActiveUsersDailyRow[]>;
 
-  findDailyUserTransactions(
+  findUserAggregatedInRange(
     ctx: IContext,
     communityId: string,
     range: DateRange,
-  ): Promise<UserTransactionDailyRow[]>;
+  ): Promise<UserTransactionAggregateRow[]>;
 
   findCommentsByDateRange(
     ctx: IContext,
@@ -104,6 +125,5 @@ export interface IReportRepository {
   ): Promise<UserProfileForReportRow[]>;
 
   refreshTransactionSummaryDaily(ctx: IContext, tx: Prisma.TransactionClient): Promise<void>;
-  refreshTransactionActiveUsersDaily(ctx: IContext, tx: Prisma.TransactionClient): Promise<void>;
   refreshUserTransactionDaily(ctx: IContext, tx: Prisma.TransactionClient): Promise<void>;
 }

--- a/src/application/domain/report/data/interface.ts
+++ b/src/application/domain/report/data/interface.ts
@@ -105,10 +105,11 @@ export interface IReportRepository {
     range: DateRange,
   ): Promise<TransactionActiveUsersDailyRow[]>;
 
-  findUserAggregatedInRange(
+  findTopUsersByTotalPoints(
     ctx: IContext,
     communityId: string,
     range: DateRange,
+    topN: number,
   ): Promise<UserTransactionAggregateRow[]>;
 
   findCommentsByDateRange(

--- a/src/application/domain/report/data/interface.ts
+++ b/src/application/domain/report/data/interface.ts
@@ -1,0 +1,109 @@
+import { Prisma, TransactionReason, Role } from "@prisma/client";
+import { IContext } from "@/types/server";
+
+export interface TransactionSummaryDailyRow {
+  date: Date;
+  communityId: string;
+  reason: TransactionReason;
+  txCount: number;
+  pointsSum: bigint;
+  chainRootCount: number;
+  chainDescendantCount: number;
+  maxChainDepth: number | null;
+  sumChainDepth: number;
+  issuanceCount: number;
+  burnCount: number;
+}
+
+export interface TransactionActiveUsersDailyRow {
+  date: Date;
+  communityId: string;
+  activeUsers: number;
+  senders: number;
+  receivers: number;
+}
+
+export interface UserTransactionDailyRow {
+  date: Date;
+  communityId: string;
+  userId: string;
+  walletId: string;
+  txCountIn: number;
+  txCountOut: number;
+  pointsIn: bigint;
+  pointsOut: bigint;
+  donationOutCount: number;
+  donationOutPoints: bigint;
+  receivedDonationCount: number;
+  chainRootCount: number;
+  maxChainDepthStarted: number | null;
+  chainDepthReachedMax: number | null;
+  uniqueCounterparties: number;
+}
+
+export interface TransactionCommentRow {
+  transactionId: string;
+  date: Date;
+  createdAt: Date;
+  communityId: string;
+  fromUserId: string | null;
+  toUserId: string | null;
+  createdByUserId: string | null;
+  reason: TransactionReason;
+  points: number;
+  comment: string;
+  chainDepth: number | null;
+}
+
+export interface UserProfileForReportRow {
+  userId: string;
+  communityId: string;
+  name: string;
+  userBio: string | null;
+  membershipBio: string | null;
+  headline: string | null;
+  role: Role;
+  joinedAt: Date;
+}
+
+export interface DateRange {
+  from: Date;
+  to: Date;
+}
+
+export interface IReportRepository {
+  findDailySummaries(
+    ctx: IContext,
+    communityId: string,
+    range: DateRange,
+  ): Promise<TransactionSummaryDailyRow[]>;
+
+  findDailyActiveUsers(
+    ctx: IContext,
+    communityId: string,
+    range: DateRange,
+  ): Promise<TransactionActiveUsersDailyRow[]>;
+
+  findDailyUserTransactions(
+    ctx: IContext,
+    communityId: string,
+    range: DateRange,
+  ): Promise<UserTransactionDailyRow[]>;
+
+  findCommentsByDateRange(
+    ctx: IContext,
+    communityId: string,
+    range: DateRange,
+    limit?: number,
+  ): Promise<TransactionCommentRow[]>;
+
+  findUserProfiles(
+    ctx: IContext,
+    communityId: string,
+    userIds: string[],
+  ): Promise<UserProfileForReportRow[]>;
+
+  refreshTransactionSummaryDaily(ctx: IContext, tx: Prisma.TransactionClient): Promise<void>;
+  refreshTransactionActiveUsersDaily(ctx: IContext, tx: Prisma.TransactionClient): Promise<void>;
+  refreshUserTransactionDaily(ctx: IContext, tx: Prisma.TransactionClient): Promise<void>;
+}

--- a/src/application/domain/report/data/repository.ts
+++ b/src/application/domain/report/data/repository.ts
@@ -8,11 +8,10 @@ import {
   TransactionCommentRow,
   TransactionSummaryDailyRow,
   UserProfileForReportRow,
-  UserTransactionDailyRow,
+  UserTransactionAggregateRow,
 } from "@/application/domain/report/data/interface";
 import {
   refreshMaterializedViewTransactionSummaryDaily,
-  refreshMaterializedViewTransactionActiveUsersDaily,
   refreshMaterializedViewUserTransactionDaily,
 } from "@prisma/client/sql";
 
@@ -36,36 +35,94 @@ export default class ReportRepository implements IReportRepository {
     );
   }
 
+  /**
+   * Derive (date, active_users, senders, receivers) straight from
+   * mv_user_transaction_daily. Aggregating in SQL with FILTER clauses keeps
+   * us from shipping a separate MV just for distinct-count queries.
+   */
   async findDailyActiveUsers(
     ctx: IContext,
     communityId: string,
     range: DateRange,
   ): Promise<TransactionActiveUsersDailyRow[]> {
-    return ctx.issuer.public(ctx, (tx) =>
-      tx.transactionActiveUsersDailyView.findMany({
-        where: {
-          communityId,
-          date: { gte: range.from, lte: range.to },
-        },
-        orderBy: [{ date: "asc" }],
-      }),
-    );
+    return ctx.issuer.public(ctx, async (tx) => {
+      const rows = await tx.$queryRaw<
+        {
+          date: Date;
+          active_users: number;
+          senders: number;
+          receivers: number;
+        }[]
+      >`
+        SELECT
+          "date",
+          COUNT(DISTINCT "user_id")::int AS "active_users",
+          COUNT(DISTINCT "user_id") FILTER (WHERE "tx_count_out" > 0)::int AS "senders",
+          COUNT(DISTINCT "user_id") FILTER (WHERE "tx_count_in" > 0)::int AS "receivers"
+        FROM "mv_user_transaction_daily"
+        WHERE "community_id" = ${communityId}
+          AND "date" BETWEEN ${range.from} AND ${range.to}
+        GROUP BY "date"
+        ORDER BY "date" ASC
+      `;
+      return rows.map((r) => ({
+        date: r.date,
+        communityId,
+        activeUsers: r.active_users,
+        senders: r.senders,
+        receivers: r.receivers,
+      }));
+    });
   }
 
-  async findDailyUserTransactions(
+  /**
+   * Per-user aggregate over the reporting window. Uses Prisma `groupBy` so
+   * the sum / max is computed in the database and we do not drag every
+   * per-day row into Node for reduction.
+   */
+  async findUserAggregatedInRange(
     ctx: IContext,
     communityId: string,
     range: DateRange,
-  ): Promise<UserTransactionDailyRow[]> {
-    return ctx.issuer.public(ctx, (tx) =>
-      tx.userTransactionDailyView.findMany({
+  ): Promise<UserTransactionAggregateRow[]> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      const rows = await tx.userTransactionDailyView.groupBy({
+        by: ["userId"],
         where: {
           communityId,
           date: { gte: range.from, lte: range.to },
         },
-        orderBy: [{ date: "asc" }, { userId: "asc" }],
-      }),
-    );
+        _sum: {
+          txCountIn: true,
+          txCountOut: true,
+          pointsIn: true,
+          pointsOut: true,
+          donationOutCount: true,
+          donationOutPoints: true,
+          receivedDonationCount: true,
+          chainRootCount: true,
+          uniqueCounterparties: true,
+        },
+        _max: {
+          maxChainDepthStarted: true,
+          chainDepthReachedMax: true,
+        },
+      });
+      return rows.map((r) => ({
+        userId: r.userId,
+        txCountIn: r._sum.txCountIn ?? 0,
+        txCountOut: r._sum.txCountOut ?? 0,
+        pointsIn: r._sum.pointsIn ?? 0n,
+        pointsOut: r._sum.pointsOut ?? 0n,
+        donationOutCount: r._sum.donationOutCount ?? 0,
+        donationOutPoints: r._sum.donationOutPoints ?? 0n,
+        receivedDonationCount: r._sum.receivedDonationCount ?? 0,
+        chainRootCount: r._sum.chainRootCount ?? 0,
+        maxChainDepthStarted: r._max.maxChainDepthStarted ?? null,
+        chainDepthReachedMax: r._max.chainDepthReachedMax ?? null,
+        uniqueCounterpartiesSum: r._sum.uniqueCounterparties ?? 0,
+      }));
+    });
   }
 
   async findCommentsByDateRange(
@@ -107,13 +164,6 @@ export default class ReportRepository implements IReportRepository {
     tx: Prisma.TransactionClient,
   ): Promise<void> {
     await tx.$queryRawTyped(refreshMaterializedViewTransactionSummaryDaily());
-  }
-
-  async refreshTransactionActiveUsersDaily(
-    ctx: IContext,
-    tx: Prisma.TransactionClient,
-  ): Promise<void> {
-    await tx.$queryRawTyped(refreshMaterializedViewTransactionActiveUsersDaily());
   }
 
   async refreshUserTransactionDaily(

--- a/src/application/domain/report/data/repository.ts
+++ b/src/application/domain/report/data/repository.ts
@@ -39,6 +39,10 @@ export default class ReportRepository implements IReportRepository {
    * Derive (date, active_users, senders, receivers) straight from
    * mv_user_transaction_daily. Aggregating in SQL with FILTER clauses keeps
    * us from shipping a separate MV just for distinct-count queries.
+   *
+   * `date` is an `@db.Date` column; the explicit `::date` cast on the bound
+   * parameters avoids Postgres treating the JS Date as a timestamp(tz) and
+   * losing the index on a boundary compare.
    */
   async findDailyActiveUsers(
     ctx: IContext,
@@ -61,7 +65,7 @@ export default class ReportRepository implements IReportRepository {
           COUNT(DISTINCT "user_id") FILTER (WHERE "tx_count_in" > 0)::int AS "receivers"
         FROM "mv_user_transaction_daily"
         WHERE "community_id" = ${communityId}
-          AND "date" BETWEEN ${range.from} AND ${range.to}
+          AND "date" BETWEEN ${range.from}::date AND ${range.to}::date
         GROUP BY "date"
         ORDER BY "date" ASC
       `;
@@ -76,51 +80,66 @@ export default class ReportRepository implements IReportRepository {
   }
 
   /**
-   * Per-user aggregate over the reporting window. Uses Prisma `groupBy` so
-   * the sum / max is computed in the database and we do not drag every
-   * per-day row into Node for reduction.
+   * Top-N user aggregates over the reporting window, ranked by total
+   * points (in + out). The ORDER BY / LIMIT live in SQL so we only ship
+   * the winners to Node — no sort/slice over every community member.
    */
-  async findUserAggregatedInRange(
+  async findTopUsersByTotalPoints(
     ctx: IContext,
     communityId: string,
     range: DateRange,
+    topN: number,
   ): Promise<UserTransactionAggregateRow[]> {
     return ctx.issuer.public(ctx, async (tx) => {
-      const rows = await tx.userTransactionDailyView.groupBy({
-        by: ["userId"],
-        where: {
-          communityId,
-          date: { gte: range.from, lte: range.to },
-        },
-        _sum: {
-          txCountIn: true,
-          txCountOut: true,
-          pointsIn: true,
-          pointsOut: true,
-          donationOutCount: true,
-          donationOutPoints: true,
-          receivedDonationCount: true,
-          chainRootCount: true,
-          uniqueCounterparties: true,
-        },
-        _max: {
-          maxChainDepthStarted: true,
-          chainDepthReachedMax: true,
-        },
-      });
+      const rows = await tx.$queryRaw<
+        {
+          user_id: string;
+          tx_count_in: number;
+          tx_count_out: number;
+          points_in: bigint;
+          points_out: bigint;
+          donation_out_count: number;
+          donation_out_points: bigint;
+          received_donation_count: number;
+          chain_root_count: number;
+          max_chain_depth_started: number | null;
+          chain_depth_reached_max: number | null;
+          unique_counterparties_sum: number;
+        }[]
+      >`
+        SELECT
+          "user_id",
+          COALESCE(SUM("tx_count_in"), 0)::int AS "tx_count_in",
+          COALESCE(SUM("tx_count_out"), 0)::int AS "tx_count_out",
+          COALESCE(SUM("points_in"), 0)::bigint AS "points_in",
+          COALESCE(SUM("points_out"), 0)::bigint AS "points_out",
+          COALESCE(SUM("donation_out_count"), 0)::int AS "donation_out_count",
+          COALESCE(SUM("donation_out_points"), 0)::bigint AS "donation_out_points",
+          COALESCE(SUM("received_donation_count"), 0)::int AS "received_donation_count",
+          COALESCE(SUM("chain_root_count"), 0)::int AS "chain_root_count",
+          MAX("max_chain_depth_started")::int AS "max_chain_depth_started",
+          MAX("chain_depth_reached_max")::int AS "chain_depth_reached_max",
+          COALESCE(SUM("unique_counterparties"), 0)::int AS "unique_counterparties_sum"
+        FROM "mv_user_transaction_daily"
+        WHERE "community_id" = ${communityId}
+          AND "date" BETWEEN ${range.from}::date AND ${range.to}::date
+        GROUP BY "user_id"
+        ORDER BY (COALESCE(SUM("points_in"), 0) + COALESCE(SUM("points_out"), 0)) DESC
+        LIMIT ${topN}
+      `;
       return rows.map((r) => ({
-        userId: r.userId,
-        txCountIn: r._sum.txCountIn ?? 0,
-        txCountOut: r._sum.txCountOut ?? 0,
-        pointsIn: r._sum.pointsIn ?? 0n,
-        pointsOut: r._sum.pointsOut ?? 0n,
-        donationOutCount: r._sum.donationOutCount ?? 0,
-        donationOutPoints: r._sum.donationOutPoints ?? 0n,
-        receivedDonationCount: r._sum.receivedDonationCount ?? 0,
-        chainRootCount: r._sum.chainRootCount ?? 0,
-        maxChainDepthStarted: r._max.maxChainDepthStarted ?? null,
-        chainDepthReachedMax: r._max.chainDepthReachedMax ?? null,
-        uniqueCounterpartiesSum: r._sum.uniqueCounterparties ?? 0,
+        userId: r.user_id,
+        txCountIn: r.tx_count_in,
+        txCountOut: r.tx_count_out,
+        pointsIn: r.points_in,
+        pointsOut: r.points_out,
+        donationOutCount: r.donation_out_count,
+        donationOutPoints: r.donation_out_points,
+        receivedDonationCount: r.received_donation_count,
+        chainRootCount: r.chain_root_count,
+        maxChainDepthStarted: r.max_chain_depth_started,
+        chainDepthReachedMax: r.chain_depth_reached_max,
+        uniqueCounterpartiesSum: r.unique_counterparties_sum,
       }));
     });
   }

--- a/src/application/domain/report/data/repository.ts
+++ b/src/application/domain/report/data/repository.ts
@@ -1,0 +1,125 @@
+import { Prisma } from "@prisma/client";
+import { injectable } from "tsyringe";
+import { IContext } from "@/types/server";
+import {
+  DateRange,
+  IReportRepository,
+  TransactionActiveUsersDailyRow,
+  TransactionCommentRow,
+  TransactionSummaryDailyRow,
+  UserProfileForReportRow,
+  UserTransactionDailyRow,
+} from "@/application/domain/report/data/interface";
+import {
+  refreshMaterializedViewTransactionSummaryDaily,
+  refreshMaterializedViewTransactionActiveUsersDaily,
+  refreshMaterializedViewUserTransactionDaily,
+} from "@prisma/client/sql";
+
+const DEFAULT_COMMENT_LIMIT = 200;
+
+@injectable()
+export default class ReportRepository implements IReportRepository {
+  async findDailySummaries(
+    ctx: IContext,
+    communityId: string,
+    range: DateRange,
+  ): Promise<TransactionSummaryDailyRow[]> {
+    return ctx.issuer.public(ctx, (tx) =>
+      tx.transactionSummaryDailyView.findMany({
+        where: {
+          communityId,
+          date: { gte: range.from, lte: range.to },
+        },
+        orderBy: [{ date: "asc" }, { reason: "asc" }],
+      }),
+    );
+  }
+
+  async findDailyActiveUsers(
+    ctx: IContext,
+    communityId: string,
+    range: DateRange,
+  ): Promise<TransactionActiveUsersDailyRow[]> {
+    return ctx.issuer.public(ctx, (tx) =>
+      tx.transactionActiveUsersDailyView.findMany({
+        where: {
+          communityId,
+          date: { gte: range.from, lte: range.to },
+        },
+        orderBy: [{ date: "asc" }],
+      }),
+    );
+  }
+
+  async findDailyUserTransactions(
+    ctx: IContext,
+    communityId: string,
+    range: DateRange,
+  ): Promise<UserTransactionDailyRow[]> {
+    return ctx.issuer.public(ctx, (tx) =>
+      tx.userTransactionDailyView.findMany({
+        where: {
+          communityId,
+          date: { gte: range.from, lte: range.to },
+        },
+        orderBy: [{ date: "asc" }, { userId: "asc" }],
+      }),
+    );
+  }
+
+  async findCommentsByDateRange(
+    ctx: IContext,
+    communityId: string,
+    range: DateRange,
+    limit: number = DEFAULT_COMMENT_LIMIT,
+  ): Promise<TransactionCommentRow[]> {
+    return ctx.issuer.public(ctx, (tx) =>
+      tx.transactionCommentView.findMany({
+        where: {
+          communityId,
+          date: { gte: range.from, lte: range.to },
+        },
+        orderBy: [{ createdAt: "desc" }],
+        take: limit,
+      }),
+    );
+  }
+
+  async findUserProfiles(
+    ctx: IContext,
+    communityId: string,
+    userIds: string[],
+  ): Promise<UserProfileForReportRow[]> {
+    if (userIds.length === 0) return [];
+    return ctx.issuer.public(ctx, (tx) =>
+      tx.userProfileForReportView.findMany({
+        where: {
+          communityId,
+          userId: { in: userIds },
+        },
+      }),
+    );
+  }
+
+  async refreshTransactionSummaryDaily(
+    ctx: IContext,
+    tx: Prisma.TransactionClient,
+  ): Promise<void> {
+    await tx.$queryRawTyped(refreshMaterializedViewTransactionSummaryDaily());
+  }
+
+  async refreshTransactionActiveUsersDaily(
+    ctx: IContext,
+    tx: Prisma.TransactionClient,
+  ): Promise<void> {
+    await tx.$queryRawTyped(refreshMaterializedViewTransactionActiveUsersDaily());
+  }
+
+  async refreshUserTransactionDaily(
+    ctx: IContext,
+    tx: Prisma.TransactionClient,
+  ): Promise<void> {
+    await tx.$queryRawTyped(refreshMaterializedViewUserTransactionDaily());
+  }
+}

--- a/src/application/domain/report/presenter.ts
+++ b/src/application/domain/report/presenter.ts
@@ -95,47 +95,40 @@ export default class ReportPresenter {
     referenceDate: Date;
     summaries: TransactionSummaryDailyRow[];
     activeUsers: TransactionActiveUsersDailyRow[];
-    userAggregates: UserTransactionAggregateRow[];
+    /**
+     * Already ordered by DB (SUM(points_in) + SUM(points_out)) DESC and
+     * limited to top N in the repository, so the presenter does no sort/slice.
+     */
+    topUserAggregates: UserTransactionAggregateRow[];
     profiles: UserProfileForReportRow[];
     comments: TransactionCommentRow[];
-    topN?: number;
   }): WeeklyReportPayload {
-    const topN = input.topN ?? 10;
     const profileByUserId = new Map(input.profiles.map((p) => [p.userId, p]));
 
-    // Period-level aggregation is done in SQL via groupBy; sort+slice the
-    // result here to pick the top N users by total activity.
-    const topUsers: TopUserItem[] = [...input.userAggregates]
-      .sort((a, b) => {
-        const totalB = bigintToSafeNumber(b.pointsIn) + bigintToSafeNumber(b.pointsOut);
-        const totalA = bigintToSafeNumber(a.pointsIn) + bigintToSafeNumber(a.pointsOut);
-        return totalB - totalA;
-      })
-      .slice(0, topN)
-      .map((u) => {
-        const p = profileByUserId.get(u.userId);
-        return {
-          user_id: u.userId,
-          name: p?.name ?? "",
-          user_bio: p?.userBio ?? null,
-          membership_bio: p?.membershipBio ?? null,
-          headline: p?.headline ?? null,
-          role: p?.role ?? "MEMBER",
-          joined_at: p ? toJstIsoDate(p.joinedAt) : "",
-          days_since_joined: p ? daysBetweenJst(p.joinedAt, input.referenceDate) : 0,
-          tx_count_in: u.txCountIn,
-          tx_count_out: u.txCountOut,
-          points_in: bigintToSafeNumber(u.pointsIn),
-          points_out: bigintToSafeNumber(u.pointsOut),
-          donation_out_count: u.donationOutCount,
-          donation_out_points: bigintToSafeNumber(u.donationOutPoints),
-          received_donation_count: u.receivedDonationCount,
-          chain_root_count: u.chainRootCount,
-          max_chain_depth_started: u.maxChainDepthStarted,
-          chain_depth_reached_max: u.chainDepthReachedMax,
-          unique_counterparties_sum: u.uniqueCounterpartiesSum,
-        };
-      });
+    const topUsers: TopUserItem[] = input.topUserAggregates.map((u) => {
+      const p = profileByUserId.get(u.userId);
+      return {
+        user_id: u.userId,
+        name: p?.name ?? "",
+        user_bio: p?.userBio ?? null,
+        membership_bio: p?.membershipBio ?? null,
+        headline: p?.headline ?? null,
+        role: p?.role ?? "MEMBER",
+        joined_at: p ? toJstIsoDate(p.joinedAt) : "",
+        days_since_joined: p ? daysBetweenJst(p.joinedAt, input.referenceDate) : 0,
+        tx_count_in: u.txCountIn,
+        tx_count_out: u.txCountOut,
+        points_in: bigintToSafeNumber(u.pointsIn),
+        points_out: bigintToSafeNumber(u.pointsOut),
+        donation_out_count: u.donationOutCount,
+        donation_out_points: bigintToSafeNumber(u.donationOutPoints),
+        received_donation_count: u.receivedDonationCount,
+        chain_root_count: u.chainRootCount,
+        max_chain_depth_started: u.maxChainDepthStarted,
+        chain_depth_reached_max: u.chainDepthReachedMax,
+        unique_counterparties_sum: u.uniqueCounterpartiesSum,
+      };
+    });
 
     return {
       period: {

--- a/src/application/domain/report/presenter.ts
+++ b/src/application/domain/report/presenter.ts
@@ -1,0 +1,232 @@
+import {
+  TransactionActiveUsersDailyRow,
+  TransactionCommentRow,
+  TransactionSummaryDailyRow,
+  UserProfileForReportRow,
+  UserTransactionDailyRow,
+} from "@/application/domain/report/data/interface";
+
+// ---------------------------------------------------------------------------
+// AI-facing report payload types
+//
+// These are plain, JSON-serialisable shapes designed to be fed to an LLM as
+// the dataset for report generation. Keep keys snake_case for LLM-friendly
+// token boundaries, and convert BigInt to number (safe: point amounts fit
+// well inside Number.MAX_SAFE_INTEGER for our scale).
+// ---------------------------------------------------------------------------
+
+export interface WeeklyReportPayload {
+  period: { from: string; to: string };
+  community_id: string;
+  daily_summaries: DailySummaryItem[];
+  daily_active_users: DailyActiveUsersItem[];
+  top_users: TopUserItem[];
+  highlight_comments: CommentItem[];
+}
+
+export interface DailySummaryItem {
+  date: string;
+  reason: string;
+  tx_count: number;
+  points_sum: number;
+  chain_root_count: number;
+  chain_descendant_count: number;
+  max_chain_depth: number | null;
+  avg_chain_depth: number | null;
+  issuance_count: number;
+  burn_count: number;
+}
+
+export interface DailyActiveUsersItem {
+  date: string;
+  active_users: number;
+  senders: number;
+  receivers: number;
+}
+
+export interface TopUserItem {
+  user_id: string;
+  name: string;
+  user_bio: string | null;
+  membership_bio: string | null;
+  headline: string | null;
+  role: string;
+  joined_at: string;
+  days_since_joined: number;
+  tx_count_in: number;
+  tx_count_out: number;
+  points_in: number;
+  points_out: number;
+  donation_out_count: number;
+  donation_out_points: number;
+  received_donation_count: number;
+  chain_root_count: number;
+  max_chain_depth_started: number | null;
+  chain_depth_reached_max: number | null;
+  unique_counterparties: number;
+}
+
+export interface CommentItem {
+  transaction_id: string;
+  date: string;
+  reason: string;
+  points: number;
+  comment: string;
+  from_user_id: string | null;
+  to_user_id: string | null;
+  created_by_user_id: string | null;
+  chain_depth: number | null;
+}
+
+export default class ReportPresenter {
+  static weeklyPayload(input: {
+    communityId: string;
+    range: { from: Date; to: Date };
+    referenceDate: Date;
+    summaries: TransactionSummaryDailyRow[];
+    activeUsers: TransactionActiveUsersDailyRow[];
+    userTransactions: UserTransactionDailyRow[];
+    profiles: UserProfileForReportRow[];
+    comments: TransactionCommentRow[];
+    topN?: number;
+  }): WeeklyReportPayload {
+    const topN = input.topN ?? 10;
+    const profileByUserId = new Map(input.profiles.map((p) => [p.userId, p]));
+
+    // Aggregate per user across the period for ranking / AI context.
+    const userAgg = new Map<string, UserAggregate>();
+    for (const r of input.userTransactions) {
+      const cur = userAgg.get(r.userId) ?? emptyAggregate(r.userId);
+      cur.txCountIn += r.txCountIn;
+      cur.txCountOut += r.txCountOut;
+      cur.pointsIn += Number(r.pointsIn);
+      cur.pointsOut += Number(r.pointsOut);
+      cur.donationOutCount += r.donationOutCount;
+      cur.donationOutPoints += Number(r.donationOutPoints);
+      cur.receivedDonationCount += r.receivedDonationCount;
+      cur.chainRootCount += r.chainRootCount;
+      cur.maxChainDepthStarted = maxNullable(cur.maxChainDepthStarted, r.maxChainDepthStarted);
+      cur.chainDepthReachedMax = maxNullable(cur.chainDepthReachedMax, r.chainDepthReachedMax);
+      cur.uniqueCounterpartiesSum += r.uniqueCounterparties;
+      userAgg.set(r.userId, cur);
+    }
+
+    const topUsers: TopUserItem[] = [...userAgg.values()]
+      .sort((a, b) => {
+        const totalB = b.pointsIn + b.pointsOut;
+        const totalA = a.pointsIn + a.pointsOut;
+        return totalB - totalA;
+      })
+      .slice(0, topN)
+      .map((u) => {
+        const p = profileByUserId.get(u.userId);
+        return {
+          user_id: u.userId,
+          name: p?.name ?? "",
+          user_bio: p?.userBio ?? null,
+          membership_bio: p?.membershipBio ?? null,
+          headline: p?.headline ?? null,
+          role: p?.role ?? "MEMBER",
+          joined_at: p ? toIsoDate(p.joinedAt) : "",
+          days_since_joined: p ? daysBetween(p.joinedAt, input.referenceDate) : 0,
+          tx_count_in: u.txCountIn,
+          tx_count_out: u.txCountOut,
+          points_in: u.pointsIn,
+          points_out: u.pointsOut,
+          donation_out_count: u.donationOutCount,
+          donation_out_points: u.donationOutPoints,
+          received_donation_count: u.receivedDonationCount,
+          chain_root_count: u.chainRootCount,
+          max_chain_depth_started: u.maxChainDepthStarted,
+          chain_depth_reached_max: u.chainDepthReachedMax,
+          unique_counterparties: u.uniqueCounterpartiesSum,
+        };
+      });
+
+    return {
+      period: {
+        from: toIsoDate(input.range.from),
+        to: toIsoDate(input.range.to),
+      },
+      community_id: input.communityId,
+      daily_summaries: input.summaries.map((s) => ({
+        date: toIsoDate(s.date),
+        reason: s.reason,
+        tx_count: s.txCount,
+        points_sum: Number(s.pointsSum),
+        chain_root_count: s.chainRootCount,
+        chain_descendant_count: s.chainDescendantCount,
+        max_chain_depth: s.maxChainDepth,
+        avg_chain_depth:
+          s.txCount > 0 && s.sumChainDepth > 0 ? s.sumChainDepth / s.txCount : null,
+        issuance_count: s.issuanceCount,
+        burn_count: s.burnCount,
+      })),
+      daily_active_users: input.activeUsers.map((u) => ({
+        date: toIsoDate(u.date),
+        active_users: u.activeUsers,
+        senders: u.senders,
+        receivers: u.receivers,
+      })),
+      top_users: topUsers,
+      highlight_comments: input.comments.map((c) => ({
+        transaction_id: c.transactionId,
+        date: toIsoDate(c.date),
+        reason: c.reason,
+        points: c.points,
+        comment: c.comment,
+        from_user_id: c.fromUserId,
+        to_user_id: c.toUserId,
+        created_by_user_id: c.createdByUserId,
+        chain_depth: c.chainDepth,
+      })),
+    };
+  }
+}
+
+interface UserAggregate {
+  userId: string;
+  txCountIn: number;
+  txCountOut: number;
+  pointsIn: number;
+  pointsOut: number;
+  donationOutCount: number;
+  donationOutPoints: number;
+  receivedDonationCount: number;
+  chainRootCount: number;
+  maxChainDepthStarted: number | null;
+  chainDepthReachedMax: number | null;
+  uniqueCounterpartiesSum: number;
+}
+
+function emptyAggregate(userId: string): UserAggregate {
+  return {
+    userId,
+    txCountIn: 0,
+    txCountOut: 0,
+    pointsIn: 0,
+    pointsOut: 0,
+    donationOutCount: 0,
+    donationOutPoints: 0,
+    receivedDonationCount: 0,
+    chainRootCount: 0,
+    maxChainDepthStarted: null,
+    chainDepthReachedMax: null,
+    uniqueCounterpartiesSum: 0,
+  };
+}
+
+function maxNullable(a: number | null, b: number | null): number | null {
+  if (a === null) return b;
+  if (b === null) return a;
+  return Math.max(a, b);
+}
+
+function toIsoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function daysBetween(from: Date, to: Date): number {
+  const msPerDay = 24 * 60 * 60 * 1000;
+  return Math.floor((to.getTime() - from.getTime()) / msPerDay);
+}

--- a/src/application/domain/report/presenter.ts
+++ b/src/application/domain/report/presenter.ts
@@ -5,6 +5,11 @@ import {
   UserProfileForReportRow,
   UserTransactionDailyRow,
 } from "@/application/domain/report/data/interface";
+import {
+  bigintToSafeNumber,
+  daysBetweenJst,
+  toJstIsoDate,
+} from "@/application/domain/report/util";
 
 // ---------------------------------------------------------------------------
 // AI-facing report payload types
@@ -104,10 +109,10 @@ export default class ReportPresenter {
       const cur = userAgg.get(r.userId) ?? emptyAggregate(r.userId);
       cur.txCountIn += r.txCountIn;
       cur.txCountOut += r.txCountOut;
-      cur.pointsIn += Number(r.pointsIn);
-      cur.pointsOut += Number(r.pointsOut);
+      cur.pointsIn += bigintToSafeNumber(r.pointsIn);
+      cur.pointsOut += bigintToSafeNumber(r.pointsOut);
       cur.donationOutCount += r.donationOutCount;
-      cur.donationOutPoints += Number(r.donationOutPoints);
+      cur.donationOutPoints += bigintToSafeNumber(r.donationOutPoints);
       cur.receivedDonationCount += r.receivedDonationCount;
       cur.chainRootCount += r.chainRootCount;
       cur.maxChainDepthStarted = maxNullable(cur.maxChainDepthStarted, r.maxChainDepthStarted);
@@ -132,8 +137,8 @@ export default class ReportPresenter {
           membership_bio: p?.membershipBio ?? null,
           headline: p?.headline ?? null,
           role: p?.role ?? "MEMBER",
-          joined_at: p ? toIsoDate(p.joinedAt) : "",
-          days_since_joined: p ? daysBetween(p.joinedAt, input.referenceDate) : 0,
+          joined_at: p ? toJstIsoDate(p.joinedAt) : "",
+          days_since_joined: p ? daysBetweenJst(p.joinedAt, input.referenceDate) : 0,
           tx_count_in: u.txCountIn,
           tx_count_out: u.txCountOut,
           points_in: u.pointsIn,
@@ -150,15 +155,15 @@ export default class ReportPresenter {
 
     return {
       period: {
-        from: toIsoDate(input.range.from),
-        to: toIsoDate(input.range.to),
+        from: toJstIsoDate(input.range.from),
+        to: toJstIsoDate(input.range.to),
       },
       community_id: input.communityId,
       daily_summaries: input.summaries.map((s) => ({
-        date: toIsoDate(s.date),
+        date: toJstIsoDate(s.date),
         reason: s.reason,
         tx_count: s.txCount,
-        points_sum: Number(s.pointsSum),
+        points_sum: bigintToSafeNumber(s.pointsSum),
         chain_root_count: s.chainRootCount,
         chain_descendant_count: s.chainDescendantCount,
         max_chain_depth: s.maxChainDepth,
@@ -171,7 +176,7 @@ export default class ReportPresenter {
         burn_count: s.burnCount,
       })),
       daily_active_users: input.activeUsers.map((u) => ({
-        date: toIsoDate(u.date),
+        date: toJstIsoDate(u.date),
         active_users: u.activeUsers,
         senders: u.senders,
         receivers: u.receivers,
@@ -179,7 +184,7 @@ export default class ReportPresenter {
       top_users: topUsers,
       highlight_comments: input.comments.map((c) => ({
         transaction_id: c.transactionId,
-        date: toIsoDate(c.date),
+        date: toJstIsoDate(c.date),
         reason: c.reason,
         points: c.points,
         comment: c.comment,
@@ -230,11 +235,3 @@ function maxNullable(a: number | null, b: number | null): number | null {
   return Math.max(a, b);
 }
 
-function toIsoDate(d: Date): string {
-  return d.toISOString().slice(0, 10);
-}
-
-function daysBetween(from: Date, to: Date): number {
-  const msPerDay = 24 * 60 * 60 * 1000;
-  return Math.floor((to.getTime() - from.getTime()) / msPerDay);
-}

--- a/src/application/domain/report/presenter.ts
+++ b/src/application/domain/report/presenter.ts
@@ -168,10 +168,14 @@ export default class ReportPresenter {
         chain_descendant_count: s.chainDescendantCount,
         max_chain_depth: s.maxChainDepth,
         // chain_depth is NULL for non-chain reasons (POINT_ISSUED / TICKET_* /
-        // OPPORTUNITY_*). maxChainDepth === null signals "no chain activity",
-        // in which case avg is undefined for this row.
+        // OPPORTUNITY_*) and can also be NULL on chain-eligible reasons when
+        // no parent tx was found upstream. Divide by the count of rows that
+        // actually carry a chain_depth (root + descendant), not by the full
+        // tx_count, since SUM(chain_depth) in SQL skips NULL rows.
         avg_chain_depth:
-          s.maxChainDepth !== null && s.txCount > 0 ? s.sumChainDepth / s.txCount : null,
+          s.maxChainDepth !== null && s.chainRootCount + s.chainDescendantCount > 0
+            ? s.sumChainDepth / (s.chainRootCount + s.chainDescendantCount)
+            : null,
         issuance_count: s.issuanceCount,
         burn_count: s.burnCount,
       })),

--- a/src/application/domain/report/presenter.ts
+++ b/src/application/domain/report/presenter.ts
@@ -63,7 +63,12 @@ export interface TopUserItem {
   chain_root_count: number;
   max_chain_depth_started: number | null;
   chain_depth_reached_max: number | null;
-  unique_counterparties: number;
+  /**
+   * Sum of per-day distinct counterparty counts across the reporting window.
+   * NOT a deduplicated count of distinct counterparties for the period — the
+   * same counterparty appearing on multiple days is counted once per day.
+   */
+  unique_counterparties_sum: number;
 }
 
 export interface CommentItem {
@@ -139,7 +144,7 @@ export default class ReportPresenter {
           chain_root_count: u.chainRootCount,
           max_chain_depth_started: u.maxChainDepthStarted,
           chain_depth_reached_max: u.chainDepthReachedMax,
-          unique_counterparties: u.uniqueCounterpartiesSum,
+          unique_counterparties_sum: u.uniqueCounterpartiesSum,
         };
       });
 
@@ -157,8 +162,11 @@ export default class ReportPresenter {
         chain_root_count: s.chainRootCount,
         chain_descendant_count: s.chainDescendantCount,
         max_chain_depth: s.maxChainDepth,
+        // chain_depth is NULL for non-chain reasons (POINT_ISSUED / TICKET_* /
+        // OPPORTUNITY_*). maxChainDepth === null signals "no chain activity",
+        // in which case avg is undefined for this row.
         avg_chain_depth:
-          s.txCount > 0 && s.sumChainDepth > 0 ? s.sumChainDepth / s.txCount : null,
+          s.maxChainDepth !== null && s.txCount > 0 ? s.sumChainDepth / s.txCount : null,
         issuance_count: s.issuanceCount,
         burn_count: s.burnCount,
       })),

--- a/src/application/domain/report/presenter.ts
+++ b/src/application/domain/report/presenter.ts
@@ -3,7 +3,7 @@ import {
   TransactionCommentRow,
   TransactionSummaryDailyRow,
   UserProfileForReportRow,
-  UserTransactionDailyRow,
+  UserTransactionAggregateRow,
 } from "@/application/domain/report/data/interface";
 import {
   bigintToSafeNumber,
@@ -95,7 +95,7 @@ export default class ReportPresenter {
     referenceDate: Date;
     summaries: TransactionSummaryDailyRow[];
     activeUsers: TransactionActiveUsersDailyRow[];
-    userTransactions: UserTransactionDailyRow[];
+    userAggregates: UserTransactionAggregateRow[];
     profiles: UserProfileForReportRow[];
     comments: TransactionCommentRow[];
     topN?: number;
@@ -103,28 +103,12 @@ export default class ReportPresenter {
     const topN = input.topN ?? 10;
     const profileByUserId = new Map(input.profiles.map((p) => [p.userId, p]));
 
-    // Aggregate per user across the period for ranking / AI context.
-    const userAgg = new Map<string, UserAggregate>();
-    for (const r of input.userTransactions) {
-      const cur = userAgg.get(r.userId) ?? emptyAggregate(r.userId);
-      cur.txCountIn += r.txCountIn;
-      cur.txCountOut += r.txCountOut;
-      cur.pointsIn += bigintToSafeNumber(r.pointsIn);
-      cur.pointsOut += bigintToSafeNumber(r.pointsOut);
-      cur.donationOutCount += r.donationOutCount;
-      cur.donationOutPoints += bigintToSafeNumber(r.donationOutPoints);
-      cur.receivedDonationCount += r.receivedDonationCount;
-      cur.chainRootCount += r.chainRootCount;
-      cur.maxChainDepthStarted = maxNullable(cur.maxChainDepthStarted, r.maxChainDepthStarted);
-      cur.chainDepthReachedMax = maxNullable(cur.chainDepthReachedMax, r.chainDepthReachedMax);
-      cur.uniqueCounterpartiesSum += r.uniqueCounterparties;
-      userAgg.set(r.userId, cur);
-    }
-
-    const topUsers: TopUserItem[] = [...userAgg.values()]
+    // Period-level aggregation is done in SQL via groupBy; sort+slice the
+    // result here to pick the top N users by total activity.
+    const topUsers: TopUserItem[] = [...input.userAggregates]
       .sort((a, b) => {
-        const totalB = b.pointsIn + b.pointsOut;
-        const totalA = a.pointsIn + a.pointsOut;
+        const totalB = bigintToSafeNumber(b.pointsIn) + bigintToSafeNumber(b.pointsOut);
+        const totalA = bigintToSafeNumber(a.pointsIn) + bigintToSafeNumber(a.pointsOut);
         return totalB - totalA;
       })
       .slice(0, topN)
@@ -141,10 +125,10 @@ export default class ReportPresenter {
           days_since_joined: p ? daysBetweenJst(p.joinedAt, input.referenceDate) : 0,
           tx_count_in: u.txCountIn,
           tx_count_out: u.txCountOut,
-          points_in: u.pointsIn,
-          points_out: u.pointsOut,
+          points_in: bigintToSafeNumber(u.pointsIn),
+          points_out: bigintToSafeNumber(u.pointsOut),
           donation_out_count: u.donationOutCount,
-          donation_out_points: u.donationOutPoints,
+          donation_out_points: bigintToSafeNumber(u.donationOutPoints),
           received_donation_count: u.receivedDonationCount,
           chain_root_count: u.chainRootCount,
           max_chain_depth_started: u.maxChainDepthStarted,
@@ -200,42 +184,3 @@ export default class ReportPresenter {
     };
   }
 }
-
-interface UserAggregate {
-  userId: string;
-  txCountIn: number;
-  txCountOut: number;
-  pointsIn: number;
-  pointsOut: number;
-  donationOutCount: number;
-  donationOutPoints: number;
-  receivedDonationCount: number;
-  chainRootCount: number;
-  maxChainDepthStarted: number | null;
-  chainDepthReachedMax: number | null;
-  uniqueCounterpartiesSum: number;
-}
-
-function emptyAggregate(userId: string): UserAggregate {
-  return {
-    userId,
-    txCountIn: 0,
-    txCountOut: 0,
-    pointsIn: 0,
-    pointsOut: 0,
-    donationOutCount: 0,
-    donationOutPoints: 0,
-    receivedDonationCount: 0,
-    chainRootCount: 0,
-    maxChainDepthStarted: null,
-    chainDepthReachedMax: null,
-    uniqueCounterpartiesSum: 0,
-  };
-}
-
-function maxNullable(a: number | null, b: number | null): number | null {
-  if (a === null) return b;
-  if (b === null) return a;
-  return Math.max(a, b);
-}
-

--- a/src/application/domain/report/service.ts
+++ b/src/application/domain/report/service.ts
@@ -33,12 +33,13 @@ export default class ReportService {
     return this.repository.findDailyActiveUsers(ctx, communityId, range);
   }
 
-  async getUserAggregated(
+  async getTopUsersByTotalPoints(
     ctx: IContext,
     communityId: string,
     range: DateRange,
+    topN: number,
   ): Promise<UserTransactionAggregateRow[]> {
-    return this.repository.findUserAggregatedInRange(ctx, communityId, range);
+    return this.repository.findTopUsersByTotalPoints(ctx, communityId, range, topN);
   }
 
   async getComments(

--- a/src/application/domain/report/service.ts
+++ b/src/application/domain/report/service.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import { inject, injectable } from "tsyringe";
 import { IContext } from "@/types/server";
 import {
@@ -57,19 +58,24 @@ export default class ReportService {
     return this.repository.findUserProfiles(ctx, communityId, userIds);
   }
 
-  async refreshAllReportViews(ctx: IContext): Promise<void> {
-    // Refresh is not transactional (CONCURRENTLY cannot run inside a tx block
-    // in some Postgres configurations; typedSQL runs each statement
-    // individually via $queryRawTyped). We wrap each call in its own
-    // internal issuer block so bypassRls is applied per-statement.
-    await ctx.issuer.internal((tx) =>
-      this.repository.refreshTransactionSummaryDaily(ctx, tx),
-    );
-    await ctx.issuer.internal((tx) =>
-      this.repository.refreshTransactionActiveUsersDaily(ctx, tx),
-    );
-    await ctx.issuer.internal((tx) =>
-      this.repository.refreshUserTransactionDaily(ctx, tx),
-    );
+  async refreshTransactionSummaryDaily(
+    ctx: IContext,
+    tx: Prisma.TransactionClient,
+  ): Promise<void> {
+    return this.repository.refreshTransactionSummaryDaily(ctx, tx);
+  }
+
+  async refreshTransactionActiveUsersDaily(
+    ctx: IContext,
+    tx: Prisma.TransactionClient,
+  ): Promise<void> {
+    return this.repository.refreshTransactionActiveUsersDaily(ctx, tx);
+  }
+
+  async refreshUserTransactionDaily(
+    ctx: IContext,
+    tx: Prisma.TransactionClient,
+  ): Promise<void> {
+    return this.repository.refreshUserTransactionDaily(ctx, tx);
   }
 }

--- a/src/application/domain/report/service.ts
+++ b/src/application/domain/report/service.ts
@@ -8,7 +8,7 @@ import {
   TransactionCommentRow,
   TransactionSummaryDailyRow,
   UserProfileForReportRow,
-  UserTransactionDailyRow,
+  UserTransactionAggregateRow,
 } from "@/application/domain/report/data/interface";
 
 @injectable()
@@ -33,12 +33,12 @@ export default class ReportService {
     return this.repository.findDailyActiveUsers(ctx, communityId, range);
   }
 
-  async getDailyUserTransactions(
+  async getUserAggregated(
     ctx: IContext,
     communityId: string,
     range: DateRange,
-  ): Promise<UserTransactionDailyRow[]> {
-    return this.repository.findDailyUserTransactions(ctx, communityId, range);
+  ): Promise<UserTransactionAggregateRow[]> {
+    return this.repository.findUserAggregatedInRange(ctx, communityId, range);
   }
 
   async getComments(
@@ -63,13 +63,6 @@ export default class ReportService {
     tx: Prisma.TransactionClient,
   ): Promise<void> {
     return this.repository.refreshTransactionSummaryDaily(ctx, tx);
-  }
-
-  async refreshTransactionActiveUsersDaily(
-    ctx: IContext,
-    tx: Prisma.TransactionClient,
-  ): Promise<void> {
-    return this.repository.refreshTransactionActiveUsersDaily(ctx, tx);
   }
 
   async refreshUserTransactionDaily(

--- a/src/application/domain/report/service.ts
+++ b/src/application/domain/report/service.ts
@@ -1,0 +1,75 @@
+import { inject, injectable } from "tsyringe";
+import { IContext } from "@/types/server";
+import {
+  DateRange,
+  IReportRepository,
+  TransactionActiveUsersDailyRow,
+  TransactionCommentRow,
+  TransactionSummaryDailyRow,
+  UserProfileForReportRow,
+  UserTransactionDailyRow,
+} from "@/application/domain/report/data/interface";
+
+@injectable()
+export default class ReportService {
+  constructor(
+    @inject("ReportRepository") private readonly repository: IReportRepository,
+  ) {}
+
+  async getDailySummaries(
+    ctx: IContext,
+    communityId: string,
+    range: DateRange,
+  ): Promise<TransactionSummaryDailyRow[]> {
+    return this.repository.findDailySummaries(ctx, communityId, range);
+  }
+
+  async getDailyActiveUsers(
+    ctx: IContext,
+    communityId: string,
+    range: DateRange,
+  ): Promise<TransactionActiveUsersDailyRow[]> {
+    return this.repository.findDailyActiveUsers(ctx, communityId, range);
+  }
+
+  async getDailyUserTransactions(
+    ctx: IContext,
+    communityId: string,
+    range: DateRange,
+  ): Promise<UserTransactionDailyRow[]> {
+    return this.repository.findDailyUserTransactions(ctx, communityId, range);
+  }
+
+  async getComments(
+    ctx: IContext,
+    communityId: string,
+    range: DateRange,
+    limit?: number,
+  ): Promise<TransactionCommentRow[]> {
+    return this.repository.findCommentsByDateRange(ctx, communityId, range, limit);
+  }
+
+  async getUserProfiles(
+    ctx: IContext,
+    communityId: string,
+    userIds: string[],
+  ): Promise<UserProfileForReportRow[]> {
+    return this.repository.findUserProfiles(ctx, communityId, userIds);
+  }
+
+  async refreshAllReportViews(ctx: IContext): Promise<void> {
+    // Refresh is not transactional (CONCURRENTLY cannot run inside a tx block
+    // in some Postgres configurations; typedSQL runs each statement
+    // individually via $queryRawTyped). We wrap each call in its own
+    // internal issuer block so bypassRls is applied per-statement.
+    await ctx.issuer.internal((tx) =>
+      this.repository.refreshTransactionSummaryDaily(ctx, tx),
+    );
+    await ctx.issuer.internal((tx) =>
+      this.repository.refreshTransactionActiveUsersDaily(ctx, tx),
+    );
+    await ctx.issuer.internal((tx) =>
+      this.repository.refreshUserTransactionDaily(ctx, tx),
+    );
+  }
+}

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -1,0 +1,80 @@
+import { inject, injectable } from "tsyringe";
+import { IContext } from "@/types/server";
+import ReportService from "@/application/domain/report/service";
+import ReportPresenter, {
+  WeeklyReportPayload,
+} from "@/application/domain/report/presenter";
+
+@injectable()
+export default class ReportUseCase {
+  constructor(@inject("ReportService") private readonly service: ReportService) {}
+
+  /**
+   * Build the AI-facing data payload for a fixed-length report window ending
+   * at `referenceDate` (inclusive). Default window is 7 days (weekly).
+   *
+   * Callers are responsible for authorization: only users belonging to the
+   * target community (or system admins) should reach this usecase, because
+   * materialized views bypass RLS.
+   */
+  async buildReportPayload(
+    ctx: IContext,
+    params: {
+      communityId: string;
+      referenceDate: Date;
+      windowDays?: number;
+      topN?: number;
+      commentLimit?: number;
+    },
+  ): Promise<WeeklyReportPayload> {
+    const windowDays = params.windowDays ?? 7;
+    const to = truncateToDate(params.referenceDate);
+    const from = addDays(to, -(windowDays - 1));
+    const range = { from, to };
+
+    const [summaries, activeUsers, userTransactions, comments] = await Promise.all([
+      this.service.getDailySummaries(ctx, params.communityId, range),
+      this.service.getDailyActiveUsers(ctx, params.communityId, range),
+      this.service.getDailyUserTransactions(ctx, params.communityId, range),
+      this.service.getComments(ctx, params.communityId, range, params.commentLimit),
+    ]);
+
+    const userIds = Array.from(new Set(userTransactions.map((u) => u.userId)));
+    const profiles = await this.service.getUserProfiles(
+      ctx,
+      params.communityId,
+      userIds,
+    );
+
+    return ReportPresenter.weeklyPayload({
+      communityId: params.communityId,
+      range,
+      referenceDate: to,
+      summaries,
+      activeUsers,
+      userTransactions,
+      profiles,
+      comments,
+      topN: params.topN,
+    });
+  }
+
+  /**
+   * Refresh all three materialized views. Called from the daily batch.
+   */
+  async refreshAllReportViews(ctx: IContext): Promise<void> {
+    await this.service.refreshAllReportViews(ctx);
+  }
+}
+
+function truncateToDate(d: Date): Date {
+  const t = new Date(d);
+  t.setUTCHours(0, 0, 0, 0);
+  return t;
+}
+
+function addDays(d: Date, days: number): Date {
+  const t = new Date(d);
+  t.setUTCDate(t.getUTCDate() + days);
+  return t;
+}

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -4,6 +4,7 @@ import ReportService from "@/application/domain/report/service";
 import ReportPresenter, {
   WeeklyReportPayload,
 } from "@/application/domain/report/presenter";
+import { addDays, truncateToJstDate } from "@/application/domain/report/util";
 
 @injectable()
 export default class ReportUseCase {
@@ -65,31 +66,4 @@ export default class ReportUseCase {
   async refreshAllReportViews(ctx: IContext): Promise<void> {
     await this.service.refreshAllReportViews(ctx);
   }
-}
-
-const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
-
-/**
- * Truncate a Date to the start of its Asia/Tokyo calendar day, returning a
- * Date whose UTC components encode that JST date at UTC 00:00.
- *
- * The materialized views bucket dates with `AT TIME ZONE 'Asia/Tokyo'` into
- * `@db.Date` columns. Prisma serializes Date values without timezone info for
- * `@db.Date`, so passing a UTC-midnight Date whose year/month/day match the
- * intended JST calendar date is what lines up the filter with the MV.
- *
- * Using naive `setUTCHours(0,0,0,0)` would cause an off-by-one during
- * 00:00–08:59 JST (= 15:00–23:59 UTC previous day).
- */
-function truncateToJstDate(d: Date): Date {
-  const jst = new Date(d.getTime() + JST_OFFSET_MS);
-  return new Date(
-    Date.UTC(jst.getUTCFullYear(), jst.getUTCMonth(), jst.getUTCDate()),
-  );
-}
-
-function addDays(d: Date, days: number): Date {
-  const t = new Date(d);
-  t.setUTCDate(t.getUTCDate() + days);
-  return t;
 }

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -33,14 +33,14 @@ export default class ReportUseCase {
     const from = addDays(to, -(windowDays - 1));
     const range = { from, to };
 
-    const [summaries, activeUsers, userTransactions, comments] = await Promise.all([
+    const [summaries, activeUsers, userAggregates, comments] = await Promise.all([
       this.service.getDailySummaries(ctx, params.communityId, range),
       this.service.getDailyActiveUsers(ctx, params.communityId, range),
-      this.service.getDailyUserTransactions(ctx, params.communityId, range),
+      this.service.getUserAggregated(ctx, params.communityId, range),
       this.service.getComments(ctx, params.communityId, range, params.commentLimit),
     ]);
 
-    const userIds = Array.from(new Set(userTransactions.map((u) => u.userId)));
+    const userIds = userAggregates.map((u) => u.userId);
     const profiles = await this.service.getUserProfiles(
       ctx,
       params.communityId,
@@ -53,7 +53,7 @@ export default class ReportUseCase {
       referenceDate: to,
       summaries,
       activeUsers,
-      userTransactions,
+      userAggregates,
       profiles,
       comments,
       topN: params.topN,
@@ -61,19 +61,20 @@ export default class ReportUseCase {
   }
 
   /**
-   * Refresh all three materialized views. Called from the daily batch.
+   * Refresh the two materialized views backing the report dataset. Called
+   * from the daily batch.
    *
    * Each refresh runs in its own bypass-RLS transaction (per CLAUDE.md:
    * transactions are managed at the UseCase layer, not the Service layer).
    * They are sequential rather than parallel to keep DB load predictable
    * during the nightly window.
+   *
+   * Note: active-user counts no longer have a dedicated MV — they are
+   * derived at query time from mv_user_transaction_daily.
    */
   async refreshAllReportViews(ctx: IContext): Promise<void> {
     await ctx.issuer.internal((tx) =>
       this.service.refreshTransactionSummaryDaily(ctx, tx),
-    );
-    await ctx.issuer.internal((tx) =>
-      this.service.refreshTransactionActiveUsersDaily(ctx, tx),
     );
     await ctx.issuer.internal((tx) =>
       this.service.refreshUserTransactionDaily(ctx, tx),

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -28,7 +28,7 @@ export default class ReportUseCase {
     },
   ): Promise<WeeklyReportPayload> {
     const windowDays = params.windowDays ?? 7;
-    const to = truncateToDate(params.referenceDate);
+    const to = truncateToJstDate(params.referenceDate);
     const from = addDays(to, -(windowDays - 1));
     const range = { from, to };
 
@@ -67,10 +67,25 @@ export default class ReportUseCase {
   }
 }
 
-function truncateToDate(d: Date): Date {
-  const t = new Date(d);
-  t.setUTCHours(0, 0, 0, 0);
-  return t;
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+/**
+ * Truncate a Date to the start of its Asia/Tokyo calendar day, returning a
+ * Date whose UTC components encode that JST date at UTC 00:00.
+ *
+ * The materialized views bucket dates with `AT TIME ZONE 'Asia/Tokyo'` into
+ * `@db.Date` columns. Prisma serializes Date values without timezone info for
+ * `@db.Date`, so passing a UTC-midnight Date whose year/month/day match the
+ * intended JST calendar date is what lines up the filter with the MV.
+ *
+ * Using naive `setUTCHours(0,0,0,0)` would cause an off-by-one during
+ * 00:00–08:59 JST (= 15:00–23:59 UTC previous day).
+ */
+function truncateToJstDate(d: Date): Date {
+  const jst = new Date(d.getTime() + JST_OFFSET_MS);
+  return new Date(
+    Date.UTC(jst.getUTCFullYear(), jst.getUTCMonth(), jst.getUTCDate()),
+  );
 }
 
 function addDays(d: Date, days: number): Date {

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -62,8 +62,21 @@ export default class ReportUseCase {
 
   /**
    * Refresh all three materialized views. Called from the daily batch.
+   *
+   * Each refresh runs in its own bypass-RLS transaction (per CLAUDE.md:
+   * transactions are managed at the UseCase layer, not the Service layer).
+   * They are sequential rather than parallel to keep DB load predictable
+   * during the nightly window.
    */
   async refreshAllReportViews(ctx: IContext): Promise<void> {
-    await this.service.refreshAllReportViews(ctx);
+    await ctx.issuer.internal((tx) =>
+      this.service.refreshTransactionSummaryDaily(ctx, tx),
+    );
+    await ctx.issuer.internal((tx) =>
+      this.service.refreshTransactionActiveUsersDaily(ctx, tx),
+    );
+    await ctx.issuer.internal((tx) =>
+      this.service.refreshUserTransactionDaily(ctx, tx),
+    );
   }
 }

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -6,6 +6,13 @@ import ReportPresenter, {
 } from "@/application/domain/report/presenter";
 import { addDays, truncateToJstDate } from "@/application/domain/report/util";
 
+const DEFAULT_WINDOW_DAYS = 7;
+const DEFAULT_TOP_N = 10;
+const DEFAULT_COMMENT_LIMIT = 200;
+const MAX_WINDOW_DAYS = 90;
+const MAX_TOP_N = 100;
+const MAX_COMMENT_LIMIT = 1000;
+
 @injectable()
 export default class ReportUseCase {
   constructor(@inject("ReportService") private readonly service: ReportService) {}
@@ -28,19 +35,32 @@ export default class ReportUseCase {
       commentLimit?: number;
     },
   ): Promise<WeeklyReportPayload> {
-    const windowDays = params.windowDays ?? 7;
+    const windowDays = clampInt(
+      params.windowDays ?? DEFAULT_WINDOW_DAYS,
+      1,
+      MAX_WINDOW_DAYS,
+      "windowDays",
+    );
+    const topN = clampInt(params.topN ?? DEFAULT_TOP_N, 1, MAX_TOP_N, "topN");
+    const commentLimit = clampInt(
+      params.commentLimit ?? DEFAULT_COMMENT_LIMIT,
+      0,
+      MAX_COMMENT_LIMIT,
+      "commentLimit",
+    );
+
     const to = truncateToJstDate(params.referenceDate);
     const from = addDays(to, -(windowDays - 1));
     const range = { from, to };
 
-    const [summaries, activeUsers, userAggregates, comments] = await Promise.all([
+    const [summaries, activeUsers, topUserAggregates, comments] = await Promise.all([
       this.service.getDailySummaries(ctx, params.communityId, range),
       this.service.getDailyActiveUsers(ctx, params.communityId, range),
-      this.service.getUserAggregated(ctx, params.communityId, range),
-      this.service.getComments(ctx, params.communityId, range, params.commentLimit),
+      this.service.getTopUsersByTotalPoints(ctx, params.communityId, range, topN),
+      this.service.getComments(ctx, params.communityId, range, commentLimit),
     ]);
 
-    const userIds = userAggregates.map((u) => u.userId);
+    const userIds = topUserAggregates.map((u) => u.userId);
     const profiles = await this.service.getUserProfiles(
       ctx,
       params.communityId,
@@ -53,10 +73,9 @@ export default class ReportUseCase {
       referenceDate: to,
       summaries,
       activeUsers,
-      userAggregates,
+      topUserAggregates,
       profiles,
       comments,
-      topN: params.topN,
     });
   }
 
@@ -80,4 +99,14 @@ export default class ReportUseCase {
       this.service.refreshUserTransactionDaily(ctx, tx),
     );
   }
+}
+
+function clampInt(value: number, min: number, max: number, name: string): number {
+  if (!Number.isInteger(value)) {
+    throw new RangeError(`${name} must be an integer, got ${value}`);
+  }
+  if (value < min || value > max) {
+    throw new RangeError(`${name} must be between ${min} and ${max}, got ${value}`);
+  }
+  return value;
 }

--- a/src/application/domain/report/util.ts
+++ b/src/application/domain/report/util.ts
@@ -43,14 +43,20 @@ export function daysBetweenJst(a: Date, b: Date): number {
 }
 
 /**
- * Convert a Date originating from a JST-bucketed `@db.Date` column (or one
- * produced by `truncateToJstDate`) into an ISO `YYYY-MM-DD` string.
+ * Convert any Date into the ISO `YYYY-MM-DD` string of its Asia/Tokyo
+ * calendar day. Safe to call on either:
+ *   - a Date sourced from a JST-bucketed `@db.Date` column (already at UTC
+ *     00:00 with the JST year/month/day), or
+ *   - a Date holding a full TIMESTAMPTZ value (e.g. `joinedAt` from
+ *     `m.created_at`).
  *
- * Such Dates are stored as UTC 00:00 with the JST calendar year/month/day, so
- * `toISOString().slice(0,10)` directly yields the intended JST date string.
+ * Internally truncates to the JST day before formatting, so the previous
+ * `d.toISOString().slice(0,10)` shortcut — which silently emitted the UTC
+ * calendar date for full timestamps falling in the 15:00–23:59 UTC window —
+ * is no longer a footgun.
  */
 export function toJstIsoDate(d: Date): string {
-  return d.toISOString().slice(0, 10);
+  return truncateToJstDate(d).toISOString().slice(0, 10);
 }
 
 /**

--- a/src/application/domain/report/util.ts
+++ b/src/application/domain/report/util.ts
@@ -1,0 +1,71 @@
+/**
+ * JST timezone utilities for the report dataset.
+ *
+ * The materialized views bucket dates with `AT TIME ZONE 'Asia/Tokyo'` into
+ * `@db.Date` columns. Prisma serializes Date values without timezone info for
+ * `@db.Date`, so passing a UTC-midnight Date whose year/month/day match the
+ * intended JST calendar date is what lines up the filter with the MV. These
+ * helpers centralise that contract.
+ */
+
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+/**
+ * Truncate a Date to the start of its Asia/Tokyo calendar day, returning a
+ * Date whose UTC components encode that JST date at UTC 00:00.
+ *
+ * Using naive `setUTCHours(0,0,0,0)` would cause an off-by-one during
+ * 00:00–08:59 JST (= 15:00–23:59 UTC previous day).
+ */
+export function truncateToJstDate(d: Date): Date {
+  const jst = new Date(d.getTime() + JST_OFFSET_MS);
+  return new Date(
+    Date.UTC(jst.getUTCFullYear(), jst.getUTCMonth(), jst.getUTCDate()),
+  );
+}
+
+export function addDays(d: Date, days: number): Date {
+  const t = new Date(d);
+  t.setUTCDate(t.getUTCDate() + days);
+  return t;
+}
+
+/**
+ * Number of full JST days between two timestamps (b - a). Both inputs are
+ * truncated to their JST calendar day first so the result is independent of
+ * the time-of-day component.
+ */
+export function daysBetweenJst(a: Date, b: Date): number {
+  const msPerDay = 24 * 60 * 60 * 1000;
+  const aDay = truncateToJstDate(a);
+  const bDay = truncateToJstDate(b);
+  return Math.floor((bDay.getTime() - aDay.getTime()) / msPerDay);
+}
+
+/**
+ * Convert a Date originating from a JST-bucketed `@db.Date` column (or one
+ * produced by `truncateToJstDate`) into an ISO `YYYY-MM-DD` string.
+ *
+ * Such Dates are stored as UTC 00:00 with the JST calendar year/month/day, so
+ * `toISOString().slice(0,10)` directly yields the intended JST date string.
+ */
+export function toJstIsoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Convert a BigInt to a Number, throwing if the value would lose precision
+ * (i.e. lies outside Number.MAX_SAFE_INTEGER). Used for AI-payload fields
+ * where downstream consumers expect plain JSON numbers; failing fast surfaces
+ * the issue rather than silently corrupting rankings/aggregates.
+ */
+export function bigintToSafeNumber(value: bigint): number {
+  const MAX = BigInt(Number.MAX_SAFE_INTEGER);
+  const MIN = BigInt(Number.MIN_SAFE_INTEGER);
+  if (value > MAX || value < MIN) {
+    throw new RangeError(
+      `Report value ${value.toString()} exceeds JavaScript safe integer range`,
+    );
+  }
+  return Number(value);
+}

--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -3,6 +3,9 @@ import { prismaClient, PrismaClientIssuer } from "@/infrastructure/prisma/client
 import TransactionUseCase from "@/application/domain/transaction/usecase";
 import TransactionRepository from "@/application/domain/transaction/data/repository";
 import TransactionConverter from "@/application/domain/transaction/data/converter";
+import ReportRepository from "@/application/domain/report/data/repository";
+import ReportService from "@/application/domain/report/service";
+import ReportUseCase from "@/application/domain/report/usecase";
 import ICommunityRepository from "@/application/domain/account/community/data/repository";
 import TransactionService from "@/application/domain/transaction/service";
 import MembershipService from "@/application/domain/account/membership/service";
@@ -329,6 +332,13 @@ export function registerProductionDependencies() {
   container.register("TransactionVerificationUseCase", {
     useClass: TransactionVerificationUseCase,
   });
+
+  // ------------------------------
+  // 📊 Report
+  // ------------------------------
+  container.register("ReportRepository", { useClass: ReportRepository });
+  container.register("ReportService", { useClass: ReportService });
+  container.register("ReportUseCase", { useClass: ReportUseCase });
 
   // ------------------------------
   // 👓 View

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -6,6 +6,7 @@ import { syncDIDVC } from "@/presentation/batch/syncDIDVC";
 import { requestDIDVC } from "@/presentation/batch/requestDIDVC";
 import { syncNftMetadata } from "@/presentation/batch/syncNftMetadata";
 import { refreshPointViews } from "@/presentation/batch/refreshPointViews";
+import { refreshReportViews } from "@/presentation/batch/refreshReportViews";
 
 export async function batchProcess() {
   switch (process.env.BATCH_PROCESS_NAME) {
@@ -29,6 +30,9 @@ export async function batchProcess() {
       return;
     case "refresh-point-views":
       await refreshPointViews();
+      return;
+    case "refresh-report-views":
+      await refreshReportViews();
       return;
     default:
       logger.error("Invalid batch process called.");

--- a/src/infrastructure/prisma/factories/__generated__/index.ts
+++ b/src/infrastructure/prisma/factories/__generated__/index.ts
@@ -46,6 +46,11 @@ import type { MembershipParticipationCountView } from "@prisma/client";
 import type { MembershipHostedOpportunityCountView } from "@prisma/client";
 import type { CurrentPointView } from "@prisma/client";
 import type { AccumulatedPointView } from "@prisma/client";
+import type { TransactionSummaryDailyView } from "@prisma/client";
+import type { TransactionActiveUsersDailyView } from "@prisma/client";
+import type { UserTransactionDailyView } from "@prisma/client";
+import type { TransactionCommentView } from "@prisma/client";
+import type { UserProfileForReportView } from "@prisma/client";
 import type { EarliestReservableSlotView } from "@prisma/client";
 import type { OpportunityAccumulatedParticipantsView } from "@prisma/client";
 import type { RemainingCapacityView } from "@prisma/client";
@@ -948,6 +953,21 @@ const modelFieldDefinitions: ModelWithFields[] = [{
                 type: "Wallet",
                 relationName: "AccumulatedPointViewToWallet"
             }]
+    }, {
+        name: "TransactionSummaryDailyView",
+        fields: []
+    }, {
+        name: "TransactionActiveUsersDailyView",
+        fields: []
+    }, {
+        name: "UserTransactionDailyView",
+        fields: []
+    }, {
+        name: "TransactionCommentView",
+        fields: []
+    }, {
+        name: "UserProfileForReportView",
+        fields: []
     }, {
         name: "EarliestReservableSlotView",
         fields: [{
@@ -9261,6 +9281,813 @@ export const defineAccumulatedPointViewFactory = (<TOptions extends AccumulatedP
 }) as AccumulatedPointViewFactoryBuilder;
 
 defineAccumulatedPointViewFactory.withTransientFields = defaultTransientFieldValues => options => defineAccumulatedPointViewFactoryInternal(options, defaultTransientFieldValues);
+
+type TransactionSummaryDailyViewScalarOrEnumFields = {
+    date: Date;
+    communityId: string;
+    reason: TransactionReason;
+    txCount: number;
+    pointsSum: (bigint | number);
+    chainRootCount: number;
+    chainDescendantCount: number;
+    sumChainDepth: number;
+    issuanceCount: number;
+    burnCount: number;
+};
+
+type TransactionSummaryDailyViewFactoryDefineInput = {
+    date?: Date;
+    communityId?: string;
+    reason?: TransactionReason;
+    txCount?: number;
+    pointsSum?: (bigint | number);
+    chainRootCount?: number;
+    chainDescendantCount?: number;
+    maxChainDepth?: number | null;
+    sumChainDepth?: number;
+    issuanceCount?: number;
+    burnCount?: number;
+};
+
+type TransactionSummaryDailyViewTransientFields = Record<string, unknown> & Partial<Record<keyof TransactionSummaryDailyViewFactoryDefineInput, never>>;
+
+type TransactionSummaryDailyViewFactoryTrait<TTransients extends Record<string, unknown>> = {
+    data?: Resolver<Partial<TransactionSummaryDailyViewFactoryDefineInput>, BuildDataOptions<TTransients>>;
+} & CallbackDefineOptions<TransactionSummaryDailyView, Prisma.TransactionSummaryDailyViewCreateInput, TTransients>;
+
+type TransactionSummaryDailyViewFactoryDefineOptions<TTransients extends Record<string, unknown> = Record<string, unknown>> = {
+    defaultData?: Resolver<TransactionSummaryDailyViewFactoryDefineInput, BuildDataOptions<TTransients>>;
+    traits?: {
+        [traitName: TraitName]: TransactionSummaryDailyViewFactoryTrait<TTransients>;
+    };
+} & CallbackDefineOptions<TransactionSummaryDailyView, Prisma.TransactionSummaryDailyViewCreateInput, TTransients>;
+
+type TransactionSummaryDailyViewTraitKeys<TOptions extends TransactionSummaryDailyViewFactoryDefineOptions<any>> = Exclude<keyof TOptions["traits"], number>;
+
+export interface TransactionSummaryDailyViewFactoryInterfaceWithoutTraits<TTransients extends Record<string, unknown>> {
+    readonly _factoryFor: "TransactionSummaryDailyView";
+    build(inputData?: Partial<Prisma.TransactionSummaryDailyViewCreateInput & TTransients>): PromiseLike<Prisma.TransactionSummaryDailyViewCreateInput>;
+    buildCreateInput(inputData?: Partial<Prisma.TransactionSummaryDailyViewCreateInput & TTransients>): PromiseLike<Prisma.TransactionSummaryDailyViewCreateInput>;
+    buildList(list: readonly Partial<Prisma.TransactionSummaryDailyViewCreateInput & TTransients>[]): PromiseLike<Prisma.TransactionSummaryDailyViewCreateInput[]>;
+    buildList(count: number, item?: Partial<Prisma.TransactionSummaryDailyViewCreateInput & TTransients>): PromiseLike<Prisma.TransactionSummaryDailyViewCreateInput[]>;
+    pickForConnect(inputData: TransactionSummaryDailyView): Pick<TransactionSummaryDailyView, "date" | "communityId" | "reason">;
+    create(inputData?: Partial<Prisma.TransactionSummaryDailyViewCreateInput & TTransients>): PromiseLike<TransactionSummaryDailyView>;
+    createList(list: readonly Partial<Prisma.TransactionSummaryDailyViewCreateInput & TTransients>[]): PromiseLike<TransactionSummaryDailyView[]>;
+    createList(count: number, item?: Partial<Prisma.TransactionSummaryDailyViewCreateInput & TTransients>): PromiseLike<TransactionSummaryDailyView[]>;
+    createForConnect(inputData?: Partial<Prisma.TransactionSummaryDailyViewCreateInput & TTransients>): PromiseLike<Pick<TransactionSummaryDailyView, "date" | "communityId" | "reason">>;
+}
+
+export interface TransactionSummaryDailyViewFactoryInterface<TTransients extends Record<string, unknown> = Record<string, unknown>, TTraitName extends TraitName = TraitName> extends TransactionSummaryDailyViewFactoryInterfaceWithoutTraits<TTransients> {
+    use(name: TTraitName, ...names: readonly TTraitName[]): TransactionSummaryDailyViewFactoryInterfaceWithoutTraits<TTransients>;
+}
+
+function autoGenerateTransactionSummaryDailyViewScalarsOrEnums({ seq }: {
+    readonly seq: number;
+}): TransactionSummaryDailyViewScalarOrEnumFields {
+    return {
+        date: getScalarFieldValueGenerator().DateTime({ modelName: "TransactionSummaryDailyView", fieldName: "date", isId: true, isUnique: false, seq }),
+        communityId: getScalarFieldValueGenerator().String({ modelName: "TransactionSummaryDailyView", fieldName: "communityId", isId: true, isUnique: false, seq }),
+        reason: "POINT_ISSUED",
+        txCount: getScalarFieldValueGenerator().Int({ modelName: "TransactionSummaryDailyView", fieldName: "txCount", isId: false, isUnique: false, seq }),
+        pointsSum: getScalarFieldValueGenerator().BigInt({ modelName: "TransactionSummaryDailyView", fieldName: "pointsSum", isId: false, isUnique: false, seq }),
+        chainRootCount: getScalarFieldValueGenerator().Int({ modelName: "TransactionSummaryDailyView", fieldName: "chainRootCount", isId: false, isUnique: false, seq }),
+        chainDescendantCount: getScalarFieldValueGenerator().Int({ modelName: "TransactionSummaryDailyView", fieldName: "chainDescendantCount", isId: false, isUnique: false, seq }),
+        sumChainDepth: getScalarFieldValueGenerator().Int({ modelName: "TransactionSummaryDailyView", fieldName: "sumChainDepth", isId: false, isUnique: false, seq }),
+        issuanceCount: getScalarFieldValueGenerator().Int({ modelName: "TransactionSummaryDailyView", fieldName: "issuanceCount", isId: false, isUnique: false, seq }),
+        burnCount: getScalarFieldValueGenerator().Int({ modelName: "TransactionSummaryDailyView", fieldName: "burnCount", isId: false, isUnique: false, seq })
+    };
+}
+
+function defineTransactionSummaryDailyViewFactoryInternal<TTransients extends Record<string, unknown>, TOptions extends TransactionSummaryDailyViewFactoryDefineOptions<TTransients>>({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }: TOptions, defaultTransientFieldValues: TTransients): TransactionSummaryDailyViewFactoryInterface<TTransients, TransactionSummaryDailyViewTraitKeys<TOptions>> {
+    const getFactoryWithTraits = (traitKeys: readonly TransactionSummaryDailyViewTraitKeys<TOptions>[] = []) => {
+        const seqKey = {};
+        const getSeq = () => getSequenceCounter(seqKey);
+        const screen = createScreener("TransactionSummaryDailyView", modelFieldDefinitions);
+        const handleAfterBuild = createCallbackChain([
+            onAfterBuild,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterBuild),
+        ]);
+        const handleBeforeCreate = createCallbackChain([
+            ...traitKeys.slice().reverse().map(traitKey => traitsDefs[traitKey]?.onBeforeCreate),
+            onBeforeCreate,
+        ]);
+        const handleAfterCreate = createCallbackChain([
+            onAfterCreate,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterCreate),
+        ]);
+        const build = async (inputData: Partial<Prisma.TransactionSummaryDailyViewCreateInput & TTransients> = {}) => {
+            const seq = getSeq();
+            const requiredScalarData = autoGenerateTransactionSummaryDailyViewScalarsOrEnums({ seq });
+            const resolveValue = normalizeResolver<TransactionSummaryDailyViewFactoryDefineInput, BuildDataOptions<any>>(defaultDataResolver ?? {});
+            const [transientFields, filteredInputData] = destructure(defaultTransientFieldValues, inputData);
+            const resolverInput = { seq, ...transientFields };
+            const defaultData = await traitKeys.reduce(async (queue, traitKey) => {
+                const acc = await queue;
+                const resolveTraitValue = normalizeResolver<Partial<TransactionSummaryDailyViewFactoryDefineInput>, BuildDataOptions<TTransients>>(traitsDefs[traitKey]?.data ?? {});
+                const traitData = await resolveTraitValue(resolverInput);
+                return {
+                    ...acc,
+                    ...traitData,
+                };
+            }, resolveValue(resolverInput));
+            const defaultAssociations = {} as Prisma.TransactionSummaryDailyViewCreateInput;
+            const data: Prisma.TransactionSummaryDailyViewCreateInput = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...filteredInputData };
+            await handleAfterBuild(data, transientFields);
+            return data;
+        };
+        const buildList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.TransactionSummaryDailyViewCreateInput & TTransients>>(...args).map(data => build(data)));
+        const pickForConnect = (inputData: TransactionSummaryDailyView) => ({
+            date: inputData.date,
+            communityId: inputData.communityId,
+            reason: inputData.reason
+        });
+        const create = async (inputData: Partial<Prisma.TransactionSummaryDailyViewCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
+            const [transientFields] = destructure(defaultTransientFieldValues, inputData);
+            await handleBeforeCreate(data, transientFields);
+            const createdData = await getClient<PrismaClient>().transactionSummaryDailyView.create({ data });
+            await handleAfterCreate(createdData, transientFields);
+            return createdData;
+        };
+        const createList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.TransactionSummaryDailyViewCreateInput & TTransients>>(...args).map(data => create(data)));
+        const createForConnect = (inputData: Partial<Prisma.TransactionSummaryDailyViewCreateInput & TTransients> = {}) => create(inputData).then(pickForConnect);
+        return {
+            _factoryFor: "TransactionSummaryDailyView" as const,
+            build,
+            buildList,
+            buildCreateInput: build,
+            pickForConnect,
+            create,
+            createList,
+            createForConnect,
+        };
+    };
+    const factory = getFactoryWithTraits();
+    const useTraits = (name: TransactionSummaryDailyViewTraitKeys<TOptions>, ...names: readonly TransactionSummaryDailyViewTraitKeys<TOptions>[]) => {
+        return getFactoryWithTraits([name, ...names]);
+    };
+    return {
+        ...factory,
+        use: useTraits,
+    };
+}
+
+interface TransactionSummaryDailyViewFactoryBuilder {
+    <TOptions extends TransactionSummaryDailyViewFactoryDefineOptions>(options?: TOptions): TransactionSummaryDailyViewFactoryInterface<{}, TransactionSummaryDailyViewTraitKeys<TOptions>>;
+    withTransientFields: <TTransients extends TransactionSummaryDailyViewTransientFields>(defaultTransientFieldValues: TTransients) => <TOptions extends TransactionSummaryDailyViewFactoryDefineOptions<TTransients>>(options?: TOptions) => TransactionSummaryDailyViewFactoryInterface<TTransients, TransactionSummaryDailyViewTraitKeys<TOptions>>;
+}
+
+/**
+ * Define factory for {@link TransactionSummaryDailyView} model.
+ *
+ * @param options
+ * @returns factory {@link TransactionSummaryDailyViewFactoryInterface}
+ */
+export const defineTransactionSummaryDailyViewFactory = (<TOptions extends TransactionSummaryDailyViewFactoryDefineOptions>(options?: TOptions): TransactionSummaryDailyViewFactoryInterface<TOptions> => {
+    return defineTransactionSummaryDailyViewFactoryInternal(options ?? {}, {});
+}) as TransactionSummaryDailyViewFactoryBuilder;
+
+defineTransactionSummaryDailyViewFactory.withTransientFields = defaultTransientFieldValues => options => defineTransactionSummaryDailyViewFactoryInternal(options ?? {}, defaultTransientFieldValues);
+
+type TransactionActiveUsersDailyViewScalarOrEnumFields = {
+    date: Date;
+    communityId: string;
+    activeUsers: number;
+    senders: number;
+    receivers: number;
+};
+
+type TransactionActiveUsersDailyViewFactoryDefineInput = {
+    date?: Date;
+    communityId?: string;
+    activeUsers?: number;
+    senders?: number;
+    receivers?: number;
+};
+
+type TransactionActiveUsersDailyViewTransientFields = Record<string, unknown> & Partial<Record<keyof TransactionActiveUsersDailyViewFactoryDefineInput, never>>;
+
+type TransactionActiveUsersDailyViewFactoryTrait<TTransients extends Record<string, unknown>> = {
+    data?: Resolver<Partial<TransactionActiveUsersDailyViewFactoryDefineInput>, BuildDataOptions<TTransients>>;
+} & CallbackDefineOptions<TransactionActiveUsersDailyView, Prisma.TransactionActiveUsersDailyViewCreateInput, TTransients>;
+
+type TransactionActiveUsersDailyViewFactoryDefineOptions<TTransients extends Record<string, unknown> = Record<string, unknown>> = {
+    defaultData?: Resolver<TransactionActiveUsersDailyViewFactoryDefineInput, BuildDataOptions<TTransients>>;
+    traits?: {
+        [traitName: TraitName]: TransactionActiveUsersDailyViewFactoryTrait<TTransients>;
+    };
+} & CallbackDefineOptions<TransactionActiveUsersDailyView, Prisma.TransactionActiveUsersDailyViewCreateInput, TTransients>;
+
+type TransactionActiveUsersDailyViewTraitKeys<TOptions extends TransactionActiveUsersDailyViewFactoryDefineOptions<any>> = Exclude<keyof TOptions["traits"], number>;
+
+export interface TransactionActiveUsersDailyViewFactoryInterfaceWithoutTraits<TTransients extends Record<string, unknown>> {
+    readonly _factoryFor: "TransactionActiveUsersDailyView";
+    build(inputData?: Partial<Prisma.TransactionActiveUsersDailyViewCreateInput & TTransients>): PromiseLike<Prisma.TransactionActiveUsersDailyViewCreateInput>;
+    buildCreateInput(inputData?: Partial<Prisma.TransactionActiveUsersDailyViewCreateInput & TTransients>): PromiseLike<Prisma.TransactionActiveUsersDailyViewCreateInput>;
+    buildList(list: readonly Partial<Prisma.TransactionActiveUsersDailyViewCreateInput & TTransients>[]): PromiseLike<Prisma.TransactionActiveUsersDailyViewCreateInput[]>;
+    buildList(count: number, item?: Partial<Prisma.TransactionActiveUsersDailyViewCreateInput & TTransients>): PromiseLike<Prisma.TransactionActiveUsersDailyViewCreateInput[]>;
+    pickForConnect(inputData: TransactionActiveUsersDailyView): Pick<TransactionActiveUsersDailyView, "date" | "communityId">;
+    create(inputData?: Partial<Prisma.TransactionActiveUsersDailyViewCreateInput & TTransients>): PromiseLike<TransactionActiveUsersDailyView>;
+    createList(list: readonly Partial<Prisma.TransactionActiveUsersDailyViewCreateInput & TTransients>[]): PromiseLike<TransactionActiveUsersDailyView[]>;
+    createList(count: number, item?: Partial<Prisma.TransactionActiveUsersDailyViewCreateInput & TTransients>): PromiseLike<TransactionActiveUsersDailyView[]>;
+    createForConnect(inputData?: Partial<Prisma.TransactionActiveUsersDailyViewCreateInput & TTransients>): PromiseLike<Pick<TransactionActiveUsersDailyView, "date" | "communityId">>;
+}
+
+export interface TransactionActiveUsersDailyViewFactoryInterface<TTransients extends Record<string, unknown> = Record<string, unknown>, TTraitName extends TraitName = TraitName> extends TransactionActiveUsersDailyViewFactoryInterfaceWithoutTraits<TTransients> {
+    use(name: TTraitName, ...names: readonly TTraitName[]): TransactionActiveUsersDailyViewFactoryInterfaceWithoutTraits<TTransients>;
+}
+
+function autoGenerateTransactionActiveUsersDailyViewScalarsOrEnums({ seq }: {
+    readonly seq: number;
+}): TransactionActiveUsersDailyViewScalarOrEnumFields {
+    return {
+        date: getScalarFieldValueGenerator().DateTime({ modelName: "TransactionActiveUsersDailyView", fieldName: "date", isId: true, isUnique: false, seq }),
+        communityId: getScalarFieldValueGenerator().String({ modelName: "TransactionActiveUsersDailyView", fieldName: "communityId", isId: true, isUnique: false, seq }),
+        activeUsers: getScalarFieldValueGenerator().Int({ modelName: "TransactionActiveUsersDailyView", fieldName: "activeUsers", isId: false, isUnique: false, seq }),
+        senders: getScalarFieldValueGenerator().Int({ modelName: "TransactionActiveUsersDailyView", fieldName: "senders", isId: false, isUnique: false, seq }),
+        receivers: getScalarFieldValueGenerator().Int({ modelName: "TransactionActiveUsersDailyView", fieldName: "receivers", isId: false, isUnique: false, seq })
+    };
+}
+
+function defineTransactionActiveUsersDailyViewFactoryInternal<TTransients extends Record<string, unknown>, TOptions extends TransactionActiveUsersDailyViewFactoryDefineOptions<TTransients>>({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }: TOptions, defaultTransientFieldValues: TTransients): TransactionActiveUsersDailyViewFactoryInterface<TTransients, TransactionActiveUsersDailyViewTraitKeys<TOptions>> {
+    const getFactoryWithTraits = (traitKeys: readonly TransactionActiveUsersDailyViewTraitKeys<TOptions>[] = []) => {
+        const seqKey = {};
+        const getSeq = () => getSequenceCounter(seqKey);
+        const screen = createScreener("TransactionActiveUsersDailyView", modelFieldDefinitions);
+        const handleAfterBuild = createCallbackChain([
+            onAfterBuild,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterBuild),
+        ]);
+        const handleBeforeCreate = createCallbackChain([
+            ...traitKeys.slice().reverse().map(traitKey => traitsDefs[traitKey]?.onBeforeCreate),
+            onBeforeCreate,
+        ]);
+        const handleAfterCreate = createCallbackChain([
+            onAfterCreate,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterCreate),
+        ]);
+        const build = async (inputData: Partial<Prisma.TransactionActiveUsersDailyViewCreateInput & TTransients> = {}) => {
+            const seq = getSeq();
+            const requiredScalarData = autoGenerateTransactionActiveUsersDailyViewScalarsOrEnums({ seq });
+            const resolveValue = normalizeResolver<TransactionActiveUsersDailyViewFactoryDefineInput, BuildDataOptions<any>>(defaultDataResolver ?? {});
+            const [transientFields, filteredInputData] = destructure(defaultTransientFieldValues, inputData);
+            const resolverInput = { seq, ...transientFields };
+            const defaultData = await traitKeys.reduce(async (queue, traitKey) => {
+                const acc = await queue;
+                const resolveTraitValue = normalizeResolver<Partial<TransactionActiveUsersDailyViewFactoryDefineInput>, BuildDataOptions<TTransients>>(traitsDefs[traitKey]?.data ?? {});
+                const traitData = await resolveTraitValue(resolverInput);
+                return {
+                    ...acc,
+                    ...traitData,
+                };
+            }, resolveValue(resolverInput));
+            const defaultAssociations = {} as Prisma.TransactionActiveUsersDailyViewCreateInput;
+            const data: Prisma.TransactionActiveUsersDailyViewCreateInput = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...filteredInputData };
+            await handleAfterBuild(data, transientFields);
+            return data;
+        };
+        const buildList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.TransactionActiveUsersDailyViewCreateInput & TTransients>>(...args).map(data => build(data)));
+        const pickForConnect = (inputData: TransactionActiveUsersDailyView) => ({
+            date: inputData.date,
+            communityId: inputData.communityId
+        });
+        const create = async (inputData: Partial<Prisma.TransactionActiveUsersDailyViewCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
+            const [transientFields] = destructure(defaultTransientFieldValues, inputData);
+            await handleBeforeCreate(data, transientFields);
+            const createdData = await getClient<PrismaClient>().transactionActiveUsersDailyView.create({ data });
+            await handleAfterCreate(createdData, transientFields);
+            return createdData;
+        };
+        const createList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.TransactionActiveUsersDailyViewCreateInput & TTransients>>(...args).map(data => create(data)));
+        const createForConnect = (inputData: Partial<Prisma.TransactionActiveUsersDailyViewCreateInput & TTransients> = {}) => create(inputData).then(pickForConnect);
+        return {
+            _factoryFor: "TransactionActiveUsersDailyView" as const,
+            build,
+            buildList,
+            buildCreateInput: build,
+            pickForConnect,
+            create,
+            createList,
+            createForConnect,
+        };
+    };
+    const factory = getFactoryWithTraits();
+    const useTraits = (name: TransactionActiveUsersDailyViewTraitKeys<TOptions>, ...names: readonly TransactionActiveUsersDailyViewTraitKeys<TOptions>[]) => {
+        return getFactoryWithTraits([name, ...names]);
+    };
+    return {
+        ...factory,
+        use: useTraits,
+    };
+}
+
+interface TransactionActiveUsersDailyViewFactoryBuilder {
+    <TOptions extends TransactionActiveUsersDailyViewFactoryDefineOptions>(options?: TOptions): TransactionActiveUsersDailyViewFactoryInterface<{}, TransactionActiveUsersDailyViewTraitKeys<TOptions>>;
+    withTransientFields: <TTransients extends TransactionActiveUsersDailyViewTransientFields>(defaultTransientFieldValues: TTransients) => <TOptions extends TransactionActiveUsersDailyViewFactoryDefineOptions<TTransients>>(options?: TOptions) => TransactionActiveUsersDailyViewFactoryInterface<TTransients, TransactionActiveUsersDailyViewTraitKeys<TOptions>>;
+}
+
+/**
+ * Define factory for {@link TransactionActiveUsersDailyView} model.
+ *
+ * @param options
+ * @returns factory {@link TransactionActiveUsersDailyViewFactoryInterface}
+ */
+export const defineTransactionActiveUsersDailyViewFactory = (<TOptions extends TransactionActiveUsersDailyViewFactoryDefineOptions>(options?: TOptions): TransactionActiveUsersDailyViewFactoryInterface<TOptions> => {
+    return defineTransactionActiveUsersDailyViewFactoryInternal(options ?? {}, {});
+}) as TransactionActiveUsersDailyViewFactoryBuilder;
+
+defineTransactionActiveUsersDailyViewFactory.withTransientFields = defaultTransientFieldValues => options => defineTransactionActiveUsersDailyViewFactoryInternal(options ?? {}, defaultTransientFieldValues);
+
+type UserTransactionDailyViewScalarOrEnumFields = {
+    date: Date;
+    communityId: string;
+    userId: string;
+    walletId: string;
+    txCountIn: number;
+    txCountOut: number;
+    pointsIn: (bigint | number);
+    pointsOut: (bigint | number);
+    donationOutCount: number;
+    donationOutPoints: (bigint | number);
+    receivedDonationCount: number;
+    chainRootCount: number;
+    uniqueCounterparties: number;
+};
+
+type UserTransactionDailyViewFactoryDefineInput = {
+    date?: Date;
+    communityId?: string;
+    userId?: string;
+    walletId?: string;
+    txCountIn?: number;
+    txCountOut?: number;
+    pointsIn?: (bigint | number);
+    pointsOut?: (bigint | number);
+    donationOutCount?: number;
+    donationOutPoints?: (bigint | number);
+    receivedDonationCount?: number;
+    chainRootCount?: number;
+    maxChainDepthStarted?: number | null;
+    chainDepthReachedMax?: number | null;
+    uniqueCounterparties?: number;
+};
+
+type UserTransactionDailyViewTransientFields = Record<string, unknown> & Partial<Record<keyof UserTransactionDailyViewFactoryDefineInput, never>>;
+
+type UserTransactionDailyViewFactoryTrait<TTransients extends Record<string, unknown>> = {
+    data?: Resolver<Partial<UserTransactionDailyViewFactoryDefineInput>, BuildDataOptions<TTransients>>;
+} & CallbackDefineOptions<UserTransactionDailyView, Prisma.UserTransactionDailyViewCreateInput, TTransients>;
+
+type UserTransactionDailyViewFactoryDefineOptions<TTransients extends Record<string, unknown> = Record<string, unknown>> = {
+    defaultData?: Resolver<UserTransactionDailyViewFactoryDefineInput, BuildDataOptions<TTransients>>;
+    traits?: {
+        [traitName: TraitName]: UserTransactionDailyViewFactoryTrait<TTransients>;
+    };
+} & CallbackDefineOptions<UserTransactionDailyView, Prisma.UserTransactionDailyViewCreateInput, TTransients>;
+
+type UserTransactionDailyViewTraitKeys<TOptions extends UserTransactionDailyViewFactoryDefineOptions<any>> = Exclude<keyof TOptions["traits"], number>;
+
+export interface UserTransactionDailyViewFactoryInterfaceWithoutTraits<TTransients extends Record<string, unknown>> {
+    readonly _factoryFor: "UserTransactionDailyView";
+    build(inputData?: Partial<Prisma.UserTransactionDailyViewCreateInput & TTransients>): PromiseLike<Prisma.UserTransactionDailyViewCreateInput>;
+    buildCreateInput(inputData?: Partial<Prisma.UserTransactionDailyViewCreateInput & TTransients>): PromiseLike<Prisma.UserTransactionDailyViewCreateInput>;
+    buildList(list: readonly Partial<Prisma.UserTransactionDailyViewCreateInput & TTransients>[]): PromiseLike<Prisma.UserTransactionDailyViewCreateInput[]>;
+    buildList(count: number, item?: Partial<Prisma.UserTransactionDailyViewCreateInput & TTransients>): PromiseLike<Prisma.UserTransactionDailyViewCreateInput[]>;
+    pickForConnect(inputData: UserTransactionDailyView): Pick<UserTransactionDailyView, "date" | "communityId" | "userId" | "walletId">;
+    create(inputData?: Partial<Prisma.UserTransactionDailyViewCreateInput & TTransients>): PromiseLike<UserTransactionDailyView>;
+    createList(list: readonly Partial<Prisma.UserTransactionDailyViewCreateInput & TTransients>[]): PromiseLike<UserTransactionDailyView[]>;
+    createList(count: number, item?: Partial<Prisma.UserTransactionDailyViewCreateInput & TTransients>): PromiseLike<UserTransactionDailyView[]>;
+    createForConnect(inputData?: Partial<Prisma.UserTransactionDailyViewCreateInput & TTransients>): PromiseLike<Pick<UserTransactionDailyView, "date" | "communityId" | "userId" | "walletId">>;
+}
+
+export interface UserTransactionDailyViewFactoryInterface<TTransients extends Record<string, unknown> = Record<string, unknown>, TTraitName extends TraitName = TraitName> extends UserTransactionDailyViewFactoryInterfaceWithoutTraits<TTransients> {
+    use(name: TTraitName, ...names: readonly TTraitName[]): UserTransactionDailyViewFactoryInterfaceWithoutTraits<TTransients>;
+}
+
+function autoGenerateUserTransactionDailyViewScalarsOrEnums({ seq }: {
+    readonly seq: number;
+}): UserTransactionDailyViewScalarOrEnumFields {
+    return {
+        date: getScalarFieldValueGenerator().DateTime({ modelName: "UserTransactionDailyView", fieldName: "date", isId: true, isUnique: false, seq }),
+        communityId: getScalarFieldValueGenerator().String({ modelName: "UserTransactionDailyView", fieldName: "communityId", isId: true, isUnique: false, seq }),
+        userId: getScalarFieldValueGenerator().String({ modelName: "UserTransactionDailyView", fieldName: "userId", isId: true, isUnique: false, seq }),
+        walletId: getScalarFieldValueGenerator().String({ modelName: "UserTransactionDailyView", fieldName: "walletId", isId: true, isUnique: false, seq }),
+        txCountIn: getScalarFieldValueGenerator().Int({ modelName: "UserTransactionDailyView", fieldName: "txCountIn", isId: false, isUnique: false, seq }),
+        txCountOut: getScalarFieldValueGenerator().Int({ modelName: "UserTransactionDailyView", fieldName: "txCountOut", isId: false, isUnique: false, seq }),
+        pointsIn: getScalarFieldValueGenerator().BigInt({ modelName: "UserTransactionDailyView", fieldName: "pointsIn", isId: false, isUnique: false, seq }),
+        pointsOut: getScalarFieldValueGenerator().BigInt({ modelName: "UserTransactionDailyView", fieldName: "pointsOut", isId: false, isUnique: false, seq }),
+        donationOutCount: getScalarFieldValueGenerator().Int({ modelName: "UserTransactionDailyView", fieldName: "donationOutCount", isId: false, isUnique: false, seq }),
+        donationOutPoints: getScalarFieldValueGenerator().BigInt({ modelName: "UserTransactionDailyView", fieldName: "donationOutPoints", isId: false, isUnique: false, seq }),
+        receivedDonationCount: getScalarFieldValueGenerator().Int({ modelName: "UserTransactionDailyView", fieldName: "receivedDonationCount", isId: false, isUnique: false, seq }),
+        chainRootCount: getScalarFieldValueGenerator().Int({ modelName: "UserTransactionDailyView", fieldName: "chainRootCount", isId: false, isUnique: false, seq }),
+        uniqueCounterparties: getScalarFieldValueGenerator().Int({ modelName: "UserTransactionDailyView", fieldName: "uniqueCounterparties", isId: false, isUnique: false, seq })
+    };
+}
+
+function defineUserTransactionDailyViewFactoryInternal<TTransients extends Record<string, unknown>, TOptions extends UserTransactionDailyViewFactoryDefineOptions<TTransients>>({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }: TOptions, defaultTransientFieldValues: TTransients): UserTransactionDailyViewFactoryInterface<TTransients, UserTransactionDailyViewTraitKeys<TOptions>> {
+    const getFactoryWithTraits = (traitKeys: readonly UserTransactionDailyViewTraitKeys<TOptions>[] = []) => {
+        const seqKey = {};
+        const getSeq = () => getSequenceCounter(seqKey);
+        const screen = createScreener("UserTransactionDailyView", modelFieldDefinitions);
+        const handleAfterBuild = createCallbackChain([
+            onAfterBuild,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterBuild),
+        ]);
+        const handleBeforeCreate = createCallbackChain([
+            ...traitKeys.slice().reverse().map(traitKey => traitsDefs[traitKey]?.onBeforeCreate),
+            onBeforeCreate,
+        ]);
+        const handleAfterCreate = createCallbackChain([
+            onAfterCreate,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterCreate),
+        ]);
+        const build = async (inputData: Partial<Prisma.UserTransactionDailyViewCreateInput & TTransients> = {}) => {
+            const seq = getSeq();
+            const requiredScalarData = autoGenerateUserTransactionDailyViewScalarsOrEnums({ seq });
+            const resolveValue = normalizeResolver<UserTransactionDailyViewFactoryDefineInput, BuildDataOptions<any>>(defaultDataResolver ?? {});
+            const [transientFields, filteredInputData] = destructure(defaultTransientFieldValues, inputData);
+            const resolverInput = { seq, ...transientFields };
+            const defaultData = await traitKeys.reduce(async (queue, traitKey) => {
+                const acc = await queue;
+                const resolveTraitValue = normalizeResolver<Partial<UserTransactionDailyViewFactoryDefineInput>, BuildDataOptions<TTransients>>(traitsDefs[traitKey]?.data ?? {});
+                const traitData = await resolveTraitValue(resolverInput);
+                return {
+                    ...acc,
+                    ...traitData,
+                };
+            }, resolveValue(resolverInput));
+            const defaultAssociations = {} as Prisma.UserTransactionDailyViewCreateInput;
+            const data: Prisma.UserTransactionDailyViewCreateInput = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...filteredInputData };
+            await handleAfterBuild(data, transientFields);
+            return data;
+        };
+        const buildList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.UserTransactionDailyViewCreateInput & TTransients>>(...args).map(data => build(data)));
+        const pickForConnect = (inputData: UserTransactionDailyView) => ({
+            date: inputData.date,
+            communityId: inputData.communityId,
+            userId: inputData.userId,
+            walletId: inputData.walletId
+        });
+        const create = async (inputData: Partial<Prisma.UserTransactionDailyViewCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
+            const [transientFields] = destructure(defaultTransientFieldValues, inputData);
+            await handleBeforeCreate(data, transientFields);
+            const createdData = await getClient<PrismaClient>().userTransactionDailyView.create({ data });
+            await handleAfterCreate(createdData, transientFields);
+            return createdData;
+        };
+        const createList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.UserTransactionDailyViewCreateInput & TTransients>>(...args).map(data => create(data)));
+        const createForConnect = (inputData: Partial<Prisma.UserTransactionDailyViewCreateInput & TTransients> = {}) => create(inputData).then(pickForConnect);
+        return {
+            _factoryFor: "UserTransactionDailyView" as const,
+            build,
+            buildList,
+            buildCreateInput: build,
+            pickForConnect,
+            create,
+            createList,
+            createForConnect,
+        };
+    };
+    const factory = getFactoryWithTraits();
+    const useTraits = (name: UserTransactionDailyViewTraitKeys<TOptions>, ...names: readonly UserTransactionDailyViewTraitKeys<TOptions>[]) => {
+        return getFactoryWithTraits([name, ...names]);
+    };
+    return {
+        ...factory,
+        use: useTraits,
+    };
+}
+
+interface UserTransactionDailyViewFactoryBuilder {
+    <TOptions extends UserTransactionDailyViewFactoryDefineOptions>(options?: TOptions): UserTransactionDailyViewFactoryInterface<{}, UserTransactionDailyViewTraitKeys<TOptions>>;
+    withTransientFields: <TTransients extends UserTransactionDailyViewTransientFields>(defaultTransientFieldValues: TTransients) => <TOptions extends UserTransactionDailyViewFactoryDefineOptions<TTransients>>(options?: TOptions) => UserTransactionDailyViewFactoryInterface<TTransients, UserTransactionDailyViewTraitKeys<TOptions>>;
+}
+
+/**
+ * Define factory for {@link UserTransactionDailyView} model.
+ *
+ * @param options
+ * @returns factory {@link UserTransactionDailyViewFactoryInterface}
+ */
+export const defineUserTransactionDailyViewFactory = (<TOptions extends UserTransactionDailyViewFactoryDefineOptions>(options?: TOptions): UserTransactionDailyViewFactoryInterface<TOptions> => {
+    return defineUserTransactionDailyViewFactoryInternal(options ?? {}, {});
+}) as UserTransactionDailyViewFactoryBuilder;
+
+defineUserTransactionDailyViewFactory.withTransientFields = defaultTransientFieldValues => options => defineUserTransactionDailyViewFactoryInternal(options ?? {}, defaultTransientFieldValues);
+
+type TransactionCommentViewScalarOrEnumFields = {
+    transactionId: string;
+    date: Date;
+    createdAt: Date;
+    communityId: string;
+    reason: TransactionReason;
+    points: number;
+    comment: string;
+};
+
+type TransactionCommentViewFactoryDefineInput = {
+    transactionId?: string;
+    date?: Date;
+    createdAt?: Date;
+    communityId?: string;
+    fromUserId?: string | null;
+    toUserId?: string | null;
+    createdByUserId?: string | null;
+    reason?: TransactionReason;
+    points?: number;
+    comment?: string;
+    chainDepth?: number | null;
+};
+
+type TransactionCommentViewTransientFields = Record<string, unknown> & Partial<Record<keyof TransactionCommentViewFactoryDefineInput, never>>;
+
+type TransactionCommentViewFactoryTrait<TTransients extends Record<string, unknown>> = {
+    data?: Resolver<Partial<TransactionCommentViewFactoryDefineInput>, BuildDataOptions<TTransients>>;
+} & CallbackDefineOptions<TransactionCommentView, Prisma.TransactionCommentViewCreateInput, TTransients>;
+
+type TransactionCommentViewFactoryDefineOptions<TTransients extends Record<string, unknown> = Record<string, unknown>> = {
+    defaultData?: Resolver<TransactionCommentViewFactoryDefineInput, BuildDataOptions<TTransients>>;
+    traits?: {
+        [traitName: TraitName]: TransactionCommentViewFactoryTrait<TTransients>;
+    };
+} & CallbackDefineOptions<TransactionCommentView, Prisma.TransactionCommentViewCreateInput, TTransients>;
+
+type TransactionCommentViewTraitKeys<TOptions extends TransactionCommentViewFactoryDefineOptions<any>> = Exclude<keyof TOptions["traits"], number>;
+
+export interface TransactionCommentViewFactoryInterfaceWithoutTraits<TTransients extends Record<string, unknown>> {
+    readonly _factoryFor: "TransactionCommentView";
+    build(inputData?: Partial<Prisma.TransactionCommentViewCreateInput & TTransients>): PromiseLike<Prisma.TransactionCommentViewCreateInput>;
+    buildCreateInput(inputData?: Partial<Prisma.TransactionCommentViewCreateInput & TTransients>): PromiseLike<Prisma.TransactionCommentViewCreateInput>;
+    buildList(list: readonly Partial<Prisma.TransactionCommentViewCreateInput & TTransients>[]): PromiseLike<Prisma.TransactionCommentViewCreateInput[]>;
+    buildList(count: number, item?: Partial<Prisma.TransactionCommentViewCreateInput & TTransients>): PromiseLike<Prisma.TransactionCommentViewCreateInput[]>;
+    pickForConnect(inputData: TransactionCommentView): Pick<TransactionCommentView, "transactionId">;
+    create(inputData?: Partial<Prisma.TransactionCommentViewCreateInput & TTransients>): PromiseLike<TransactionCommentView>;
+    createList(list: readonly Partial<Prisma.TransactionCommentViewCreateInput & TTransients>[]): PromiseLike<TransactionCommentView[]>;
+    createList(count: number, item?: Partial<Prisma.TransactionCommentViewCreateInput & TTransients>): PromiseLike<TransactionCommentView[]>;
+    createForConnect(inputData?: Partial<Prisma.TransactionCommentViewCreateInput & TTransients>): PromiseLike<Pick<TransactionCommentView, "transactionId">>;
+}
+
+export interface TransactionCommentViewFactoryInterface<TTransients extends Record<string, unknown> = Record<string, unknown>, TTraitName extends TraitName = TraitName> extends TransactionCommentViewFactoryInterfaceWithoutTraits<TTransients> {
+    use(name: TTraitName, ...names: readonly TTraitName[]): TransactionCommentViewFactoryInterfaceWithoutTraits<TTransients>;
+}
+
+function autoGenerateTransactionCommentViewScalarsOrEnums({ seq }: {
+    readonly seq: number;
+}): TransactionCommentViewScalarOrEnumFields {
+    return {
+        transactionId: getScalarFieldValueGenerator().String({ modelName: "TransactionCommentView", fieldName: "transactionId", isId: true, isUnique: false, seq }),
+        date: getScalarFieldValueGenerator().DateTime({ modelName: "TransactionCommentView", fieldName: "date", isId: false, isUnique: false, seq }),
+        createdAt: getScalarFieldValueGenerator().DateTime({ modelName: "TransactionCommentView", fieldName: "createdAt", isId: false, isUnique: false, seq }),
+        communityId: getScalarFieldValueGenerator().String({ modelName: "TransactionCommentView", fieldName: "communityId", isId: false, isUnique: false, seq }),
+        reason: "POINT_ISSUED",
+        points: getScalarFieldValueGenerator().Int({ modelName: "TransactionCommentView", fieldName: "points", isId: false, isUnique: false, seq }),
+        comment: getScalarFieldValueGenerator().String({ modelName: "TransactionCommentView", fieldName: "comment", isId: false, isUnique: false, seq })
+    };
+}
+
+function defineTransactionCommentViewFactoryInternal<TTransients extends Record<string, unknown>, TOptions extends TransactionCommentViewFactoryDefineOptions<TTransients>>({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }: TOptions, defaultTransientFieldValues: TTransients): TransactionCommentViewFactoryInterface<TTransients, TransactionCommentViewTraitKeys<TOptions>> {
+    const getFactoryWithTraits = (traitKeys: readonly TransactionCommentViewTraitKeys<TOptions>[] = []) => {
+        const seqKey = {};
+        const getSeq = () => getSequenceCounter(seqKey);
+        const screen = createScreener("TransactionCommentView", modelFieldDefinitions);
+        const handleAfterBuild = createCallbackChain([
+            onAfterBuild,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterBuild),
+        ]);
+        const handleBeforeCreate = createCallbackChain([
+            ...traitKeys.slice().reverse().map(traitKey => traitsDefs[traitKey]?.onBeforeCreate),
+            onBeforeCreate,
+        ]);
+        const handleAfterCreate = createCallbackChain([
+            onAfterCreate,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterCreate),
+        ]);
+        const build = async (inputData: Partial<Prisma.TransactionCommentViewCreateInput & TTransients> = {}) => {
+            const seq = getSeq();
+            const requiredScalarData = autoGenerateTransactionCommentViewScalarsOrEnums({ seq });
+            const resolveValue = normalizeResolver<TransactionCommentViewFactoryDefineInput, BuildDataOptions<any>>(defaultDataResolver ?? {});
+            const [transientFields, filteredInputData] = destructure(defaultTransientFieldValues, inputData);
+            const resolverInput = { seq, ...transientFields };
+            const defaultData = await traitKeys.reduce(async (queue, traitKey) => {
+                const acc = await queue;
+                const resolveTraitValue = normalizeResolver<Partial<TransactionCommentViewFactoryDefineInput>, BuildDataOptions<TTransients>>(traitsDefs[traitKey]?.data ?? {});
+                const traitData = await resolveTraitValue(resolverInput);
+                return {
+                    ...acc,
+                    ...traitData,
+                };
+            }, resolveValue(resolverInput));
+            const defaultAssociations = {} as Prisma.TransactionCommentViewCreateInput;
+            const data: Prisma.TransactionCommentViewCreateInput = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...filteredInputData };
+            await handleAfterBuild(data, transientFields);
+            return data;
+        };
+        const buildList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.TransactionCommentViewCreateInput & TTransients>>(...args).map(data => build(data)));
+        const pickForConnect = (inputData: TransactionCommentView) => ({
+            transactionId: inputData.transactionId
+        });
+        const create = async (inputData: Partial<Prisma.TransactionCommentViewCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
+            const [transientFields] = destructure(defaultTransientFieldValues, inputData);
+            await handleBeforeCreate(data, transientFields);
+            const createdData = await getClient<PrismaClient>().transactionCommentView.create({ data });
+            await handleAfterCreate(createdData, transientFields);
+            return createdData;
+        };
+        const createList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.TransactionCommentViewCreateInput & TTransients>>(...args).map(data => create(data)));
+        const createForConnect = (inputData: Partial<Prisma.TransactionCommentViewCreateInput & TTransients> = {}) => create(inputData).then(pickForConnect);
+        return {
+            _factoryFor: "TransactionCommentView" as const,
+            build,
+            buildList,
+            buildCreateInput: build,
+            pickForConnect,
+            create,
+            createList,
+            createForConnect,
+        };
+    };
+    const factory = getFactoryWithTraits();
+    const useTraits = (name: TransactionCommentViewTraitKeys<TOptions>, ...names: readonly TransactionCommentViewTraitKeys<TOptions>[]) => {
+        return getFactoryWithTraits([name, ...names]);
+    };
+    return {
+        ...factory,
+        use: useTraits,
+    };
+}
+
+interface TransactionCommentViewFactoryBuilder {
+    <TOptions extends TransactionCommentViewFactoryDefineOptions>(options?: TOptions): TransactionCommentViewFactoryInterface<{}, TransactionCommentViewTraitKeys<TOptions>>;
+    withTransientFields: <TTransients extends TransactionCommentViewTransientFields>(defaultTransientFieldValues: TTransients) => <TOptions extends TransactionCommentViewFactoryDefineOptions<TTransients>>(options?: TOptions) => TransactionCommentViewFactoryInterface<TTransients, TransactionCommentViewTraitKeys<TOptions>>;
+}
+
+/**
+ * Define factory for {@link TransactionCommentView} model.
+ *
+ * @param options
+ * @returns factory {@link TransactionCommentViewFactoryInterface}
+ */
+export const defineTransactionCommentViewFactory = (<TOptions extends TransactionCommentViewFactoryDefineOptions>(options?: TOptions): TransactionCommentViewFactoryInterface<TOptions> => {
+    return defineTransactionCommentViewFactoryInternal(options ?? {}, {});
+}) as TransactionCommentViewFactoryBuilder;
+
+defineTransactionCommentViewFactory.withTransientFields = defaultTransientFieldValues => options => defineTransactionCommentViewFactoryInternal(options ?? {}, defaultTransientFieldValues);
+
+type UserProfileForReportViewScalarOrEnumFields = {
+    userId: string;
+    communityId: string;
+    name: string;
+    role: Role;
+    joinedAt: Date;
+};
+
+type UserProfileForReportViewFactoryDefineInput = {
+    userId?: string;
+    communityId?: string;
+    name?: string;
+    userBio?: string | null;
+    membershipBio?: string | null;
+    headline?: string | null;
+    role?: Role;
+    joinedAt?: Date;
+};
+
+type UserProfileForReportViewTransientFields = Record<string, unknown> & Partial<Record<keyof UserProfileForReportViewFactoryDefineInput, never>>;
+
+type UserProfileForReportViewFactoryTrait<TTransients extends Record<string, unknown>> = {
+    data?: Resolver<Partial<UserProfileForReportViewFactoryDefineInput>, BuildDataOptions<TTransients>>;
+} & CallbackDefineOptions<UserProfileForReportView, Prisma.UserProfileForReportViewCreateInput, TTransients>;
+
+type UserProfileForReportViewFactoryDefineOptions<TTransients extends Record<string, unknown> = Record<string, unknown>> = {
+    defaultData?: Resolver<UserProfileForReportViewFactoryDefineInput, BuildDataOptions<TTransients>>;
+    traits?: {
+        [traitName: TraitName]: UserProfileForReportViewFactoryTrait<TTransients>;
+    };
+} & CallbackDefineOptions<UserProfileForReportView, Prisma.UserProfileForReportViewCreateInput, TTransients>;
+
+type UserProfileForReportViewTraitKeys<TOptions extends UserProfileForReportViewFactoryDefineOptions<any>> = Exclude<keyof TOptions["traits"], number>;
+
+export interface UserProfileForReportViewFactoryInterfaceWithoutTraits<TTransients extends Record<string, unknown>> {
+    readonly _factoryFor: "UserProfileForReportView";
+    build(inputData?: Partial<Prisma.UserProfileForReportViewCreateInput & TTransients>): PromiseLike<Prisma.UserProfileForReportViewCreateInput>;
+    buildCreateInput(inputData?: Partial<Prisma.UserProfileForReportViewCreateInput & TTransients>): PromiseLike<Prisma.UserProfileForReportViewCreateInput>;
+    buildList(list: readonly Partial<Prisma.UserProfileForReportViewCreateInput & TTransients>[]): PromiseLike<Prisma.UserProfileForReportViewCreateInput[]>;
+    buildList(count: number, item?: Partial<Prisma.UserProfileForReportViewCreateInput & TTransients>): PromiseLike<Prisma.UserProfileForReportViewCreateInput[]>;
+    pickForConnect(inputData: UserProfileForReportView): Pick<UserProfileForReportView, "userId" | "communityId">;
+    create(inputData?: Partial<Prisma.UserProfileForReportViewCreateInput & TTransients>): PromiseLike<UserProfileForReportView>;
+    createList(list: readonly Partial<Prisma.UserProfileForReportViewCreateInput & TTransients>[]): PromiseLike<UserProfileForReportView[]>;
+    createList(count: number, item?: Partial<Prisma.UserProfileForReportViewCreateInput & TTransients>): PromiseLike<UserProfileForReportView[]>;
+    createForConnect(inputData?: Partial<Prisma.UserProfileForReportViewCreateInput & TTransients>): PromiseLike<Pick<UserProfileForReportView, "userId" | "communityId">>;
+}
+
+export interface UserProfileForReportViewFactoryInterface<TTransients extends Record<string, unknown> = Record<string, unknown>, TTraitName extends TraitName = TraitName> extends UserProfileForReportViewFactoryInterfaceWithoutTraits<TTransients> {
+    use(name: TTraitName, ...names: readonly TTraitName[]): UserProfileForReportViewFactoryInterfaceWithoutTraits<TTransients>;
+}
+
+function autoGenerateUserProfileForReportViewScalarsOrEnums({ seq }: {
+    readonly seq: number;
+}): UserProfileForReportViewScalarOrEnumFields {
+    return {
+        userId: getScalarFieldValueGenerator().String({ modelName: "UserProfileForReportView", fieldName: "userId", isId: true, isUnique: false, seq }),
+        communityId: getScalarFieldValueGenerator().String({ modelName: "UserProfileForReportView", fieldName: "communityId", isId: true, isUnique: false, seq }),
+        name: getScalarFieldValueGenerator().String({ modelName: "UserProfileForReportView", fieldName: "name", isId: false, isUnique: false, seq }),
+        role: "OWNER",
+        joinedAt: getScalarFieldValueGenerator().DateTime({ modelName: "UserProfileForReportView", fieldName: "joinedAt", isId: false, isUnique: false, seq })
+    };
+}
+
+function defineUserProfileForReportViewFactoryInternal<TTransients extends Record<string, unknown>, TOptions extends UserProfileForReportViewFactoryDefineOptions<TTransients>>({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }: TOptions, defaultTransientFieldValues: TTransients): UserProfileForReportViewFactoryInterface<TTransients, UserProfileForReportViewTraitKeys<TOptions>> {
+    const getFactoryWithTraits = (traitKeys: readonly UserProfileForReportViewTraitKeys<TOptions>[] = []) => {
+        const seqKey = {};
+        const getSeq = () => getSequenceCounter(seqKey);
+        const screen = createScreener("UserProfileForReportView", modelFieldDefinitions);
+        const handleAfterBuild = createCallbackChain([
+            onAfterBuild,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterBuild),
+        ]);
+        const handleBeforeCreate = createCallbackChain([
+            ...traitKeys.slice().reverse().map(traitKey => traitsDefs[traitKey]?.onBeforeCreate),
+            onBeforeCreate,
+        ]);
+        const handleAfterCreate = createCallbackChain([
+            onAfterCreate,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterCreate),
+        ]);
+        const build = async (inputData: Partial<Prisma.UserProfileForReportViewCreateInput & TTransients> = {}) => {
+            const seq = getSeq();
+            const requiredScalarData = autoGenerateUserProfileForReportViewScalarsOrEnums({ seq });
+            const resolveValue = normalizeResolver<UserProfileForReportViewFactoryDefineInput, BuildDataOptions<any>>(defaultDataResolver ?? {});
+            const [transientFields, filteredInputData] = destructure(defaultTransientFieldValues, inputData);
+            const resolverInput = { seq, ...transientFields };
+            const defaultData = await traitKeys.reduce(async (queue, traitKey) => {
+                const acc = await queue;
+                const resolveTraitValue = normalizeResolver<Partial<UserProfileForReportViewFactoryDefineInput>, BuildDataOptions<TTransients>>(traitsDefs[traitKey]?.data ?? {});
+                const traitData = await resolveTraitValue(resolverInput);
+                return {
+                    ...acc,
+                    ...traitData,
+                };
+            }, resolveValue(resolverInput));
+            const defaultAssociations = {} as Prisma.UserProfileForReportViewCreateInput;
+            const data: Prisma.UserProfileForReportViewCreateInput = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...filteredInputData };
+            await handleAfterBuild(data, transientFields);
+            return data;
+        };
+        const buildList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.UserProfileForReportViewCreateInput & TTransients>>(...args).map(data => build(data)));
+        const pickForConnect = (inputData: UserProfileForReportView) => ({
+            userId: inputData.userId,
+            communityId: inputData.communityId
+        });
+        const create = async (inputData: Partial<Prisma.UserProfileForReportViewCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
+            const [transientFields] = destructure(defaultTransientFieldValues, inputData);
+            await handleBeforeCreate(data, transientFields);
+            const createdData = await getClient<PrismaClient>().userProfileForReportView.create({ data });
+            await handleAfterCreate(createdData, transientFields);
+            return createdData;
+        };
+        const createList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.UserProfileForReportViewCreateInput & TTransients>>(...args).map(data => create(data)));
+        const createForConnect = (inputData: Partial<Prisma.UserProfileForReportViewCreateInput & TTransients> = {}) => create(inputData).then(pickForConnect);
+        return {
+            _factoryFor: "UserProfileForReportView" as const,
+            build,
+            buildList,
+            buildCreateInput: build,
+            pickForConnect,
+            create,
+            createList,
+            createForConnect,
+        };
+    };
+    const factory = getFactoryWithTraits();
+    const useTraits = (name: UserProfileForReportViewTraitKeys<TOptions>, ...names: readonly UserProfileForReportViewTraitKeys<TOptions>[]) => {
+        return getFactoryWithTraits([name, ...names]);
+    };
+    return {
+        ...factory,
+        use: useTraits,
+    };
+}
+
+interface UserProfileForReportViewFactoryBuilder {
+    <TOptions extends UserProfileForReportViewFactoryDefineOptions>(options?: TOptions): UserProfileForReportViewFactoryInterface<{}, UserProfileForReportViewTraitKeys<TOptions>>;
+    withTransientFields: <TTransients extends UserProfileForReportViewTransientFields>(defaultTransientFieldValues: TTransients) => <TOptions extends UserProfileForReportViewFactoryDefineOptions<TTransients>>(options?: TOptions) => UserProfileForReportViewFactoryInterface<TTransients, UserProfileForReportViewTraitKeys<TOptions>>;
+}
+
+/**
+ * Define factory for {@link UserProfileForReportView} model.
+ *
+ * @param options
+ * @returns factory {@link UserProfileForReportViewFactoryInterface}
+ */
+export const defineUserProfileForReportViewFactory = (<TOptions extends UserProfileForReportViewFactoryDefineOptions>(options?: TOptions): UserProfileForReportViewFactoryInterface<TOptions> => {
+    return defineUserProfileForReportViewFactoryInternal(options ?? {}, {});
+}) as UserProfileForReportViewFactoryBuilder;
+
+defineUserProfileForReportViewFactory.withTransientFields = defaultTransientFieldValues => options => defineUserProfileForReportViewFactoryInternal(options ?? {}, defaultTransientFieldValues);
 
 type EarliestReservableSlotViewScalarOrEnumFields = {};
 

--- a/src/infrastructure/prisma/factories/__generated__/index.ts
+++ b/src/infrastructure/prisma/factories/__generated__/index.ts
@@ -52,7 +52,6 @@ import type { MembershipHostedOpportunityCountView } from "@prisma/client";
 import type { CurrentPointView } from "@prisma/client";
 import type { AccumulatedPointView } from "@prisma/client";
 import type { TransactionSummaryDailyView } from "@prisma/client";
-import type { TransactionActiveUsersDailyView } from "@prisma/client";
 import type { UserTransactionDailyView } from "@prisma/client";
 import type { TransactionCommentView } from "@prisma/client";
 import type { UserProfileForReportView } from "@prisma/client";
@@ -1057,9 +1056,6 @@ const modelFieldDefinitions: ModelWithFields[] = [{
             }]
     }, {
         name: "TransactionSummaryDailyView",
-        fields: []
-    }, {
-        name: "TransactionActiveUsersDailyView",
         fields: []
     }, {
         name: "UserTransactionDailyView",
@@ -10426,156 +10422,6 @@ export const defineTransactionSummaryDailyViewFactory = (<TOptions extends Trans
 }) as TransactionSummaryDailyViewFactoryBuilder;
 
 defineTransactionSummaryDailyViewFactory.withTransientFields = defaultTransientFieldValues => options => defineTransactionSummaryDailyViewFactoryInternal(options ?? {}, defaultTransientFieldValues);
-
-type TransactionActiveUsersDailyViewScalarOrEnumFields = {
-    date: Date;
-    communityId: string;
-    activeUsers: number;
-    senders: number;
-    receivers: number;
-};
-
-type TransactionActiveUsersDailyViewFactoryDefineInput = {
-    date?: Date;
-    communityId?: string;
-    activeUsers?: number;
-    senders?: number;
-    receivers?: number;
-};
-
-type TransactionActiveUsersDailyViewTransientFields = Record<string, unknown> & Partial<Record<keyof TransactionActiveUsersDailyViewFactoryDefineInput, never>>;
-
-type TransactionActiveUsersDailyViewFactoryTrait<TTransients extends Record<string, unknown>> = {
-    data?: Resolver<Partial<TransactionActiveUsersDailyViewFactoryDefineInput>, BuildDataOptions<TTransients>>;
-} & CallbackDefineOptions<TransactionActiveUsersDailyView, Prisma.TransactionActiveUsersDailyViewCreateInput, TTransients>;
-
-type TransactionActiveUsersDailyViewFactoryDefineOptions<TTransients extends Record<string, unknown> = Record<string, unknown>> = {
-    defaultData?: Resolver<TransactionActiveUsersDailyViewFactoryDefineInput, BuildDataOptions<TTransients>>;
-    traits?: {
-        [traitName: TraitName]: TransactionActiveUsersDailyViewFactoryTrait<TTransients>;
-    };
-} & CallbackDefineOptions<TransactionActiveUsersDailyView, Prisma.TransactionActiveUsersDailyViewCreateInput, TTransients>;
-
-type TransactionActiveUsersDailyViewTraitKeys<TOptions extends TransactionActiveUsersDailyViewFactoryDefineOptions<any>> = Exclude<keyof TOptions["traits"], number>;
-
-export interface TransactionActiveUsersDailyViewFactoryInterfaceWithoutTraits<TTransients extends Record<string, unknown>> {
-    readonly _factoryFor: "TransactionActiveUsersDailyView";
-    build(inputData?: Partial<Prisma.TransactionActiveUsersDailyViewCreateInput & TTransients>): PromiseLike<Prisma.TransactionActiveUsersDailyViewCreateInput>;
-    buildCreateInput(inputData?: Partial<Prisma.TransactionActiveUsersDailyViewCreateInput & TTransients>): PromiseLike<Prisma.TransactionActiveUsersDailyViewCreateInput>;
-    buildList(list: readonly Partial<Prisma.TransactionActiveUsersDailyViewCreateInput & TTransients>[]): PromiseLike<Prisma.TransactionActiveUsersDailyViewCreateInput[]>;
-    buildList(count: number, item?: Partial<Prisma.TransactionActiveUsersDailyViewCreateInput & TTransients>): PromiseLike<Prisma.TransactionActiveUsersDailyViewCreateInput[]>;
-    pickForConnect(inputData: TransactionActiveUsersDailyView): Pick<TransactionActiveUsersDailyView, "date" | "communityId">;
-    create(inputData?: Partial<Prisma.TransactionActiveUsersDailyViewCreateInput & TTransients>): PromiseLike<TransactionActiveUsersDailyView>;
-    createList(list: readonly Partial<Prisma.TransactionActiveUsersDailyViewCreateInput & TTransients>[]): PromiseLike<TransactionActiveUsersDailyView[]>;
-    createList(count: number, item?: Partial<Prisma.TransactionActiveUsersDailyViewCreateInput & TTransients>): PromiseLike<TransactionActiveUsersDailyView[]>;
-    createForConnect(inputData?: Partial<Prisma.TransactionActiveUsersDailyViewCreateInput & TTransients>): PromiseLike<Pick<TransactionActiveUsersDailyView, "date" | "communityId">>;
-}
-
-export interface TransactionActiveUsersDailyViewFactoryInterface<TTransients extends Record<string, unknown> = Record<string, unknown>, TTraitName extends TraitName = TraitName> extends TransactionActiveUsersDailyViewFactoryInterfaceWithoutTraits<TTransients> {
-    use(name: TTraitName, ...names: readonly TTraitName[]): TransactionActiveUsersDailyViewFactoryInterfaceWithoutTraits<TTransients>;
-}
-
-function autoGenerateTransactionActiveUsersDailyViewScalarsOrEnums({ seq }: {
-    readonly seq: number;
-}): TransactionActiveUsersDailyViewScalarOrEnumFields {
-    return {
-        date: getScalarFieldValueGenerator().DateTime({ modelName: "TransactionActiveUsersDailyView", fieldName: "date", isId: true, isUnique: false, seq }),
-        communityId: getScalarFieldValueGenerator().String({ modelName: "TransactionActiveUsersDailyView", fieldName: "communityId", isId: true, isUnique: false, seq }),
-        activeUsers: getScalarFieldValueGenerator().Int({ modelName: "TransactionActiveUsersDailyView", fieldName: "activeUsers", isId: false, isUnique: false, seq }),
-        senders: getScalarFieldValueGenerator().Int({ modelName: "TransactionActiveUsersDailyView", fieldName: "senders", isId: false, isUnique: false, seq }),
-        receivers: getScalarFieldValueGenerator().Int({ modelName: "TransactionActiveUsersDailyView", fieldName: "receivers", isId: false, isUnique: false, seq })
-    };
-}
-
-function defineTransactionActiveUsersDailyViewFactoryInternal<TTransients extends Record<string, unknown>, TOptions extends TransactionActiveUsersDailyViewFactoryDefineOptions<TTransients>>({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }: TOptions, defaultTransientFieldValues: TTransients): TransactionActiveUsersDailyViewFactoryInterface<TTransients, TransactionActiveUsersDailyViewTraitKeys<TOptions>> {
-    const getFactoryWithTraits = (traitKeys: readonly TransactionActiveUsersDailyViewTraitKeys<TOptions>[] = []) => {
-        const seqKey = {};
-        const getSeq = () => getSequenceCounter(seqKey);
-        const screen = createScreener("TransactionActiveUsersDailyView", modelFieldDefinitions);
-        const handleAfterBuild = createCallbackChain([
-            onAfterBuild,
-            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterBuild),
-        ]);
-        const handleBeforeCreate = createCallbackChain([
-            ...traitKeys.slice().reverse().map(traitKey => traitsDefs[traitKey]?.onBeforeCreate),
-            onBeforeCreate,
-        ]);
-        const handleAfterCreate = createCallbackChain([
-            onAfterCreate,
-            ...traitKeys.map(traitKey => traitsDefs[traitKey]?.onAfterCreate),
-        ]);
-        const build = async (inputData: Partial<Prisma.TransactionActiveUsersDailyViewCreateInput & TTransients> = {}) => {
-            const seq = getSeq();
-            const requiredScalarData = autoGenerateTransactionActiveUsersDailyViewScalarsOrEnums({ seq });
-            const resolveValue = normalizeResolver<TransactionActiveUsersDailyViewFactoryDefineInput, BuildDataOptions<any>>(defaultDataResolver ?? {});
-            const [transientFields, filteredInputData] = destructure(defaultTransientFieldValues, inputData);
-            const resolverInput = { seq, ...transientFields };
-            const defaultData = await traitKeys.reduce(async (queue, traitKey) => {
-                const acc = await queue;
-                const resolveTraitValue = normalizeResolver<Partial<TransactionActiveUsersDailyViewFactoryDefineInput>, BuildDataOptions<TTransients>>(traitsDefs[traitKey]?.data ?? {});
-                const traitData = await resolveTraitValue(resolverInput);
-                return {
-                    ...acc,
-                    ...traitData,
-                };
-            }, resolveValue(resolverInput));
-            const defaultAssociations = {} as Prisma.TransactionActiveUsersDailyViewCreateInput;
-            const data: Prisma.TransactionActiveUsersDailyViewCreateInput = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...filteredInputData };
-            await handleAfterBuild(data, transientFields);
-            return data;
-        };
-        const buildList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.TransactionActiveUsersDailyViewCreateInput & TTransients>>(...args).map(data => build(data)));
-        const pickForConnect = (inputData: TransactionActiveUsersDailyView) => ({
-            date: inputData.date,
-            communityId: inputData.communityId
-        });
-        const create = async (inputData: Partial<Prisma.TransactionActiveUsersDailyViewCreateInput & TTransients> = {}) => {
-            const data = await build({ ...inputData }).then(screen);
-            const [transientFields] = destructure(defaultTransientFieldValues, inputData);
-            await handleBeforeCreate(data, transientFields);
-            const createdData = await getClient<PrismaClient>().transactionActiveUsersDailyView.create({ data });
-            await handleAfterCreate(createdData, transientFields);
-            return createdData;
-        };
-        const createList = (...args: unknown[]) => Promise.all(normalizeList<Partial<Prisma.TransactionActiveUsersDailyViewCreateInput & TTransients>>(...args).map(data => create(data)));
-        const createForConnect = (inputData: Partial<Prisma.TransactionActiveUsersDailyViewCreateInput & TTransients> = {}) => create(inputData).then(pickForConnect);
-        return {
-            _factoryFor: "TransactionActiveUsersDailyView" as const,
-            build,
-            buildList,
-            buildCreateInput: build,
-            pickForConnect,
-            create,
-            createList,
-            createForConnect,
-        };
-    };
-    const factory = getFactoryWithTraits();
-    const useTraits = (name: TransactionActiveUsersDailyViewTraitKeys<TOptions>, ...names: readonly TransactionActiveUsersDailyViewTraitKeys<TOptions>[]) => {
-        return getFactoryWithTraits([name, ...names]);
-    };
-    return {
-        ...factory,
-        use: useTraits,
-    };
-}
-
-interface TransactionActiveUsersDailyViewFactoryBuilder {
-    <TOptions extends TransactionActiveUsersDailyViewFactoryDefineOptions>(options?: TOptions): TransactionActiveUsersDailyViewFactoryInterface<{}, TransactionActiveUsersDailyViewTraitKeys<TOptions>>;
-    withTransientFields: <TTransients extends TransactionActiveUsersDailyViewTransientFields>(defaultTransientFieldValues: TTransients) => <TOptions extends TransactionActiveUsersDailyViewFactoryDefineOptions<TTransients>>(options?: TOptions) => TransactionActiveUsersDailyViewFactoryInterface<TTransients, TransactionActiveUsersDailyViewTraitKeys<TOptions>>;
-}
-
-/**
- * Define factory for {@link TransactionActiveUsersDailyView} model.
- *
- * @param options
- * @returns factory {@link TransactionActiveUsersDailyViewFactoryInterface}
- */
-export const defineTransactionActiveUsersDailyViewFactory = (<TOptions extends TransactionActiveUsersDailyViewFactoryDefineOptions>(options?: TOptions): TransactionActiveUsersDailyViewFactoryInterface<TOptions> => {
-    return defineTransactionActiveUsersDailyViewFactoryInternal(options ?? {}, {});
-}) as TransactionActiveUsersDailyViewFactoryBuilder;
-
-defineTransactionActiveUsersDailyViewFactory.withTransientFields = defaultTransientFieldValues => options => defineTransactionActiveUsersDailyViewFactoryInternal(options ?? {}, defaultTransientFieldValues);
 
 type UserTransactionDailyViewScalarOrEnumFields = {
     date: Date;

--- a/src/infrastructure/prisma/migrations/20260416000000_add_transaction_report_views/migration.sql
+++ b/src/infrastructure/prisma/migrations/20260416000000_add_transaction_report_views/migration.sql
@@ -7,6 +7,12 @@
 -- All day bucketing is done in Asia/Tokyo.
 -- RLS does not apply to materialized views; application layer MUST filter by
 -- community_id for every access.
+--
+-- Cross-community transfers are not a supported business operation: every
+-- transaction usecase constructs its from/to wallet pair within a single
+-- community. The views still defensively reject any (from, to) pair where
+-- both wallets exist but disagree on community_id, so a data anomaly cannot
+-- silently leak activity across communities at the view layer.
 -- ============================================================================
 
 -- ----------------------------------------------------------------------------
@@ -31,6 +37,9 @@ FROM "t_transactions" t
 LEFT JOIN "t_wallets" fw ON fw."id" = t."from"
 LEFT JOIN "t_wallets" tw ON tw."id" = t."to"
 WHERE COALESCE(fw."community_id", tw."community_id") IS NOT NULL
+  AND (fw."community_id" IS NULL
+       OR tw."community_id" IS NULL
+       OR fw."community_id" = tw."community_id")
 GROUP BY
     ((t."created_at" AT TIME ZONE 'Asia/Tokyo')::date),
     COALESCE(fw."community_id", tw."community_id"),
@@ -59,6 +68,9 @@ WITH events AS (
     LEFT JOIN "t_wallets" fw ON fw."id" = t."from"
     LEFT JOIN "t_wallets" tw ON tw."id" = t."to"
     WHERE COALESCE(fw."community_id", tw."community_id") IS NOT NULL
+      AND (fw."community_id" IS NULL
+           OR tw."community_id" IS NULL
+           OR fw."community_id" = tw."community_id")
 ),
 user_activity AS (
     SELECT "date", "community_id", "from_user_id" AS "user_id", 'sender' AS "role"
@@ -166,7 +178,10 @@ LEFT JOIN "t_wallets" fw ON fw."id" = t."from"
 LEFT JOIN "t_wallets" tw ON tw."id" = t."to"
 WHERE t."comment" IS NOT NULL
   AND t."comment" <> ''
-  AND COALESCE(fw."community_id", tw."community_id") IS NOT NULL;
+  AND COALESCE(fw."community_id", tw."community_id") IS NOT NULL
+  AND (fw."community_id" IS NULL
+       OR tw."community_id" IS NULL
+       OR fw."community_id" = tw."community_id");
 
 
 -- ----------------------------------------------------------------------------

--- a/src/infrastructure/prisma/migrations/20260416000000_add_transaction_report_views/migration.sql
+++ b/src/infrastructure/prisma/migrations/20260416000000_add_transaction_report_views/migration.sql
@@ -1,0 +1,186 @@
+-- ============================================================================
+-- Transaction Report Views
+--
+-- Dataset for AI-generated weekly/periodic reports. Three materialized views
+-- (daily aggregates) plus two regular views (raw comments, user profiles).
+--
+-- All day bucketing is done in Asia/Tokyo.
+-- RLS does not apply to materialized views; application layer MUST filter by
+-- community_id for every access.
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- MV-1: mv_transaction_summary_daily
+--   Granularity: (date, community_id, reason)
+--   Purpose: Community-wide volume / reason breakdown / chain propagation
+-- ----------------------------------------------------------------------------
+CREATE MATERIALIZED VIEW "mv_transaction_summary_daily" AS
+SELECT
+    ((t."created_at" AT TIME ZONE 'Asia/Tokyo')::date) AS "date",
+    COALESCE(fw."community_id", tw."community_id") AS "community_id",
+    t."reason" AS "reason",
+    COUNT(*)::int AS "tx_count",
+    COALESCE(SUM(t."to_point_change"), 0)::bigint AS "points_sum",
+    COUNT(*) FILTER (WHERE t."chain_depth" = 1)::int AS "chain_root_count",
+    COUNT(*) FILTER (WHERE t."chain_depth" >= 2)::int AS "chain_descendant_count",
+    MAX(t."chain_depth")::int AS "max_chain_depth",
+    COALESCE(SUM(t."chain_depth"), 0)::int AS "sum_chain_depth",
+    COUNT(*) FILTER (WHERE t."from" IS NULL)::int AS "issuance_count",
+    COUNT(*) FILTER (WHERE t."to" IS NULL)::int AS "burn_count"
+FROM "t_transactions" t
+LEFT JOIN "t_wallets" fw ON fw."id" = t."from"
+LEFT JOIN "t_wallets" tw ON tw."id" = t."to"
+WHERE COALESCE(fw."community_id", tw."community_id") IS NOT NULL
+GROUP BY
+    ((t."created_at" AT TIME ZONE 'Asia/Tokyo')::date),
+    COALESCE(fw."community_id", tw."community_id"),
+    t."reason";
+
+CREATE UNIQUE INDEX "mv_transaction_summary_daily_unique_id"
+    ON "mv_transaction_summary_daily" ("date", "community_id", "reason");
+
+CREATE INDEX "mv_transaction_summary_daily_community_date_idx"
+    ON "mv_transaction_summary_daily" ("community_id", "date" DESC);
+
+
+-- ----------------------------------------------------------------------------
+-- MV-2: mv_transaction_active_users_daily
+--   Granularity: (date, community_id)
+--   Purpose: DISTINCT active/sender/receiver user counts (not GROUP BY-able)
+-- ----------------------------------------------------------------------------
+CREATE MATERIALIZED VIEW "mv_transaction_active_users_daily" AS
+WITH events AS (
+    SELECT
+        ((t."created_at" AT TIME ZONE 'Asia/Tokyo')::date) AS "date",
+        COALESCE(fw."community_id", tw."community_id") AS "community_id",
+        fw."user_id" AS "from_user_id",
+        tw."user_id" AS "to_user_id"
+    FROM "t_transactions" t
+    LEFT JOIN "t_wallets" fw ON fw."id" = t."from"
+    LEFT JOIN "t_wallets" tw ON tw."id" = t."to"
+    WHERE COALESCE(fw."community_id", tw."community_id") IS NOT NULL
+),
+user_activity AS (
+    SELECT "date", "community_id", "from_user_id" AS "user_id", 'sender' AS "role"
+        FROM events WHERE "from_user_id" IS NOT NULL
+    UNION ALL
+    SELECT "date", "community_id", "to_user_id" AS "user_id", 'receiver' AS "role"
+        FROM events WHERE "to_user_id" IS NOT NULL
+)
+SELECT
+    "date",
+    "community_id",
+    COUNT(DISTINCT "user_id")::int AS "active_users",
+    COUNT(DISTINCT "user_id") FILTER (WHERE "role" = 'sender')::int AS "senders",
+    COUNT(DISTINCT "user_id") FILTER (WHERE "role" = 'receiver')::int AS "receivers"
+FROM user_activity
+GROUP BY "date", "community_id";
+
+CREATE UNIQUE INDEX "mv_transaction_active_users_daily_unique_id"
+    ON "mv_transaction_active_users_daily" ("date", "community_id");
+
+
+-- ----------------------------------------------------------------------------
+-- MV-3: mv_user_transaction_daily
+--   Granularity: (date, community_id, user_id, wallet_id)
+--   Purpose: Per-user activity / contribution ranking / AI highlight picking
+-- ----------------------------------------------------------------------------
+CREATE MATERIALIZED VIEW "mv_user_transaction_daily" AS
+WITH user_events AS (
+    -- Outgoing (user is the `from` side)
+    SELECT
+        ((t."created_at" AT TIME ZONE 'Asia/Tokyo')::date) AS "date",
+        fw."community_id" AS "community_id",
+        fw."user_id" AS "user_id",
+        fw."id" AS "wallet_id",
+        'out'::text AS "direction",
+        t."reason" AS "reason",
+        t."to_point_change" AS "points",
+        t."chain_depth" AS "chain_depth",
+        tw."user_id" AS "counterparty_user_id"
+    FROM "t_transactions" t
+    INNER JOIN "t_wallets" fw ON fw."id" = t."from" AND fw."user_id" IS NOT NULL
+    LEFT JOIN "t_wallets" tw ON tw."id" = t."to"
+    UNION ALL
+    -- Incoming (user is the `to` side)
+    SELECT
+        ((t."created_at" AT TIME ZONE 'Asia/Tokyo')::date) AS "date",
+        tw."community_id" AS "community_id",
+        tw."user_id" AS "user_id",
+        tw."id" AS "wallet_id",
+        'in'::text AS "direction",
+        t."reason" AS "reason",
+        t."to_point_change" AS "points",
+        t."chain_depth" AS "chain_depth",
+        fw."user_id" AS "counterparty_user_id"
+    FROM "t_transactions" t
+    INNER JOIN "t_wallets" tw ON tw."id" = t."to" AND tw."user_id" IS NOT NULL
+    LEFT JOIN "t_wallets" fw ON fw."id" = t."from"
+)
+SELECT
+    "date",
+    "community_id",
+    "user_id",
+    "wallet_id",
+    COUNT(*) FILTER (WHERE "direction" = 'in')::int AS "tx_count_in",
+    COUNT(*) FILTER (WHERE "direction" = 'out')::int AS "tx_count_out",
+    COALESCE(SUM("points") FILTER (WHERE "direction" = 'in'), 0)::bigint AS "points_in",
+    COALESCE(SUM("points") FILTER (WHERE "direction" = 'out'), 0)::bigint AS "points_out",
+    COUNT(*) FILTER (WHERE "direction" = 'out' AND "reason" = 'DONATION')::int AS "donation_out_count",
+    COALESCE(SUM("points") FILTER (WHERE "direction" = 'out' AND "reason" = 'DONATION'), 0)::bigint AS "donation_out_points",
+    COUNT(*) FILTER (WHERE "direction" = 'in' AND "reason" = 'DONATION')::int AS "received_donation_count",
+    COUNT(*) FILTER (WHERE "direction" = 'out' AND "chain_depth" = 1)::int AS "chain_root_count",
+    MAX("chain_depth") FILTER (WHERE "direction" = 'out')::int AS "max_chain_depth_started",
+    MAX("chain_depth") FILTER (WHERE "direction" = 'in')::int AS "chain_depth_reached_max",
+    COUNT(DISTINCT "counterparty_user_id")::int AS "unique_counterparties"
+FROM user_events
+GROUP BY "date", "community_id", "user_id", "wallet_id";
+
+CREATE UNIQUE INDEX "mv_user_transaction_daily_unique_id"
+    ON "mv_user_transaction_daily" ("date", "community_id", "user_id", "wallet_id");
+
+CREATE INDEX "mv_user_transaction_daily_community_date_idx"
+    ON "mv_user_transaction_daily" ("community_id", "date" DESC);
+
+
+-- ----------------------------------------------------------------------------
+-- VIEW-4: v_transaction_comments (regular view, real-time)
+--   Granularity: per transaction with non-empty comment
+--   Purpose: AI-input qualitative data
+-- ----------------------------------------------------------------------------
+CREATE VIEW "v_transaction_comments" AS
+SELECT
+    t."id" AS "transaction_id",
+    ((t."created_at" AT TIME ZONE 'Asia/Tokyo')::date) AS "date",
+    t."created_at" AS "created_at",
+    COALESCE(fw."community_id", tw."community_id") AS "community_id",
+    fw."user_id" AS "from_user_id",
+    tw."user_id" AS "to_user_id",
+    t."created_by" AS "created_by_user_id",
+    t."reason" AS "reason",
+    t."to_point_change" AS "points",
+    t."comment" AS "comment",
+    t."chain_depth" AS "chain_depth"
+FROM "t_transactions" t
+LEFT JOIN "t_wallets" fw ON fw."id" = t."from"
+LEFT JOIN "t_wallets" tw ON tw."id" = t."to"
+WHERE t."comment" IS NOT NULL AND t."comment" <> '';
+
+
+-- ----------------------------------------------------------------------------
+-- VIEW-5: v_user_profile_for_report (regular view, real-time)
+--   Granularity: (user, community)
+--   Purpose: AI-input profile context (bio/headline/joined_at)
+-- ----------------------------------------------------------------------------
+CREATE VIEW "v_user_profile_for_report" AS
+SELECT
+    u."id" AS "user_id",
+    m."community_id" AS "community_id",
+    u."name" AS "name",
+    u."bio" AS "user_bio",
+    m."bio" AS "membership_bio",
+    m."headline" AS "headline",
+    m."role" AS "role",
+    m."created_at" AS "joined_at"
+FROM "t_users" u
+INNER JOIN "t_memberships" m ON m."user_id" = u."id";

--- a/src/infrastructure/prisma/migrations/20260416000000_add_transaction_report_views/migration.sql
+++ b/src/infrastructure/prisma/migrations/20260416000000_add_transaction_report_views/migration.sql
@@ -113,6 +113,8 @@ WITH user_events AS (
     FROM "t_transactions" t
     INNER JOIN "t_wallets" fw ON fw."id" = t."from" AND fw."user_id" IS NOT NULL
     LEFT JOIN "t_wallets" tw ON tw."id" = t."to"
+    WHERE tw."community_id" IS NULL
+       OR tw."community_id" = fw."community_id"
     UNION ALL
     -- Incoming (user is the `to` side)
     SELECT
@@ -128,6 +130,8 @@ WITH user_events AS (
     FROM "t_transactions" t
     INNER JOIN "t_wallets" tw ON tw."id" = t."to" AND tw."user_id" IS NOT NULL
     LEFT JOIN "t_wallets" fw ON fw."id" = t."from"
+    WHERE fw."community_id" IS NULL
+       OR fw."community_id" = tw."community_id"
 )
 SELECT
     "date",

--- a/src/infrastructure/prisma/migrations/20260416000000_add_transaction_report_views/migration.sql
+++ b/src/infrastructure/prisma/migrations/20260416000000_add_transaction_report_views/migration.sql
@@ -164,7 +164,9 @@ SELECT
 FROM "t_transactions" t
 LEFT JOIN "t_wallets" fw ON fw."id" = t."from"
 LEFT JOIN "t_wallets" tw ON tw."id" = t."to"
-WHERE t."comment" IS NOT NULL AND t."comment" <> '';
+WHERE t."comment" IS NOT NULL
+  AND t."comment" <> ''
+  AND COALESCE(fw."community_id", tw."community_id") IS NOT NULL;
 
 
 -- ----------------------------------------------------------------------------

--- a/src/infrastructure/prisma/migrations/20260416000000_add_transaction_report_views/migration.sql
+++ b/src/infrastructure/prisma/migrations/20260416000000_add_transaction_report_views/migration.sql
@@ -53,43 +53,11 @@ CREATE INDEX "mv_transaction_summary_daily_community_date_idx"
 
 
 -- ----------------------------------------------------------------------------
--- MV-2: mv_transaction_active_users_daily
---   Granularity: (date, community_id)
---   Purpose: DISTINCT active/sender/receiver user counts (not GROUP BY-able)
+-- (MV-2 removed): DISTINCT active/sender/receiver user counts are derived
+-- directly from mv_user_transaction_daily via a GROUP BY in the repository.
+-- Skipping a dedicated MV avoids an extra refresh job without materially
+-- impacting query cost.
 -- ----------------------------------------------------------------------------
-CREATE MATERIALIZED VIEW "mv_transaction_active_users_daily" AS
-WITH events AS (
-    SELECT
-        ((t."created_at" AT TIME ZONE 'Asia/Tokyo')::date) AS "date",
-        COALESCE(fw."community_id", tw."community_id") AS "community_id",
-        fw."user_id" AS "from_user_id",
-        tw."user_id" AS "to_user_id"
-    FROM "t_transactions" t
-    LEFT JOIN "t_wallets" fw ON fw."id" = t."from"
-    LEFT JOIN "t_wallets" tw ON tw."id" = t."to"
-    WHERE COALESCE(fw."community_id", tw."community_id") IS NOT NULL
-      AND (fw."community_id" IS NULL
-           OR tw."community_id" IS NULL
-           OR fw."community_id" = tw."community_id")
-),
-user_activity AS (
-    SELECT "date", "community_id", "from_user_id" AS "user_id", 'sender' AS "role"
-        FROM events WHERE "from_user_id" IS NOT NULL
-    UNION ALL
-    SELECT "date", "community_id", "to_user_id" AS "user_id", 'receiver' AS "role"
-        FROM events WHERE "to_user_id" IS NOT NULL
-)
-SELECT
-    "date",
-    "community_id",
-    COUNT(DISTINCT "user_id")::int AS "active_users",
-    COUNT(DISTINCT "user_id") FILTER (WHERE "role" = 'sender')::int AS "senders",
-    COUNT(DISTINCT "user_id") FILTER (WHERE "role" = 'receiver')::int AS "receivers"
-FROM user_activity
-GROUP BY "date", "community_id";
-
-CREATE UNIQUE INDEX "mv_transaction_active_users_daily_unique_id"
-    ON "mv_transaction_active_users_daily" ("date", "community_id");
 
 
 -- ----------------------------------------------------------------------------

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -666,6 +666,91 @@ view AccumulatedPointView {
   @@map("mv_accumulated_points")
 }
 
+// ---- Transaction Report Views ----
+// Dataset for AI-generated reports. See migration
+// 20260416000000_add_transaction_report_views for the underlying SQL.
+// NOTE: Materialized views bypass RLS. Always filter by communityId at the
+// application layer when querying these views.
+
+view TransactionSummaryDailyView {
+  date                 DateTime          @db.Date
+  communityId          String            @map("community_id")
+  reason               TransactionReason
+  txCount              Int               @map("tx_count")
+  pointsSum            BigInt            @map("points_sum") @db.BigInt
+  chainRootCount       Int               @map("chain_root_count")
+  chainDescendantCount Int               @map("chain_descendant_count")
+  maxChainDepth        Int?              @map("max_chain_depth")
+  sumChainDepth        Int               @map("sum_chain_depth")
+  issuanceCount        Int               @map("issuance_count")
+  burnCount            Int               @map("burn_count")
+
+  @@id([date, communityId, reason])
+  @@map("mv_transaction_summary_daily")
+}
+
+view TransactionActiveUsersDailyView {
+  date        DateTime @db.Date
+  communityId String   @map("community_id")
+  activeUsers Int      @map("active_users")
+  senders     Int
+  receivers   Int
+
+  @@id([date, communityId])
+  @@map("mv_transaction_active_users_daily")
+}
+
+view UserTransactionDailyView {
+  date                  DateTime @db.Date
+  communityId           String   @map("community_id")
+  userId                String   @map("user_id")
+  walletId              String   @map("wallet_id")
+  txCountIn             Int      @map("tx_count_in")
+  txCountOut            Int      @map("tx_count_out")
+  pointsIn              BigInt   @map("points_in") @db.BigInt
+  pointsOut             BigInt   @map("points_out") @db.BigInt
+  donationOutCount      Int      @map("donation_out_count")
+  donationOutPoints     BigInt   @map("donation_out_points") @db.BigInt
+  receivedDonationCount Int      @map("received_donation_count")
+  chainRootCount        Int      @map("chain_root_count")
+  maxChainDepthStarted  Int?     @map("max_chain_depth_started")
+  chainDepthReachedMax  Int?     @map("chain_depth_reached_max")
+  uniqueCounterparties  Int      @map("unique_counterparties")
+
+  @@id([date, communityId, userId, walletId])
+  @@map("mv_user_transaction_daily")
+}
+
+view TransactionCommentView {
+  transactionId   String            @id @map("transaction_id")
+  date            DateTime          @db.Date
+  createdAt       DateTime          @map("created_at")
+  communityId     String            @map("community_id")
+  fromUserId      String?           @map("from_user_id")
+  toUserId        String?           @map("to_user_id")
+  createdByUserId String?           @map("created_by_user_id")
+  reason          TransactionReason
+  points          Int
+  comment         String
+  chainDepth      Int?              @map("chain_depth")
+
+  @@map("v_transaction_comments")
+}
+
+view UserProfileForReportView {
+  userId        String   @map("user_id")
+  communityId   String   @map("community_id")
+  name          String
+  userBio       String?  @map("user_bio")
+  membershipBio String?  @map("membership_bio")
+  headline      String?
+  role          Role
+  joinedAt      DateTime @map("joined_at")
+
+  @@id([userId, communityId])
+  @@map("v_user_profile_for_report")
+}
+
 enum WalletType {
   COMMUNITY
   MEMBER

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -693,17 +693,6 @@ view TransactionSummaryDailyView {
   @@map("mv_transaction_summary_daily")
 }
 
-view TransactionActiveUsersDailyView {
-  date        DateTime @db.Date
-  communityId String   @map("community_id")
-  activeUsers Int      @map("active_users")
-  senders     Int
-  receivers   Int
-
-  @@id([date, communityId])
-  @@map("mv_transaction_active_users_daily")
-}
-
 view UserTransactionDailyView {
   date                  DateTime @db.Date
   communityId           String   @map("community_id")

--- a/src/infrastructure/prisma/sql/refreshMaterializedViewTransactionActiveUsersDaily.sql
+++ b/src/infrastructure/prisma/sql/refreshMaterializedViewTransactionActiveUsersDaily.sql
@@ -1,1 +1,0 @@
-REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_transaction_active_users_daily";

--- a/src/infrastructure/prisma/sql/refreshMaterializedViewTransactionActiveUsersDaily.sql
+++ b/src/infrastructure/prisma/sql/refreshMaterializedViewTransactionActiveUsersDaily.sql
@@ -1,0 +1,1 @@
+REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_transaction_active_users_daily";

--- a/src/infrastructure/prisma/sql/refreshMaterializedViewTransactionSummaryDaily.sql
+++ b/src/infrastructure/prisma/sql/refreshMaterializedViewTransactionSummaryDaily.sql
@@ -1,0 +1,1 @@
+REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_transaction_summary_daily";

--- a/src/infrastructure/prisma/sql/refreshMaterializedViewUserTransactionDaily.sql
+++ b/src/infrastructure/prisma/sql/refreshMaterializedViewUserTransactionDaily.sql
@@ -1,0 +1,1 @@
+REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_user_transaction_daily";

--- a/src/presentation/batch/refreshReportViews.ts
+++ b/src/presentation/batch/refreshReportViews.ts
@@ -1,0 +1,32 @@
+import "reflect-metadata";
+import "@/application/provider";
+import { container } from "tsyringe";
+import { PrismaClientIssuer } from "@/infrastructure/prisma/client";
+import logger from "@/infrastructure/logging";
+import ReportUseCase from "@/application/domain/report/usecase";
+import { IContext } from "@/types/server";
+
+/**
+ * Daily batch: refresh materialized views that back the transaction-based
+ * report dataset.
+ *
+ * Trigger this via Cloud Scheduler (or an equivalent) once per day, after
+ * the JST day boundary (e.g. 01:00 JST) so the previous day is fully
+ * captured.
+ */
+export async function refreshReportViews() {
+  const issuer = container.resolve<PrismaClientIssuer>("PrismaClientIssuer");
+  const reportUseCase = container.resolve<ReportUseCase>("ReportUseCase");
+
+  logger.debug("🔄 Starting report views refresh batch...");
+
+  const ctx = { issuer } as IContext;
+
+  try {
+    await reportUseCase.refreshAllReportViews(ctx);
+    logger.debug("✅ Report views refresh batch completed successfully");
+  } catch (error) {
+    logger.error("❌ Error in report views refresh batch:", error);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
This PR introduces a reporting infrastructure for AI-generated weekly/periodic transaction reports. It adds **two materialized views** for efficient aggregation, **two regular views** for comments and user profiles, and a full service layer to query and present this data in an LLM-friendly format.

## Key Changes

### Database Schema & Views
- **Two materialized views** for transaction analytics:
  - `mv_transaction_summary_daily`: Daily aggregates by (date, community_id, reason) with volume, points, and chain propagation metrics
  - `mv_user_transaction_daily`: Per-user daily activity with incoming/outgoing transactions, donations, and chain depth tracking
- **Two regular views** for report context:
  - `v_transaction_comments`: Transaction comments with metadata for AI highlighting
  - `v_user_profile_for_report`: User profiles (name, bio, role, joined_at) for top user ranking
- All views use Asia/Tokyo timezone for day bucketing
- Unique indexes on MVs (for `REFRESH MATERIALIZED VIEW CONCURRENTLY`) plus query optimization indexes
- Defensive same-community guard on every view that joins both wallet sides (rejects any `(from, to)` pair that disagrees on `community_id`)
- Distinct active/sender/receiver user counts are derived from `mv_user_transaction_daily` at query time rather than a dedicated MV

### Application Layer
- **ReportRepository**: query / aggregate / refresh the MVs and views. Uses Prisma `groupBy` for simple aggregates and targeted raw SQL (with `::date` casts) for DISTINCT counts and top-N ranking
- **ReportService**: thin facade around the repository
- **ReportUseCase**: orchestrates the fetches; manages `ctx.issuer.internal` transactions per CLAUDE.md; validates `windowDays` / `topN` / `commentLimit` ranges
- **ReportPresenter**: transforms DB rows into `WeeklyReportPayload`
  - snake_case keys for LLM token boundaries
  - BigInt → Number via `bigintToSafeNumber` safe-integer guard (fails fast on overflow)
  - JST date strings via `toJstIsoDate` / `truncateToJstDate`
  - `avg_chain_depth` divided by `chain_root_count + chain_descendant_count` (SQL `SUM` skips NULL chain_depth rows)
  - Top-N ranking is computed in SQL (`ORDER BY SUM(points_in) + SUM(points_out) DESC LIMIT N`); presenter does no sort/slice

### Batch Processing
- `refreshReportViews` **sequentially** runs `REFRESH MATERIALIZED VIEW CONCURRENTLY` on each MV to keep DB load predictable during the nightly window. Registered in `batch.ts` as `refresh-report-views` for Cloud Scheduler.

### Type Safety & Testing
- Generated Prisma factory types for the new views in `__generated__/index.ts`
- Factory functions support traits, transient fields, and callback hooks for testing

## Implementation Notes
- Materialized views bypass RLS; the application layer **must** filter by `communityId` on every access
- Date ranges are inclusive on both ends, JST bucketed
- Default report window is 7 days (weekly); `windowDays` is configurable within `[1, 90]`
- `topN` is configurable within `[1, 100]` (default 10); `commentLimit` within `[0, 1000]` (default 200)
- Chain depth metrics cover root count, descendant count, max depth, and sum for averaging

https://claude.ai/code/session_0113rnPuGjN67zbt8hDbzBay

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/816" rel="nofollow noreferrer noopener" target="_blank">
  <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
</a>