### PR TITLE
feat(llm): add provider-neutral LlmClient + Anthropic implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     }
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.90.0",
     "@apollo/server": "^4.12.0",
     "@dotenvx/dotenvx": "^1.41.0",
     "@escape.tech/graphql-armor": "^3.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
 
   .:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.90.0
+        version: 0.90.0
       '@apollo/server':
         specifier: ^4.12.0
         version: 4.12.2(graphql@16.10.0)
@@ -364,6 +367,15 @@ packages:
 
   '@antfu/utils@8.1.1':
     resolution: {integrity: sha512-Mex9nXf9vR6AhcXmMrlz/HVgYYZpVGJ6YlPgwl7UnaFpnshXs6EK/oa5Gpf3CzENMjkvEx2tQtntGnb7UtSTOQ==}
+
+  '@anthropic-ai/sdk@0.90.0':
+    resolution: {integrity: sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@apollo/cache-control-types@1.0.3':
     resolution: {integrity: sha512-F17/vCp7QVwom9eG7ToauIKdAxpSoadsJnqIfyryLFSkLSOEqu+eC5Z3N8OXcUVStuOMcNHlyraRsA6rRICu4g==}
@@ -6081,6 +6093,10 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -7976,6 +7992,9 @@ packages:
     resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
     engines: {node: '>= 14.0.0'}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
     engines: {node: '>=18.12'}
@@ -8585,6 +8604,10 @@ snapshots:
   '@antfu/ni@0.21.4': {}
 
   '@antfu/utils@8.1.1': {}
+
+  '@anthropic-ai/sdk@0.90.0':
+    dependencies:
+      json-schema-to-ts: 3.1.1
 
   '@apollo/cache-control-types@1.0.3(graphql@16.10.0)':
     dependencies:
@@ -16374,6 +16397,11 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.27.6
+      ts-algebra: 2.0.0
+
   json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
@@ -18493,6 +18521,8 @@ snapshots:
       punycode: 2.3.1
 
   triple-beam@1.4.1: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.1.0(typescript@5.8.3):
     dependencies:

--- a/src/__tests__/unit/infrastructure/libs/llm/anthropic.test.ts
+++ b/src/__tests__/unit/infrastructure/libs/llm/anthropic.test.ts
@@ -1,0 +1,209 @@
+import "reflect-metadata";
+
+/**
+ * Mock the Anthropic SDK before importing the wrapper. `jest.mock`
+ * with the default-export-as-a-class shape so that
+ * `new Anthropic({...})` in the wrapper constructor picks up our stub
+ * and `client.messages.create(...)` is fully observable from tests.
+ */
+const mockMessagesCreate = jest.fn();
+const mockAnthropicConstructor = jest.fn();
+
+jest.mock("@anthropic-ai/sdk", () => {
+  const MockAnthropic = jest.fn().mockImplementation((opts: unknown) => {
+    mockAnthropicConstructor(opts);
+    return { messages: { create: mockMessagesCreate } };
+  });
+  return { __esModule: true, default: MockAnthropic };
+});
+
+import { AnthropicLlmClient } from "@/infrastructure/libs/llm/anthropic/client";
+
+describe("AnthropicLlmClient", () => {
+  const originalApiKey = process.env.ANTHROPIC_API_KEY;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.ANTHROPIC_API_KEY = "test-api-key";
+  });
+
+  afterAll(() => {
+    if (originalApiKey === undefined) {
+      delete process.env.ANTHROPIC_API_KEY;
+    } else {
+      process.env.ANTHROPIC_API_KEY = originalApiKey;
+    }
+  });
+
+  describe("constructor", () => {
+    it("throws when ANTHROPIC_API_KEY is missing", () => {
+      delete process.env.ANTHROPIC_API_KEY;
+      expect(() => new AnthropicLlmClient()).toThrow(/ANTHROPIC_API_KEY is not set/);
+    });
+
+    it("constructs the SDK with maxRetries=2 and the resolved key", () => {
+      new AnthropicLlmClient();
+      expect(mockAnthropicConstructor).toHaveBeenCalledWith({
+        apiKey: "test-api-key",
+        maxRetries: 2,
+      });
+    });
+  });
+
+  describe("complete", () => {
+    const defaultResponse = {
+      content: [{ type: "text", text: "hello" }],
+      model: "claude-sonnet-4-6",
+      stop_reason: "end_turn",
+      usage: {
+        input_tokens: 100,
+        output_tokens: 30,
+        cache_read_input_tokens: 80,
+        cache_creation_input_tokens: 0,
+      },
+    };
+
+    it("maps { cache: true } onto a cache_control ephemeral text block and leaves uncached blocks bare", async () => {
+      mockMessagesCreate.mockResolvedValueOnce(defaultResponse);
+      const sut = new AnthropicLlmClient();
+
+      await sut.complete({
+        system: [{ text: "stable preamble", cache: true }, { text: "volatile tail" }],
+        messages: [{ role: "user", content: "hi" }],
+        model: "claude-sonnet-4-6",
+        maxTokens: 1024,
+      });
+
+      expect(mockMessagesCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          system: [
+            {
+              type: "text",
+              text: "stable preamble",
+              cache_control: { type: "ephemeral" },
+            },
+            { type: "text", text: "volatile tail" },
+          ],
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it("maps snake_case usage fields to camelCase and defaults cache metrics to 0 when absent", async () => {
+      mockMessagesCreate.mockResolvedValueOnce({
+        content: [{ type: "text", text: "ok" }],
+        model: "claude-sonnet-4-6",
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+          // cache_* fields omitted — wrapper should default both to 0
+        },
+      });
+      const sut = new AnthropicLlmClient();
+
+      const result = await sut.complete({
+        system: [{ text: "p" }],
+        messages: [{ role: "user", content: "q" }],
+        model: "claude-sonnet-4-6",
+        maxTokens: 256,
+      });
+
+      expect(result.usage).toEqual({
+        inputTokens: 10,
+        outputTokens: 5,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      });
+    });
+
+    it("concatenates multiple text blocks into a single string and ignores non-text blocks", async () => {
+      mockMessagesCreate.mockResolvedValueOnce({
+        content: [
+          { type: "thinking", thinking: "internal" },
+          { type: "text", text: "part 1 " },
+          { type: "tool_use", id: "toolu_1", name: "x", input: {} },
+          { type: "text", text: "part 2" },
+        ],
+        model: "claude-opus-4-6",
+        stop_reason: "end_turn",
+        usage: { input_tokens: 1, output_tokens: 1 },
+      });
+      const sut = new AnthropicLlmClient();
+
+      const result = await sut.complete({
+        system: [{ text: "p" }],
+        messages: [{ role: "user", content: "q" }],
+        model: "claude-opus-4-6",
+        maxTokens: 256,
+      });
+
+      expect(result.text).toBe("part 1 part 2");
+      expect(result.stopReason).toBe("end_turn");
+      expect(result.model).toBe("claude-opus-4-6");
+    });
+
+    it("omits temperature from the SDK payload when the caller did not supply it (Opus 4.7 would otherwise 400)", async () => {
+      mockMessagesCreate.mockResolvedValueOnce(defaultResponse);
+      const sut = new AnthropicLlmClient();
+
+      await sut.complete({
+        system: [{ text: "p" }],
+        messages: [{ role: "user", content: "q" }],
+        model: "claude-opus-4-7",
+        maxTokens: 256,
+      });
+
+      const payload = mockMessagesCreate.mock.calls[0][0];
+      expect(payload).not.toHaveProperty("temperature");
+    });
+
+    it("passes temperature through when provided", async () => {
+      mockMessagesCreate.mockResolvedValueOnce(defaultResponse);
+      const sut = new AnthropicLlmClient();
+
+      await sut.complete({
+        system: [{ text: "p" }],
+        messages: [{ role: "user", content: "q" }],
+        model: "claude-sonnet-4-6",
+        maxTokens: 256,
+        temperature: 0.7,
+      });
+
+      expect(mockMessagesCreate.mock.calls[0][0]).toMatchObject({ temperature: 0.7 });
+    });
+
+    it("forwards AbortSignal to the SDK request options", async () => {
+      mockMessagesCreate.mockResolvedValueOnce(defaultResponse);
+      const sut = new AnthropicLlmClient();
+      const controller = new AbortController();
+
+      await sut.complete({
+        system: [{ text: "p" }],
+        messages: [{ role: "user", content: "q" }],
+        model: "claude-sonnet-4-6",
+        maxTokens: 256,
+        signal: controller.signal,
+      });
+
+      expect(mockMessagesCreate).toHaveBeenCalledWith(expect.any(Object), {
+        signal: controller.signal,
+      });
+    });
+
+    it("omits stop_sequences from the SDK payload when the caller passes an empty list", async () => {
+      mockMessagesCreate.mockResolvedValueOnce(defaultResponse);
+      const sut = new AnthropicLlmClient();
+
+      await sut.complete({
+        system: [{ text: "p" }],
+        messages: [{ role: "user", content: "q" }],
+        model: "claude-sonnet-4-6",
+        maxTokens: 256,
+        stopSequences: [],
+      });
+
+      expect(mockMessagesCreate.mock.calls[0][0]).not.toHaveProperty("stop_sequences");
+    });
+  });
+});

--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -30,6 +30,7 @@ import IdentityService from "@/application/domain/account/identity/service";
 import IdentityUseCase from "@/application/domain/account/identity/usecase";
 import { NmkrClient } from "@/infrastructure/libs/nmkr/api/client";
 import { CardanoShopifyAppClient } from "@/infrastructure/libs/cardanoShopifyApp/api/client";
+import { AnthropicLlmClient } from "@/infrastructure/libs/llm";
 import IdentityRepository from "@/application/domain/account/identity/data/repository";
 import IdentityConverter from "@/application/domain/account/identity/data/converter";
 import DIDIssuanceRequestRepository from "@/application/domain/account/identity/didIssuanceRequest/data/repository";
@@ -350,6 +351,7 @@ export function registerProductionDependencies() {
   container.register("ReportRepository", { useClass: ReportRepository });
   container.register("ReportService", { useClass: ReportService });
   container.register("ReportUseCase", { useClass: ReportUseCase });
+  container.register("LlmClient", { useClass: AnthropicLlmClient });
 
   // ------------------------------
   // 🗳️ Vote

--- a/src/infrastructure/libs/llm/anthropic/client.ts
+++ b/src/infrastructure/libs/llm/anthropic/client.ts
@@ -50,10 +50,18 @@ export class AnthropicLlmClient implements LlmClient {
     );
 
     // `response.content` is a discriminated union; narrow to text blocks
-    // before reading `.text`. Non-text blocks (thinking, tool_use) do not
-    // exist in Phase 1 requests but would be silently dropped here if
-    // a caller ever enabled them — acceptable because the caller would
-    // then want to read them directly from a richer interface.
+    // before reading `.text`. Phase 1 never requests thinking or tools,
+    // so these blocks cannot appear in the response under the current
+    // call shape — any that do slip in are dropped silently from the
+    // returned `text`.
+    //
+    // `usage.outputTokens` still counts every generated block (thinking
+    // included), so a future caller that turns on thinking or tool use
+    // without first extending `LlmCompleteResult` will see a confusing
+    // short `text` paired with a large `outputTokens`. When that day
+    // comes, add `thinking?: string` / `toolUse?: ...` fields to
+    // `LlmCompleteResult` and collect them here rather than trying to
+    // reuse the `text` field.
     const text = response.content
       .filter((block): block is Anthropic.TextBlock => block.type === "text")
       .map((block) => block.text)

--- a/src/infrastructure/libs/llm/anthropic/client.ts
+++ b/src/infrastructure/libs/llm/anthropic/client.ts
@@ -1,0 +1,92 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { injectable } from "tsyringe";
+import {
+  LlmClient,
+  LlmCompleteParams,
+  LlmCompleteResult,
+  LlmSystemBlock,
+} from "@/infrastructure/libs/llm/types";
+
+const DEFAULT_MAX_RETRIES = 2;
+
+/**
+ * Thin Anthropic SDK wrapper implementing the provider-neutral
+ * `LlmClient` interface. Reads the API key from `ANTHROPIC_API_KEY`
+ * at construction time (matching the existing `NmkrClient` convention
+ * in this codebase) and fails fast if it is missing so that missing
+ * configuration surfaces at boot, not at the first inference call.
+ *
+ * The SDK retries 429 and 5xx errors automatically with exponential
+ * backoff (`maxRetries: 2` here). A wall-clock timeout on the whole
+ * operation belongs in the caller — pass an `AbortController.signal`
+ * through `params.signal`.
+ */
+@injectable()
+export class AnthropicLlmClient implements LlmClient {
+  private readonly client: Anthropic;
+
+  constructor() {
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) {
+      throw new Error("ANTHROPIC_API_KEY is not set; AnthropicLlmClient cannot be constructed.");
+    }
+    this.client = new Anthropic({ apiKey, maxRetries: DEFAULT_MAX_RETRIES });
+  }
+
+  async complete(params: LlmCompleteParams): Promise<LlmCompleteResult> {
+    const system = params.system.map(toAnthropicSystemBlock);
+
+    const response = await this.client.messages.create(
+      {
+        model: params.model,
+        max_tokens: params.maxTokens,
+        system,
+        messages: params.messages,
+        ...(params.temperature !== undefined && { temperature: params.temperature }),
+        ...(params.stopSequences &&
+          params.stopSequences.length > 0 && { stop_sequences: params.stopSequences }),
+      },
+      { signal: params.signal },
+    );
+
+    // `response.content` is a discriminated union; narrow to text blocks
+    // before reading `.text`. Non-text blocks (thinking, tool_use) do not
+    // exist in Phase 1 requests but would be silently dropped here if
+    // a caller ever enabled them — acceptable because the caller would
+    // then want to read them directly from a richer interface.
+    const text = response.content
+      .filter((block): block is Anthropic.TextBlock => block.type === "text")
+      .map((block) => block.text)
+      .join("");
+
+    return {
+      text,
+      model: response.model,
+      usage: {
+        inputTokens: response.usage.input_tokens,
+        outputTokens: response.usage.output_tokens,
+        cacheReadTokens: response.usage.cache_read_input_tokens ?? 0,
+        cacheCreationTokens: response.usage.cache_creation_input_tokens ?? 0,
+      },
+      stopReason: response.stop_reason,
+    };
+  }
+}
+
+/**
+ * Map our `{text, cache?}` shape onto the Anthropic SDK's text block
+ * with ephemeral `cache_control`. The wrapper always emits array-form
+ * system prompts (never the bare-string shortcut) so adding a cached
+ * block on a subsequent call does not change the prefix shape and
+ * invalidate earlier cache reads.
+ */
+function toAnthropicSystemBlock(block: LlmSystemBlock): Anthropic.TextBlockParam {
+  if (block.cache) {
+    return {
+      type: "text",
+      text: block.text,
+      cache_control: { type: "ephemeral" },
+    };
+  }
+  return { type: "text", text: block.text };
+}

--- a/src/infrastructure/libs/llm/index.ts
+++ b/src/infrastructure/libs/llm/index.ts
@@ -1,0 +1,9 @@
+export { AnthropicLlmClient } from "@/infrastructure/libs/llm/anthropic/client";
+export type {
+  LlmClient,
+  LlmCompleteParams,
+  LlmCompleteResult,
+  LlmMessage,
+  LlmSystemBlock,
+  LlmUsage,
+} from "@/infrastructure/libs/llm/types";

--- a/src/infrastructure/libs/llm/types.ts
+++ b/src/infrastructure/libs/llm/types.ts
@@ -1,0 +1,103 @@
+/**
+ * Thin, provider-neutral LLM client interface consumed by the Report
+ * AI-generation usecase (PR-D onwards). Kept intentionally small for
+ * Phase 1 — blocking `complete()` only, no streaming, no tool use.
+ *
+ * The concrete implementation (AnthropicLlmClient) lives in
+ * `./anthropic/client.ts`; additional providers (Gemini, OpenAI) can
+ * ship as sibling folders without touching the callers.
+ */
+
+/**
+ * One block of the system prompt. Split into blocks so the caller can
+ * mark only the stable preamble with `cache: true` (ephemeral prompt
+ * caching) while keeping volatile segments — date stamps, per-request
+ * IDs — uncached in a trailing block.
+ *
+ * Minimum cacheable prefix at the provider layer: 4096 tokens on Opus
+ * 4.6/4.7, 2048 on Sonnet 4.6. Shorter prefixes silently don't cache —
+ * `cache: true` never errors, it just stops paying off.
+ */
+export interface LlmSystemBlock {
+  text: string;
+  cache?: boolean;
+}
+
+export interface LlmMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export interface LlmCompleteParams {
+  /**
+   * Render order at the provider is `tools` → `system` → `messages`.
+   * Keep stable segments (frozen instructions, shared examples) first
+   * and any per-request content last; any byte change in the prefix
+   * invalidates everything after it in the cache.
+   */
+  system: LlmSystemBlock[];
+  messages: LlmMessage[];
+
+  /**
+   * Provider-specific model identifier. The wrapper does not validate
+   * or default — the caller (template row in the DB) decides. Known
+   * good values at time of writing: `claude-opus-4-7`, `claude-opus-4-6`,
+   * `claude-sonnet-4-6`, `claude-haiku-4-5`.
+   */
+  model: string;
+
+  /**
+   * Hard ceiling on the number of tokens the model may generate.
+   * Non-streaming requests should stay well under the model's maximum
+   * output (128K on Opus 4.6/4.7) — the Anthropic SDK enforces
+   * streaming for very large outputs to avoid HTTP timeouts. ~16000 is
+   * a safe non-streaming default for report generation.
+   */
+  maxTokens: number;
+
+  /**
+   * Optional. On Opus 4.7 this parameter is removed (API returns 400);
+   * on Opus 4.6 and Sonnet 4.6 it is accepted. The wrapper passes it
+   * through verbatim when set, and omits the field entirely when
+   * undefined — the model-aware decision stays in the caller.
+   */
+  temperature?: number;
+
+  stopSequences?: string[];
+
+  /**
+   * Per-request abort hook. The Anthropic SDK handles retries
+   * (max 2, exponential backoff) internally; wrap the whole call in an
+   * `AbortController` if the caller wants a wall-clock timeout.
+   */
+  signal?: AbortSignal;
+}
+
+export interface LlmUsage {
+  /** Prompt tokens processed at full price (not served from cache). */
+  inputTokens: number;
+  /** Generated tokens. */
+  outputTokens: number;
+  /** Prompt tokens served from cache (~0.1× input price). */
+  cacheReadTokens: number;
+  /** Prompt tokens written to cache this request (~1.25× input price). */
+  cacheCreationTokens: number;
+}
+
+export interface LlmCompleteResult {
+  /**
+   * Concatenation of every text block in the response. Non-text blocks
+   * (thinking, tool use) are ignored in Phase 1; if/when the wrapper
+   * starts producing them, callers of this shape will break noisily
+   * rather than silently drop reasoning.
+   */
+  text: string;
+  /** Echoed back from the provider — may differ from the requested model alias. */
+  model: string;
+  usage: LlmUsage;
+  stopReason: string | null;
+}
+
+export interface LlmClient {
+  complete(params: LlmCompleteParams): Promise<LlmCompleteResult>;
+}

--- a/src/infrastructure/libs/llm/types.ts
+++ b/src/infrastructure/libs/llm/types.ts
@@ -48,10 +48,18 @@ export interface LlmCompleteParams {
 
   /**
    * Hard ceiling on the number of tokens the model may generate.
-   * Non-streaming requests should stay well under the model's maximum
-   * output (128K on Opus 4.6/4.7) — the Anthropic SDK enforces
-   * streaming for very large outputs to avoid HTTP timeouts. ~16000 is
-   * a safe non-streaming default for report generation.
+   *
+   * Model maximums at time of writing (used as a hard cap by the API):
+   *   - Opus 4.6 / Opus 4.7: 128K
+   *   - Sonnet 4.6 / Haiku 4.5: 64K
+   *
+   * The wrapper is non-streaming (`complete()` only in Phase 1) and the
+   * Anthropic SDK requires streaming for "very large" values to avoid
+   * HTTP timeouts — in practice, anything beyond ~16K starts hitting
+   * the default SDK timeout. Keep `maxTokens` well under the model
+   * ceiling unless the caller also switches to a streaming entry
+   * point. ~16000 is a safe non-streaming default for report
+   * generation, well inside both model caps and SDK timeouts.
    */
   maxTokens: number;
 


### PR DESCRIPTION
## Summary

AI レポート生成機能 Phase 1 MVP の **PR-C**。provider-neutral な `LlmClient` interface + Anthropic SDK 実装を追加。

**依存関係**: PR-A (#831, merged) / PR-B (#835, merged) とは独立。PR-D (AI generation usecase) は本 PR と PR-B が merge された時点で着手可能。

### 追加レイヤ

```
src/infrastructure/libs/llm/
├── types.ts                  # LlmClient interface + 周辺型
├── anthropic/client.ts       # AnthropicLlmClient implements LlmClient
└── index.ts                  # re-export
```

### 設計ポイント

- **`complete()` のみの薄い wrapper** — Phase 1 は streaming / tool use / thinking 無し。将来の拡張はオプション param で追加できるよう interface を最小に
- **`system` は `{text, cache?}[]` の list** — caller が安定な preamble に `cache: true` を付けて ephemeral prompt caching を効かせつつ、volatile な tail block は別扱いできる
- **Prefix-match invariant に沿った API 形** — provider の cache は prefix match で、prefix に 1 byte でも変化があると cache が飛ぶ。wrapper 側で常に **array 形式の system prompt** を emit することで「後から cache block を追加 → prefix shape が変わって cache miss」みたいな事故を予防
- **Snake_case → camelCase マッピング**:
  - `input_tokens` → `inputTokens`
  - `output_tokens` → `outputTokens`
  - `cache_read_input_tokens` → `cacheReadTokens` (無ければ 0)
  - `cache_creation_input_tokens` → `cacheCreationTokens` (無ければ 0)
- **Discriminated union narrowing** — `response.content` は `ContentBlock[]`。text 以外 (`thinking` / `tool_use`) は無視して text block のみ concat
- **API key は constructor で fail fast** — `process.env.ANTHROPIC_API_KEY` を読み、無ければ throw (既存 `NmkrClient` の流儀踏襲、boot 時に発覚させる)
- **`maxRetries: 2`** — SDK 内蔵 retry (429/5xx 指数バックオフ)。wall-clock timeout は caller が `AbortController.signal` で持つ
- **`temperature` の扱い**: Opus 4.7 は `temperature` を送ると 400 になるので wrapper は optional、未指定時は payload から完全除外。Opus 4.6 / Sonnet 4.6 では渡せる (判断は caller 責任)

### DI 登録

`src/application/provider.ts` の 📊 Report block に `LlmClient` トークンで `AnthropicLlmClient` を登録。PR-D の UseCase は `@inject("LlmClient")` で受け取る。

### 変更ファイル

- `package.json` / `pnpm-lock.yaml` — `@anthropic-ai/sdk@^0.90.0` 追加
- `src/infrastructure/libs/llm/types.ts` — 新規 (LlmClient / LlmCompleteParams / LlmCompleteResult / LlmUsage / LlmSystemBlock / LlmMessage)
- `src/infrastructure/libs/llm/anthropic/client.ts` — 新規 (AnthropicLlmClient)
- `src/infrastructure/libs/llm/index.ts` — 新規 (re-export)
- `src/application/provider.ts` — LlmClient DI 登録
- `src/__tests__/unit/infrastructure/libs/llm/anthropic.test.ts` — 新規 (9 ケース)

## Test plan

- [x] `pnpm test src/__tests__/unit/infrastructure/libs/llm/anthropic.test.ts` → 9/9 pass
  - Constructor: API key 欠如 throw / maxRetries=2 渡される
  - `cache: true` → `cache_control: {type: "ephemeral"}` 付与
  - 未設定 block は plain `{type: "text", text}` のまま
  - Usage snake_case → camelCase map、cache_* 欠如時は 0 default
  - Non-text block (thinking / tool_use) を無視して text block だけ concat
  - Temperature 未指定時は payload から除外 (Opus 4.7 400 回避)
  - Temperature 指定時は SDK に渡る
  - AbortSignal が SDK request option に forward
  - `stopSequences: []` は payload から除外
- [x] `pnpm test src/__tests__/unit/report/presenter.test.ts` → 7/7 pass (PR-A 回帰確認)
- [x] `npx tsc --noEmit` で新規エラーなし

## 次の PR

- **PR-D**: AI 生成 UseCase + GraphQL — 本 PR + PR-B merge 完了後に着手可能
- **PR-F**: 週次バッチ — PR-D merge 後

https://claude.ai/code/session_0113rnPuGjN67zbt8hDbzBay
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/839" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
