### PR TITLE
Add startup progress tracking for local development

### DIFF
--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -3,7 +3,9 @@ import { printEnvBanner } from "@/utils/envBanner";
 import { startProgress, step } from "@/utils/startupProgress";
 
 printEnvBanner();
-startProgress(7);
+// In batch mode, `main()` in `src/index.ts` short-circuits before the
+// server-startup steps fire, so the progress would otherwise stop at [2/7].
+startProgress(process.env.PROCESS_TYPE === "batch" ? 2 : 7);
 step("Environment loaded");
 
 const { tracingReady } = await import("@/infrastructure/logging/tracing");

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -1,9 +1,13 @@
 import "reflect-metadata";
 import { printEnvBanner } from "@/utils/envBanner";
+import { startProgress, step } from "@/utils/startupProgress";
 
 printEnvBanner();
+startProgress(7);
+step("Environment loaded");
 
 const { tracingReady } = await import("@/infrastructure/logging/tracing");
 await tracingReady;
+step("Tracing initialized");
 
 await import("../index");

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ async function startServer() {
   } else {
     server = http.createServer(app);
   }
-  step("HTTPS certs loaded");
+  step(process.env.NODE_HTTPS === "true" ? "HTTPS certs loaded" : "HTTP server created");
 
   const apolloServer = await createApolloServer(server);
   step("Apollo Server created");

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,10 +17,13 @@ import cookieParser from "cookie-parser";
 import { handleSessionLogin } from "@/presentation/middleware/session";
 import { sessionLoginRateLimit } from "@/presentation/middleware/rate-limit";
 import { botBlocker } from "@/presentation/middleware/bot-blocker";
