### PR TITLE
feat(report): extend weekly payload with community_context and deepest_chain

### DIFF
--- a/src/__tests__/unit/report/presenter.test.ts
+++ b/src/__tests__/unit/report/presenter.test.ts
@@ -1,0 +1,171 @@
+import "reflect-metadata";
+import { Role, TransactionReason } from "@prisma/client";
+import ReportPresenter from "@/application/domain/report/presenter";
+import { CommunityContextRow, DeepestChainRow } from "@/application/domain/report/data/interface";
+
+/**
+ * Pure-function tests for the Phase-1 additions on ReportPresenter:
+ * community_context, deepest_chain, and the custom_context pass-through.
+ * Pre-existing payload fields have integration coverage elsewhere; this
+ * suite focuses on the new code paths only.
+ */
+describe("ReportPresenter.weeklyPayload (community_context / deepest_chain)", () => {
+  const baseInput = {
+    communityId: "community-1",
+    range: {
+      from: new Date(Date.UTC(2026, 3, 10)),
+      to: new Date(Date.UTC(2026, 3, 16)),
+    },
+    referenceDate: new Date(Date.UTC(2026, 3, 16)),
+    summaries: [],
+    activeUsers: [],
+    topUserAggregates: [],
+    profiles: [],
+    comments: [],
+  };
+
+  const sampleContext: CommunityContextRow = {
+    communityId: "community-1",
+    name: "Example Community",
+    pointName: "ExamplePoint",
+    bio: "Community bio",
+    establishedAt: new Date(Date.UTC(2025, 0, 1)),
+    website: "https://example.com",
+    totalMembers: 20,
+    activeUsersInWindow: 5,
+  };
+
+  const sampleDeepest: DeepestChainRow = {
+    transactionId: "tx-1",
+    chainDepth: 4,
+    reason: TransactionReason.GRANT,
+    comment: "thanks!",
+    date: new Date(Date.UTC(2026, 3, 14)),
+    fromUserId: "user-a",
+    toUserId: "user-b",
+    createdByUserId: "user-a",
+    parentTxId: "tx-0",
+  };
+
+  it("maps community_context and computes active_rate when members > 0", () => {
+    const payload = ReportPresenter.weeklyPayload({
+      ...baseInput,
+      communityContext: sampleContext,
+      deepestChain: null,
+    });
+
+    expect(payload.community_context).toEqual({
+      community_id: "community-1",
+      name: "Example Community",
+      point_name: "ExamplePoint",
+      bio: "Community bio",
+      established_at: "2025-01-01",
+      website: "https://example.com",
+      total_members: 20,
+      active_users_in_window: 5,
+      active_rate: 0.25,
+      custom_context: null,
+    });
+  });
+
+  it("emits active_rate null when the community has no JOINED members (no divide-by-zero)", () => {
+    const payload = ReportPresenter.weeklyPayload({
+      ...baseInput,
+      communityContext: { ...sampleContext, totalMembers: 0, activeUsersInWindow: 0 },
+      deepestChain: null,
+    });
+
+    expect(payload.community_context?.active_rate).toBeNull();
+  });
+
+  it("passes customContext through to community_context.custom_context", () => {
+    const payload = ReportPresenter.weeklyPayload({
+      ...baseInput,
+      communityContext: sampleContext,
+      deepestChain: null,
+      customContext: "## Mission\nLocal mutual aid.",
+    });
+
+    expect(payload.community_context?.custom_context).toBe("## Mission\nLocal mutual aid.");
+  });
+
+  it("emits community_context = null when the repository returned null", () => {
+    const payload = ReportPresenter.weeklyPayload({
+      ...baseInput,
+      communityContext: null,
+      deepestChain: null,
+    });
+
+    expect(payload.community_context).toBeNull();
+  });
+
+  it("maps deepest_chain and converts the date to a JST ISO day", () => {
+    const payload = ReportPresenter.weeklyPayload({
+      ...baseInput,
+      communityContext: null,
+      deepestChain: sampleDeepest,
+    });
+
+    expect(payload.deepest_chain).toEqual({
+      transaction_id: "tx-1",
+      chain_depth: 4,
+      reason: TransactionReason.GRANT,
+      comment: "thanks!",
+      date: "2026-04-14",
+      from_user_id: "user-a",
+      to_user_id: "user-b",
+      created_by_user_id: "user-a",
+      parent_tx_id: "tx-0",
+    });
+  });
+
+  it("emits deepest_chain = null when no chained transaction exists in the window", () => {
+    const payload = ReportPresenter.weeklyPayload({
+      ...baseInput,
+      communityContext: null,
+      deepestChain: null,
+    });
+
+    expect(payload.deepest_chain).toBeNull();
+  });
+
+  it("leaves pre-existing payload fields intact alongside the new blocks", () => {
+    const payload = ReportPresenter.weeklyPayload({
+      ...baseInput,
+      topUserAggregates: [
+        {
+          userId: "user-a",
+          txCountIn: 1,
+          txCountOut: 2,
+          pointsIn: 10n,
+          pointsOut: 20n,
+          donationOutCount: 0,
+          donationOutPoints: 0n,
+          receivedDonationCount: 0,
+          chainRootCount: 1,
+          maxChainDepthStarted: 2,
+          chainDepthReachedMax: null,
+          uniqueCounterpartiesSum: 1,
+        },
+      ],
+      profiles: [
+        {
+          userId: "user-a",
+          communityId: "community-1",
+          name: "Alice",
+          userBio: null,
+          membershipBio: null,
+          headline: null,
+          role: Role.MEMBER,
+          joinedAt: new Date(Date.UTC(2026, 3, 1)),
+        },
+      ],
+      communityContext: sampleContext,
+      deepestChain: sampleDeepest,
+    });
+
+    expect(payload.period).toEqual({ from: "2026-04-10", to: "2026-04-16" });
+    expect(payload.top_users).toHaveLength(1);
+    expect(payload.top_users[0].user_id).toBe("user-a");
+  });
+});

