### PR TITLE
Update community image URL path and make reservation thumbnail optional

### DIFF
--- a/src/__tests__/unit/notification/notification.service.test.ts
+++ b/src/__tests__/unit/notification/notification.service.test.ts
@@ -56,7 +56,11 @@ describe("NotificationService - Point Transfer Notifications", () => {
       user: null,
       community: {
         name: "テストコミュニティ",
-        image: { url: "https://example.com/community.jpg" },
+        config: {
+          portalConfig: {
+            squareLogoPath: "https://example.com/community.jpg",
+          },
+        },
       },
     },
     toWallet: {

--- a/src/application/domain/notification/presenter/message/acceptReservationMessage.ts
+++ b/src/application/domain/notification/presenter/message/acceptReservationMessage.ts
@@ -2,7 +2,7 @@ import { messagingApi } from "@line/bot-sdk";
 
 export interface ReservationAcceptedParams {
   title: string;
-  thumbnail: string;
+  thumbnail?: string;
   year: string;
   date: string;
   time: string;
@@ -30,7 +30,7 @@ export function buildReservationAcceptedMessage(
 function buildBubble(params: ReservationAcceptedParams): messagingApi.FlexBubble {
   return {
     type: "bubble",
-    header: buildHeader(params.thumbnail),
+    ...(params.thumbnail ? { header: buildHeader(params.thumbnail) } : {}),
     body: buildBody(params),
     footer: buildFooter(params.redirectUrl),
   };

--- a/src/application/domain/notification/service.ts
+++ b/src/application/domain/notification/service.ts
@@ -448,7 +448,7 @@ export default class NotificationService {
 
     const communityName = transferDetail.fromWallet?.community?.name ?? "コミュニティ";
     const communityImageUrl = this.safeImageUrl(
-      transferDetail.fromWallet?.community?.image?.url,
+      transferDetail.fromWallet?.community?.config?.portalConfig?.squareLogoPath,
       DEFAULT_HOST_IMAGE_URL,
     );
     const toUserName = transferDetail.toWallet?.user?.name ?? "ユーザー";
@@ -732,7 +732,13 @@ export default class NotificationService {
                 community: {
                   select: {
                     name: true,
-                    image: { select: { url: true } },
+                    config: {
+                      select: {
+                        portalConfig: {
+                          select: { squareLogoPath: true },
+                        },
+                      },
+                    },
                   },
                 },
               },

--- a/src/application/domain/notification/service.ts
+++ b/src/application/domain/notification/service.ts
@@ -32,9 +32,7 @@ dayjs.locale("ja");
 dayjs.tz.setDefault("Asia/Tokyo");
 
 export const DEFAULT_HOST_IMAGE_URL =
-  "https://storage.googleapis.com/prod-civicship-storage-public/asset/neo88/placeholder.jpg";
-export const DEFAULT_THUMBNAIL =
-  "https://storage.googleapis.com/prod-civicship-storage-public/asset/neo88/ogp.jpg";
+  "https://storage.googleapis.com/prod-civicship-storage-public/communities/default/placeholder.jpg";
 
 @injectable()
 export default class NotificationService {
@@ -322,7 +320,7 @@ export default class NotificationService {
       const redirectUrl = `${liffBaseUrl}/participations/${participationId}`;
       const message = buildReservationAcceptedMessage({
         title,
-        thumbnail: this.safeImageUrl(images[0]?.url, DEFAULT_THUMBNAIL),
+        thumbnail: this.optionalImageUrl(images[0]?.url),
         year,
         date,
         time,


### PR DESCRIPTION
## Summary
This PR updates the notification service to use the new community portal configuration structure for image URLs and makes the reservation notification thumbnail optional.

## Key Changes
- **Updated DEFAULT_HOST_IMAGE_URL**: Changed from `neo88/placeholder.jpg` to `communities/default/placeholder.jpg` to reflect the new asset organization structure
- **Removed DEFAULT_THUMBNAIL constant**: This constant is no longer needed as thumbnails are now optional
- **Updated community image URL path**: Changed from `community.image.url` to `community.config.portalConfig.squareLogoPath` to align with the new data model structure
- **Made reservation thumbnail optional**: 
  - Changed `thumbnail` parameter type from `string` to `string | undefined` in `ReservationAcceptedParams`
  - Updated `buildBubble()` to conditionally include the header only when thumbnail is provided
  - Changed `safeImageUrl()` call to `optionalImageUrl()` for thumbnail handling
- **Updated database query**: Modified the Prisma select statement to fetch the new `config.portalConfig.squareLogoPath` path instead of `image.url`
- **Updated test fixtures**: Modified test data to reflect the new community image URL structure

## Implementation Details
The thumbnail is now truly optional in the reservation accepted message - if no image URL is available, the message bubble will be rendered without a header section entirely, rather than using a fallback default thumbnail.

https://claude.ai/code/session_01VhUunHvM1GqAP5JzFvgzEt
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/819" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
