### PR TITLE
Support Community participants in TransactionChain

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -2047,21 +2047,70 @@ type Transaction {
   updatedAt: Datetime
 }
 
+"""
+ポイントの旅（chain）の全体像。
+depth はチェーンの長さ（ステップ数）、steps は古い順（起点→現在）に並ぶ。
+"""
 type TransactionChain {
   depth: Int!
   steps: [TransactionChainStep!]!
 }
 
+"""
+参加者がコミュニティ（COMMUNITY wallet の所有者）である場合の表現。
+id は Community.id。GRANT / ONBOARDING のような、community wallet から
+発行される transaction の起点ステップで登場する。
+"""
+type TransactionChainCommunity implements TransactionChainParticipant {
+  bio: String
+  id: ID!
+  image: String
+  name: String!
+}
+
+"""
+chain の 1 ステップに登場する参加者（User または Community）。
+共通フィールドを束ねた interface。実体の判別は __typename で行う。
+"""
+interface TransactionChainParticipant {
+  bio: String
+  id: ID!
+  image: String
+  name: String!
+}
+
+"""
+chain の1ステップ。ある transaction（ポイントの移動 1回分）に対応する。
+from が送信元、to が送信先。どちらも User または Community を表す
+TransactionChainParticipant interface で、__typename で判別できる。
+"""
 type TransactionChainStep {
   createdAt: Datetime!
-  fromUser: TransactionChainUser
+
+  """
+  送信元の参加者。
+  - GRANT / ONBOARDING の起点ステップでは TransactionChainCommunity（community wallet 発）
+  - それ以外のステップは TransactionChainUser
+  - ウォレットが削除済み（退会済みユーザー等）の場合は null
+  """
+  from: TransactionChainParticipant
   id: ID!
   points: Int!
   reason: TransactionReason!
-  toUser: TransactionChainUser
+
+  """
+  送信先の参加者。
+  現状の業務ロジックでは常に TransactionChainUser（MEMBER wallet 宛）。
+  ウォレットが削除済みの場合は null。
+  """
+  to: TransactionChainParticipant
 }
 