--- a/src/application/domain/report/data/interface.ts
+++ b/src/application/domain/report/data/interface.ts
@@ -87,6 +87,46 @@ export interface UserProfileForReportRow {
   joinedAt: Date;
 }
 
+/**
+ * Per-community metadata needed to contextualise the AI report: identity /
+ * naming, headline bio + website + established date, total member count, and
+ * the distinct active-user count within the reporting window. Shaped for a
+ * single LLM payload block, not a generic community read model.
+ *
+ * `activeUsersInWindow` is a *distinct* count across the range (not the
+ * sum of per-day active-user counts, which over-counts users active on
+ * multiple days). Paired with `totalMembers` it lets the presenter emit an
+ * `active_rate` without a second round trip.
+ */
+export interface CommunityContextRow {
+  communityId: string;
+  name: string;
+  pointName: string;
+  bio: string | null;
+  establishedAt: Date | null;
+  website: string | null;
+  totalMembers: number;
+  activeUsersInWindow: number;
+}
+
+/**
+ * Single deepest transaction-chain reached within the reporting window, used
+ * by the report as a qualitative highlight ("how far did a single point
+ * travel?"). `chainDepth` is guaranteed non-null by the filter. `date` is
+ * the JST calendar day bucket matching the report window boundaries.
+ */
+export interface DeepestChainRow {
+  transactionId: string;
+  chainDepth: number;
+  reason: TransactionReason;
+  comment: string | null;
+  date: Date;
+  fromUserId: string | null;
+  toUserId: string | null;
+  createdByUserId: string | null;
+  parentTxId: string | null;
+}
+
 export interface DateRange {
   from: Date;
   to: Date;
@@ -124,6 +164,18 @@ export interface IReportRepository {
     communityId: string,
     userIds: string[],
   ): Promise<UserProfileForReportRow[]>;
+
+  findCommunityContext(
+    ctx: IContext,
+    communityId: string,
+    range: DateRange,
+  ): Promise<CommunityContextRow | null>;
+
+  findDeepestChain(
+    ctx: IContext,
+    communityId: string,
+    range: DateRange,
+  ): Promise<DeepestChainRow | null>;
 
   refreshTransactionSummaryDaily(ctx: IContext, tx: Prisma.TransactionClient): Promise<void>;
   refreshUserTransactionDaily(ctx: IContext, tx: Prisma.TransactionClient): Promise<void>;

--- a/src/application/domain/report/data/repository.ts
+++ b/src/application/domain/report/data/repository.ts
@@ -1,8 +1,10 @@
-import { Prisma } from "@prisma/client";
+import { Prisma, TransactionReason } from "@prisma/client";
 import { injectable } from "tsyringe";
 import { IContext } from "@/types/server";
 import {
+  CommunityContextRow,
   DateRange,
+  DeepestChainRow,
   IReportRepository,
   TransactionActiveUsersDailyRow,
   TransactionCommentRow,
@@ -178,17 +180,151 @@ export default class ReportRepository implements IReportRepository {
     );
   }
 
-  async refreshTransactionSummaryDaily(
+  /**
+   * Pull community identity + reporting-window activity stats in a single
+   * round trip. Member count lives in `t_memberships` (RLS-protected but
+   * read-safe for community members and admins via `issuer.public`), and
+   * the distinct active-user count is scanned directly off
+   * `mv_user_transaction_daily` for the same JST window used by the report
+   * helpers elsewhere in this file.
+   *
+   * Returns null when the community is not found; the presenter treats this
+   * as an optional block so the payload still serialises for a soft-deleted
+   * or mis-passed community id.
+   */
+  async findCommunityContext(
     ctx: IContext,
-    tx: Prisma.TransactionClient,
-  ): Promise<void> {
+    communityId: string,
+    range: DateRange,
+  ): Promise<CommunityContextRow | null> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      const rows = await tx.$queryRaw<
+        {
+          id: string;
+          name: string;
+          point_name: string;
+          bio: string | null;
+          established_at: Date | null;
+          website: string | null;
+          total_members: number;
+          active_users_in_window: number;
+        }[]
+      >`
+        WITH member_count AS (
+          SELECT COUNT(*)::int AS n
+          FROM "t_memberships"
+          WHERE "community_id" = ${communityId}
+            AND "status" = 'JOINED'
+        ),
+        active_in_window AS (
+          SELECT COUNT(DISTINCT "user_id")::int AS n
+          FROM "mv_user_transaction_daily"
+          WHERE "community_id" = ${communityId}
+            AND "date" BETWEEN ${range.from}::date AND ${range.to}::date
+        )
+        SELECT
+          c."id",
+          c."name",
+          c."point_name",
+          c."bio",
+          c."established_at",
+          c."website",
+          (SELECT n FROM member_count) AS "total_members",
+          (SELECT n FROM active_in_window) AS "active_users_in_window"
+        FROM "t_communities" c
+        WHERE c."id" = ${communityId}
+        LIMIT 1
+      `;
+      if (rows.length === 0) return null;
+      const r = rows[0];
+      return {
+        communityId: r.id,
+        name: r.name,
+        pointName: r.point_name,
+        bio: r.bio,
+        establishedAt: r.established_at,
+        website: r.website,
+        totalMembers: r.total_members,
+        activeUsersInWindow: r.active_users_in_window,
+      };
+    });
+  }
+
+  /**
+   * The single transaction with the largest `chain_depth` within the JST
+   * reporting window. Mirrors the community-scoping predicate used by
+   * `mv_transaction_summary_daily` / `v_transaction_comments`:
+   * `COALESCE(fw.community_id, tw.community_id) = $1` plus the
+   * defensive-consistency check that rejects cross-community pairs.
+   *
+   * ORDER BY depth DESC, created_at ASC so that ties resolve to the
+   * *earliest* deep chain in the window — intuitively "the one that started
+   * the cascade" rather than whichever the planner picked first. Returns
+   * null when no chained transaction exists for the window.
+   */
+  async findDeepestChain(
+    ctx: IContext,
+    communityId: string,
+    range: DateRange,
+  ): Promise<DeepestChainRow | null> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      const rows = await tx.$queryRaw<
+        {
+          id: string;
+          chain_depth: number;
+          reason: TransactionReason;
+          comment: string | null;
+          date: Date;
+          from_user_id: string | null;
+          to_user_id: string | null;
+          created_by_user_id: string | null;
+          parent_tx_id: string | null;
+        }[]
+      >`
+        SELECT
+          t."id",
+          t."chain_depth"::int AS "chain_depth",
+          t."reason",
+          t."comment",
+          ((t."created_at" AT TIME ZONE 'Asia/Tokyo')::date) AS "date",
+          fw."user_id" AS "from_user_id",
+          tw."user_id" AS "to_user_id",
+          t."created_by" AS "created_by_user_id",
+          t."parent_tx_id"
+        FROM "t_transactions" t
+        LEFT JOIN "t_wallets" fw ON fw."id" = t."from"
+        LEFT JOIN "t_wallets" tw ON tw."id" = t."to"
+        WHERE COALESCE(fw."community_id", tw."community_id") = ${communityId}
+          AND (fw."community_id" IS NULL
+               OR tw."community_id" IS NULL
+               OR fw."community_id" = tw."community_id")
+          AND t."chain_depth" IS NOT NULL
+          AND ((t."created_at" AT TIME ZONE 'Asia/Tokyo')::date)
+              BETWEEN ${range.from}::date AND ${range.to}::date
+        ORDER BY t."chain_depth" DESC, t."created_at" ASC
+        LIMIT 1
+      `;
+      if (rows.length === 0) return null;
+      const r = rows[0];
+      return {
+        transactionId: r.id,
+        chainDepth: r.chain_depth,
+        reason: r.reason,
+        comment: r.comment,
+        date: r.date,
+        fromUserId: r.from_user_id,
+        toUserId: r.to_user_id,
+        createdByUserId: r.created_by_user_id,
+        parentTxId: r.parent_tx_id,
+      };
+    });
+  }
+
+  async refreshTransactionSummaryDaily(ctx: IContext, tx: Prisma.TransactionClient): Promise<void> {
     await tx.$queryRawTyped(refreshMaterializedViewTransactionSummaryDaily());
   }
 
