### PR TITLE
Add communityId column to NftToken for direct community relation

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -999,6 +999,12 @@ type NftInstancesConnection {
 
 type NftToken {
   address: String!
+
+  """
+  トークンを所有するコミュニティ。複数コミュニティで共用する場合や運用都合で未設定の場合は null。
+  portal 側の「このコミュニティに属する NftToken」一覧取得で参照される。
+  """
+  community: Community
   createdAt: Datetime!
   id: ID!
   json: JSON
@@ -1016,6 +1022,12 @@ type NftTokenEdge implements Edge {
 input NftTokenFilterInput {
   address: [String!]
   and: [NftTokenFilterInput!]
+
+  """
+  指定したコミュニティに直接紐付く NftToken に絞る（NftToken.community_id を直接参照）。
+  NftToken.communityId が NULL のトークンは除外される。
+  """
+  communityId: ID
   not: NftTokenFilterInput
   or: [NftTokenFilterInput!]
   type: [String!]

--- a/src/__tests__/unit/account/nft-token.converter.test.ts
+++ b/src/__tests__/unit/account/nft-token.converter.test.ts
@@ -1,0 +1,102 @@
+import "reflect-metadata";
+import NftTokenConverter from "@/application/domain/account/nft-token/data/converter";
+import { GqlSortDirection } from "@/types/graphql";
+
+describe("NftTokenConverter.filter", () => {
+  const converter = new NftTokenConverter();
+
+  it("returns empty where when input is undefined", () => {
+    expect(converter.filter(undefined)).toEqual({});
+  });
+
+  it("returns empty where when input has no meaningful fields", () => {
+    expect(converter.filter({})).toEqual({});
+  });
+
+  it("filters by address array", () => {
+    const where = converter.filter({ address: ["addr1", "addr2"] });
+    expect(where).toEqual({ AND: [{ address: { in: ["addr1", "addr2"] } }] });
+  });
+
+  it("filters by type array", () => {
+    const where = converter.filter({ type: ["ERC-721"] });
+    expect(where).toEqual({ AND: [{ type: { in: ["ERC-721"] } }] });
+  });
+
+  it("filters by communityId (direct column match)", () => {
+    const where = converter.filter({ communityId: "community-1" });
+    expect(where).toEqual({ AND: [{ communityId: "community-1" }] });
+  });
+
+  it("ignores empty string communityId (truthy check)", () => {
+    // 空文字列は設定ミスの可能性が高いので条件に含めない（他のフィルタと同様の挙動）
+    expect(converter.filter({ communityId: "" })).toEqual({});
+  });
+
+  it("ignores undefined communityId", () => {
+    // GraphQL input 型上は undefined のみ許容されるが、ランタイムの防御として
+    // truthy チェックで null も安全に弾く。
+    expect(converter.filter({ communityId: undefined })).toEqual({});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(converter.filter({ communityId: null as any })).toEqual({});
+  });
+
+  it("combines multiple top-level filters with AND", () => {
+    const where = converter.filter({
+      communityId: "community-1",
+      type: ["ERC-721"],
+    });
+    expect(where).toEqual({
+      AND: [{ type: { in: ["ERC-721"] } }, { communityId: "community-1" }],
+    });
+  });
+
+  it("applies and[] by flattening into AND conditions", () => {
+    const where = converter.filter({
+      communityId: "community-1",
+      and: [{ type: ["ERC-721"] }, { address: ["addr1"] }],
+    });
+    expect(where.AND).toEqual([
+      { communityId: "community-1" },
+      { AND: [{ type: { in: ["ERC-721"] } }] },
+      { AND: [{ address: { in: ["addr1"] } }] },
+    ]);
+  });
+
+  it("applies or[] correctly", () => {
+    const where = converter.filter({
+      or: [{ communityId: "c1" }, { communityId: "c2" }],
+    });
+    expect(where.OR).toEqual([{ AND: [{ communityId: "c1" }] }, { AND: [{ communityId: "c2" }] }]);
+  });
+
+  it("applies not correctly", () => {
+    const where = converter.filter({
+      not: { communityId: "c1" },
+    });
+    expect(where.NOT).toEqual({ AND: [{ communityId: "c1" }] });
+  });
+});
+
+describe("NftTokenConverter.sort", () => {
+  const converter = new NftTokenConverter();
+
+  it("returns default sort when input is undefined", () => {
+    expect(converter.sort(undefined)).toEqual([{ createdAt: "desc" }, { id: "asc" }]);
+  });
+
+  it("sorts by createdAt asc", () => {
+    expect(converter.sort({ createdAt: GqlSortDirection.Asc })).toEqual([
+      { createdAt: "asc" },
+      { id: "asc" },
+    ]);
+  });
+
+  it("combines multiple sort fields in declared order + id asc tiebreaker", () => {
+    const result = converter.sort({
+      name: GqlSortDirection.Asc,
+      address: GqlSortDirection.Desc,
+    });
+    expect(result).toEqual([{ name: "asc" }, { address: "desc" }, { id: "asc" }]);
+  });
+});

--- a/src/application/domain/account/nft-token/controller/resolver.ts
+++ b/src/application/domain/account/nft-token/controller/resolver.ts
@@ -2,6 +2,7 @@ import { GqlQueryNftTokensArgs, GqlQueryNftTokenArgs } from "@/types/graphql";
 import { IContext } from "@/types/server";
 import { inject, injectable } from "tsyringe";
 import NftTokenUseCase from "@/application/domain/account/nft-token/usecase";
+import { PrismaNftToken } from "@/application/domain/account/nft-token/data/type";
 
 @injectable()
 export default class NftTokenResolver {
@@ -13,6 +14,12 @@ export default class NftTokenResolver {
     },
     nftToken: async (_: unknown, args: GqlQueryNftTokenArgs, ctx: IContext) => {
       return this.useCase.getNftToken(args.id, ctx);
+    },
+  };
+
+  NftToken = {
+    community: (parent: PrismaNftToken, _: unknown, ctx: IContext) => {
+      return parent.communityId ? ctx.loaders.community.load(parent.communityId) : null;
     },
   };
 }

--- a/src/application/domain/account/nft-token/data/converter.ts
+++ b/src/application/domain/account/nft-token/data/converter.ts
@@ -17,6 +17,11 @@ export default class NftTokenConverter {
       conditions.push({ type: { in: input.type } });
     }
 
+    // NftToken.community_id を直接参照（FK）。nullable のため NULL は自然に除外される。
+    if (input.communityId !== undefined && input.communityId !== null) {
+      conditions.push({ communityId: input.communityId });
+    }
+
     const allAndConditions: Prisma.NftTokenWhereInput[] = [...conditions];
 
     if (input.and?.length) {

--- a/src/application/domain/account/nft-token/data/converter.ts
+++ b/src/application/domain/account/nft-token/data/converter.ts
@@ -18,7 +18,8 @@ export default class NftTokenConverter {
     }
 
     // NftToken.community_id を直接参照（FK）。nullable のため NULL は自然に除外される。
-    if (input.communityId !== undefined && input.communityId !== null) {
+    // 空文字列も弾くために他フィルタと同様の truthy チェック。
+    if (input.communityId) {
       conditions.push({ communityId: input.communityId });
     }
 

--- a/src/application/domain/account/nft-token/data/type.ts
+++ b/src/application/domain/account/nft-token/data/type.ts
@@ -7,6 +7,7 @@ export const nftTokenSelect = Prisma.validator<Prisma.NftTokenSelect>()({
   symbol: true,
   type: true,
   json: true,
+  communityId: true,
   createdAt: true,
   updatedAt: true,
 });

--- a/src/application/domain/account/nft-token/presenter.ts
+++ b/src/application/domain/account/nft-token/presenter.ts
@@ -9,6 +9,8 @@ export default class NftTokenPresenter {
     return {
       __typename: "NftToken",
       ...nftToken,
+      // community は field resolver で解決される。communityId はスプレッドに含まれる。
+      community: null,
     };
   }
 

--- a/src/application/domain/account/nft-token/schema/query.graphql
+++ b/src/application/domain/account/nft-token/schema/query.graphql
@@ -12,6 +12,11 @@ extend type Query {
 input NftTokenFilterInput {
   address: [String!]
   type: [String!]
+  """
+  指定したコミュニティに直接紐付く NftToken に絞る（NftToken.community_id を直接参照）。
+  NftToken.communityId が NULL のトークンは除外される。
+  """
+  communityId: ID
 
   and: [NftTokenFilterInput!]
   or: [NftTokenFilterInput!]

--- a/src/application/domain/account/nft-token/schema/type.graphql
+++ b/src/application/domain/account/nft-token/schema/type.graphql
@@ -5,6 +5,11 @@ type NftToken {
   symbol: String
   type: String!
   json: JSON
+  """
+  トークンを所有するコミュニティ。複数コミュニティで共用する場合や運用都合で未設定の場合は null。
+  portal 側の「このコミュニティに属する NftToken」一覧取得で参照される。
+  """
+  community: Community
   createdAt: Datetime!
   updatedAt: Datetime
 }

--- a/src/application/domain/vote/controller/dataloader.ts
+++ b/src/application/domain/vote/controller/dataloader.ts
@@ -5,6 +5,7 @@ import {
   PrismaVoteOption,
   PrismaVoteBallot,
 } from "@/application/domain/vote/data/type";
+import { nftTokenSelect } from "@/application/domain/account/nft-token/data/type";
 import {
   createLoaderById,
   createLoaderByCompositeKey,
@@ -41,22 +42,15 @@ export function createMyVoteBallotLoader(prisma: PrismaClient) {
 }
 
 // NftToken を id でバッチロード（VoteGate / VotePowerPolicy の nftToken フィールドリゾルバー用）
-// GQL NftToken 型の必須フィールド（createdAt: Datetime!）を含む完全な select を使用
+// NftToken ドメインの nftTokenSelect を共有することで、GQL NftToken 型の全フィールド
+// （`community` 解決に必要な `communityId` を含む）を漏れなく取得する。
+// select を独自定義すると NftToken ドメインのフィールド追加に追従漏れが発生するリスクがある。
 export function createNftTokenLoader(prisma: PrismaClient) {
   return createLoaderById(
     async (ids) =>
       prisma.nftToken.findMany({
         where: { id: { in: [...ids] } },
-        select: {
-          id: true,
-          address: true,
-          name: true,
-          symbol: true,
-          type: true,
-          json: true,
-          createdAt: true,
-          updatedAt: true,
-        },
+        select: nftTokenSelect,
       }),
     (record) => record,
   );

--- a/src/infrastructure/prisma/migrations/20260416120000_add_community_id_to_nft_token/migration.sql
+++ b/src/infrastructure/prisma/migrations/20260416120000_add_community_id_to_nft_token/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "t_nft_tokens" ADD COLUMN     "community_id" TEXT;
+
+-- CreateIndex
+CREATE INDEX "t_nft_tokens_community_id_idx" ON "t_nft_tokens"("community_id");
+
+-- AddForeignKey
+ALTER TABLE "t_nft_tokens" ADD CONSTRAINT "t_nft_tokens_community_id_fkey" FOREIGN KEY ("community_id") REFERENCES "t_communities"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -194,6 +194,7 @@ model Community {
   articles       Article[]
 
   nftInstance NftInstance[]
+  nftTokens   NftToken[]
   voteTopics  VoteTopic[]
 
   createdAt DateTime  @default(now()) @map("created_at")
@@ -1361,6 +1362,12 @@ model NftToken {
   symbol String?
   json   Json?
 
+  // トークンを所有するコミュニティ。portal 側の「このコミュニティに属する NFT Token」
+  // 一覧取得で使用する。複数コミュニティで共用するケースや運用都合で未設定のケースも
+  // ありえるため nullable にしている。
+  communityId String?    @map("community_id")
+  community   Community? @relation(fields: [communityId], references: [id], onDelete: SetNull)
+
   nftInstances      NftInstance[]
   voteGates         VoteGate[]
   votePowerPolicies VotePowerPolicy[]
@@ -1368,6 +1375,7 @@ model NftToken {
   createdAt DateTime  @default(now()) @map("created_at")
   updatedAt DateTime? @updatedAt @map("updated_at")
 
+  @@index([communityId])
   @@map("t_nft_tokens")
 }
 

--- a/src/presentation/graphql/resolver.ts
+++ b/src/presentation/graphql/resolver.ts
@@ -114,6 +114,7 @@ const resolvers = {
   Wallet: wallet.Wallet,
   NftWallet: nftWallet.NftWallet,
   NftInstance: nftInstance.NftInstance,
+  NftToken: nftToken.NftToken,
   Membership: membership.Membership,
   Community: community.Community,
   CommunityConfig: community.CommunityConfig,

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1447,6 +1447,11 @@ export type GqlNftInstancesConnection = {
 export type GqlNftToken = {
   __typename?: 'NftToken';
   address: Scalars['String']['output'];
+  /**
+   * トークンを所有するコミュニティ。複数コミュニティで共用する場合や運用都合で未設定の場合は null。
+   * portal 側の「このコミュニティに属する NftToken」一覧取得で参照される。
+   */
+  community?: Maybe<GqlCommunity>;
   createdAt: Scalars['Datetime']['output'];
   id: Scalars['ID']['output'];
   json?: Maybe<Scalars['JSON']['output']>;
@@ -1465,6 +1470,11 @@ export type GqlNftTokenEdge = GqlEdge & {
 export type GqlNftTokenFilterInput = {
   address?: InputMaybe<Array<Scalars['String']['input']>>;
   and?: InputMaybe<Array<GqlNftTokenFilterInput>>;
+  /**
+   * 指定したコミュニティに直接紐付く NftToken に絞る（NftToken.community_id を直接参照）。
+   * NftToken.communityId が NULL のトークンは除外される。
+   */
+  communityId?: InputMaybe<Scalars['ID']['input']>;
   not?: InputMaybe<GqlNftTokenFilterInput>;
   or?: InputMaybe<Array<GqlNftTokenFilterInput>>;
   type?: InputMaybe<Array<Scalars['String']['input']>>;
@@ -3721,7 +3731,7 @@ export type GqlResolversUnionTypes<_RefType extends Record<string, unknown>> = R
 
 /** Mapping of interface types */
 export type GqlResolversInterfaceTypes<_RefType extends Record<string, unknown>> = ResolversObject<{
-  Edge: ( Omit<GqlArticleEdge, 'node'> & { node?: Maybe<_RefType['Article']> } ) | ( Omit<GqlCityEdge, 'node'> & { node?: Maybe<_RefType['City']> } ) | ( Omit<GqlCommunityEdge, 'node'> & { node?: Maybe<_RefType['Community']> } ) | ( Omit<GqlEvaluationEdge, 'node'> & { node?: Maybe<_RefType['Evaluation']> } ) | ( Omit<GqlEvaluationHistoryEdge, 'node'> & { node?: Maybe<_RefType['EvaluationHistory']> } ) | ( Omit<GqlIncentiveGrantEdge, 'node'> & { node?: Maybe<_RefType['IncentiveGrant']> } ) | ( Omit<GqlMembershipEdge, 'node'> & { node?: Maybe<_RefType['Membership']> } ) | ( Omit<GqlNftInstanceEdge, 'node'> & { node: _RefType['NftInstance'] } ) | ( GqlNftTokenEdge ) | ( Omit<GqlOpportunityEdge, 'node'> & { node?: Maybe<_RefType['Opportunity']> } ) | ( Omit<GqlOpportunitySlotEdge, 'node'> & { node?: Maybe<_RefType['OpportunitySlot']> } ) | ( Omit<GqlParticipationEdge, 'node'> & { node?: Maybe<_RefType['Participation']> } ) | ( Omit<GqlParticipationStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['ParticipationStatusHistory']> } ) | ( Omit<GqlPlaceEdge, 'node'> & { node?: Maybe<_RefType['Place']> } ) | ( Omit<GqlPortfolioEdge, 'node'> & { node?: Maybe<_RefType['Portfolio']> } ) | ( Omit<GqlReservationEdge, 'node'> & { node?: Maybe<_RefType['Reservation']> } ) | ( Omit<GqlReservationHistoryEdge, 'node'> & { node?: Maybe<_RefType['ReservationHistory']> } ) | ( Omit<GqlStateEdge, 'node'> & { node?: Maybe<_RefType['State']> } ) | ( Omit<GqlTicketClaimLinkEdge, 'node'> & { node?: Maybe<_RefType['TicketClaimLink']> } ) | ( Omit<GqlTicketEdge, 'node'> & { node?: Maybe<_RefType['Ticket']> } ) | ( Omit<GqlTicketIssuerEdge, 'node'> & { node?: Maybe<_RefType['TicketIssuer']> } ) | ( Omit<GqlTicketStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['TicketStatusHistory']> } ) | ( Omit<GqlTransactionEdge, 'node'> & { node?: Maybe<_RefType['Transaction']> } ) | ( Omit<GqlUserEdge, 'node'> & { node?: Maybe<_RefType['User']> } ) | ( Omit<GqlUtilityEdge, 'node'> & { node?: Maybe<_RefType['Utility']> } ) | ( Omit<GqlVcIssuanceRequestEdge, 'node'> & { node?: Maybe<_RefType['VcIssuanceRequest']> } ) | ( Omit<GqlWalletEdge, 'node'> & { node?: Maybe<_RefType['Wallet']> } );
+  Edge: ( Omit<GqlArticleEdge, 'node'> & { node?: Maybe<_RefType['Article']> } ) | ( Omit<GqlCityEdge, 'node'> & { node?: Maybe<_RefType['City']> } ) | ( Omit<GqlCommunityEdge, 'node'> & { node?: Maybe<_RefType['Community']> } ) | ( Omit<GqlEvaluationEdge, 'node'> & { node?: Maybe<_RefType['Evaluation']> } ) | ( Omit<GqlEvaluationHistoryEdge, 'node'> & { node?: Maybe<_RefType['EvaluationHistory']> } ) | ( Omit<GqlIncentiveGrantEdge, 'node'> & { node?: Maybe<_RefType['IncentiveGrant']> } ) | ( Omit<GqlMembershipEdge, 'node'> & { node?: Maybe<_RefType['Membership']> } ) | ( Omit<GqlNftInstanceEdge, 'node'> & { node: _RefType['NftInstance'] } ) | ( Omit<GqlNftTokenEdge, 'node'> & { node: _RefType['NftToken'] } ) | ( Omit<GqlOpportunityEdge, 'node'> & { node?: Maybe<_RefType['Opportunity']> } ) | ( Omit<GqlOpportunitySlotEdge, 'node'> & { node?: Maybe<_RefType['OpportunitySlot']> } ) | ( Omit<GqlParticipationEdge, 'node'> & { node?: Maybe<_RefType['Participation']> } ) | ( Omit<GqlParticipationStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['ParticipationStatusHistory']> } ) | ( Omit<GqlPlaceEdge, 'node'> & { node?: Maybe<_RefType['Place']> } ) | ( Omit<GqlPortfolioEdge, 'node'> & { node?: Maybe<_RefType['Portfolio']> } ) | ( Omit<GqlReservationEdge, 'node'> & { node?: Maybe<_RefType['Reservation']> } ) | ( Omit<GqlReservationHistoryEdge, 'node'> & { node?: Maybe<_RefType['ReservationHistory']> } ) | ( Omit<GqlStateEdge, 'node'> & { node?: Maybe<_RefType['State']> } ) | ( Omit<GqlTicketClaimLinkEdge, 'node'> & { node?: Maybe<_RefType['TicketClaimLink']> } ) | ( Omit<GqlTicketEdge, 'node'> & { node?: Maybe<_RefType['Ticket']> } ) | ( Omit<GqlTicketIssuerEdge, 'node'> & { node?: Maybe<_RefType['TicketIssuer']> } ) | ( Omit<GqlTicketStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['TicketStatusHistory']> } ) | ( Omit<GqlTransactionEdge, 'node'> & { node?: Maybe<_RefType['Transaction']> } ) | ( Omit<GqlUserEdge, 'node'> & { node?: Maybe<_RefType['User']> } ) | ( Omit<GqlUtilityEdge, 'node'> & { node?: Maybe<_RefType['Utility']> } ) | ( Omit<GqlVcIssuanceRequestEdge, 'node'> & { node?: Maybe<_RefType['VcIssuanceRequest']> } ) | ( Omit<GqlWalletEdge, 'node'> & { node?: Maybe<_RefType['Wallet']> } );
 }>;
 
 /** Mapping between all available schema types and the resolvers types */
@@ -3862,16 +3872,16 @@ export type GqlResolversTypes = ResolversObject<{
   NestedPlaceCreateInput: GqlNestedPlaceCreateInput;
   NestedPlacesBulkConnectOrCreateInput: GqlNestedPlacesBulkConnectOrCreateInput;
   NestedPlacesBulkUpdateInput: GqlNestedPlacesBulkUpdateInput;
-  NftInstance: ResolverTypeWrapper<Omit<GqlNftInstance, 'community' | 'nftWallet'> & { community?: Maybe<GqlResolversTypes['Community']>, nftWallet?: Maybe<GqlResolversTypes['NftWallet']> }>;
+  NftInstance: ResolverTypeWrapper<Omit<GqlNftInstance, 'community' | 'nftToken' | 'nftWallet'> & { community?: Maybe<GqlResolversTypes['Community']>, nftToken?: Maybe<GqlResolversTypes['NftToken']>, nftWallet?: Maybe<GqlResolversTypes['NftWallet']> }>;
   NftInstanceEdge: ResolverTypeWrapper<Omit<GqlNftInstanceEdge, 'node'> & { node: GqlResolversTypes['NftInstance'] }>;
   NftInstanceFilterInput: GqlNftInstanceFilterInput;
   NftInstanceSortInput: GqlNftInstanceSortInput;
   NftInstancesConnection: ResolverTypeWrapper<Omit<GqlNftInstancesConnection, 'edges'> & { edges: Array<GqlResolversTypes['NftInstanceEdge']> }>;
-  NftToken: ResolverTypeWrapper<GqlNftToken>;
-  NftTokenEdge: ResolverTypeWrapper<GqlNftTokenEdge>;
+  NftToken: ResolverTypeWrapper<Omit<GqlNftToken, 'community'> & { community?: Maybe<GqlResolversTypes['Community']> }>;
+  NftTokenEdge: ResolverTypeWrapper<Omit<GqlNftTokenEdge, 'node'> & { node: GqlResolversTypes['NftToken'] }>;
   NftTokenFilterInput: GqlNftTokenFilterInput;
   NftTokenSortInput: GqlNftTokenSortInput;
-  NftTokensConnection: ResolverTypeWrapper<GqlNftTokensConnection>;
+  NftTokensConnection: ResolverTypeWrapper<Omit<GqlNftTokensConnection, 'edges'> & { edges: Array<GqlResolversTypes['NftTokenEdge']> }>;
   NftWallet: ResolverTypeWrapper<Omit<GqlNftWallet, 'user'> & { user: GqlResolversTypes['User'] }>;
   OpportunitiesConnection: ResolverTypeWrapper<Omit<GqlOpportunitiesConnection, 'edges'> & { edges: Array<GqlResolversTypes['OpportunityEdge']> }>;
   Opportunity: ResolverTypeWrapper<Opportunity>;
@@ -4080,15 +4090,15 @@ export type GqlResolversTypes = ResolversObject<{
   VoteCastInput: GqlVoteCastInput;
   VoteCastPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['VoteCastPayload']>;
   VoteCastSuccess: ResolverTypeWrapper<GqlVoteCastSuccess>;
-  VoteGate: ResolverTypeWrapper<GqlVoteGate>;
+  VoteGate: ResolverTypeWrapper<Omit<GqlVoteGate, 'nftToken'> & { nftToken?: Maybe<GqlResolversTypes['NftToken']> }>;
   VoteGateInput: GqlVoteGateInput;
   VoteGateType: GqlVoteGateType;
   VoteOption: ResolverTypeWrapper<GqlVoteOption>;
   VoteOptionInput: GqlVoteOptionInput;
-  VotePowerPolicy: ResolverTypeWrapper<GqlVotePowerPolicy>;
+  VotePowerPolicy: ResolverTypeWrapper<Omit<GqlVotePowerPolicy, 'nftToken'> & { nftToken?: Maybe<GqlResolversTypes['NftToken']> }>;
   VotePowerPolicyInput: GqlVotePowerPolicyInput;
   VotePowerPolicyType: GqlVotePowerPolicyType;
-  VoteTopic: ResolverTypeWrapper<Omit<GqlVoteTopic, 'community'> & { community: GqlResolversTypes['Community'] }>;
+  VoteTopic: ResolverTypeWrapper<Omit<GqlVoteTopic, 'community' | 'gate' | 'powerPolicy'> & { community: GqlResolversTypes['Community'], gate: GqlResolversTypes['VoteGate'], powerPolicy: GqlResolversTypes['VotePowerPolicy'] }>;
   VoteTopicCreateInput: GqlVoteTopicCreateInput;
   VoteTopicCreatePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['VoteTopicCreatePayload']>;
   VoteTopicCreateSuccess: ResolverTypeWrapper<Omit<GqlVoteTopicCreateSuccess, 'voteTopic'> & { voteTopic: GqlResolversTypes['VoteTopic'] }>;
@@ -4231,16 +4241,16 @@ export type GqlResolversParentTypes = ResolversObject<{
   NestedPlaceCreateInput: GqlNestedPlaceCreateInput;
   NestedPlacesBulkConnectOrCreateInput: GqlNestedPlacesBulkConnectOrCreateInput;
   NestedPlacesBulkUpdateInput: GqlNestedPlacesBulkUpdateInput;
-  NftInstance: Omit<GqlNftInstance, 'community' | 'nftWallet'> & { community?: Maybe<GqlResolversParentTypes['Community']>, nftWallet?: Maybe<GqlResolversParentTypes['NftWallet']> };
+  NftInstance: Omit<GqlNftInstance, 'community' | 'nftToken' | 'nftWallet'> & { community?: Maybe<GqlResolversParentTypes['Community']>, nftToken?: Maybe<GqlResolversParentTypes['NftToken']>, nftWallet?: Maybe<GqlResolversParentTypes['NftWallet']> };
   NftInstanceEdge: Omit<GqlNftInstanceEdge, 'node'> & { node: GqlResolversParentTypes['NftInstance'] };
   NftInstanceFilterInput: GqlNftInstanceFilterInput;
   NftInstanceSortInput: GqlNftInstanceSortInput;
   NftInstancesConnection: Omit<GqlNftInstancesConnection, 'edges'> & { edges: Array<GqlResolversParentTypes['NftInstanceEdge']> };
-  NftToken: GqlNftToken;
-  NftTokenEdge: GqlNftTokenEdge;
+  NftToken: Omit<GqlNftToken, 'community'> & { community?: Maybe<GqlResolversParentTypes['Community']> };
+  NftTokenEdge: Omit<GqlNftTokenEdge, 'node'> & { node: GqlResolversParentTypes['NftToken'] };
   NftTokenFilterInput: GqlNftTokenFilterInput;
   NftTokenSortInput: GqlNftTokenSortInput;
-  NftTokensConnection: GqlNftTokensConnection;
+  NftTokensConnection: Omit<GqlNftTokensConnection, 'edges'> & { edges: Array<GqlResolversParentTypes['NftTokenEdge']> };
   NftWallet: Omit<GqlNftWallet, 'user'> & { user: GqlResolversParentTypes['User'] };
   OpportunitiesConnection: Omit<GqlOpportunitiesConnection, 'edges'> & { edges: Array<GqlResolversParentTypes['OpportunityEdge']> };
   Opportunity: Opportunity;
@@ -4428,13 +4438,13 @@ export type GqlResolversParentTypes = ResolversObject<{
   VoteCastInput: GqlVoteCastInput;
   VoteCastPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['VoteCastPayload'];
   VoteCastSuccess: GqlVoteCastSuccess;
-  VoteGate: GqlVoteGate;
+  VoteGate: Omit<GqlVoteGate, 'nftToken'> & { nftToken?: Maybe<GqlResolversParentTypes['NftToken']> };
   VoteGateInput: GqlVoteGateInput;
   VoteOption: GqlVoteOption;
   VoteOptionInput: GqlVoteOptionInput;
-  VotePowerPolicy: GqlVotePowerPolicy;
+  VotePowerPolicy: Omit<GqlVotePowerPolicy, 'nftToken'> & { nftToken?: Maybe<GqlResolversParentTypes['NftToken']> };
   VotePowerPolicyInput: GqlVotePowerPolicyInput;
-  VoteTopic: Omit<GqlVoteTopic, 'community'> & { community: GqlResolversParentTypes['Community'] };
+  VoteTopic: Omit<GqlVoteTopic, 'community' | 'gate' | 'powerPolicy'> & { community: GqlResolversParentTypes['Community'], gate: GqlResolversParentTypes['VoteGate'], powerPolicy: GqlResolversParentTypes['VotePowerPolicy'] };
   VoteTopicCreateInput: GqlVoteTopicCreateInput;
   VoteTopicCreatePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['VoteTopicCreatePayload'];
   VoteTopicCreateSuccess: Omit<GqlVoteTopicCreateSuccess, 'voteTopic'> & { voteTopic: GqlResolversParentTypes['VoteTopic'] };
@@ -5047,6 +5057,7 @@ export type GqlNftInstancesConnectionResolvers<ContextType = any, ParentType ext
 
 export type GqlNftTokenResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['NftToken'] = GqlResolversParentTypes['NftToken']> = ResolversObject<{
   address?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  community?: Resolver<Maybe<GqlResolversTypes['Community']>, ParentType, ContextType>;
   createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
   id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
   json?: Resolver<Maybe<GqlResolversTypes['JSON']>, ParentType, ContextType>;


### PR DESCRIPTION
## Summary

`NftToken` に `communityId` カラムを追加し、community と直接 FK で紐付ける設計に変更します。これまでは `NftToken` 自体に community の情報がなく、portal 側でコミュニティ絞り込みを行うには `NftInstance` 経由の間接フィルタを使う必要がありました。今回の変更で直接カラムでスコープできるようになり、portal 側の `useNftTokens.ts` で filter を再有効化できる状態になります。

## Key Changes

### Prisma Schema

- `NftToken` モデルに以下を追加:
  - `communityId String? @map("community_id")`
  - `community Community? @relation(fields: [communityId], references: [id], onDelete: SetNull)`
  - `@@index([communityId])`
- `Community` モデルに `nftTokens NftToken[]` back-relation を追加
- **nullable 前提**: 既存 token は NULL のまま運用。コミュニティ横断で共用する token や、運用都合で未設定の token も表現可能。

### Migration

`20260416120000_add_community_id_to_nft_token/migration.sql` を新規作成:

```sql
ALTER TABLE "t_nft_tokens" ADD COLUMN "community_id" TEXT;
CREATE INDEX "t_nft_tokens_community_id_idx" ON "t_nft_tokens"("community_id");
ALTER TABLE "t_nft_tokens" ADD CONSTRAINT "t_nft_tokens_community_id_fkey"
  FOREIGN KEY ("community_id") REFERENCES "t_communities"("id")
  ON DELETE SET NULL ON UPDATE CASCADE;
```

`onDelete: SET NULL` を採用しており、community 削除時に token 側は孤立するが物理削除はされません。

### GraphQL Schema

- `NftToken.community: Community` フィールド追加（field resolver + DataLoader で解決、N+1 回避）
- `NftTokenFilterInput.communityId` の semantic を「`nftInstances.some.communityId` 経由」から「**`NftToken.community_id` カラム直接参照**」に変更
- description も更新し、`communityId` が NULL の token はフィルタ結果から自然に除外されることを明記

### Code

| ファイル | 変更内容 |
|---|---|
| `data/type.ts` | `nftTokenSelect` に `communityId: true` を追加 |
| `data/converter.ts` | `communityId` フィルタを直接カラム一致 (`{ communityId: input.communityId }`) に変更 |
| `presenter.ts` | `community: null` を明示（field resolver が上書きする前提） |
| `controller/resolver.ts` | `NftToken` 型の field resolver を追加（`community` を `ctx.loaders.community` で batch load） |
| `presentation/graphql/resolver.ts` | `NftToken: nftToken.NftToken` を resolver registry に登録 |

## Design Notes

### なぜ直接カラム化するか

前 PR で提案した `nftInstances.some.communityId` 経由のフィルタは「実例が 1 件以上あるトークン」という semantic で、token 自体がコミュニティに属するという素朴な関係を表現できていませんでした。portal 側の UI で「このコミュニティに属する NftToken」を表示したいユースケースが明確になったため、直接 FK を張る設計に変更します。

### なぜ nullable か

- **既存データ**: NftToken に community 情報がなかったため、backfill せず NULL のまま残す
- **運用の柔軟性**: コミュニティ横断で共用する token の表現余地を残す
- **filter への影響**: `communityId` フィルタ指定時は NULL が除外されるだけなので、portal の「コミュニティ内 token 表示」ユースケースに実害なし

### upsert を今回拡張しない理由

既存の `NftTokenRepository.upsert(data: { address, name, symbol, type, json }, tx)` シグネチャはそのまま。新規に token を作成する NFT 登録フローで `communityId` を渡す必要が出てきた時点で、個別に拡張します。今回のスコープはあくまで「community との紐付けの**受け皿**を用意する」ことであり、書き込み経路を強制する変更は別件。

## Verification

- [ ] `pnpm tsc --noEmit` でコンパイル通過（nft-token 関連エラー 0 件を確認済み）
- [ ] `pnpm db:deploy` で migration が正常適用される
- [ ] GraphQL Playground で以下が動作:
  ```graphql
  query {
    nftTokens(filter: { communityId: "<community-id>" }, first: 10) {
      totalCount
      nodes {
        id
        address
        community { id name }
      }
    }
  }
  ```
  - `communityId` フィルタで該当 community の token のみ返る
  - `community` フィールドが正しく解決される（NULL の token は `community: null`）
  - 複数ノードがあっても Community クエリは DataLoader で batch されて N+1 にならない
- [ ] `pnpm lint` 通過

## Follow-up

- **portal 側**: `useNftTokens.ts` で `filter: { communityId }` を渡して全件取得から絞り込みに戻す
- **書き込み経路**: 新規 NFT 登録時に `communityId` をどこから供給するかの設計（別 PR）
- **既存データの backfill**: 必要になった時点で `NftInstance` 経由で推定値を埋めるスクリプトを検討（今回はスコープ外）

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/830" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