+import { step, done, isProgressEnabled } from "@/utils/startupProgress";
 
 const port = Number(process.env.PORT ?? 3000);
 
 async function startServer() {
+  step("DI container registered");
+
   const app = express();
   app.set("trust proxy", 1);
 
@@ -36,8 +39,10 @@ async function startServer() {
   } else {
     server = http.createServer(app);
   }
+  step("HTTPS certs loaded");
 
   const apolloServer = await createApolloServer(server);
+  step("Apollo Server created");
 
   app.use((req, res, next): void => {
     if (req.method === "TRACE") {
@@ -95,12 +100,18 @@ async function startServer() {
     res.status(status).json({ error: err.expose ? err.message : "Internal Server Error" });
   });
 
+  step("Middleware registered");
+
   server.listen(port, () => {
     const protocol = process.env.NODE_HTTPS === "true" ? "https" : "http";
     const host = "localhost";
     const url = `${protocol}://${host}:${port}/graphql`;
 
-    logger.info(`🚀 Server ready at ${url}`);
+    if (isProgressEnabled()) {
+      done(`Server ready at ${url}`);
+    } else {
+      logger.info(`🚀 Server ready at ${url}`);
+    }
   });
 }
 

--- a/src/utils/startupProgress.ts
+++ b/src/utils/startupProgress.ts
@@ -1,0 +1,53 @@
+import { performance } from "node:perf_hooks";
+
+/**
+ * Prints per-step startup progress lines to stdout so local runs show which
+ * phase of bootstrap is slow. Only active when `LOCAL_DEV=true` is set by a
+ * local-facing npm script (`pnpm dev*`), mirroring the gate used by
+ * `src/utils/envBanner.ts`. In Cloud Run / GCP the flag is never set, so these
+ * calls become no-ops and the existing structured `logger.info` output is
+ * preserved.
+ *
+ * Usage:
+ *   startProgress(7);
+ *   step("Environment loaded");
+ *   ...
+ *   done(`Server ready at ${url}`);
+ */
+const enabled = process.env.LOCAL_DEV === "true";
+
+let totalSteps = 0;
+let currentStep = 0;
+let startMark = 0;
+let lastMark = 0;
+
+export function startProgress(total: number): void {
+  if (!enabled) return;
+  totalSteps = total;
+  currentStep = 0;
+  startMark = performance.now();
+  lastMark = startMark;
+}
+
+export function step(label: string): void {
+  if (!enabled) return;
+  currentStep += 1;
+  const now = performance.now();
+  const ms = Math.round(now - lastMark);
+  lastMark = now;
+  console.log(`[${currentStep}/${totalSteps}] ✓ ${label} (${ms}ms)`);
+}
+
+export function done(label: string): void {
+  if (!enabled) return;
+  currentStep += 1;
+  const now = performance.now();
+  const ms = Math.round(now - lastMark);
+  const total = Math.round(now - startMark);
+  lastMark = now;
+  console.log(`[${currentStep}/${totalSteps}] 🚀 ${label} (${ms}ms, total ${total}ms)`);
+}
+
+export function isProgressEnabled(): boolean {
+  return enabled;
+}

--- a/src/utils/startupProgress.ts
+++ b/src/utils/startupProgress.ts
@@ -14,7 +14,12 @@ import { performance } from "node:perf_hooks";
  *   ...
  *   done(`Server ready at ${url}`);
  */
-const enabled = process.env.LOCAL_DEV === "true";
+// Read `LOCAL_DEV` at call time (matching the pattern used by
+// `src/utils/envBanner.ts`) so test setups or programmatic entrypoints that
+// toggle the env var after module import still get the correct behavior.
+function isEnabled(): boolean {
+  return process.env.LOCAL_DEV === "true";
+}
 
 let totalSteps = 0;
 let currentStep = 0;
@@ -22,7 +27,7 @@ let startMark = 0;
 let lastMark = 0;
 
 export function startProgress(total: number): void {
-  if (!enabled) return;
+  if (!isEnabled()) return;
   totalSteps = total;
   currentStep = 0;
   startMark = performance.now();
@@ -30,7 +35,7 @@ export function startProgress(total: number): void {
 }
 
 export function step(label: string): void {
-  if (!enabled) return;
+  if (!isEnabled()) return;
   currentStep += 1;
   const now = performance.now();
   const ms = Math.round(now - lastMark);
@@ -39,7 +44,7 @@ export function step(label: string): void {
 }
 
 export function done(label: string): void {
-  if (!enabled) return;
+  if (!isEnabled()) return;
   currentStep += 1;
   const now = performance.now();
   const ms = Math.round(now - lastMark);
@@ -49,5 +54,5 @@ export function done(label: string): void {
 }
 
 export function isProgressEnabled(): boolean {
-  return enabled;
+  return isEnabled();
 }


### PR DESCRIPTION
## Summary
This PR adds a startup progress tracking utility that displays per-step bootstrap progress to stdout during local development, helping identify which phase of startup is slow.

## Key Changes
- **New utility module** (`src/utils/startupProgress.ts`): Provides functions to track and display startup progress
  - `startProgress(total)`: Initialize progress tracking with total step count
  - `step(label)`: Log completion of a step with elapsed time since last step
  - `done(label)`: Log final step with both step duration and total startup time
  - `isProgressEnabled()`: Check if progress tracking is active
  - Only active when `LOCAL_DEV=true` environment variable is set (matching the pattern used by `envBanner.ts`)
  - In production (Cloud Run/GCP), calls become no-ops and existing structured logging is preserved

- **Updated bootstrap flow** (`src/bootstrap/index.ts`): 
  - Initialize progress tracking with 7 total steps
  - Add progress markers for "Environment loaded" and "Tracing initialized"

- **Updated server startup** (`src/index.ts`):
  - Add progress markers for key initialization phases: DI container, HTTPS certs, Apollo Server, and middleware
  - Replace direct logger call with conditional output that uses progress tracking in local dev mode

## Implementation Details
- Uses Node.js `performance.now()` for accurate millisecond-level timing
- Tracks both individual step duration and cumulative startup time
- Progress output format: `[step/total] ✓ label (Xms)` for steps, `[step/total] 🚀 label (Xms, total Yms)` for completion
- Zero overhead in production environments through early returns when disabled

https://claude.ai/code/session_01CxXG1n4q2nPMmrSg3q1Gan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/817" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
