### PR TITLE
Add comprehensive documentation to voting system GraphQL schema

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -869,15 +869,50 @@ type Mutation {
   utilityDelete(id: ID!, permission: CheckCommunityPermissionInput!): UtilityDeletePayload
   utilitySetPublishStatus(id: ID!, input: UtilitySetPublishStatusInput!, permission: CheckCommunityPermissionInput!): UtilitySetPublishStatusPayload
   utilityUpdateInfo(id: ID!, input: UtilityUpdateInfoInput!, permission: CheckCommunityPermissionInput!): UtilityUpdateInfoPayload
+
+  """
+  ユーザー: 投票実行。
+  同一 topicId への再投票は **upsert で上書き** される（投票履歴は残らない）。
+  投票の取消（withdraw）は現時点で未サポート。
+  eligibility と power は呼び出しごとに再チェックされ、NFT_COUNT の場合は呼び出し時点の保有数が新しい power として記録される。
+  """
   voteCast(input: VoteCastInput!): VoteCastPayload!
+
+  """
+  管理者: 投票テーマ・ゲート・ポリシー・選択肢を 1 トランザクションで一括作成。
+  Gate と PowerPolicy のクロス検証（NFT トークンの一致等）は行わない。
+  """
   voteTopicCreate(input: VoteTopicCreateInput!, permission: CheckCommunityPermissionInput!): VoteTopicCreatePayload!
+
+  """
+  管理者: 投票テーマ削除。
+  gate / powerPolicy / options / ballots は onDelete: Cascade で自動削除される。
+  """
   voteTopicDelete(id: ID!, permission: CheckCommunityPermissionInput!): VoteTopicDeletePayload!
 }
 
+"""ログインユーザーの投票資格と現状。再投票可能性の判定にも利用する。"""
 type MyVoteEligibility {
+  """
+  **リクエスト時点**で計算される power。
+  VoteBallot.power（投票時スナップショット）とは別物で、NFT_COUNT ポリシー下では乖離しうる。
+  """
   currentPower: Int
+
+  """
+  投票可能か。**投票済みでも再投票可能なら true** を返す
+  （期間内 & ゲート通過なら常に true。投票済みフラグは myBallot の有無で判定）。
+  """
   eligible: Boolean!
+
+  """ログインユーザーの投票（VoteTopic.myBallot と同じ値）。"""
   myBallot: VoteBallot
+
+  """
+  eligible=false 時の理由コード。次のいずれか:
+  GATE_NOT_CONFIGURED / GATE_NFT_TOKEN_NOT_CONFIGURED / REQUIRED_NFT_NOT_FOUND /
+  NOT_A_MEMBER / INSUFFICIENT_ROLE / UNKNOWN_GATE_TYPE
+  """
   reason: String
 }
 