-type TransactionChainUser {
+"""
+参加者がユーザー（MEMBER wallet の所有者）である場合の表現。
+id は User.id。
+"""
+type TransactionChainUser implements TransactionChainParticipant {
   bio: String
   id: ID!
   image: String

--- a/src/application/domain/transaction/data/repository.ts
+++ b/src/application/domain/transaction/data/repository.ts
@@ -1,7 +1,11 @@
 import { Prisma } from "@prisma/client";
 import { IContext } from "@/types/server";
 import { ITransactionRepository } from "@/application/domain/transaction/data/interface";
-import { transactionSelectDetail, PrismaTransactionDetail, TransactionChainRow } from "@/application/domain/transaction/data/type";
+import {
+  transactionSelectDetail,
+  PrismaTransactionDetail,
+  TransactionChainRow,
+} from "@/application/domain/transaction/data/type";
 import { refreshMaterializedViewCurrentPoints } from "@prisma/client/sql";
 import { injectable } from "tsyringe";
 
@@ -72,19 +76,33 @@ export default class TransactionRepository implements ITransactionRepository {
           c.created_at,
           fu.id   AS from_user_id,
           fu.name AS from_user_name,
-          fi.url  AS from_user_image,
+          fui.url AS from_user_image,
           fu.bio  AS from_user_bio,
+          fc.id   AS from_community_id,
+          fc.name AS from_community_name,
+          fpc.square_logo_path AS from_community_image,
+          fc.bio  AS from_community_bio,
           tu.id   AS to_user_id,
           tu.name AS to_user_name,
-          ti.url  AS to_user_image,
-          tu.bio  AS to_user_bio
+          tui.url AS to_user_image,
+          tu.bio  AS to_user_bio,
+          tc.id   AS to_community_id,
+          tc.name AS to_community_name,
+          tpc.square_logo_path AS to_community_image,
+          tc.bio  AS to_community_bio
         FROM chain c
-        LEFT JOIN t_wallets fw ON fw.id = c."from"
-        LEFT JOIN t_users   fu ON fu.id = fw.user_id
-        LEFT JOIN t_images  fi ON fi.id = fu.image_id
-        LEFT JOIN t_wallets tw ON tw.id = c."to"
-        LEFT JOIN t_users   tu ON tu.id = tw.user_id
-        LEFT JOIN t_images  ti ON ti.id = tu.image_id
+        LEFT JOIN t_wallets                fw  ON fw.id = c."from"
+        LEFT JOIN t_users                  fu  ON fu.id = fw.user_id
+        LEFT JOIN t_images                 fui ON fui.id = fu.image_id
+        LEFT JOIN t_communities            fc  ON fc.id = fw.community_id AND fw.type = 'COMMUNITY'
+        LEFT JOIN t_community_configs      fcc ON fcc.community_id = fc.id
+        LEFT JOIN t_community_portal_configs fpc ON fpc.config_id = fcc.id
+        LEFT JOIN t_wallets                tw  ON tw.id = c."to"
+        LEFT JOIN t_users                  tu  ON tu.id = tw.user_id
+        LEFT JOIN t_images                 tui ON tui.id = tu.image_id
+        LEFT JOIN t_communities            tc  ON tc.id = tw.community_id AND tw.type = 'COMMUNITY'
+        LEFT JOIN t_community_configs      tcc ON tcc.community_id = tc.id
+        LEFT JOIN t_community_portal_configs tpc ON tpc.config_id = tcc.id
         ORDER BY c.seq DESC
       `;
     });

--- a/src/application/domain/transaction/data/type.ts
+++ b/src/application/domain/transaction/data/type.ts
@@ -47,8 +47,16 @@ export type TransactionChainRow = {
   from_user_name: string | null;
   from_user_image: string | null;
   from_user_bio: string | null;
+  from_community_id: string | null;
+  from_community_name: string | null;
+  from_community_image: string | null;
+  from_community_bio: string | null;
   to_user_id: string | null;
   to_user_name: string | null;
   to_user_image: string | null;
   to_user_bio: string | null;
+  to_community_id: string | null;
+  to_community_name: string | null;
+  to_community_image: string | null;
+  to_community_bio: string | null;
 };

--- a/src/application/domain/transaction/presenter.ts
+++ b/src/application/domain/transaction/presenter.ts
@@ -82,60 +82,64 @@ export default class TransactionPresenter {
         reason: row.reason as GqlTransactionReason,
         points: row.points,
         createdAt: row.created_at,
-        from: buildParticipant(
-          row.from_user_id,
-          row.from_user_name,
-          row.from_user_image,
-          row.from_user_bio,
-          row.from_community_id,
-          row.from_community_name,
-          row.from_community_image,
-          row.from_community_bio,
-        ),
-        to: buildParticipant(
-          row.to_user_id,
-          row.to_user_name,
-          row.to_user_image,
-          row.to_user_bio,
-          row.to_community_id,
-          row.to_community_name,
-          row.to_community_image,
-          row.to_community_bio,
-        ),
+        from: buildParticipant({
+          userId: row.from_user_id,
+          userName: row.from_user_name,
+          userImage: row.from_user_image,
+          userBio: row.from_user_bio,
+          communityId: row.from_community_id,
+          communityName: row.from_community_name,
+          communityImage: row.from_community_image,
+          communityBio: row.from_community_bio,
+        }),
+        to: buildParticipant({
+          userId: row.to_user_id,
+          userName: row.to_user_name,
+          userImage: row.to_user_image,
+          userBio: row.to_user_bio,
+          communityId: row.to_community_id,
+          communityName: row.to_community_name,
+          communityImage: row.to_community_image,
+          communityBio: row.to_community_bio,
+        }),
       })),
     };
   }
 }
 
+type ParticipantCandidate = {
+  userId: string | null;
+  userName: string | null;
+  userImage: string | null;
+  userBio: string | null;
+  communityId: string | null;
+  communityName: string | null;
+  communityImage: string | null;
+  communityBio: string | null;
+};
+
 // wallet の user_id / community_id の非nullをもとに、どちらの参加者かを決定する。
 // COMMUNITY wallet の場合 community_id のみ非null、MEMBER wallet の場合 user_id のみ非null になる。
 // ウォレットが削除済み等でどちらも null の場合は null を返す。
 function buildParticipant(
-  userId: string | null,
-  userName: string | null,
-  userImage: string | null,
-  userBio: string | null,
-  communityId: string | null,
-  communityName: string | null,
-  communityImage: string | null,
-  communityBio: string | null,
+  data: ParticipantCandidate,
 ): GqlTransactionChainUser | GqlTransactionChainCommunity | null {
-  if (userId) {
+  if (data.userId) {
     return {
       __typename: "TransactionChainUser",
-      id: userId,
-      name: userName ?? "",
-      image: userImage ?? null,
-      bio: userBio ?? null,
+      id: data.userId,
+      name: data.userName ?? "",
+      image: data.userImage ?? null,
+      bio: data.userBio ?? null,
     };
   }
-  if (communityId) {
+  if (data.communityId) {
     return {
       __typename: "TransactionChainCommunity",
-      id: communityId,
-      name: communityName ?? "",
-      image: communityImage ?? null,
-      bio: communityBio ?? null,
+      id: data.communityId,
+      name: data.communityName ?? "",
+      image: data.communityImage ?? null,
+      bio: data.communityBio ?? null,
     };
   }
   return null;

--- a/src/application/domain/transaction/presenter.ts
+++ b/src/application/domain/transaction/presenter.ts
@@ -5,13 +5,22 @@ import {
   GqlTransactionGrantCommunityPointSuccess,
   GqlTransactionDonateSelfPointSuccess,
   GqlTransactionChain,
+  GqlTransactionChainCommunity,
+  GqlTransactionChainUser,
   GqlTransactionReason,
   GqlTransactionUpdateMetadataSuccess,
 } from "@/types/graphql";
-import { PrismaTransactionDetail, TransactionChainRow } from "@/application/domain/transaction/data/type";
+import {
+  PrismaTransactionDetail,
+  TransactionChainRow,
+} from "@/application/domain/transaction/data/type";
 
 export default class TransactionPresenter {
-  static query(r: GqlTransaction[], hasNextPage: boolean, cursor?: string): GqlTransactionsConnection {
+  static query(
+    r: GqlTransaction[],
+    hasNextPage: boolean,
+    cursor?: string,
+  ): GqlTransactionsConnection {
     return {
       __typename: "TransactionsConnection",
       totalCount: r.length,
@@ -73,25 +82,61 @@ export default class TransactionPresenter {
         reason: row.reason as GqlTransactionReason,
         points: row.points,
         createdAt: row.created_at,
-        fromUser: row.from_user_id
-          ? {
-              __typename: "TransactionChainUser",
-              id: row.from_user_id,
-              name: row.from_user_name ?? "",
-              image: row.from_user_image ?? null,
-              bio: row.from_user_bio ?? null,
-            }
-          : null,
-        toUser: row.to_user_id
-          ? {
-              __typename: "TransactionChainUser",
-              id: row.to_user_id,
-              name: row.to_user_name ?? "",
-              image: row.to_user_image ?? null,
-              bio: row.to_user_bio ?? null,
-            }
-          : null,
+        from: buildParticipant(
+          row.from_user_id,
+          row.from_user_name,
+          row.from_user_image,
+          row.from_user_bio,
+          row.from_community_id,
+          row.from_community_name,
+          row.from_community_image,
+          row.from_community_bio,
+        ),
+        to: buildParticipant(
+          row.to_user_id,
+          row.to_user_name,
+          row.to_user_image,
+          row.to_user_bio,
+          row.to_community_id,
+          row.to_community_name,
+          row.to_community_image,
+          row.to_community_bio,
+        ),
       })),
     };
   }
+}
+
+// wallet の user_id / community_id の非nullをもとに、どちらの参加者かを決定する。
+// COMMUNITY wallet の場合 community_id のみ非null、MEMBER wallet の場合 user_id のみ非null になる。
+// ウォレットが削除済み等でどちらも null の場合は null を返す。
+function buildParticipant(
+  userId: string | null,
+  userName: string | null,
+  userImage: string | null,
+  userBio: string | null,
+  communityId: string | null,
+  communityName: string | null,
+  communityImage: string | null,
+  communityBio: string | null,
+): GqlTransactionChainUser | GqlTransactionChainCommunity | null {
+  if (userId) {
+    return {
+      __typename: "TransactionChainUser",
+      id: userId,
+      name: userName ?? "",
+      image: userImage ?? null,
+      bio: userBio ?? null,
+    };
+  }
+  if (communityId) {
+    return {
+      __typename: "TransactionChainCommunity",
+      id: communityId,
+      name: communityName ?? "",
+      image: communityImage ?? null,
+      bio: communityBio ?? null,
+    };
+  }
+  return null;
 }

--- a/src/application/domain/transaction/presenter.ts
+++ b/src/application/domain/transaction/presenter.ts
@@ -83,63 +83,75 @@ export default class TransactionPresenter {
         points: row.points,
         createdAt: row.created_at,
         from: buildParticipant({
-          userId: row.from_user_id,
-          userName: row.from_user_name,
-          userImage: row.from_user_image,
-          userBio: row.from_user_bio,
-          communityId: row.from_community_id,
-          communityName: row.from_community_name,
-          communityImage: row.from_community_image,
-          communityBio: row.from_community_bio,
+          user: {
+            id: row.from_user_id,
+            name: row.from_user_name,
+            image: row.from_user_image,
+            bio: row.from_user_bio,
+          },
+          community: {
+            id: row.from_community_id,
+            name: row.from_community_name,
+            image: row.from_community_image,
+            bio: row.from_community_bio,
+          },
         }),
         to: buildParticipant({
-          userId: row.to_user_id,
-          userName: row.to_user_name,
-          userImage: row.to_user_image,
-          userBio: row.to_user_bio,
-          communityId: row.to_community_id,
-          communityName: row.to_community_name,
-          communityImage: row.to_community_image,
-          communityBio: row.to_community_bio,
+          user: {
+            id: row.to_user_id,
+            name: row.to_user_name,
+            image: row.to_user_image,
+            bio: row.to_user_bio,
+          },
+          community: {
+            id: row.to_community_id,
+            name: row.to_community_name,
+            image: row.to_community_image,
+            bio: row.to_community_bio,
+          },
         }),
       })),
     };
   }
 }
 
-type ParticipantCandidate = {
-  userId: string | null;
-  userName: string | null;
-  userImage: string | null;
-  userBio: string | null;
-  communityId: string | null;
-  communityName: string | null;
-  communityImage: string | null;
-  communityBio: string | null;
+type ParticipantFields = {
+  id: string | null;
+  name: string | null;
+  image: string | null;
+  bio: string | null;
 };
 
-// wallet の user_id / community_id の非nullをもとに、どちらの参加者かを決定する。
-// COMMUNITY wallet の場合 community_id のみ非null、MEMBER wallet の場合 user_id のみ非null になる。
-// ウォレットが削除済み等でどちらも null の場合は null を返す。
+type ParticipantCandidate = {
+  user: ParticipantFields;
+  community: ParticipantFields;
+};
+
+// chain SQL の conditional JOIN 結果から、どちらの参加者かを決定する:
+// - MEMBER wallet:    t_users JOIN がヒット → user.id が非null
+// - COMMUNITY wallet: t_communities JOIN がヒット（JOIN 条件に wallet.type='COMMUNITY' 付き）→ community.id が非null
+// - wallet 削除済み / JOIN が全て外れた場合: どちらも null → null を返す
+// NOTE: t_wallets.community_id 自体は MEMBER wallet にも存在するが、JOIN 条件で
+// wallet.type='COMMUNITY' を指定しているため、community.id 側は COMMUNITY wallet の場合だけ非null になる。
 function buildParticipant(
   data: ParticipantCandidate,
 ): GqlTransactionChainUser | GqlTransactionChainCommunity | null {
-  if (data.userId) {
+  if (data.user.id) {
     return {
       __typename: "TransactionChainUser",
-      id: data.userId,
-      name: data.userName ?? "",
-      image: data.userImage ?? null,
-      bio: data.userBio ?? null,
+      id: data.user.id,
+      name: data.user.name ?? "",
+      image: data.user.image ?? null,
+      bio: data.user.bio ?? null,
     };
   }
-  if (data.communityId) {
+  if (data.community.id) {
     return {
       __typename: "TransactionChainCommunity",
-      id: data.communityId,
-      name: data.communityName ?? "",
-      image: data.communityImage ?? null,
-      bio: data.communityBio ?? null,
+      id: data.community.id,
+      name: data.community.name ?? "",
+      image: data.community.image ?? null,
+      bio: data.community.bio ?? null,
     };
   }
   return null;

--- a/src/application/domain/transaction/schema/type.graphql
+++ b/src/application/domain/transaction/schema/type.graphql
@@ -34,21 +34,68 @@ type Transaction {
   updatedAt: Datetime
 }
 
+"""
+ポイントの旅（chain）の全体像。
+depth はチェーンの長さ（ステップ数）、steps は古い順（起点→現在）に並ぶ。
+"""
 type TransactionChain {
   depth: Int!
   steps: [TransactionChainStep!]!
 }
 
+"""
+chain の1ステップ。ある transaction（ポイントの移動 1回分）に対応する。
+from が送信元、to が送信先。どちらも User または Community を表す
+TransactionChainParticipant interface で、__typename で判別できる。
+"""
 type TransactionChainStep {
   id: ID!
   reason: TransactionReason!
   points: Int!
-  fromUser: TransactionChainUser
-  toUser: TransactionChainUser
+  """
+  送信元の参加者。
+  - GRANT / ONBOARDING の起点ステップでは TransactionChainCommunity（community wallet 発）
+  - それ以外のステップは TransactionChainUser
+  - ウォレットが削除済み（退会済みユーザー等）の場合は null
+  """
+  from: TransactionChainParticipant
+  """
+  送信先の参加者。
+  現状の業務ロジックでは常に TransactionChainUser（MEMBER wallet 宛）。
+  ウォレットが削除済みの場合は null。
+  """
+  to: TransactionChainParticipant
   createdAt: Datetime!
 }
 
-type TransactionChainUser {
+"""
+chain の 1 ステップに登場する参加者（User または Community）。
+共通フィールドを束ねた interface。実体の判別は __typename で行う。
+"""
+interface TransactionChainParticipant {
+  id: ID!
+  name: String!
+  image: String
+  bio: String
+}
+
+"""
+参加者がユーザー（MEMBER wallet の所有者）である場合の表現。
+id は User.id。
+"""
+type TransactionChainUser implements TransactionChainParticipant {
+  id: ID!
+  name: String!
+  image: String
+  bio: String
+}
+
+"""
+参加者がコミュニティ（COMMUNITY wallet の所有者）である場合の表現。
+id は Community.id。GRANT / ONBOARDING のような、community wallet から
+発行される transaction の起点ステップで登場する。
+"""
+type TransactionChainCommunity implements TransactionChainParticipant {
   id: ID!
   name: String!
   image: String

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -2947,23 +2947,71 @@ export type GqlTransaction = {
   updatedAt?: Maybe<Scalars['Datetime']['output']>;
 };
 
+/**
+ * ポイントの旅（chain）の全体像。
+ * depth はチェーンの長さ（ステップ数）、steps は古い順（起点→現在）に並ぶ。
+ */
 export type GqlTransactionChain = {
   __typename?: 'TransactionChain';
   depth: Scalars['Int']['output'];
   steps: Array<GqlTransactionChainStep>;
 };
 
+/**
+ * 参加者がコミュニティ（COMMUNITY wallet の所有者）である場合の表現。
+ * id は Community.id。GRANT / ONBOARDING のような、community wallet から
+ * 発行される transaction の起点ステップで登場する。
+ */
+export type GqlTransactionChainCommunity = GqlTransactionChainParticipant & {
+  __typename?: 'TransactionChainCommunity';
+  bio?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  image?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+};
+
+/**
+ * chain の 1 ステップに登場する参加者（User または Community）。
+ * 共通フィールドを束ねた interface。実体の判別は __typename で行う。
+ */
+export type GqlTransactionChainParticipant = {
+  bio?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  image?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+};
+
+/**
+ * chain の1ステップ。ある transaction（ポイントの移動 1回分）に対応する。
+ * from が送信元、to が送信先。どちらも User または Community を表す
+ * TransactionChainParticipant interface で、__typename で判別できる。
+ */
 export type GqlTransactionChainStep = {
   __typename?: 'TransactionChainStep';
   createdAt: Scalars['Datetime']['output'];
-  fromUser?: Maybe<GqlTransactionChainUser>;
+  /**
+   * 送信元の参加者。
+   * - GRANT / ONBOARDING の起点ステップでは TransactionChainCommunity（community wallet 発）
+   * - それ以外のステップは TransactionChainUser
+   * - ウォレットが削除済み（退会済みユーザー等）の場合は null
+   */
+  from?: Maybe<GqlTransactionChainParticipant>;
   id: Scalars['ID']['output'];
   points: Scalars['Int']['output'];
   reason: GqlTransactionReason;
-  toUser?: Maybe<GqlTransactionChainUser>;
+  /**
+   * 送信先の参加者。
+   * 現状の業務ロジックでは常に TransactionChainUser（MEMBER wallet 宛）。
+   * ウォレットが削除済みの場合は null。
+   */
+  to?: Maybe<GqlTransactionChainParticipant>;
 };
 
-export type GqlTransactionChainUser = {
+/**
+ * 参加者がユーザー（MEMBER wallet の所有者）である場合の表現。
+ * id は User.id。
+ */
+export type GqlTransactionChainUser = GqlTransactionChainParticipant & {
   __typename?: 'TransactionChainUser';
   bio?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
@@ -3756,6 +3804,7 @@ export type GqlResolversUnionTypes<_RefType extends Record<string, unknown>> = R
 /** Mapping of interface types */
 export type GqlResolversInterfaceTypes<_RefType extends Record<string, unknown>> = ResolversObject<{
   Edge: ( Omit<GqlArticleEdge, 'node'> & { node?: Maybe<_RefType['Article']> } ) | ( Omit<GqlCityEdge, 'node'> & { node?: Maybe<_RefType['City']> } ) | ( Omit<GqlCommunityEdge, 'node'> & { node?: Maybe<_RefType['Community']> } ) | ( Omit<GqlEvaluationEdge, 'node'> & { node?: Maybe<_RefType['Evaluation']> } ) | ( Omit<GqlEvaluationHistoryEdge, 'node'> & { node?: Maybe<_RefType['EvaluationHistory']> } ) | ( Omit<GqlIncentiveGrantEdge, 'node'> & { node?: Maybe<_RefType['IncentiveGrant']> } ) | ( Omit<GqlMembershipEdge, 'node'> & { node?: Maybe<_RefType['Membership']> } ) | ( Omit<GqlNftInstanceEdge, 'node'> & { node: _RefType['NftInstance'] } ) | ( Omit<GqlNftTokenEdge, 'node'> & { node: _RefType['NftToken'] } ) | ( Omit<GqlOpportunityEdge, 'node'> & { node?: Maybe<_RefType['Opportunity']> } ) | ( Omit<GqlOpportunitySlotEdge, 'node'> & { node?: Maybe<_RefType['OpportunitySlot']> } ) | ( Omit<GqlParticipationEdge, 'node'> & { node?: Maybe<_RefType['Participation']> } ) | ( Omit<GqlParticipationStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['ParticipationStatusHistory']> } ) | ( Omit<GqlPlaceEdge, 'node'> & { node?: Maybe<_RefType['Place']> } ) | ( Omit<GqlPortfolioEdge, 'node'> & { node?: Maybe<_RefType['Portfolio']> } ) | ( Omit<GqlReservationEdge, 'node'> & { node?: Maybe<_RefType['Reservation']> } ) | ( Omit<GqlReservationHistoryEdge, 'node'> & { node?: Maybe<_RefType['ReservationHistory']> } ) | ( Omit<GqlStateEdge, 'node'> & { node?: Maybe<_RefType['State']> } ) | ( Omit<GqlTicketClaimLinkEdge, 'node'> & { node?: Maybe<_RefType['TicketClaimLink']> } ) | ( Omit<GqlTicketEdge, 'node'> & { node?: Maybe<_RefType['Ticket']> } ) | ( Omit<GqlTicketIssuerEdge, 'node'> & { node?: Maybe<_RefType['TicketIssuer']> } ) | ( Omit<GqlTicketStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['TicketStatusHistory']> } ) | ( Omit<GqlTransactionEdge, 'node'> & { node?: Maybe<_RefType['Transaction']> } ) | ( Omit<GqlUserEdge, 'node'> & { node?: Maybe<_RefType['User']> } ) | ( Omit<GqlUtilityEdge, 'node'> & { node?: Maybe<_RefType['Utility']> } ) | ( Omit<GqlVcIssuanceRequestEdge, 'node'> & { node?: Maybe<_RefType['VcIssuanceRequest']> } ) | ( Omit<GqlWalletEdge, 'node'> & { node?: Maybe<_RefType['Wallet']> } );
+  TransactionChainParticipant: ( GqlTransactionChainCommunity ) | ( GqlTransactionChainUser );
 }>;
 
 /** Mapping between all available schema types and the resolvers types */
@@ -4053,8 +4102,10 @@ export type GqlResolversTypes = ResolversObject<{
   TicketUseSuccess: ResolverTypeWrapper<Omit<GqlTicketUseSuccess, 'ticket'> & { ticket: GqlResolversTypes['Ticket'] }>;
   TicketsConnection: ResolverTypeWrapper<Omit<GqlTicketsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['TicketEdge']>>> }>;
   Transaction: ResolverTypeWrapper<Transaction>;
-  TransactionChain: ResolverTypeWrapper<GqlTransactionChain>;
-  TransactionChainStep: ResolverTypeWrapper<GqlTransactionChainStep>;
+  TransactionChain: ResolverTypeWrapper<Omit<GqlTransactionChain, 'steps'> & { steps: Array<GqlResolversTypes['TransactionChainStep']> }>;
+  TransactionChainCommunity: ResolverTypeWrapper<GqlTransactionChainCommunity>;
+  TransactionChainParticipant: ResolverTypeWrapper<GqlResolversInterfaceTypes<GqlResolversTypes>['TransactionChainParticipant']>;
+  TransactionChainStep: ResolverTypeWrapper<Omit<GqlTransactionChainStep, 'from' | 'to'> & { from?: Maybe<GqlResolversTypes['TransactionChainParticipant']>, to?: Maybe<GqlResolversTypes['TransactionChainParticipant']> }>;
   TransactionChainUser: ResolverTypeWrapper<GqlTransactionChainUser>;
   TransactionDonateSelfPointInput: GqlTransactionDonateSelfPointInput;
   TransactionDonateSelfPointPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['TransactionDonateSelfPointPayload']>;
@@ -4405,8 +4456,10 @@ export type GqlResolversParentTypes = ResolversObject<{
   TicketUseSuccess: Omit<GqlTicketUseSuccess, 'ticket'> & { ticket: GqlResolversParentTypes['Ticket'] };
   TicketsConnection: Omit<GqlTicketsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['TicketEdge']>>> };
   Transaction: Transaction;
-  TransactionChain: GqlTransactionChain;
-  TransactionChainStep: GqlTransactionChainStep;
+  TransactionChain: Omit<GqlTransactionChain, 'steps'> & { steps: Array<GqlResolversParentTypes['TransactionChainStep']> };
+  TransactionChainCommunity: GqlTransactionChainCommunity;
+  TransactionChainParticipant: GqlResolversInterfaceTypes<GqlResolversParentTypes>['TransactionChainParticipant'];
+  TransactionChainStep: Omit<GqlTransactionChainStep, 'from' | 'to'> & { from?: Maybe<GqlResolversParentTypes['TransactionChainParticipant']>, to?: Maybe<GqlResolversParentTypes['TransactionChainParticipant']> };
   TransactionChainUser: GqlTransactionChainUser;
   TransactionDonateSelfPointInput: GqlTransactionDonateSelfPointInput;
   TransactionDonateSelfPointPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['TransactionDonateSelfPointPayload'];
@@ -5758,13 +5811,29 @@ export type GqlTransactionChainResolvers<ContextType = any, ParentType extends G
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type GqlTransactionChainCommunityResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TransactionChainCommunity'] = GqlResolversParentTypes['TransactionChainCommunity']> = ResolversObject<{
+  bio?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  image?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTransactionChainParticipantResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TransactionChainParticipant'] = GqlResolversParentTypes['TransactionChainParticipant']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'TransactionChainCommunity' | 'TransactionChainUser', ParentType, ContextType>;
+  bio?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  image?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+}>;
+
 export type GqlTransactionChainStepResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TransactionChainStep'] = GqlResolversParentTypes['TransactionChainStep']> = ResolversObject<{
   createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
-  fromUser?: Resolver<Maybe<GqlResolversTypes['TransactionChainUser']>, ParentType, ContextType>;
+  from?: Resolver<Maybe<GqlResolversTypes['TransactionChainParticipant']>, ParentType, ContextType>;
   id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
   points?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   reason?: Resolver<GqlResolversTypes['TransactionReason'], ParentType, ContextType>;
-  toUser?: Resolver<Maybe<GqlResolversTypes['TransactionChainUser']>, ParentType, ContextType>;
+  to?: Resolver<Maybe<GqlResolversTypes['TransactionChainParticipant']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -6289,6 +6358,8 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   TicketsConnection?: GqlTicketsConnectionResolvers<ContextType>;
   Transaction?: GqlTransactionResolvers<ContextType>;
   TransactionChain?: GqlTransactionChainResolvers<ContextType>;
+  TransactionChainCommunity?: GqlTransactionChainCommunityResolvers<ContextType>;
+  TransactionChainParticipant?: GqlTransactionChainParticipantResolvers<ContextType>;
   TransactionChainStep?: GqlTransactionChainStepResolvers<ContextType>;
   TransactionChainUser?: GqlTransactionChainUserResolvers<ContextType>;
   TransactionDonateSelfPointPayload?: GqlTransactionDonateSelfPointPayloadResolvers<ContextType>;


### PR DESCRIPTION
## Summary
This PR extends the TransactionChain GraphQL schema to support both User and Community participants, enabling proper representation of point transfers that originate from community wallets (e.g., GRANT, ONBOARDING transactions).

## Key Changes

- **New GraphQL Interface**: Introduced `TransactionChainParticipant` interface to represent either a User or Community in transaction chains
- **New Type**: Added `TransactionChainCommunity` type implementing `TransactionChainParticipant` to represent community wallet owners
- **Updated Types**: Modified `TransactionChainUser` to implement `TransactionChainParticipant` interface
- **Field Renaming**: Renamed `fromUser`/`toUser` fields to `from`/`to` in `TransactionChainStep` to reflect they can be either participant type
- **Database Query Enhancement**: Extended SQL query in `TransactionRepository` to join community data alongside user data for both sender and recipient wallets
- **Type Definitions**: Updated `TransactionChainRow` type to include community fields (`from_community_*` and `to_community_*`)
- **Presenter Logic**: Implemented `buildParticipant()` helper function to determine participant type based on wallet ownership (user_id vs community_id)

## Implementation Details

- The participant type is determined by checking which ID is non-null in the wallet record (COMMUNITY wallets have `community_id`, MEMBER wallets have `user_id`)
- Handles edge cases where wallets may be deleted (both IDs null) by returning null
- All GraphQL schema files and generated TypeScript types have been updated consistently
- Added comprehensive JSDoc comments in Japanese explaining the purpose and behavior of each type

https://claude.ai/code/session_01MZWF4AwGKuP9ZhS1gbEyWy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/832" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