-  async refreshUserTransactionDaily(
-    ctx: IContext,
-    tx: Prisma.TransactionClient,
-  ): Promise<void> {
+  async refreshUserTransactionDaily(ctx: IContext, tx: Prisma.TransactionClient): Promise<void> {
     await tx.$queryRawTyped(refreshMaterializedViewUserTransactionDaily());
   }
 }

--- a/src/application/domain/report/data/repository.ts
+++ b/src/application/domain/report/data/repository.ts
@@ -299,8 +299,14 @@ export default class ReportRepository implements IReportRepository {
                OR tw."community_id" IS NULL
                OR fw."community_id" = tw."community_id")
           AND t."chain_depth" IS NOT NULL
-          AND ((t."created_at" AT TIME ZONE 'Asia/Tokyo')::date)
-              BETWEEN ${range.from}::date AND ${range.to}::date
+          -- SARGable timestamptz comparison so the planner can use the
+          -- B-tree index on "created_at" (wrapping it in
+          -- (... AT TIME ZONE ...)::date would suppress the index).
+          -- Half-open window [from JST 00:00, (to + 1 day) JST 00:00)
+          -- covers exactly the JST calendar days from..to inclusive,
+          -- matching the bucketing used by the report MVs.
+          AND t."created_at" >= (${range.from}::date AT TIME ZONE 'Asia/Tokyo')
+          AND t."created_at" <  ((${range.to}::date + 1) AT TIME ZONE 'Asia/Tokyo')
         ORDER BY t."chain_depth" DESC, t."created_at" ASC
         LIMIT 1
       `;

--- a/src/application/domain/report/presenter.ts
+++ b/src/application/domain/report/presenter.ts
@@ -1,15 +1,13 @@
 import {
+  CommunityContextRow,
+  DeepestChainRow,
   TransactionActiveUsersDailyRow,
   TransactionCommentRow,
   TransactionSummaryDailyRow,
   UserProfileForReportRow,
   UserTransactionAggregateRow,
 } from "@/application/domain/report/data/interface";
-import {
-  bigintToSafeNumber,
-  daysBetweenJst,
-  toJstIsoDate,
-} from "@/application/domain/report/util";
+import { bigintToSafeNumber, daysBetweenJst, toJstIsoDate } from "@/application/domain/report/util";
 
 // ---------------------------------------------------------------------------
 // AI-facing report payload types
@@ -23,10 +21,45 @@ import {
 export interface WeeklyReportPayload {
   period: { from: string; to: string };
   community_id: string;
+  community_context: CommunityContext | null;
+  deepest_chain: DeepestChainItem | null;
   daily_summaries: DailySummaryItem[];
   daily_active_users: DailyActiveUsersItem[];
   top_users: TopUserItem[];
   highlight_comments: CommentItem[];
+}
+
+/**
+ * AI-facing community snapshot. `active_rate` is `active_users_in_window /
+ * total_members` (null when the community has no JOINED members yet, so the
+ * LLM does not emit a divide-by-zero ratio). `custom_context` is a free-text
+ * markdown field sourced from `ReportTemplate.communityContext`, piped
+ * through untouched so editors can steer tone / vision / references without
+ * a schema change.
+ */
+export interface CommunityContext {
+  community_id: string;
+  name: string;
+  point_name: string;
+  bio: string | null;
+  established_at: string | null;
+  website: string | null;
+  total_members: number;
+  active_users_in_window: number;
+  active_rate: number | null;
+  custom_context: string | null;
+}
+
+export interface DeepestChainItem {
+  transaction_id: string;
+  chain_depth: number;
+  reason: string;
+  comment: string | null;
+  date: string;
+  from_user_id: string | null;
+  to_user_id: string | null;
+  created_by_user_id: string | null;
+  parent_tx_id: string | null;
 }
 
 export interface DailySummaryItem {
@@ -102,8 +135,51 @@ export default class ReportPresenter {
     topUserAggregates: UserTransactionAggregateRow[];
     profiles: UserProfileForReportRow[];
     comments: TransactionCommentRow[];
+    communityContext: CommunityContextRow | null;
+    deepestChain: DeepestChainRow | null;
+    /**
+     * Optional markdown blob sourced from `ReportTemplate.communityContext`.
+     * Populated by the AI-generation usecase (PR-D) when rendering under a
+     * community-scoped template; left unset for raw payload dumps and the
+     * single-variant Phase 1 flow.
+     */
+    customContext?: string | null;
   }): WeeklyReportPayload {
     const profileByUserId = new Map(input.profiles.map((p) => [p.userId, p]));
+
+    const communityContext: CommunityContext | null = input.communityContext
+      ? {
+          community_id: input.communityContext.communityId,
+          name: input.communityContext.name,
+          point_name: input.communityContext.pointName,
+          bio: input.communityContext.bio,
+          established_at: input.communityContext.establishedAt
+            ? toJstIsoDate(input.communityContext.establishedAt)
+            : null,
+          website: input.communityContext.website,
+          total_members: input.communityContext.totalMembers,
+          active_users_in_window: input.communityContext.activeUsersInWindow,
+          active_rate:
+            input.communityContext.totalMembers > 0
+              ? input.communityContext.activeUsersInWindow / input.communityContext.totalMembers
+              : null,
+          custom_context: input.customContext ?? null,
+        }
+      : null;
+
+    const deepestChain: DeepestChainItem | null = input.deepestChain
+      ? {
+          transaction_id: input.deepestChain.transactionId,
+          chain_depth: input.deepestChain.chainDepth,
+          reason: input.deepestChain.reason,
+          comment: input.deepestChain.comment,
+          date: toJstIsoDate(input.deepestChain.date),
+          from_user_id: input.deepestChain.fromUserId,
+          to_user_id: input.deepestChain.toUserId,
+          created_by_user_id: input.deepestChain.createdByUserId,
+          parent_tx_id: input.deepestChain.parentTxId,
+        }
+      : null;
 
     const topUsers: TopUserItem[] = input.topUserAggregates.map((u) => {
       const p = profileByUserId.get(u.userId);
@@ -136,6 +212,8 @@ export default class ReportPresenter {
         to: toJstIsoDate(input.range.to),
       },
       community_id: input.communityId,
+      community_context: communityContext,
+      deepest_chain: deepestChain,
       daily_summaries: input.summaries.map((s) => ({
         date: toJstIsoDate(s.date),
         reason: s.reason,

--- a/src/application/domain/report/service.ts
+++ b/src/application/domain/report/service.ts
@@ -2,7 +2,9 @@ import { Prisma } from "@prisma/client";
 import { inject, injectable } from "tsyringe";
 import { IContext } from "@/types/server";
 import {
+  CommunityContextRow,
   DateRange,
+  DeepestChainRow,
   IReportRepository,
   TransactionActiveUsersDailyRow,
   TransactionCommentRow,
@@ -13,9 +15,7 @@ import {
 
 @injectable()
 export default class ReportService {
-  constructor(
-    @inject("ReportRepository") private readonly repository: IReportRepository,
-  ) {}
+  constructor(@inject("ReportRepository") private readonly repository: IReportRepository) {}
 
   async getDailySummaries(
     ctx: IContext,
@@ -59,17 +59,27 @@ export default class ReportService {
     return this.repository.findUserProfiles(ctx, communityId, userIds);
   }
 
-  async refreshTransactionSummaryDaily(
+  async getCommunityContext(
     ctx: IContext,
-    tx: Prisma.TransactionClient,
-  ): Promise<void> {
+    communityId: string,
+    range: DateRange,
+  ): Promise<CommunityContextRow | null> {
+    return this.repository.findCommunityContext(ctx, communityId, range);
+  }
+
+  async getDeepestChain(
+    ctx: IContext,
+    communityId: string,
+    range: DateRange,
+  ): Promise<DeepestChainRow | null> {
+    return this.repository.findDeepestChain(ctx, communityId, range);
+  }
+
+  async refreshTransactionSummaryDaily(ctx: IContext, tx: Prisma.TransactionClient): Promise<void> {
     return this.repository.refreshTransactionSummaryDaily(ctx, tx);
   }
 
-  async refreshUserTransactionDaily(
-    ctx: IContext,
-    tx: Prisma.TransactionClient,
-  ): Promise<void> {
+  async refreshUserTransactionDaily(ctx: IContext, tx: Prisma.TransactionClient): Promise<void> {
     return this.repository.refreshUserTransactionDaily(ctx, tx);
   }
 }

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -1,9 +1,7 @@
 import { inject, injectable } from "tsyringe";
 import { IContext } from "@/types/server";
 import ReportService from "@/application/domain/report/service";
-import ReportPresenter, {
-  WeeklyReportPayload,
-} from "@/application/domain/report/presenter";
+import ReportPresenter, { WeeklyReportPayload } from "@/application/domain/report/presenter";
 import { addDays, truncateToJstDate } from "@/application/domain/report/util";
 
 const DEFAULT_WINDOW_DAYS = 7;
@@ -53,19 +51,18 @@ export default class ReportUseCase {
     const from = addDays(to, -(windowDays - 1));
     const range = { from, to };
 
-    const [summaries, activeUsers, topUserAggregates, comments] = await Promise.all([
-      this.service.getDailySummaries(ctx, params.communityId, range),
-      this.service.getDailyActiveUsers(ctx, params.communityId, range),
-      this.service.getTopUsersByTotalPoints(ctx, params.communityId, range, topN),
-      this.service.getComments(ctx, params.communityId, range, commentLimit),
-    ]);
+    const [summaries, activeUsers, topUserAggregates, comments, communityContext, deepestChain] =
+      await Promise.all([
+        this.service.getDailySummaries(ctx, params.communityId, range),
+        this.service.getDailyActiveUsers(ctx, params.communityId, range),
+        this.service.getTopUsersByTotalPoints(ctx, params.communityId, range, topN),
+        this.service.getComments(ctx, params.communityId, range, commentLimit),
+        this.service.getCommunityContext(ctx, params.communityId, range),
+        this.service.getDeepestChain(ctx, params.communityId, range),
+      ]);
 
     const userIds = topUserAggregates.map((u) => u.userId);
-    const profiles = await this.service.getUserProfiles(
-      ctx,
-      params.communityId,
-      userIds,
-    );
+    const profiles = await this.service.getUserProfiles(ctx, params.communityId, userIds);
 
     return ReportPresenter.weeklyPayload({
       communityId: params.communityId,
@@ -76,6 +73,8 @@ export default class ReportUseCase {
       topUserAggregates,
       profiles,
       comments,
+      communityContext,
+      deepestChain,
     });
   }
 
@@ -92,12 +91,8 @@ export default class ReportUseCase {
    * derived at query time from mv_user_transaction_daily.
    */
   async refreshAllReportViews(ctx: IContext): Promise<void> {
-    await ctx.issuer.internal((tx) =>
-      this.service.refreshTransactionSummaryDaily(ctx, tx),
-    );
-    await ctx.issuer.internal((tx) =>
-      this.service.refreshUserTransactionDaily(ctx, tx),
-    );
+    await ctx.issuer.internal((tx) => this.service.refreshTransactionSummaryDaily(ctx, tx));
+    await ctx.issuer.internal((tx) => this.service.refreshUserTransactionDaily(ctx, tx));
   }
 }
 


### PR DESCRIPTION
## Summary

AI レポート生成機能 Phase 1 MVP の **PR-A**。LLM 関連の変更を一切含まず、`buildReportPayload` の出力に 2 つの新ブロックを追加するだけの後方互換変更。後続 PR (PR-B/C/D/F) と独立に merge 可能。

### 追加された payload ブロック

- **`community_context`** — community 識別情報 + window 内アクティビティ統計
  - `name`, `point_name`, `bio`, `established_at`, `website`
  - `total_members` (JOINED membership 数)
  - `active_users_in_window` (window 内の **distinct** active user 数 ※ daily の合計ではない)
  - `active_rate` = `active_users_in_window / total_members` (members=0 で `null`、divide-by-zero ガード)
  - `custom_context` (free-text markdown、PR-D で `ReportTemplate.communityContext` から pass-through 予定。PR-A 単体 merge 時は常に `null`)
- **`deepest_chain`** — window 内で `chain_depth` 最大の単一 transaction (point の伝播ハイライト)
  - `transaction_id`, `chain_depth`, `reason`, `comment`, `date` (JST), `from_user_id`, `to_user_id`, `created_by_user_id`, `parent_tx_id`
  - 該当無し時は `null`

### 実装メモ

- **community_context** のクエリは CTE で member count と active-in-window を 1 round trip にまとめている (個別 SELECT を撃たない)
- **deepest_chain** は既存 `mv_transaction_summary_daily` / `v_transaction_comments` と同じ wallet ベースの community scoping (`COALESCE(fw.community_id, tw.community_id) = $1` + cross-community defensive check) を踏襲
- ORDER BY `chain_depth DESC, created_at ASC` で同 depth が複数ある場合は **最も早い** chain (= cascade の起点) を選ぶ
- `usecase.ts` の `Promise.all` に 2 件追加するだけで、既存の並列度を保持
- presenter は pure function、`customContext` を optional parameter として用意し PR-D で signature 変更不要にしてある

### 変更ファイル

- `src/application/domain/report/data/interface.ts` — `CommunityContextRow` / `DeepestChainRow` 型追加
- `src/application/domain/report/data/repository.ts` — `findCommunityContext` / `findDeepestChain` raw SQL 追加
- `src/application/domain/report/service.ts` — 2 メソッド委譲
- `src/application/domain/report/usecase.ts` — `Promise.all` 拡張
- `src/application/domain/report/presenter.ts` — payload 型と mapping 拡張
- `src/__tests__/unit/report/presenter.test.ts` (新規) — 7 ケース、新規 path のみ

## Test plan

- [x] `pnpm test src/__tests__/unit/report/presenter.test.ts` で 7/7 pass
  - `active_rate` 計算 (members > 0)
  - `active_rate = null` (members = 0)
  - `customContext` pass-through
  - `community_context = null` (repository null 時)
  - `deepest_chain` mapping + JST 日付変換
  - `deepest_chain = null` (該当 chain 無し時)
  - 既存 payload field との回帰チェック
- [x] `npx tsc --noEmit` で新規エラーなし (pre-existing の `@prisma/client/sql` エラー 4 件は env/CI 起因、本 PR 起因ではない)
- [x] `prettier --write` 適用済
- [ ] dev DB で `buildReportPayload` を呼んで JSON 内容を目視確認 (reviewer 側で実施推奨)

## 次の PR

本 PR-A は AI レポート生成機能 Phase 1 MVP の payload 拡張部分。後続:
- **PR-B**: Prisma model + migration (`Report` / `ReportTemplate` / `ReportFeedback` + enum 3 つ)
- **PR-C**: Anthropic LLM client 共通化
- **PR-D**: AI 生成 UseCase + GraphQL (PR-A/B/C 全 merge 後)
- **PR-F**: 週次バッチ (PR-D merge 後)

PR-B/C は本 PR に依存せず並列開発可能。

https://claude.ai/code/session_0113rnPuGjN67zbt8hDbzBay
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