@@ -1500,6 +1535,12 @@ type Query {
   incentiveGrants(cursor: String, filter: IncentiveGrantFilterInput, first: Int, sort: IncentiveGrantSortInput): IncentiveGrantsConnection!
   membership(communityId: ID!, userId: ID!): Membership
   memberships(cursor: MembershipCursorInput, filter: MembershipFilterInput, first: Int, sort: MembershipSortInput): MembershipsConnection!
+
+  """
+  ログインユーザーの投票資格確認。
+  投票画面（単一トピックにフォーカス）で利用する想定。
+  一覧画面では各ノードの VoteTopic.myEligibility を使う方が効率的。
+  """
   myVoteEligibility(topicId: ID!): MyVoteEligibility!
   myWallet: Wallet
   nftInstance(id: ID!): NftInstance
@@ -1546,7 +1587,14 @@ type Query {
   - Returns data integrity verification results
   """
   verifyTransactions(txIds: [ID!]!): [TransactionVerificationResult!]
+
+  """投票テーマ詳細（myBallot / myEligibility はフィールドリゾルバー経由で解決）。"""
   voteTopic(id: ID!): VoteTopic
+
+  """
+  コミュニティの投票テーマ一覧（カーソルページネーション）。
+  各ノードの myBallot / myEligibility は DataLoader 経由で解決され、N+1 は発生しない。
+  """
   voteTopics(communityId: ID!, cursor: String, first: Int): VoteTopicsConnection!
   wallet(id: ID!): Wallet
   wallets(cursor: String, filter: WalletFilterInput, first: Int, sort: WalletSortInput): WalletsConnection!
@@ -2317,10 +2365,21 @@ enum VerificationStatus {
   VERIFIED
 }
 
+"""
+個々の投票レコード。同一 (userId, topicId) に対し常に 1 レコード。
+再投票は upsert で上書きされるため**投票履歴は保持されない**。
+投票の取消（withdraw）は現時点で未サポート。
+"""
 type VoteBallot {
   createdAt: Datetime!
   id: ID!
   option: VoteOption!
+
+  """
+  投票時点の power **スナップショット**。
+  NFT_COUNT ポリシーの場合、投票後に NFT 保有数が変化しても本フィールドは変わらない
+  （現時点の power は MyVoteEligibility.currentPower を参照）。
+  """
   power: Int!
   updatedAt: Datetime
 }
@@ -2334,15 +2393,29 @@ type VoteCastPayload {
   ballot: VoteBallot!
 }
 
+"""
+誰が投票できるか（資格ゲート）。
+VotePowerPolicy（何票持つか）とは**独立に設定される**。
+スキーマレベルでのクロス検証は行わないため、Gate=NFT(tokenA) + PowerPolicy=NFT_COUNT(tokenB)
+のような食い違いも作成可能。この場合 A のみ保有するユーザーは eligible=true / currentPower=0 になる。
+組み合わせの妥当性は呼び出し側（管理 UI 等）で担保すること。
+"""
 type VoteGate {
   id: ID!
+
+  """type=NFT のときの参照 NftToken"""
   nftToken: NftToken
+
+  """type=MEMBERSHIP のときに要求する最低ロール（未指定時は MEMBER 以上）"""
   requiredRole: Role
   type: VoteGateType!
 }
 
 input VoteGateInput {
+  """type=NFT のとき必須。MEMBERSHIP のときは無視される。"""
   nftTokenId: ID
+
+  """type=MEMBERSHIP のときに任意指定（未指定時は MEMBER 以上で可）。NFT のときは無視される。"""
   requiredRole: Role
   type: VoteGateType!
 }
@@ -2352,26 +2425,45 @@ enum VoteGateType {
   NFT
 }
 
+"""
+投票選択肢。
+voteCount / totalPower は投票・再投票時にトランザクション内で直接更新される**非正規化カラム**で、
+集計コストを O(1) に抑える。PowerPolicy=FLAT のとき voteCount == totalPower、
+NFT_COUNT では乖離する。一般的には勝敗判定に totalPower、参加者数表示に voteCount を使う。
+"""
 type VoteOption {
   id: ID!
   label: String!
   orderIndex: Int!
+
+  """票の重み合計（= Σ power）。endsAt 到達前は一般ユーザーに null（管理者は常に実値を参照可）。"""
   totalPower: Int
+
+  """投票した**人数**。endsAt 到達前は一般ユーザーに null（管理者は常に実値を参照可）。"""
   voteCount: Int
 }
 
 input VoteOptionInput {
   label: String!
+
+  """0 以上の整数。オプション間で重複不可。"""
   orderIndex: Int!
 }
 
+"""
+投票の重み（1 人が何票持つか）を決めるポリシー。
+VoteGate（投票可能か）とは独立に設定される。
+"""
 type VotePowerPolicy {
   id: ID!
+
+  """type=NFT_COUNT のときに参照する NftToken（保有数を power とする）"""
   nftToken: NftToken
   type: VotePowerPolicyType!
 }
 
 input VotePowerPolicyInput {
+  """type=NFT_COUNT のとき必須。FLAT のときは無視される。"""
   nftTokenId: ID
   type: VotePowerPolicyType!
 }
@@ -2388,7 +2480,15 @@ type VoteTopic {
   endsAt: Datetime!
   gate: VoteGate!
   id: ID!
+
+  """
+  ログインユーザーの投票（未ログイン・未投票は null）。
+  MyVoteEligibility.myBallot と同じ値を返すため、一覧画面ではこちらを利用することを推奨
+  （投票画面のように資格情報も必要な場合は myEligibility.myBallot を使う）。
+  """
   myBallot: VoteBallot
+
+  """ログインユーザーの投票資格情報（未ログインは null）。"""
   myEligibility: MyVoteEligibility
   options: [VoteOption!]!
   phase: VoteTopicPhase!
@@ -2422,6 +2522,12 @@ type VoteTopicEdge {
   node: VoteTopic!
 }
 
+"""
+投票テーマの現在フェーズ。
+startsAt / endsAt と現在時刻から**レスポンス時点で**計算される値で、DB カラムではない。
+長時間開いたままの画面（カウントダウン等）ではクライアント側で古くなるため、
+精密な期間判定には startsAt / endsAt を直接比較すること。一覧表示などでは phase を利用して構わない。
+"""
 enum VoteTopicPhase {
   CLOSED
   OPEN

--- a/src/application/domain/vote/schema/mutation.graphql
+++ b/src/application/domain/vote/schema/mutation.graphql
@@ -3,18 +3,29 @@
 # ------------------------------
 
 extend type Mutation {
-    # 管理者: 投票テーマ・ゲート・ポリシー・選択肢を一括作成
+    """
+    管理者: 投票テーマ・ゲート・ポリシー・選択肢を 1 トランザクションで一括作成。
+    Gate と PowerPolicy のクロス検証（NFT トークンの一致等）は行わない。
+    """
     voteTopicCreate(
         input: VoteTopicCreateInput!
         permission: CheckCommunityPermissionInput!
     ): VoteTopicCreatePayload!
         @authz(rules: [IsCommunityManager])
 
-    # ユーザー: 投票実行（既存投票は upsert で上書き）
+    """
+    ユーザー: 投票実行。
+    同一 topicId への再投票は **upsert で上書き** される（投票履歴は残らない）。
+    投票の取消（withdraw）は現時点で未サポート。
+    eligibility と power は呼び出しごとに再チェックされ、NFT_COUNT の場合は呼び出し時点の保有数が新しい power として記録される。
+    """
     voteCast(input: VoteCastInput!): VoteCastPayload!
         @authz(rules: [IsUser])
 
-    # 管理者: 投票テーマ削除
+    """
+    管理者: 投票テーマ削除。
+    gate / powerPolicy / options / ballots は onDelete: Cascade で自動削除される。
+    """
     voteTopicDelete(
         id: ID!
         permission: CheckCommunityPermissionInput!
@@ -35,17 +46,21 @@ input VoteTopicCreateInput {
 
 input VoteGateInput {
     type: VoteGateType!
+    "type=NFT のとき必須。MEMBERSHIP のときは無視される。"
     nftTokenId: ID
+    "type=MEMBERSHIP のときに任意指定（未指定時は MEMBER 以上で可）。NFT のときは無視される。"
     requiredRole: Role
 }
 
 input VotePowerPolicyInput {
     type: VotePowerPolicyType!
+    "type=NFT_COUNT のとき必須。FLAT のときは無視される。"
     nftTokenId: ID
 }
 
 input VoteOptionInput {
     label: String!
+    "0 以上の整数。オプション間で重複不可。"
     orderIndex: Int!
 }
 

--- a/src/application/domain/vote/schema/query.graphql
+++ b/src/application/domain/vote/schema/query.graphql
@@ -3,17 +3,24 @@
 # ------------------------------
 
 extend type Query {
-    # コミュニティの投票テーマ一覧（カーソルページネーション付き）
+    """
+    コミュニティの投票テーマ一覧（カーソルページネーション）。
+    各ノードの myBallot / myEligibility は DataLoader 経由で解決され、N+1 は発生しない。
+    """
     voteTopics(
         communityId: ID!
         first: Int
         cursor: String
     ): VoteTopicsConnection!
 
-    # 投票テーマ詳細（myBallot / myEligibility はフィールドリゾルバー経由）
+    """投票テーマ詳細（myBallot / myEligibility はフィールドリゾルバー経由で解決）。"""
     voteTopic(id: ID!): VoteTopic
 
-    # ログインユーザーの投票資格確認
+    """
+    ログインユーザーの投票資格確認。
+    投票画面（単一トピックにフォーカス）で利用する想定。
+    一覧画面では各ノードの VoteTopic.myEligibility を使う方が効率的。
+    """
     myVoteEligibility(topicId: ID!): MyVoteEligibility!
         @authz(rules: [IsUser])
 }

--- a/src/application/domain/vote/schema/type.graphql
+++ b/src/application/domain/vote/schema/type.graphql
@@ -12,32 +12,58 @@ enum VotePowerPolicyType {
     NFT_COUNT
 }
 
-# 投票テーマの現在フェーズ（startsAt / endsAt から計算、DB には持たない）
+"""
+投票テーマの現在フェーズ。
+startsAt / endsAt と現在時刻から**レスポンス時点で**計算される値で、DB カラムではない。
+長時間開いたままの画面（カウントダウン等）ではクライアント側で古くなるため、
+精密な期間判定には startsAt / endsAt を直接比較すること。一覧表示などでは phase を利用して構わない。
+"""
 enum VoteTopicPhase {
     UPCOMING
     OPEN
     CLOSED
 }
 
+"""
+誰が投票できるか（資格ゲート）。
+VotePowerPolicy（何票持つか）とは**独立に設定される**。
+スキーマレベルでのクロス検証は行わないため、Gate=NFT(tokenA) + PowerPolicy=NFT_COUNT(tokenB)
+のような食い違いも作成可能。この場合 A のみ保有するユーザーは eligible=true / currentPower=0 になる。
+組み合わせの妥当性は呼び出し側（管理 UI 等）で担保すること。
+"""
 type VoteGate {
     id: ID!
     type: VoteGateType!
+    "type=NFT のときの参照 NftToken"
     nftToken: NftToken
+    "type=MEMBERSHIP のときに要求する最低ロール（未指定時は MEMBER 以上）"
     requiredRole: Role
 }
 
+"""
+投票の重み（1 人が何票持つか）を決めるポリシー。
+VoteGate（投票可能か）とは独立に設定される。
+"""
 type VotePowerPolicy {
     id: ID!
     type: VotePowerPolicyType!
+    "type=NFT_COUNT のときに参照する NftToken（保有数を power とする）"
     nftToken: NftToken
 }
 
+"""
+投票選択肢。
+voteCount / totalPower は投票・再投票時にトランザクション内で直接更新される**非正規化カラム**で、
+集計コストを O(1) に抑える。PowerPolicy=FLAT のとき voteCount == totalPower、
+NFT_COUNT では乖離する。一般的には勝敗判定に totalPower、参加者数表示に voteCount を使う。
+"""
 type VoteOption {
     id: ID!
     label: String!
     orderIndex: Int!
-    # 投票期間終了後のみ値を返す（期間中は null）
+    """投票した**人数**。endsAt 到達前は一般ユーザーに null（管理者は常に実値を参照可）。"""
     voteCount: Int
+    """票の重み合計（= Σ power）。endsAt 到達前は一般ユーザーに null（管理者は常に実値を参照可）。"""
     totalPower: Int
 }
 
@@ -52,26 +78,57 @@ type VoteTopic {
     gate: VoteGate!
     powerPolicy: VotePowerPolicy!
     options: [VoteOption!]!
-    # ログインユーザーの投票（未ログイン・未投票は null）
+    """
+    ログインユーザーの投票（未ログイン・未投票は null）。
+    MyVoteEligibility.myBallot と同じ値を返すため、一覧画面ではこちらを利用することを推奨
+    （投票画面のように資格情報も必要な場合は myEligibility.myBallot を使う）。
+    """
     myBallot: VoteBallot
-    # ログインユーザーの資格情報（未ログインは null）
+    """ログインユーザーの投票資格情報（未ログインは null）。"""
     myEligibility: MyVoteEligibility
     createdAt: Datetime!
     updatedAt: Datetime
 }
 
+"""
+個々の投票レコード。同一 (userId, topicId) に対し常に 1 レコード。
+再投票は upsert で上書きされるため**投票履歴は保持されない**。
+投票の取消（withdraw）は現時点で未サポート。
+"""
 type VoteBallot {
     id: ID!
     option: VoteOption!
+    """
+    投票時点の power **スナップショット**。
+    NFT_COUNT ポリシーの場合、投票後に NFT 保有数が変化しても本フィールドは変わらない
+    （現時点の power は MyVoteEligibility.currentPower を参照）。
+    """
     power: Int!
     createdAt: Datetime!
     updatedAt: Datetime
 }
 
+"""
+ログインユーザーの投票資格と現状。再投票可能性の判定にも利用する。
+"""
 type MyVoteEligibility {
+    """
+    投票可能か。**投票済みでも再投票可能なら true** を返す
+    （期間内 & ゲート通過なら常に true。投票済みフラグは myBallot の有無で判定）。
+    """
     eligible: Boolean!
+    """
+    eligible=false 時の理由コード。次のいずれか:
+    GATE_NOT_CONFIGURED / GATE_NFT_TOKEN_NOT_CONFIGURED / REQUIRED_NFT_NOT_FOUND /
+    NOT_A_MEMBER / INSUFFICIENT_ROLE / UNKNOWN_GATE_TYPE
+    """
     reason: String
+    """
+    **リクエスト時点**で計算される power。
+    VoteBallot.power（投票時スナップショット）とは別物で、NFT_COUNT ポリシー下では乖離しうる。
+    """
     currentPower: Int
+    """ログインユーザーの投票（VoteTopic.myBallot と同じ値）。"""
     myBallot: VoteBallot
 }
 

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -953,8 +953,22 @@ export type GqlMutation = {
   utilityDelete?: Maybe<GqlUtilityDeletePayload>;
   utilitySetPublishStatus?: Maybe<GqlUtilitySetPublishStatusPayload>;
   utilityUpdateInfo?: Maybe<GqlUtilityUpdateInfoPayload>;
+  /**
+   * ユーザー: 投票実行。
+   * 同一 topicId への再投票は **upsert で上書き** される（投票履歴は残らない）。
+   * 投票の取消（withdraw）は現時点で未サポート。
+   * eligibility と power は呼び出しごとに再チェックされ、NFT_COUNT の場合は呼び出し時点の保有数が新しい power として記録される。
+   */
   voteCast: GqlVoteCastPayload;
+  /**
+   * 管理者: 投票テーマ・ゲート・ポリシー・選択肢を 1 トランザクションで一括作成。
+   * Gate と PowerPolicy のクロス検証（NFT トークンの一致等）は行わない。
+   */
   voteTopicCreate: GqlVoteTopicCreatePayload;
+  /**
+   * 管理者: 投票テーマ削除。
+   * gate / powerPolicy / options / ballots は onDelete: Cascade で自動削除される。
+   */
   voteTopicDelete: GqlVoteTopicDeletePayload;
 };
 
@@ -1317,11 +1331,26 @@ export type GqlMutationVoteTopicDeleteArgs = {
   permission: GqlCheckCommunityPermissionInput;
 };
 
+/** ログインユーザーの投票資格と現状。再投票可能性の判定にも利用する。 */
 export type GqlMyVoteEligibility = {
   __typename?: 'MyVoteEligibility';
+  /**
+   * **リクエスト時点**で計算される power。
+   * VoteBallot.power（投票時スナップショット）とは別物で、NFT_COUNT ポリシー下では乖離しうる。
+   */
   currentPower?: Maybe<Scalars['Int']['output']>;
+  /**
+   * 投票可能か。**投票済みでも再投票可能なら true** を返す
+   * （期間内 & ゲート通過なら常に true。投票済みフラグは myBallot の有無で判定）。
+   */
   eligible: Scalars['Boolean']['output'];
+  /** ログインユーザーの投票（VoteTopic.myBallot と同じ値）。 */
   myBallot?: Maybe<GqlVoteBallot>;
+  /**
+   * eligible=false 時の理由コード。次のいずれか:
+   * GATE_NOT_CONFIGURED / GATE_NFT_TOKEN_NOT_CONFIGURED / REQUIRED_NFT_NOT_FOUND /
+   * NOT_A_MEMBER / INSUFFICIENT_ROLE / UNKNOWN_GATE_TYPE
+   */
   reason?: Maybe<Scalars['String']['output']>;
 };
 
@@ -1998,6 +2027,11 @@ export type GqlQuery = {
   incentiveGrants: GqlIncentiveGrantsConnection;
   membership?: Maybe<GqlMembership>;
   memberships: GqlMembershipsConnection;
+  /**
+   * ログインユーザーの投票資格確認。
+   * 投票画面（単一トピックにフォーカス）で利用する想定。
+   * 一覧画面では各ノードの VoteTopic.myEligibility を使う方が効率的。
+   */
   myVoteEligibility: GqlMyVoteEligibility;
   myWallet?: Maybe<GqlWallet>;
   nftInstance?: Maybe<GqlNftInstance>;
@@ -2043,7 +2077,12 @@ export type GqlQuery = {
    * - Returns data integrity verification results
    */
   verifyTransactions?: Maybe<Array<GqlTransactionVerificationResult>>;
+  /** 投票テーマ詳細（myBallot / myEligibility はフィールドリゾルバー経由で解決）。 */
   voteTopic?: Maybe<GqlVoteTopic>;
+  /**
+   * コミュニティの投票テーマ一覧（カーソルページネーション）。
+   * 各ノードの myBallot / myEligibility は DataLoader 経由で解決され、N+1 は発生しない。
+   */
   voteTopics: GqlVoteTopicsConnection;
   wallet?: Maybe<GqlWallet>;
   wallets: GqlWalletsConnection;
@@ -3250,11 +3289,21 @@ export const GqlVerificationStatus = {
 } as const;
 
 export type GqlVerificationStatus = typeof GqlVerificationStatus[keyof typeof GqlVerificationStatus];
+/**
+ * 個々の投票レコード。同一 (userId, topicId) に対し常に 1 レコード。
+ * 再投票は upsert で上書きされるため**投票履歴は保持されない**。
+ * 投票の取消（withdraw）は現時点で未サポート。
+ */
 export type GqlVoteBallot = {
   __typename?: 'VoteBallot';
   createdAt: Scalars['Datetime']['output'];
   id: Scalars['ID']['output'];
   option: GqlVoteOption;
+  /**
+   * 投票時点の power **スナップショット**。
+   * NFT_COUNT ポリシーの場合、投票後に NFT 保有数が変化しても本フィールドは変わらない
+   * （現時点の power は MyVoteEligibility.currentPower を参照）。
+   */
   power: Scalars['Int']['output'];
   updatedAt?: Maybe<Scalars['Datetime']['output']>;
 };
@@ -3269,16 +3318,27 @@ export type GqlVoteCastPayload = {
   ballot: GqlVoteBallot;
 };
 
+/**
+ * 誰が投票できるか（資格ゲート）。
+ * VotePowerPolicy（何票持つか）とは**独立に設定される**。
+ * スキーマレベルでのクロス検証は行わないため、Gate=NFT(tokenA) + PowerPolicy=NFT_COUNT(tokenB)
+ * のような食い違いも作成可能。この場合 A のみ保有するユーザーは eligible=true / currentPower=0 になる。
+ * 組み合わせの妥当性は呼び出し側（管理 UI 等）で担保すること。
+ */
 export type GqlVoteGate = {
   __typename?: 'VoteGate';
   id: Scalars['ID']['output'];
+  /** type=NFT のときの参照 NftToken */
   nftToken?: Maybe<GqlNftToken>;
+  /** type=MEMBERSHIP のときに要求する最低ロール（未指定時は MEMBER 以上） */
   requiredRole?: Maybe<GqlRole>;
   type: GqlVoteGateType;
 };
 
 export type GqlVoteGateInput = {
+  /** type=NFT のとき必須。MEMBERSHIP のときは無視される。 */
   nftTokenId?: InputMaybe<Scalars['ID']['input']>;
+  /** type=MEMBERSHIP のときに任意指定（未指定時は MEMBER 以上で可）。NFT のときは無視される。 */
   requiredRole?: InputMaybe<GqlRole>;
   type: GqlVoteGateType;
 };
@@ -3289,28 +3349,43 @@ export const GqlVoteGateType = {
 } as const;
 
 export type GqlVoteGateType = typeof GqlVoteGateType[keyof typeof GqlVoteGateType];
+/**
+ * 投票選択肢。
+ * voteCount / totalPower は投票・再投票時にトランザクション内で直接更新される**非正規化カラム**で、
+ * 集計コストを O(1) に抑える。PowerPolicy=FLAT のとき voteCount == totalPower、
+ * NFT_COUNT では乖離する。一般的には勝敗判定に totalPower、参加者数表示に voteCount を使う。
+ */
 export type GqlVoteOption = {
   __typename?: 'VoteOption';
   id: Scalars['ID']['output'];
   label: Scalars['String']['output'];
   orderIndex: Scalars['Int']['output'];
+  /** 票の重み合計（= Σ power）。endsAt 到達前は一般ユーザーに null（管理者は常に実値を参照可）。 */
   totalPower?: Maybe<Scalars['Int']['output']>;
+  /** 投票した**人数**。endsAt 到達前は一般ユーザーに null（管理者は常に実値を参照可）。 */
   voteCount?: Maybe<Scalars['Int']['output']>;
 };
 
 export type GqlVoteOptionInput = {
   label: Scalars['String']['input'];
+  /** 0 以上の整数。オプション間で重複不可。 */
   orderIndex: Scalars['Int']['input'];
 };
 
+/**
+ * 投票の重み（1 人が何票持つか）を決めるポリシー。
+ * VoteGate（投票可能か）とは独立に設定される。
+ */
 export type GqlVotePowerPolicy = {
   __typename?: 'VotePowerPolicy';
   id: Scalars['ID']['output'];
+  /** type=NFT_COUNT のときに参照する NftToken（保有数を power とする） */
   nftToken?: Maybe<GqlNftToken>;
   type: GqlVotePowerPolicyType;
 };
 
 export type GqlVotePowerPolicyInput = {
+  /** type=NFT_COUNT のとき必須。FLAT のときは無視される。 */
   nftTokenId?: InputMaybe<Scalars['ID']['input']>;
   type: GqlVotePowerPolicyType;
 };
@@ -3329,7 +3404,13 @@ export type GqlVoteTopic = {
   endsAt: Scalars['Datetime']['output'];
   gate: GqlVoteGate;
   id: Scalars['ID']['output'];
+  /**
+   * ログインユーザーの投票（未ログイン・未投票は null）。
+   * MyVoteEligibility.myBallot と同じ値を返すため、一覧画面ではこちらを利用することを推奨
+   * （投票画面のように資格情報も必要な場合は myEligibility.myBallot を使う）。
+   */
   myBallot?: Maybe<GqlVoteBallot>;
+  /** ログインユーザーの投票資格情報（未ログインは null）。 */
   myEligibility?: Maybe<GqlMyVoteEligibility>;
   options: Array<GqlVoteOption>;
   phase: GqlVoteTopicPhase;
@@ -3366,6 +3447,12 @@ export type GqlVoteTopicEdge = {
   node: GqlVoteTopic;
 };
 
+/**
+ * 投票テーマの現在フェーズ。
+ * startsAt / endsAt と現在時刻から**レスポンス時点で**計算される値で、DB カラムではない。
+ * 長時間開いたままの画面（カウントダウン等）ではクライアント側で古くなるため、
+ * 精密な期間判定には startsAt / endsAt を直接比較すること。一覧表示などでは phase を利用して構わない。
+ */
 export const GqlVoteTopicPhase = {
   Closed: 'CLOSED',
   Open: 'OPEN',


### PR DESCRIPTION
## Summary
This PR adds extensive JSDoc/GraphQL documentation comments to the voting system's GraphQL schema and TypeScript type definitions. The documentation clarifies the behavior, constraints, and usage patterns of voting-related types and operations.

## Key Changes

- **Mutation documentation**: Added detailed descriptions for `voteCast`, `voteTopicCreate`, and `voteTopicDelete` mutations explaining:
  - Re-voting behavior (upsert overwrites, no history retained)
  - Eligibility and power re-checking on each call
  - Cascade deletion of related entities

- **Query documentation**: Enhanced `myVoteEligibility`, `voteTopic`, and `voteTopics` queries with:
  - Usage recommendations (single topic vs. list views)
  - DataLoader optimization notes for N+1 prevention
  - Field resolver resolution details

- **Type documentation**: Comprehensive docs for voting domain types:
  - `MyVoteEligibility`: Clarified `currentPower` vs. `VoteBallot.power` distinction, `eligible` flag behavior
  - `VoteBallot`: Explained snapshot semantics and immutability of recorded power
  - `VoteGate` & `VotePowerPolicy`: Documented independence and lack of cross-validation
  - `VoteOption`: Clarified denormalized `voteCount`/`totalPower` fields and visibility rules
  - `VoteTopicPhase`: Noted that phase is computed at response time, not persisted

- **Input type documentation**: Added field-level docs for `VoteGateInput`, `VotePowerPolicyInput`, and `VoteOptionInput` explaining required/optional fields and their semantics

- **Schema source files**: Updated GraphQL schema definitions in `type.graphql`, `mutation.graphql`, and `query.graphql` with corresponding documentation

## Notable Implementation Details

- Documentation uses both block comments (for types/enums) and inline comments (for fields) following GraphQL conventions
- Includes Japanese descriptions where appropriate for domain clarity
- Highlights important behavioral notes (e.g., re-voting upsert semantics, power snapshot immutability)
- Provides usage guidance to prevent common mistakes (e.g., using `myEligibility` vs. `myBallot` in different contexts)
- Clarifies the distinction between eligibility gates and power policies as independent concerns

https://claude.ai/code/session_01ET3JyA3ZPvErcMxM5QmwVS
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/821" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
