### PR TITLE
ci: roll the batch Cloud Run Job to the newly-pushed image

### DIFF
--- a/.github/workflows/deploy-to-cloud-run-dev.yml
+++ b/.github/workflows/deploy-to-cloud-run-dev.yml
@@ -135,6 +135,15 @@ jobs:
       run: |
         docker push ${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest
 
+    - name: Update Cloud Run Job (batch) to new image
+      # docker push :latest alone does not roll the Cloud Run Job to the new
+      # image — Cloud Run Jobs pin the image digest at deploy time, so we
+      # need an explicit `run jobs update` to create a new revision.
+      run: |
+        gcloud run jobs update ${{ env.BATCH_NAME }} \
+          --region=${{ env.GCP_REGION }} \
+          --image=${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest
+
     - name: Cleanup SSH Key
       if: always()
       run: rm -f ~/.ssh/google_compute_engine ~/.ssh/google_compute_engine.pub

--- a/.github/workflows/deploy-to-cloud-run-prd.yml
+++ b/.github/workflows/deploy-to-cloud-run-prd.yml
@@ -132,6 +132,15 @@ jobs:
       run: |
         docker push ${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest
 
+    - name: Update Cloud Run Job (batch) to new image
+      # docker push :latest alone does not roll the Cloud Run Job to the new
+      # image — Cloud Run Jobs pin the image digest at deploy time, so we
+      # need an explicit `run jobs update` to create a new revision.
+      run: |
+        gcloud run jobs update ${{ env.BATCH_NAME }} \
+          --region=${{ env.GCP_REGION }} \
+          --image=${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest
+
     - name: Create Git tag
       run: |
         # Install tzdata to use Japan timezone


### PR DESCRIPTION
## Summary

Fix a long-standing CI gap: both `deploy-to-cloud-run-{dev,prd}.yml` build and push the batch Docker image but never tell Cloud Run Jobs to pick it up. Cloud Run Jobs pin the image digest at deploy time, so pushing the same `:latest` on top doesn't roll the Job to the new image — the Job keeps running the digest it was last deployed with.

## How this surfaced

Today's rollout of the Report dataset:

1. `master` merge ran `deploy-to-cloud-run-prd.yml` → batch image built and pushed ✅
2. Cloud Scheduler hit the Cloud Run Job with `BATCH_PROCESS_NAME=refresh-report-views`
3. Log: `Invalid batch process called.` — the switch in `src/batch.ts` hit `default` because the running image still had the pre-PR code
4. `gcloud run jobs describe prod-civicship-batch` showed the image was last updated **2025-11-20** (5 months old)
5. Manual `gcloud run jobs update --image=.../:latest` fixed it; the next Scheduler run produced the expected `✅ Report views refresh batch completed successfully`

Any batch code change since 2025-11-20 has effectively been silently unshipped.

## Fix

Add one step right after `Push Docker image for batch job` in both workflows:

```yaml
- name: Update Cloud Run Job (batch) to new image
  run: |
    gcloud run jobs update ${{ env.BATCH_NAME }} \
      --region=${{ env.GCP_REGION }} \
      --image=${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest
```

- Uses the same Workload Identity Federation auth as the rest of the workflow (gcloud picks up the default project from the authenticated service account, matching how the existing `gcloud compute ssh` / `gcloud auth configure-docker` steps work — no new secret needed).
- `gcloud run jobs update` creates a new revision on the Cloud Run Job pointing at the freshly-pushed digest.
- No restart of currently-running Jobs — the next invocation picks up the new revision.

## Test plan

- [ ] Merge → develop → automatic dev deploy → `gcloud run jobs describe kyoso-dev-civicship-batch --format='value(metadata.labels."run.googleapis.com/lastUpdatedTime")'` shows a new timestamp
- [ ] Fire `kyoso-dev-civicship-batch-scheduler-refresh-report-views` (resume → run → pause) and confirm successful execution with logs from the newly-deployed code
- [ ] After this PR reaches master: the prod workflow will likewise auto-update `prod-civicship-batch`, removing the manual `gcloud run jobs update` step from the release runbook

https://claude.ai/code/session_0113rnPuGjN67zbt8hDbzBay
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/826" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
