### PR TITLE
feat(report): add AI generation usecase + GraphQL endpoints

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -869,7 +869,7 @@ type Mutation {
   placeDelete(id: ID!, permission: CheckCommunityPermissionInput!): PlaceDeletePayload
   placeUpdate(id: ID!, input: PlaceUpdateInput!, permission: CheckCommunityPermissionInput!): PlaceUpdatePayload
   publishReport(finalContent: String!, id: ID!): PublishReportPayload
-  rejectReport(id: ID!, reason: String): RejectReportPayload
+  rejectReport(id: ID!): RejectReportPayload
   reservationAccept(id: ID!, permission: CheckOpportunityPermissionInput!): ReservationSetStatusPayload
   reservationCancel(id: ID!, input: ReservationCancelInput!, permission: CheckIsSelfPermissionInput!): ReservationSetStatusPayload
   reservationCreate(input: ReservationCreateInput!): ReservationCreatePayload

--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -7,6 +7,12 @@ type AccumulatedPointView {
   walletId: String
 }
 
+union ApproveReportPayload = ApproveReportSuccess
+
+type ApproveReportSuccess {
+  report: Report!
+}
+
 type Article {
   authors: [User!]
   body: String
@@ -561,6 +567,20 @@ type EvaluationsConnection {
   totalCount: Int!
 }
 
+input GenerateReportInput {
+  communityId: ID!
+  parentRunId: ID
+  periodFrom: Datetime!
+  periodTo: Datetime!
+  variant: ReportVariant!
+}
+
+union GenerateReportPayload = GenerateReportSuccess
+
+type GenerateReportSuccess {
+  report: Report!
+}
+
 type Identity {
   createdAt: Datetime
   platform: IdentityPlatform
@@ -813,6 +833,7 @@ type MembershipsConnection {
 }
 
 type Mutation {
+  approveReport(id: ID!): ApproveReportPayload
   articleCreate(input: ArticleCreateInput!, permission: CheckCommunityPermissionInput!): ArticleCreatePayload
   articleDelete(id: ID!, permission: CheckCommunityPermissionInput!): ArticleDeletePayload
   articleUpdateContent(id: ID!, input: ArticleUpdateContentInput!, permission: CheckCommunityPermissionInput!): ArticleUpdateContentPayload
@@ -820,6 +841,7 @@ type Mutation {
   communityDelete(id: ID!, permission: CheckCommunityPermissionInput!): CommunityDeletePayload
   communityUpdateProfile(id: ID!, input: CommunityUpdateProfileInput!, permission: CheckCommunityPermissionInput!): CommunityUpdateProfilePayload
   evaluationBulkCreate(input: EvaluationBulkCreateInput!, permission: CheckCommunityPermissionInput!): EvaluationBulkCreatePayload
+  generateReport(input: GenerateReportInput!, permission: CheckCommunityPermissionInput!): GenerateReportPayload
   identityCheckPhoneUser(input: IdentityCheckPhoneUserInput!): IdentityCheckPhoneUserPayload!
   incentiveGrantRetry(input: IncentiveGrantRetryInput!, permission: CheckCommunityPermissionInput!): IncentiveGrantRetryPayload
   linkPhoneAuth(input: LinkPhoneAuthInput!, permission: CheckIsSelfPermissionInput!): LinkPhoneAuthPayload
@@ -846,6 +868,8 @@ type Mutation {
   placeCreate(input: PlaceCreateInput!, permission: CheckCommunityPermissionInput!): PlaceCreatePayload
   placeDelete(id: ID!, permission: CheckCommunityPermissionInput!): PlaceDeletePayload
   placeUpdate(id: ID!, input: PlaceUpdateInput!, permission: CheckCommunityPermissionInput!): PlaceUpdatePayload
+  publishReport(finalContent: String!, id: ID!): PublishReportPayload
+  rejectReport(id: ID!, reason: String): RejectReportPayload
   reservationAccept(id: ID!, permission: CheckOpportunityPermissionInput!): ReservationSetStatusPayload
   reservationCancel(id: ID!, input: ReservationCancelInput!, permission: CheckIsSelfPermissionInput!): ReservationSetStatusPayload
   reservationCreate(input: ReservationCreateInput!): ReservationCreatePayload
@@ -862,6 +886,7 @@ type Mutation {
   transactionIssueCommunityPoint(input: TransactionIssueCommunityPointInput!, permission: CheckCommunityPermissionInput!): TransactionIssueCommunityPointPayload
   transactionUpdateMetadata(communityPermission: CheckCommunityPermissionInput, id: ID!, input: TransactionUpdateMetadataInput!, permission: CheckIsSelfPermissionInput): TransactionUpdateMetadataPayload
   updatePortalConfig(input: CommunityPortalConfigInput!, permission: CheckCommunityPermissionInput!): CommunityPortalConfig!
+  updateReportTemplate(communityId: ID, input: UpdateReportTemplateInput!, variant: ReportVariant!): UpdateReportTemplatePayload
   updateSignupBonusConfig(input: UpdateSignupBonusConfigInput!, permission: CheckCommunityPermissionInput!): CommunitySignupBonusConfig!
   userDeleteMe(permission: CheckIsSelfPermissionInput!): UserDeletePayload
   userSignUp(input: UserSignUpInput!): CurrentUserPayload
@@ -1561,6 +1586,12 @@ type PortfoliosConnection {
   totalCount: Int!
 }
 
+union PublishReportPayload = PublishReportSuccess
+
+type PublishReportSuccess {
+  report: Report!
+}
+
 enum PublishStatus {
   COMMUNITY_INTERNAL
   PRIVATE
@@ -1607,6 +1638,9 @@ type Query {
   place(id: ID!): Place
   places(cursor: String, filter: PlaceFilterInput, first: Int, sort: PlaceSortInput): PlacesConnection!
   portfolios(filter: PortfolioFilterInput, first: Int, sort: PortfolioSortInput): [Portfolio!]
+  report(id: ID!): Report
+  reportTemplate(communityId: ID, variant: ReportVariant!): ReportTemplate
+  reports(communityId: ID!, cursor: String, first: Int, permission: CheckCommunityPermissionInput!, status: ReportStatus, variant: ReportVariant): ReportsConnection!
   reservation(id: ID!): Reservation
   reservationHistories(cursor: String, filter: ReservationHistoryFilterInput, first: Int, sort: ReservationHistorySortInput): ReservationHistoriesConnection!
   reservationHistory(id: ID!): ReservationHistory
@@ -1649,6 +1683,83 @@ type Query {
   voteTopics(communityId: ID!, cursor: String, first: Int): VoteTopicsConnection!
   wallet(id: ID!): Wallet
   wallets(cursor: String, filter: WalletFilterInput, first: Int, sort: WalletSortInput): WalletsConnection!
+}
+
+union RejectReportPayload = RejectReportSuccess
+
+type RejectReportSuccess {
+  report: Report!
+}
+
+type Report {
+  cacheReadTokens: Int!
+  community: Community!
+  createdAt: Datetime!
+  finalContent: String
+  generatedByUser: User
+  id: ID!
+  inputTokens: Int!
+  model: String!
+  outputMarkdown: String!
+  outputTokens: Int!
+  parentRun: Report
+  periodFrom: Datetime!
+  periodTo: Datetime!
+  publishedAt: Datetime
+  publishedByUser: User
+  regenerateCount: Int!
+  regenerations: [Report!]!
+  status: ReportStatus!
+  targetUser: User
+  template: ReportTemplate
+  updatedAt: Datetime
+  variant: String!
+}
+
+type ReportEdge implements Edge {
+  cursor: String!
+  node: Report
+}
+
+enum ReportStatus {
+  APPROVED
+  DRAFT
+  PUBLISHED
+  REJECTED
+  SUPERSEDED
+}
+
+type ReportTemplate {
+  community: Community
+  communityContext: String
+  createdAt: Datetime!
+  id: ID!
+  isEnabled: Boolean!
+  maxTokens: Int!
+  model: String!
+  scope: ReportTemplateScope!
+  stopSequences: [String!]!
+  systemPrompt: String!
+  temperature: Float!
+  updatedAt: Datetime
+  updatedByUser: User
+  userPromptTemplate: String!
+  variant: String!
+}
+
+enum ReportTemplateScope {
+  COMMUNITY
+  SYSTEM
+}
+
+enum ReportVariant {
+  WEEKLY_SUMMARY
+}
+
+type ReportsConnection {
+  edges: [ReportEdge]
+  pageInfo: PageInfo!
+  totalCount: Int!
 }
 
 type Reservation {
@@ -2219,6 +2330,23 @@ type TransactionsConnection {
   edges: [TransactionEdge]
   pageInfo: PageInfo!
   totalCount: Int!
+}
+
+input UpdateReportTemplateInput {
+  communityContext: String
+  isEnabled: Boolean
+  maxTokens: Int!
+  model: String!
+  stopSequences: [String!]
+  systemPrompt: String!
+  temperature: Float
+  userPromptTemplate: String!
+}
+
+union UpdateReportTemplatePayload = UpdateReportTemplateSuccess
+
+type UpdateReportTemplateSuccess {
+  reportTemplate: ReportTemplate!
 }
 
 input UpdateSignupBonusConfigInput {

--- a/src/application/domain/report/controller/dataloader.ts
+++ b/src/application/domain/report/controller/dataloader.ts
@@ -1,0 +1,56 @@
+import { PrismaClient } from "@prisma/client";
+import {
+  createLoaderById,
+  createHasManyLoaderByKey,
+} from "@/presentation/graphql/dataloader/utils";
+import {
+  reportSelect,
+  reportTemplateSelect,
+  PrismaReport,
+  PrismaReportTemplate,
+} from "@/application/domain/report/data/type";
+import ReportPresenter from "@/application/domain/report/presenter";
+import { GqlReport, GqlReportTemplate } from "@/types/graphql";
+
+export function createReportLoader(prisma: PrismaClient) {
+  return createLoaderById<PrismaReport, GqlReport>(
+    async (ids) =>
+      prisma.report.findMany({
+        where: { id: { in: [...ids] } },
+        select: reportSelect,
+      }),
+    ReportPresenter.report,
+  );
+}
+
+export function createReportTemplateLoader(prisma: PrismaClient) {
+  return createLoaderById<PrismaReportTemplate, GqlReportTemplate>(
+    async (ids) =>
+      prisma.reportTemplate.findMany({
+        where: { id: { in: [...ids] } },
+        select: reportTemplateSelect,
+      }),
+    ReportPresenter.reportTemplate,
+  );
+}
+
+export function createReportsByParentRunIdLoader(prisma: PrismaClient) {
+  return createHasManyLoaderByKey<"parentRunId", PrismaReport, GqlReport>(
+    "parentRunId",
+    async (parentRunIds) =>
+      prisma.report.findMany({
+        where: { parentRunId: { in: [...parentRunIds] } },
+        select: reportSelect,
+        orderBy: { createdAt: "desc" },
+      }),
+    ReportPresenter.report,
+  );
+}
+
+export function createReportLoaders(prisma: PrismaClient) {
+  return {
+    report: createReportLoader(prisma),
+    reportTemplate: createReportTemplateLoader(prisma),
+    reportsByParentRunId: createReportsByParentRunIdLoader(prisma),
+  };
+}

--- a/src/application/domain/report/controller/resolver.ts
+++ b/src/application/domain/report/controller/resolver.ts
@@ -1,0 +1,83 @@
+import { inject, injectable } from "tsyringe";
+import { IContext } from "@/types/server";
+import ReportUseCase from "@/application/domain/report/usecase";
+import {
+  GqlMutationGenerateReportArgs,
+  GqlMutationUpdateReportTemplateArgs,
+  GqlMutationApproveReportArgs,
+  GqlMutationPublishReportArgs,
+  GqlMutationRejectReportArgs,
+  GqlQueryReportsArgs,
+  GqlQueryReportArgs,
+  GqlQueryReportTemplateArgs,
+} from "@/types/graphql";
+import { PrismaReport } from "@/application/domain/report/data/type";
+
+@injectable()
+export default class ReportResolver {
+  constructor(@inject("ReportUseCase") private readonly useCase: ReportUseCase) {}
+
+  Query = {
+    reports: (_: unknown, args: GqlQueryReportsArgs, ctx: IContext) => {
+      return this.useCase.browseReports(args, ctx);
+    },
+    report: (_: unknown, args: GqlQueryReportArgs, ctx: IContext) => {
+      return this.useCase.viewReport(args, ctx);
+    },
+    reportTemplate: (_: unknown, args: GqlQueryReportTemplateArgs, ctx: IContext) => {
+      return this.useCase.viewReportTemplate(args, ctx);
+    },
+  };
+
+  Mutation = {
+    generateReport: (_: unknown, args: GqlMutationGenerateReportArgs, ctx: IContext) => {
+      return this.useCase.generateReport(args, ctx);
+    },
+    updateReportTemplate: (
+      _: unknown,
+      args: GqlMutationUpdateReportTemplateArgs,
+      ctx: IContext,
+    ) => {
+      return this.useCase.updateReportTemplate(args, ctx);
+    },
+    approveReport: (_: unknown, args: GqlMutationApproveReportArgs, ctx: IContext) => {
+      return this.useCase.approveReport(args, ctx);
+    },
+    publishReport: (_: unknown, args: GqlMutationPublishReportArgs, ctx: IContext) => {
+      return this.useCase.publishReport(args, ctx);
+    },
+    rejectReport: (_: unknown, args: GqlMutationRejectReportArgs, ctx: IContext) => {
+      return this.useCase.rejectReport(args, ctx);
+    },
+  };
+
+  Report = {
+    community: (parent: PrismaReport, _: unknown, ctx: IContext) =>
+      ctx.loaders.community.load(parent.communityId),
+    template: (parent: PrismaReport, _: unknown, ctx: IContext) =>
+      parent.templateId ? ctx.loaders.reportTemplate.load(parent.templateId) : null,
+    generatedByUser: (parent: PrismaReport, _: unknown, ctx: IContext) =>
+      parent.generatedBy ? ctx.loaders.user.load(parent.generatedBy) : null,
+    publishedByUser: (parent: PrismaReport, _: unknown, ctx: IContext) =>
+      parent.publishedBy ? ctx.loaders.user.load(parent.publishedBy) : null,
+    targetUser: (parent: PrismaReport, _: unknown, ctx: IContext) =>
+      parent.targetUserId ? ctx.loaders.user.load(parent.targetUserId) : null,
+    parentRun: (parent: PrismaReport, _: unknown, ctx: IContext) =>
+      parent.parentRunId ? ctx.loaders.report.load(parent.parentRunId) : null,
+    regenerations: (parent: PrismaReport, _: unknown, ctx: IContext) =>
+      ctx.loaders.reportsByParentRunId.load(parent.id),
+  };
+
+  ReportTemplate = {
+    community: (parent: { communityId: string | null }, _: unknown, ctx: IContext) =>
+      parent.communityId ? ctx.loaders.community.load(parent.communityId) : null,
+    updatedByUser: (parent: { updatedBy: string | null }, _: unknown, ctx: IContext) =>
+      parent.updatedBy ? ctx.loaders.user.load(parent.updatedBy) : null,
+  };
+
+  GenerateReportPayload = { __resolveType: (obj: { __typename: string }) => obj.__typename };
+  UpdateReportTemplatePayload = { __resolveType: (obj: { __typename: string }) => obj.__typename };
+  ApproveReportPayload = { __resolveType: (obj: { __typename: string }) => obj.__typename };
+  PublishReportPayload = { __resolveType: (obj: { __typename: string }) => obj.__typename };
+  RejectReportPayload = { __resolveType: (obj: { __typename: string }) => obj.__typename };
+}

--- a/src/application/domain/report/data/converter.ts
+++ b/src/application/domain/report/data/converter.ts
@@ -1,0 +1,23 @@
+import { Prisma, ReportTemplateScope } from "@prisma/client";
+import { GqlUpdateReportTemplateInput } from "@/types/graphql";
+
+export default class ReportConverter {
+  static toReportTemplateUpsertData(
+    input: GqlUpdateReportTemplateInput,
+  ): Omit<Prisma.ReportTemplateCreateInput, "variant" | "scope" | "community"> {
+    return {
+      systemPrompt: input.systemPrompt,
+      userPromptTemplate: input.userPromptTemplate,
+      communityContext: input.communityContext ?? null,
+      model: input.model,
+      temperature: input.temperature ?? 1.0,
+      maxTokens: input.maxTokens,
+      stopSequences: input.stopSequences ?? [],
+      isEnabled: input.isEnabled ?? true,
+    };
+  }
+
+  static deriveScope(communityId: string | null | undefined): ReportTemplateScope {
+    return communityId ? ReportTemplateScope.COMMUNITY : ReportTemplateScope.SYSTEM;
+  }
+}

--- a/src/application/domain/report/data/interface.ts
+++ b/src/application/domain/report/data/interface.ts
@@ -1,5 +1,6 @@
-import { Prisma, TransactionReason, Role } from "@prisma/client";
+import { Prisma, TransactionReason, Role, ReportStatus } from "@prisma/client";
 import { IContext } from "@/types/server";
+import { PrismaReport, PrismaReportTemplate } from "@/application/domain/report/data/type";
 
 export interface TransactionSummaryDailyRow {
   date: Date;
@@ -179,4 +180,51 @@ export interface IReportRepository {
 
   refreshTransactionSummaryDaily(ctx: IContext, tx: Prisma.TransactionClient): Promise<void>;
   refreshUserTransactionDaily(ctx: IContext, tx: Prisma.TransactionClient): Promise<void>;
+
+  findTemplate(
+    ctx: IContext,
+    variant: string,
+    communityId: string | null,
+  ): Promise<PrismaReportTemplate | null>;
+
+  upsertTemplate(
+    ctx: IContext,
+    variant: string,
+    communityId: string | null,
+    data: Omit<Prisma.ReportTemplateCreateInput, "variant" | "scope" | "community">,
+    tx?: Prisma.TransactionClient,
+  ): Promise<PrismaReportTemplate>;
+
+  createReport(
+    ctx: IContext,
+    data: Prisma.ReportUncheckedCreateInput,
+    tx?: Prisma.TransactionClient,
+  ): Promise<PrismaReport>;
+
+  findReportById(ctx: IContext, id: string): Promise<PrismaReport | null>;
+
+  findReports(
+    ctx: IContext,
+    params: {
+      communityId: string;
+      variant?: string;
+      status?: ReportStatus;
+      cursor?: string;
+      first?: number;
+    },
+  ): Promise<{ items: PrismaReport[]; totalCount: number }>;
+
+  updateReportStatus(
+    ctx: IContext,
+    id: string,
+    status: ReportStatus,
+    extra?: {
+      publishedAt?: Date;
+      publishedBy?: string;
+      finalContent?: string;
+    },
+    tx?: Prisma.TransactionClient,
+  ): Promise<PrismaReport>;
+
+  findReportsByParentRunId(ctx: IContext, parentRunIds: string[]): Promise<PrismaReport[]>;
 }

--- a/src/application/domain/report/data/interface.ts
+++ b/src/application/domain/report/data/interface.ts
@@ -201,7 +201,7 @@ export interface IReportRepository {
     tx?: Prisma.TransactionClient,
   ): Promise<PrismaReport>;
 
-  findReportById(ctx: IContext, id: string): Promise<PrismaReport | null>;
+  findReportById(ctx: IContext, id: string, tx?: Prisma.TransactionClient): Promise<PrismaReport | null>;
 
   findReports(
     ctx: IContext,

--- a/src/application/domain/report/data/repository.ts
+++ b/src/application/domain/report/data/repository.ts
@@ -426,10 +426,16 @@ export default class ReportRepository implements IReportRepository {
     return ctx.issuer.internal(doCreate);
   }
 
-  async findReportById(ctx: IContext, id: string): Promise<PrismaReport | null> {
-    return ctx.issuer.public(ctx, (tx) =>
-      tx.report.findUnique({ where: { id }, select: reportSelect }),
-    );
+  async findReportById(
+    ctx: IContext,
+    id: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<PrismaReport | null> {
+    const doFind = (client: Prisma.TransactionClient) =>
+      client.report.findUnique({ where: { id }, select: reportSelect });
+
+    if (tx) return doFind(tx);
+    return ctx.issuer.public(ctx, doFind);
   }
 
   async findReports(

--- a/src/application/domain/report/data/repository.ts
+++ b/src/application/domain/report/data/repository.ts
@@ -1,4 +1,4 @@
-import { Prisma, TransactionReason } from "@prisma/client";
+import { Prisma, ReportStatus, ReportTemplateScope, TransactionReason } from "@prisma/client";
 import { injectable } from "tsyringe";
 import { IContext } from "@/types/server";
 import {
@@ -12,6 +12,12 @@ import {
   UserProfileForReportRow,
   UserTransactionAggregateRow,
 } from "@/application/domain/report/data/interface";
+import {
+  PrismaReport,
+  PrismaReportTemplate,
+  reportSelect,
+  reportTemplateSelect,
+} from "@/application/domain/report/data/type";
 import {
   refreshMaterializedViewTransactionSummaryDaily,
   refreshMaterializedViewUserTransactionDaily,
@@ -332,5 +338,144 @@ export default class ReportRepository implements IReportRepository {
 
   async refreshUserTransactionDaily(ctx: IContext, tx: Prisma.TransactionClient): Promise<void> {
     await tx.$queryRawTyped(refreshMaterializedViewUserTransactionDaily());
+  }
+
+  // =========================================================================
+  // Report AI entities (ReportTemplate / Report)
+  // =========================================================================
+
+  async findTemplate(
+    ctx: IContext,
+    variant: string,
+    communityId: string | null,
+  ): Promise<PrismaReportTemplate | null> {
+    return ctx.issuer.public(ctx, (tx) =>
+      tx.reportTemplate.findFirst({
+        where: {
+          variant,
+          isEnabled: true,
+          OR: [...(communityId ? [{ communityId }] : []), { communityId: null }],
+        },
+        orderBy: { communityId: "asc" },
+        select: reportTemplateSelect,
+      }),
+    );
+  }
+
+  async upsertTemplate(
+    ctx: IContext,
+    variant: string,
+    communityId: string | null,
+    data: Omit<Prisma.ReportTemplateCreateInput, "variant" | "scope" | "community">,
+    tx?: Prisma.TransactionClient,
+  ): Promise<PrismaReportTemplate> {
+    const scope = communityId ? ReportTemplateScope.COMMUNITY : ReportTemplateScope.SYSTEM;
+    const doUpsert = async (client: Prisma.TransactionClient) => {
+      const existing = await client.reportTemplate.findFirst({
+        where: { variant, communityId },
+        select: { id: true },
+      });
+      if (existing) {
+        return client.reportTemplate.update({
+          where: { id: existing.id },
+          data,
+          select: reportTemplateSelect,
+        });
+      }
+      return client.reportTemplate.create({
+        data: {
+          ...data,
+          variant,
+          scope,
+          ...(communityId ? { community: { connect: { id: communityId } } } : {}),
+        },
+        select: reportTemplateSelect,
+      });
+    };
+
+    if (tx) return doUpsert(tx);
+    return ctx.issuer.internal(doUpsert);
+  }
+
+  async createReport(
+    ctx: IContext,
+    data: Prisma.ReportUncheckedCreateInput,
+    tx?: Prisma.TransactionClient,
+  ): Promise<PrismaReport> {
+    const doCreate = (client: Prisma.TransactionClient) =>
+      client.report.create({ data, select: reportSelect });
+
+    if (tx) return doCreate(tx);
+    return ctx.issuer.internal(doCreate);
+  }
+
+  async findReportById(ctx: IContext, id: string): Promise<PrismaReport | null> {
+    return ctx.issuer.public(ctx, (tx) =>
+      tx.report.findUnique({ where: { id }, select: reportSelect }),
+    );
+  }
+
+  async findReports(
+    ctx: IContext,
+    params: {
+      communityId: string;
+      variant?: string;
+      status?: ReportStatus;
+      cursor?: string;
+      first?: number;
+    },
+  ): Promise<{ items: PrismaReport[]; totalCount: number }> {
+    const take = params.first ?? 20;
+    const where: Prisma.ReportWhereInput = {
+      communityId: params.communityId,
+      ...(params.variant && { variant: params.variant }),
+      status: params.status ?? { not: ReportStatus.SUPERSEDED },
+    };
+    return ctx.issuer.public(ctx, async (tx) => {
+      const [items, totalCount] = await Promise.all([
+        tx.report.findMany({
+          where,
+          select: reportSelect,
+          take,
+          ...(params.cursor && { skip: 1, cursor: { id: params.cursor } }),
+          orderBy: { createdAt: "desc" },
+        }),
+        tx.report.count({ where }),
+      ]);
+      return { items, totalCount };
+    });
+  }
+
+  async updateReportStatus(
+    ctx: IContext,
+    id: string,
+    status: ReportStatus,
+    extra?: {
+      publishedAt?: Date;
+      publishedBy?: string;
+      finalContent?: string;
+    },
+    tx?: Prisma.TransactionClient,
+  ): Promise<PrismaReport> {
+    const doUpdate = (client: Prisma.TransactionClient) =>
+      client.report.update({
+        where: { id },
+        data: { status, ...extra },
+        select: reportSelect,
+      });
+
+    if (tx) return doUpdate(tx);
+    return ctx.issuer.internal(doUpdate);
+  }
+
+  async findReportsByParentRunId(ctx: IContext, parentRunIds: string[]): Promise<PrismaReport[]> {
+    if (parentRunIds.length === 0) return [];
+    return ctx.issuer.public(ctx, (tx) =>
+      tx.report.findMany({
+        where: { parentRunId: { in: parentRunIds } },
+        select: reportSelect,
+        orderBy: { createdAt: "desc" },
+      }),
+    );
   }
 }

--- a/src/application/domain/report/data/repository.ts
+++ b/src/application/domain/report/data/repository.ts
@@ -382,15 +382,32 @@ export default class ReportRepository implements IReportRepository {
           select: reportTemplateSelect,
         });
       }
-      return client.reportTemplate.create({
-        data: {
-          ...data,
-          variant,
-          scope,
-          ...(communityId ? { community: { connect: { id: communityId } } } : {}),
-        },
-        select: reportTemplateSelect,
-      });
+      try {
+        return await client.reportTemplate.create({
+          data: {
+            ...data,
+            variant,
+            scope,
+            ...(communityId ? { community: { connect: { id: communityId } } } : {}),
+          },
+          select: reportTemplateSelect,
+        });
+      } catch (e: unknown) {
+        if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
+          const raced = await client.reportTemplate.findFirst({
+            where: { variant, communityId },
+            select: { id: true },
+          });
+          if (raced) {
+            return client.reportTemplate.update({
+              where: { id: raced.id },
+              data,
+              select: reportTemplateSelect,
+            });
+          }
+        }
+        throw e;
+      }
     };
 
     if (tx) return doUpsert(tx);
@@ -436,7 +453,7 @@ export default class ReportRepository implements IReportRepository {
         tx.report.findMany({
           where,
           select: reportSelect,
-          take,
+          take: take + 1,
           ...(params.cursor && { skip: 1, cursor: { id: params.cursor } }),
           orderBy: { createdAt: "desc" },
         }),

--- a/src/application/domain/report/data/type.ts
+++ b/src/application/domain/report/data/type.ts
@@ -1,0 +1,55 @@
+import { Prisma } from "@prisma/client";
+
+export const reportSelect = Prisma.validator<Prisma.ReportSelect>()({
+  id: true,
+  communityId: true,
+  variant: true,
+  periodFrom: true,
+  periodTo: true,
+  templateId: true,
+  inputPayload: true,
+  outputMarkdown: true,
+  model: true,
+  systemPromptSnapshot: true,
+  userPromptSnapshot: true,
+  communityContextSnapshot: true,
+  inputTokens: true,
+  outputTokens: true,
+  cacheReadTokens: true,
+  targetUserId: true,
+  generatedBy: true,
+  status: true,
+  publishedAt: true,
+  publishedBy: true,
+  finalContent: true,
+  regenerateCount: true,
+  parentRunId: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
+export type PrismaReport = Prisma.ReportGetPayload<{
+  select: typeof reportSelect;
+}>;
+
+export const reportTemplateSelect = Prisma.validator<Prisma.ReportTemplateSelect>()({
+  id: true,
+  variant: true,
+  scope: true,
+  communityId: true,
+  systemPrompt: true,
+  userPromptTemplate: true,
+  communityContext: true,
+  model: true,
+  temperature: true,
+  maxTokens: true,
+  stopSequences: true,
+  isEnabled: true,
+  updatedBy: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
+export type PrismaReportTemplate = Prisma.ReportTemplateGetPayload<{
+  select: typeof reportTemplateSelect;
+}>;

--- a/src/application/domain/report/presenter.ts
+++ b/src/application/domain/report/presenter.ts
@@ -1,3 +1,5 @@
+import { GqlReport, GqlReportTemplate, GqlReportsConnection } from "@/types/graphql";
+import { PrismaReport, PrismaReportTemplate } from "@/application/domain/report/data/type";
 import {
   CommunityContextRow,
   DeepestChainRow,
@@ -252,6 +254,30 @@ export default class ReportPresenter {
         created_by_user_id: c.createdByUserId,
         chain_depth: c.chainDepth,
       })),
+    };
+  }
+
+  static report(r: PrismaReport): GqlReport {
+    return r as unknown as GqlReport;
+  }
+
+  static reportTemplate(t: PrismaReportTemplate): GqlReportTemplate {
+    return t as unknown as GqlReportTemplate;
+  }
+
+  static reportsConnection(items: PrismaReport[], totalCount: number): GqlReportsConnection {
+    return {
+      edges: items.map((r) => ({
+        cursor: r.id,
+        node: ReportPresenter.report(r),
+      })),
+      pageInfo: {
+        hasNextPage: items.length > 0 && totalCount > items.length,
+        hasPreviousPage: false,
+        startCursor: items[0]?.id ?? null,
+        endCursor: items[items.length - 1]?.id ?? null,
+      },
+      totalCount,
     };
   }
 }

--- a/src/application/domain/report/presenter.ts
+++ b/src/application/domain/report/presenter.ts
@@ -258,11 +258,11 @@ export default class ReportPresenter {
   }
 
   static report(r: PrismaReport): GqlReport {
-    return r as unknown as GqlReport;
+    return { __typename: "Report", ...r } as GqlReport;
   }
 
   static reportTemplate(t: PrismaReportTemplate): GqlReportTemplate {
-    return t as unknown as GqlReportTemplate;
+    return { __typename: "ReportTemplate", ...t } as GqlReportTemplate;
   }
 
   static reportsConnection(

--- a/src/application/domain/report/presenter.ts
+++ b/src/application/domain/report/presenter.ts
@@ -257,12 +257,17 @@ export default class ReportPresenter {
     };
   }
 
+  // Relationship fields (community, template, parentRun, regenerations,
+  // generatedByUser, publishedByUser, targetUser, updatedByUser) are
+  // resolved by field resolvers via DataLoaders — the Prisma select shape
+  // intentionally omits them.  The cast bridges the type gap until
+  // Report/ReportTemplate are added to codegen.yaml mappers.
   static report(r: PrismaReport): GqlReport {
-    return { __typename: "Report", ...r } as GqlReport;
+    return r as unknown as GqlReport;
   }
 
   static reportTemplate(t: PrismaReportTemplate): GqlReportTemplate {
-    return { __typename: "ReportTemplate", ...t } as GqlReportTemplate;
+    return t as unknown as GqlReportTemplate;
   }
 
   static reportsConnection(

--- a/src/application/domain/report/presenter.ts
+++ b/src/application/domain/report/presenter.ts
@@ -265,17 +265,23 @@ export default class ReportPresenter {
     return t as unknown as GqlReportTemplate;
   }
 
-  static reportsConnection(items: PrismaReport[], totalCount: number): GqlReportsConnection {
+  static reportsConnection(
+    items: PrismaReport[],
+    totalCount: number,
+    requestedFirst: number,
+  ): GqlReportsConnection {
+    const hasNextPage = items.length > requestedFirst;
+    const page = hasNextPage ? items.slice(0, requestedFirst) : items;
     return {
-      edges: items.map((r) => ({
+      edges: page.map((r) => ({
         cursor: r.id,
         node: ReportPresenter.report(r),
       })),
       pageInfo: {
-        hasNextPage: items.length > 0 && totalCount > items.length,
+        hasNextPage,
         hasPreviousPage: false,
-        startCursor: items[0]?.id ?? null,
-        endCursor: items[items.length - 1]?.id ?? null,
+        startCursor: page[0]?.id ?? null,
+        endCursor: page[page.length - 1]?.id ?? null,
       },
       totalCount,
     };

--- a/src/application/domain/report/schema/mutation.graphql
+++ b/src/application/domain/report/schema/mutation.graphql
@@ -1,0 +1,40 @@
+# ------------------------------
+# Report Mutation Definitions
+# ------------------------------
+input GenerateReportInput {
+  communityId: ID!
+  variant: ReportVariant!
+  periodFrom: Datetime!
+  periodTo: Datetime!
+  parentRunId: ID
+}
+
+input UpdateReportTemplateInput {
+  systemPrompt: String!
+  userPromptTemplate: String!
+  communityContext: String
+  model: String!
+  temperature: Float
+  maxTokens: Int!
+  stopSequences: [String!]
+  isEnabled: Boolean
+}
+
+extend type Mutation {
+  generateReport(
+    input: GenerateReportInput!
+    permission: CheckCommunityPermissionInput!
+  ): GenerateReportPayload @authz(compositeRules: [{ or: [IsCommunityManager, IsAdmin] }])
+
+  updateReportTemplate(
+    communityId: ID
+    variant: ReportVariant!
+    input: UpdateReportTemplateInput!
+  ): UpdateReportTemplatePayload @authz(rules: [IsAdmin])
+
+  approveReport(id: ID!): ApproveReportPayload @authz(rules: [IsAdmin])
+
+  publishReport(id: ID!, finalContent: String!): PublishReportPayload @authz(rules: [IsAdmin])
+
+  rejectReport(id: ID!, reason: String): RejectReportPayload @authz(rules: [IsAdmin])
+}

--- a/src/application/domain/report/schema/mutation.graphql
+++ b/src/application/domain/report/schema/mutation.graphql
@@ -36,5 +36,5 @@ extend type Mutation {
 
   publishReport(id: ID!, finalContent: String!): PublishReportPayload @authz(rules: [IsAdmin])
 
-  rejectReport(id: ID!, reason: String): RejectReportPayload @authz(rules: [IsAdmin])
+  rejectReport(id: ID!): RejectReportPayload @authz(rules: [IsAdmin])
 }

--- a/src/application/domain/report/schema/query.graphql
+++ b/src/application/domain/report/schema/query.graphql
@@ -1,0 +1,17 @@
+# ------------------------------
+# Report Query Definitions
+# ------------------------------
+extend type Query {
+  reports(
+    communityId: ID!
+    variant: ReportVariant
+    status: ReportStatus
+    cursor: String
+    first: Int
+    permission: CheckCommunityPermissionInput!
+  ): ReportsConnection! @authz(compositeRules: [{ or: [IsCommunityManager, IsAdmin] }])
+
+  report(id: ID!): Report @authz(rules: [IsAdmin])
+
+  reportTemplate(communityId: ID, variant: ReportVariant!): ReportTemplate @authz(rules: [IsAdmin])
+}

--- a/src/application/domain/report/schema/type.graphql
+++ b/src/application/domain/report/schema/type.graphql
@@ -1,0 +1,113 @@
+# ------------------------------
+# Report AI Generation Types
+# ------------------------------
+
+enum ReportVariant {
+  WEEKLY_SUMMARY
+}
+
+enum ReportStatus {
+  DRAFT
+  APPROVED
+  PUBLISHED
+  REJECTED
+  SUPERSEDED
+}
+
+enum ReportTemplateScope {
+  SYSTEM
+  COMMUNITY
+}
+
+type Report {
+  id: ID!
+  community: Community!
+  variant: String!
+  periodFrom: Datetime!
+  periodTo: Datetime!
+  template: ReportTemplate
+
+  outputMarkdown: String!
+  model: String!
+  inputTokens: Int!
+  outputTokens: Int!
+  cacheReadTokens: Int!
+
+  status: ReportStatus!
+  publishedAt: Datetime
+  publishedByUser: User
+  finalContent: String
+
+  regenerateCount: Int!
+  parentRun: Report
+  regenerations: [Report!]!
+
+  targetUser: User
+  generatedByUser: User
+
+  createdAt: Datetime!
+  updatedAt: Datetime
+}
+
+type ReportTemplate {
+  id: ID!
+  variant: String!
+  scope: ReportTemplateScope!
+  community: Community
+  systemPrompt: String!
+  userPromptTemplate: String!
+  communityContext: String
+  model: String!
+  temperature: Float!
+  maxTokens: Int!
+  stopSequences: [String!]!
+  isEnabled: Boolean!
+  updatedByUser: User
+  createdAt: Datetime!
+  updatedAt: Datetime
+}
+
+type ReportEdge implements Edge {
+  cursor: String!
+  node: Report
+}
+
+type ReportsConnection {
+  edges: [ReportEdge]
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+# ------------------------------
+# Mutation Payloads
+# ------------------------------
+
+type GenerateReportSuccess {
+  report: Report!
+}
+
+union GenerateReportPayload = GenerateReportSuccess
+
+type UpdateReportTemplateSuccess {
+  reportTemplate: ReportTemplate!
+}
+
+union UpdateReportTemplatePayload = UpdateReportTemplateSuccess
+
+type ApproveReportSuccess {
+  report: Report!
+}
+
+union ApproveReportPayload = ApproveReportSuccess
+
+type PublishReportSuccess {
+  report: Report!
+}
+
+union PublishReportPayload = PublishReportSuccess
+
+type RejectReportSuccess {
+  report: Report!
+}
+
+union RejectReportPayload = RejectReportSuccess

--- a/src/application/domain/report/service.ts
+++ b/src/application/domain/report/service.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "@prisma/client";
+import { Prisma, ReportStatus } from "@prisma/client";
 import { inject, injectable } from "tsyringe";
 import { IContext } from "@/types/server";
 import {
@@ -12,6 +12,9 @@ import {
   UserProfileForReportRow,
   UserTransactionAggregateRow,
 } from "@/application/domain/report/data/interface";
+import { PrismaReport, PrismaReportTemplate } from "@/application/domain/report/data/type";
+import { GqlUpdateReportTemplateInput } from "@/types/graphql";
+import ReportConverter from "@/application/domain/report/data/converter";
 
 @injectable()
 export default class ReportService {
@@ -81,5 +84,80 @@ export default class ReportService {
 
   async refreshUserTransactionDaily(ctx: IContext, tx: Prisma.TransactionClient): Promise<void> {
     return this.repository.refreshUserTransactionDaily(ctx, tx);
+  }
+
+  // =========================================================================
+  // Report AI entities
+  // =========================================================================
+
+  async getTemplate(
+    ctx: IContext,
+    variant: string,
+    communityId: string | null,
+  ): Promise<PrismaReportTemplate | null> {
+    return this.repository.findTemplate(ctx, variant, communityId);
+  }
+
+  async upsertTemplate(
+    ctx: IContext,
+    variant: string,
+    communityId: string | null,
+    input: GqlUpdateReportTemplateInput,
+    tx?: Prisma.TransactionClient,
+  ): Promise<PrismaReportTemplate> {
+    const data = ReportConverter.toReportTemplateUpsertData(input);
+    return this.repository.upsertTemplate(ctx, variant, communityId, data, tx);
+  }
+
+  async createReport(
+    ctx: IContext,
+    data: Prisma.ReportUncheckedCreateInput,
+    tx?: Prisma.TransactionClient,
+  ): Promise<PrismaReport> {
+    return this.repository.createReport(ctx, data, tx);
+  }
+
+  async getReportById(ctx: IContext, id: string): Promise<PrismaReport | null> {
+    return this.repository.findReportById(ctx, id);
+  }
+
+  async getReports(
+    ctx: IContext,
+    params: {
+      communityId: string;
+      variant?: string;
+      status?: ReportStatus;
+      cursor?: string;
+      first?: number;
+    },
+  ): Promise<{ items: PrismaReport[]; totalCount: number }> {
+    return this.repository.findReports(ctx, params);
+  }
+
+  async updateReportStatus(
+    ctx: IContext,
+    id: string,
+    status: ReportStatus,
+    extra?: { publishedAt?: Date; publishedBy?: string; finalContent?: string },
+    tx?: Prisma.TransactionClient,
+  ): Promise<PrismaReport> {
+    return this.repository.updateReportStatus(ctx, id, status, extra, tx);
+  }
+
+  assertStatusTransition(from: ReportStatus, to: ReportStatus): void {
+    const allowed: Record<ReportStatus, ReportStatus[]> = {
+      [ReportStatus.DRAFT]: [ReportStatus.APPROVED, ReportStatus.REJECTED, ReportStatus.SUPERSEDED],
+      [ReportStatus.APPROVED]: [
+        ReportStatus.PUBLISHED,
+        ReportStatus.REJECTED,
+        ReportStatus.SUPERSEDED,
+      ],
+      [ReportStatus.PUBLISHED]: [ReportStatus.SUPERSEDED],
+      [ReportStatus.REJECTED]: [],
+      [ReportStatus.SUPERSEDED]: [],
+    };
+    if (!allowed[from]?.includes(to)) {
+      throw new Error(`Invalid status transition from ${from} to ${to}`);
+    }
   }
 }

--- a/src/application/domain/report/service.ts
+++ b/src/application/domain/report/service.ts
@@ -117,8 +117,12 @@ export default class ReportService {
     return this.repository.createReport(ctx, data, tx);
   }
 
-  async getReportById(ctx: IContext, id: string): Promise<PrismaReport | null> {
-    return this.repository.findReportById(ctx, id);
+  async getReportById(
+    ctx: IContext,
+    id: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<PrismaReport | null> {
+    return this.repository.findReportById(ctx, id, tx);
   }
 
   async getReports(

--- a/src/application/domain/report/service.ts
+++ b/src/application/domain/report/service.ts
@@ -103,9 +103,10 @@ export default class ReportService {
     variant: string,
     communityId: string | null,
     input: GqlUpdateReportTemplateInput,
+    updatedBy: string,
     tx?: Prisma.TransactionClient,
   ): Promise<PrismaReportTemplate> {
-    const data = ReportConverter.toReportTemplateUpsertData(input);
+    const data = { ...ReportConverter.toReportTemplateUpsertData(input), updatedBy };
     return this.repository.upsertTemplate(ctx, variant, communityId, data, tx);
   }
 

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -224,9 +224,12 @@ export default class ReportUseCase {
   }
 
   async browseReports(
-    { communityId, variant, status, cursor, first }: GqlQueryReportsArgs,
+    { communityId, variant, status, cursor, first, permission }: GqlQueryReportsArgs,
     ctx: IContext,
   ): Promise<GqlReportsConnection> {
+    if (permission.communityId !== communityId) {
+      throw new ValidationError("communityId does not match permission.communityId", []);
+    }
     const clampedFirst = first
       ? clampInt(first, 1, MAX_REPORTS_PER_PAGE, "first")
       : DEFAULT_REPORTS_PER_PAGE;

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -1,6 +1,7 @@
 import { ReportStatus } from "@prisma/client";
 import { inject, injectable } from "tsyringe";
 import { IContext } from "@/types/server";
+import { ValidationError } from "@/errors/graphql";
 import ReportService from "@/application/domain/report/service";
 import ReportPresenter, { WeeklyReportPayload } from "@/application/domain/report/presenter";
 import { addDays, daysBetweenJst, truncateToJstDate } from "@/application/domain/report/util";
@@ -128,6 +129,12 @@ export default class ReportUseCase {
     { input, permission }: GqlMutationGenerateReportArgs,
     ctx: IContext,
   ): Promise<GqlGenerateReportPayload> {
+    if (permission.communityId !== input.communityId) {
+      throw new ValidationError(
+        "communityId in input does not match permission.communityId",
+        [],
+      );
+    }
     const communityId = permission.communityId;
     const template = await this.service.getTemplate(ctx, input.variant, communityId);
     if (!template) {
@@ -165,28 +172,25 @@ export default class ReportUseCase {
       clearTimeout(timeout);
     }
 
-    let parentRegenerateCount = 0;
-    let parentStatus: ReportStatus | null = null;
-    if (input.parentRunId) {
-      const parent = await this.service.getReportById(ctx, input.parentRunId);
-      if (!parent) throw new Error(`Parent report ${input.parentRunId} not found`);
-      if (parent.communityId !== communityId || parent.variant !== input.variant) {
-        throw new Error("Parent report must belong to the same community and variant");
-      }
-      parentRegenerateCount = parent.regenerateCount;
-      parentStatus = parent.status;
-    }
-
     const report = await ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
-      if (input.parentRunId && parentStatus && parentStatus !== ReportStatus.SUPERSEDED) {
-        this.service.assertStatusTransition(parentStatus, ReportStatus.SUPERSEDED);
-        await this.service.updateReportStatus(
-          ctx,
-          input.parentRunId,
-          ReportStatus.SUPERSEDED,
-          undefined,
-          tx,
-        );
+      let parentRegenerateCount = 0;
+      if (input.parentRunId) {
+        const parent = await this.service.getReportById(ctx, input.parentRunId, tx);
+        if (!parent) throw new Error(`Parent report ${input.parentRunId} not found`);
+        if (parent.communityId !== communityId || parent.variant !== input.variant) {
+          throw new Error("Parent report must belong to the same community and variant");
+        }
+        parentRegenerateCount = parent.regenerateCount;
+        if (parent.status !== ReportStatus.SUPERSEDED) {
+          this.service.assertStatusTransition(parent.status, ReportStatus.SUPERSEDED);
+          await this.service.updateReportStatus(
+            ctx,
+            input.parentRunId,
+            ReportStatus.SUPERSEDED,
+            undefined,
+            tx,
+          );
+        }
       }
 
       return this.service.createReport(

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from "tsyringe";
 import { IContext } from "@/types/server";
 import ReportService from "@/application/domain/report/service";
 import ReportPresenter, { WeeklyReportPayload } from "@/application/domain/report/presenter";
-import { addDays, truncateToJstDate } from "@/application/domain/report/util";
+import { addDays, daysBetweenJst, truncateToJstDate } from "@/application/domain/report/util";
 import { renderPromptTemplate } from "@/application/domain/report/util/promptRenderer";
 import { LlmClient } from "@/infrastructure/libs/llm";
 import {
@@ -26,6 +26,8 @@ import {
 } from "@/types/graphql";
 
 const LLM_TIMEOUT_MS = 60_000;
+const DEFAULT_REPORTS_PER_PAGE = 20;
+const MAX_REPORTS_PER_PAGE = 100;
 
 const DEFAULT_WINDOW_DAYS = 7;
 const DEFAULT_TOP_N = 10;
@@ -134,9 +136,11 @@ export default class ReportUseCase {
       );
     }
 
+    const windowDays = daysBetweenJst(input.periodFrom, input.periodTo) + 1;
     const payload = await this.buildReportPayload(ctx, {
       communityId,
       referenceDate: input.periodTo,
+      windowDays,
       customContext: template.communityContext ?? undefined,
     });
 
@@ -162,6 +166,7 @@ export default class ReportUseCase {
     }
 
     let parentRegenerateCount = 0;
+    let parentStatus: ReportStatus | null = null;
     if (input.parentRunId) {
       const parent = await this.service.getReportById(ctx, input.parentRunId);
       if (!parent) throw new Error(`Parent report ${input.parentRunId} not found`);
@@ -169,21 +174,19 @@ export default class ReportUseCase {
         throw new Error("Parent report must belong to the same community and variant");
       }
       parentRegenerateCount = parent.regenerateCount;
+      parentStatus = parent.status;
     }
 
     const report = await ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
-      if (input.parentRunId) {
-        const parent = await this.service.getReportById(ctx, input.parentRunId);
-        if (parent && parent.status !== ReportStatus.SUPERSEDED) {
-          this.service.assertStatusTransition(parent.status, ReportStatus.SUPERSEDED);
-          await this.service.updateReportStatus(
-            ctx,
-            input.parentRunId,
-            ReportStatus.SUPERSEDED,
-            undefined,
-            tx,
-          );
-        }
+      if (input.parentRunId && parentStatus && parentStatus !== ReportStatus.SUPERSEDED) {
+        this.service.assertStatusTransition(parentStatus, ReportStatus.SUPERSEDED);
+        await this.service.updateReportStatus(
+          ctx,
+          input.parentRunId,
+          ReportStatus.SUPERSEDED,
+          undefined,
+          tx,
+        );
       }
 
       return this.service.createReport(
@@ -220,14 +223,17 @@ export default class ReportUseCase {
     { communityId, variant, status, cursor, first }: GqlQueryReportsArgs,
     ctx: IContext,
   ): Promise<GqlReportsConnection> {
+    const clampedFirst = first
+      ? clampInt(first, 1, MAX_REPORTS_PER_PAGE, "first")
+      : DEFAULT_REPORTS_PER_PAGE;
     const result = await this.service.getReports(ctx, {
       communityId,
       variant: variant ?? undefined,
       status: status ?? undefined,
       cursor: cursor ?? undefined,
-      first: first ?? undefined,
+      first: clampedFirst,
     });
-    return ReportPresenter.reportsConnection(result.items, result.totalCount);
+    return ReportPresenter.reportsConnection(result.items, result.totalCount, clampedFirst);
   }
 
   async viewReport({ id }: GqlQueryReportArgs, ctx: IContext): Promise<GqlReport | null> {

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -258,7 +258,7 @@ export default class ReportUseCase {
     ctx: IContext,
   ): Promise<GqlUpdateReportTemplatePayload> {
     const template = await ctx.issuer.admin(ctx, (tx) =>
-      this.service.upsertTemplate(ctx, variant, communityId ?? null, input, tx),
+      this.service.upsertTemplate(ctx, variant, communityId ?? null, input, ctx.currentUser!.id, tx),
     );
     return {
       __typename: "UpdateReportTemplateSuccess",

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -270,12 +270,12 @@ export default class ReportUseCase {
     { id }: GqlMutationApproveReportArgs,
     ctx: IContext,
   ): Promise<GqlApproveReportPayload> {
-    const existing = await this.service.getReportById(ctx, id);
-    if (!existing) throw new Error(`Report ${id} not found`);
-    this.service.assertStatusTransition(existing.status, ReportStatus.APPROVED);
-    const report = await ctx.issuer.admin(ctx, (tx) =>
-      this.service.updateReportStatus(ctx, id, ReportStatus.APPROVED, undefined, tx),
-    );
+    const report = await ctx.issuer.admin(ctx, async (tx) => {
+      const existing = await this.service.getReportById(ctx, id, tx);
+      if (!existing) throw new Error(`Report ${id} not found`);
+      this.service.assertStatusTransition(existing.status, ReportStatus.APPROVED);
+      return this.service.updateReportStatus(ctx, id, ReportStatus.APPROVED, undefined, tx);
+    });
     return { __typename: "ApproveReportSuccess", report: ReportPresenter.report(report) };
   }
 
@@ -283,11 +283,11 @@ export default class ReportUseCase {
     { id, finalContent }: GqlMutationPublishReportArgs,
     ctx: IContext,
   ): Promise<GqlPublishReportPayload> {
-    const existing = await this.service.getReportById(ctx, id);
-    if (!existing) throw new Error(`Report ${id} not found`);
-    this.service.assertStatusTransition(existing.status, ReportStatus.PUBLISHED);
-    const report = await ctx.issuer.admin(ctx, (tx) =>
-      this.service.updateReportStatus(
+    const report = await ctx.issuer.admin(ctx, async (tx) => {
+      const existing = await this.service.getReportById(ctx, id, tx);
+      if (!existing) throw new Error(`Report ${id} not found`);
+      this.service.assertStatusTransition(existing.status, ReportStatus.PUBLISHED);
+      return this.service.updateReportStatus(
         ctx,
         id,
         ReportStatus.PUBLISHED,
@@ -297,8 +297,8 @@ export default class ReportUseCase {
           finalContent,
         },
         tx,
-      ),
-    );
+      );
+    });
     return { __typename: "PublishReportSuccess", report: ReportPresenter.report(report) };
   }
 
@@ -306,12 +306,12 @@ export default class ReportUseCase {
     { id }: GqlMutationRejectReportArgs,
     ctx: IContext,
   ): Promise<GqlRejectReportPayload> {
-    const existing = await this.service.getReportById(ctx, id);
-    if (!existing) throw new Error(`Report ${id} not found`);
-    this.service.assertStatusTransition(existing.status, ReportStatus.REJECTED);
-    const report = await ctx.issuer.admin(ctx, (tx) =>
-      this.service.updateReportStatus(ctx, id, ReportStatus.REJECTED, undefined, tx),
-    );
+    const report = await ctx.issuer.admin(ctx, async (tx) => {
+      const existing = await this.service.getReportById(ctx, id, tx);
+      if (!existing) throw new Error(`Report ${id} not found`);
+      this.service.assertStatusTransition(existing.status, ReportStatus.REJECTED);
+      return this.service.updateReportStatus(ctx, id, ReportStatus.REJECTED, undefined, tx);
+    });
     return { __typename: "RejectReportSuccess", report: ReportPresenter.report(report) };
   }
 

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -1,8 +1,31 @@
+import { ReportStatus } from "@prisma/client";
 import { inject, injectable } from "tsyringe";
 import { IContext } from "@/types/server";
 import ReportService from "@/application/domain/report/service";
 import ReportPresenter, { WeeklyReportPayload } from "@/application/domain/report/presenter";
 import { addDays, truncateToJstDate } from "@/application/domain/report/util";
+import { renderPromptTemplate } from "@/application/domain/report/util/promptRenderer";
+import { LlmClient } from "@/infrastructure/libs/llm";
+import {
+  GqlGenerateReportPayload,
+  GqlReportsConnection,
+  GqlReport,
+  GqlReportTemplate,
+  GqlUpdateReportTemplatePayload,
+  GqlApproveReportPayload,
+  GqlPublishReportPayload,
+  GqlRejectReportPayload,
+  GqlMutationGenerateReportArgs,
+  GqlMutationUpdateReportTemplateArgs,
+  GqlMutationApproveReportArgs,
+  GqlMutationPublishReportArgs,
+  GqlMutationRejectReportArgs,
+  GqlQueryReportsArgs,
+  GqlQueryReportArgs,
+  GqlQueryReportTemplateArgs,
+} from "@/types/graphql";
+
+const LLM_TIMEOUT_MS = 60_000;
 
 const DEFAULT_WINDOW_DAYS = 7;
 const DEFAULT_TOP_N = 10;
@@ -13,7 +36,10 @@ const MAX_COMMENT_LIMIT = 1000;
 
 @injectable()
 export default class ReportUseCase {
-  constructor(@inject("ReportService") private readonly service: ReportService) {}
+  constructor(
+    @inject("ReportService") private readonly service: ReportService,
+    @inject("LlmClient") private readonly llmClient: LlmClient,
+  ) {}
 
   /**
    * Build the AI-facing data payload for a fixed-length report window ending
@@ -31,6 +57,7 @@ export default class ReportUseCase {
       windowDays?: number;
       topN?: number;
       commentLimit?: number;
+      customContext?: string;
     },
   ): Promise<WeeklyReportPayload> {
     const windowDays = clampInt(
@@ -75,6 +102,7 @@ export default class ReportUseCase {
       comments,
       communityContext,
       deepestChain,
+      customContext: params.customContext,
     });
   }
 
@@ -90,6 +118,197 @@ export default class ReportUseCase {
    * Note: active-user counts no longer have a dedicated MV — they are
    * derived at query time from mv_user_transaction_daily.
    */
+  // =========================================================================
+  // AI Report Generation
+  // =========================================================================
+
+  async generateReport(
+    { input, permission }: GqlMutationGenerateReportArgs,
+    ctx: IContext,
+  ): Promise<GqlGenerateReportPayload> {
+    const communityId = permission.communityId;
+    const template = await this.service.getTemplate(ctx, input.variant, communityId);
+    if (!template) {
+      throw new Error(
+        `No enabled template found for variant=${input.variant}, communityId=${communityId}`,
+      );
+    }
+
+    const payload = await this.buildReportPayload(ctx, {
+      communityId,
+      referenceDate: input.periodTo,
+      customContext: template.communityContext ?? undefined,
+    });
+
+    const userPrompt = renderPromptTemplate(template.userPromptTemplate, {
+      payload_json: JSON.stringify(payload),
+    });
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), LLM_TIMEOUT_MS);
+    let llmResult;
+    try {
+      llmResult = await this.llmClient.complete({
+        system: [{ text: template.systemPrompt, cache: true }],
+        messages: [{ role: "user", content: userPrompt }],
+        model: template.model,
+        maxTokens: template.maxTokens,
+        ...(template.temperature !== null && { temperature: template.temperature }),
+        ...(template.stopSequences.length > 0 && { stopSequences: template.stopSequences }),
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    let parentRegenerateCount = 0;
+    if (input.parentRunId) {
+      const parent = await this.service.getReportById(ctx, input.parentRunId);
+      if (!parent) throw new Error(`Parent report ${input.parentRunId} not found`);
+      if (parent.communityId !== communityId || parent.variant !== input.variant) {
+        throw new Error("Parent report must belong to the same community and variant");
+      }
+      parentRegenerateCount = parent.regenerateCount;
+    }
+
+    const report = await ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
+      if (input.parentRunId) {
+        const parent = await this.service.getReportById(ctx, input.parentRunId);
+        if (parent && parent.status !== ReportStatus.SUPERSEDED) {
+          this.service.assertStatusTransition(parent.status, ReportStatus.SUPERSEDED);
+          await this.service.updateReportStatus(
+            ctx,
+            input.parentRunId,
+            ReportStatus.SUPERSEDED,
+            undefined,
+            tx,
+          );
+        }
+      }
+
+      return this.service.createReport(
+        ctx,
+        {
+          communityId,
+          variant: input.variant,
+          periodFrom: input.periodFrom,
+          periodTo: input.periodTo,
+          templateId: template.id,
+          inputPayload: payload as object,
+          outputMarkdown: llmResult.text,
+          model: llmResult.model,
+          systemPromptSnapshot: template.systemPrompt,
+          userPromptSnapshot: userPrompt,
+          communityContextSnapshot: template.communityContext,
+          inputTokens: llmResult.usage.inputTokens,
+          outputTokens: llmResult.usage.outputTokens,
+          cacheReadTokens: llmResult.usage.cacheReadTokens,
+          ...(input.parentRunId && {
+            parentRunId: input.parentRunId,
+            regenerateCount: parentRegenerateCount + 1,
+          }),
+          ...(ctx.currentUser && { generatedBy: ctx.currentUser.id }),
+        },
+        tx,
+      );
+    });
+
+    return { __typename: "GenerateReportSuccess", report: ReportPresenter.report(report) };
+  }
+
+  async browseReports(
+    { communityId, variant, status, cursor, first }: GqlQueryReportsArgs,
+    ctx: IContext,
+  ): Promise<GqlReportsConnection> {
+    const result = await this.service.getReports(ctx, {
+      communityId,
+      variant: variant ?? undefined,
+      status: status ?? undefined,
+      cursor: cursor ?? undefined,
+      first: first ?? undefined,
+    });
+    return ReportPresenter.reportsConnection(result.items, result.totalCount);
+  }
+
+  async viewReport({ id }: GqlQueryReportArgs, ctx: IContext): Promise<GqlReport | null> {
+    const report = await this.service.getReportById(ctx, id);
+    return report ? ReportPresenter.report(report) : null;
+  }
+
+  async viewReportTemplate(
+    { communityId, variant }: GqlQueryReportTemplateArgs,
+    ctx: IContext,
+  ): Promise<GqlReportTemplate | null> {
+    const template = await this.service.getTemplate(ctx, variant, communityId ?? null);
+    return template ? ReportPresenter.reportTemplate(template) : null;
+  }
+
+  async updateReportTemplate(
+    { communityId, variant, input }: GqlMutationUpdateReportTemplateArgs,
+    ctx: IContext,
+  ): Promise<GqlUpdateReportTemplatePayload> {
+    const template = await ctx.issuer.admin(ctx, (tx) =>
+      this.service.upsertTemplate(ctx, variant, communityId ?? null, input, tx),
+    );
+    return {
+      __typename: "UpdateReportTemplateSuccess",
+      reportTemplate: ReportPresenter.reportTemplate(template),
+    };
+  }
+
+  async approveReport(
+    { id }: GqlMutationApproveReportArgs,
+    ctx: IContext,
+  ): Promise<GqlApproveReportPayload> {
+    const existing = await this.service.getReportById(ctx, id);
+    if (!existing) throw new Error(`Report ${id} not found`);
+    this.service.assertStatusTransition(existing.status, ReportStatus.APPROVED);
+    const report = await ctx.issuer.admin(ctx, (tx) =>
+      this.service.updateReportStatus(ctx, id, ReportStatus.APPROVED, undefined, tx),
+    );
+    return { __typename: "ApproveReportSuccess", report: ReportPresenter.report(report) };
+  }
+
+  async publishReport(
+    { id, finalContent }: GqlMutationPublishReportArgs,
+    ctx: IContext,
+  ): Promise<GqlPublishReportPayload> {
+    const existing = await this.service.getReportById(ctx, id);
+    if (!existing) throw new Error(`Report ${id} not found`);
+    this.service.assertStatusTransition(existing.status, ReportStatus.PUBLISHED);
+    const report = await ctx.issuer.admin(ctx, (tx) =>
+      this.service.updateReportStatus(
+        ctx,
+        id,
+        ReportStatus.PUBLISHED,
+        {
+          publishedAt: new Date(),
+          publishedBy: ctx.currentUser?.id,
+          finalContent,
+        },
+        tx,
+      ),
+    );
+    return { __typename: "PublishReportSuccess", report: ReportPresenter.report(report) };
+  }
+
+  async rejectReport(
+    { id }: GqlMutationRejectReportArgs,
+    ctx: IContext,
+  ): Promise<GqlRejectReportPayload> {
+    const existing = await this.service.getReportById(ctx, id);
+    if (!existing) throw new Error(`Report ${id} not found`);
+    this.service.assertStatusTransition(existing.status, ReportStatus.REJECTED);
+    const report = await ctx.issuer.admin(ctx, (tx) =>
+      this.service.updateReportStatus(ctx, id, ReportStatus.REJECTED, undefined, tx),
+    );
+    return { __typename: "RejectReportSuccess", report: ReportPresenter.report(report) };
+  }
+
+  // =========================================================================
+  // Batch operations
+  // =========================================================================
+
   async refreshAllReportViews(ctx: IContext): Promise<void> {
     await ctx.issuer.internal((tx) => this.service.refreshTransactionSummaryDaily(ctx, tx));
     await ctx.issuer.internal((tx) => this.service.refreshUserTransactionDaily(ctx, tx));

--- a/src/application/domain/report/util.ts
+++ b/src/application/domain/report/util.ts
@@ -19,9 +19,7 @@ const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
  */
 export function truncateToJstDate(d: Date): Date {
   const jst = new Date(d.getTime() + JST_OFFSET_MS);
-  return new Date(
-    Date.UTC(jst.getUTCFullYear(), jst.getUTCMonth(), jst.getUTCDate()),
-  );
+  return new Date(Date.UTC(jst.getUTCFullYear(), jst.getUTCMonth(), jst.getUTCDate()));
 }
 
 export function addDays(d: Date, days: number): Date {
@@ -69,9 +67,7 @@ export function bigintToSafeNumber(value: bigint): number {
   const MAX = BigInt(Number.MAX_SAFE_INTEGER);
   const MIN = BigInt(Number.MIN_SAFE_INTEGER);
   if (value > MAX || value < MIN) {
-    throw new RangeError(
-      `Report value ${value.toString()} exceeds JavaScript safe integer range`,
-    );
+    throw new RangeError(`Report value ${value.toString()} exceeds JavaScript safe integer range`);
   }
   return Number(value);
 }

--- a/src/application/domain/report/util/promptRenderer.ts
+++ b/src/application/domain/report/util/promptRenderer.ts
@@ -1,0 +1,14 @@
+/**
+ * Replace `${key}` placeholders in a prompt template with the
+ * corresponding values from `vars`. Phase 1 uses a single variable
+ * `payload_json`; the renderer is intentionally simple (no Liquid /
+ * Handlebars / escaping) — the template author is responsible for
+ * prompt correctness.
+ */
+export function renderPromptTemplate(template: string, vars: Record<string, string>): string {
+  let result = template;
+  for (const [key, value] of Object.entries(vars)) {
+    result = result.replaceAll(`\${${key}}`, value);
+  }
+  return result;
+}

--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -31,6 +31,7 @@ import IdentityUseCase from "@/application/domain/account/identity/usecase";
 import { NmkrClient } from "@/infrastructure/libs/nmkr/api/client";
 import { CardanoShopifyAppClient } from "@/infrastructure/libs/cardanoShopifyApp/api/client";
 import { AnthropicLlmClient } from "@/infrastructure/libs/llm";
+import ReportResolver from "@/application/domain/report/controller/resolver";
 import IdentityRepository from "@/application/domain/account/identity/data/repository";
 import IdentityConverter from "@/application/domain/account/identity/data/converter";
 import DIDIssuanceRequestRepository from "@/application/domain/account/identity/didIssuanceRequest/data/repository";
@@ -351,6 +352,7 @@ export function registerProductionDependencies() {
   container.register("ReportRepository", { useClass: ReportRepository });
   container.register("ReportService", { useClass: ReportService });
   container.register("ReportUseCase", { useClass: ReportUseCase });
+  container.register("ReportResolver", { useClass: ReportResolver });
   container.register("LlmClient", { useClass: AnthropicLlmClient });
 
   // ------------------------------

--- a/src/presentation/graphql/dataloader/index.ts
+++ b/src/presentation/graphql/dataloader/index.ts
@@ -6,6 +6,7 @@ import { createContentLoaders } from "@/presentation/graphql/dataloader/domain/c
 import { createTransactionLoaders } from "@/presentation/graphql/dataloader/domain/transaction";
 import { createLocationLoaders } from "@/presentation/graphql/dataloader/domain/location";
 import { createVoteLoaders } from "@/presentation/graphql/dataloader/domain/vote";
+import { createReportLoaders } from "@/application/domain/report/controller/dataloader";
 
 export function createLoaders(prisma: PrismaClient) {
   return {
@@ -16,6 +17,7 @@ export function createLoaders(prisma: PrismaClient) {
     ...createTransactionLoaders(prisma),
     ...createLocationLoaders(prisma),
     ...createVoteLoaders(prisma),
+    ...createReportLoaders(prisma),
   };
 }
 

--- a/src/presentation/graphql/resolver.ts
+++ b/src/presentation/graphql/resolver.ts
@@ -27,6 +27,7 @@ import MasterResolver from "@/application/domain/location/master/controller/reso
 import NftInstanceResolver from "@/application/domain/account/nft-instance/controller/resolver";
 import NftTokenResolver from "@/application/domain/account/nft-token/controller/resolver";
 import VoteResolver from "@/application/domain/vote/controller/resolver";
+import ReportResolver from "@/application/domain/report/controller/resolver";
 import scalarResolvers from "@/presentation/graphql/scalar";
 
 const identity = container.resolve(IdentityResolver);
@@ -61,6 +62,7 @@ const transaction = container.resolve(TransactionResolver);
 const transactionVerification = container.resolve(TransactionVerificationResolver);
 const incentiveGrant = container.resolve(IncentiveGrantResolver);
 const vote = container.resolve(VoteResolver);
+const report = container.resolve(ReportResolver);
 
 const resolvers = {
   Query: {
@@ -90,6 +92,7 @@ const resolvers = {
     ...transactionVerification.Query,
     ...incentiveGrant.Query,
     ...vote.Query,
+    ...report.Query,
   },
   Mutation: {
     ...identity.Mutation,
@@ -108,6 +111,7 @@ const resolvers = {
     ...transaction.Mutation,
     ...incentiveGrant.Mutation,
     ...vote.Mutation,
+    ...report.Mutation,
   },
   Identity: identity.Identity,
   User: user.User,
@@ -142,6 +146,14 @@ const resolvers = {
   VoteGate: vote.VoteGate,
   VotePowerPolicy: vote.VotePowerPolicy,
   VoteBallot: vote.VoteBallot,
+
+  Report: report.Report,
+  ReportTemplate: report.ReportTemplate,
+  GenerateReportPayload: report.GenerateReportPayload,
+  UpdateReportTemplatePayload: report.UpdateReportTemplatePayload,
+  ApproveReportPayload: report.ApproveReportPayload,
+  PublishReportPayload: report.PublishReportPayload,
+  RejectReportPayload: report.RejectReportPayload,
 
   ...scalarResolvers,
 };

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1226,7 +1226,6 @@ export type GqlMutationPublishReportArgs = {
 
 export type GqlMutationRejectReportArgs = {
   id: Scalars['ID']['input'];
-  reason?: InputMaybe<Scalars['String']['input']>;
 };
 
 

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -29,6 +29,13 @@ export type GqlAccumulatedPointView = {
   walletId?: Maybe<Scalars['String']['output']>;
 };
 
+export type GqlApproveReportPayload = GqlApproveReportSuccess;
+
+export type GqlApproveReportSuccess = {
+  __typename?: 'ApproveReportSuccess';
+  report: GqlReport;
+};
+
 export type GqlArticle = {
   __typename?: 'Article';
   authors?: Maybe<Array<GqlUser>>;
@@ -622,6 +629,21 @@ export type GqlEvaluationsConnection = {
   totalCount: Scalars['Int']['output'];
 };
 
+export type GqlGenerateReportInput = {
+  communityId: Scalars['ID']['input'];
+  parentRunId?: InputMaybe<Scalars['ID']['input']>;
+  periodFrom: Scalars['Datetime']['input'];
+  periodTo: Scalars['Datetime']['input'];
+  variant: GqlReportVariant;
+};
+
+export type GqlGenerateReportPayload = GqlGenerateReportSuccess;
+
+export type GqlGenerateReportSuccess = {
+  __typename?: 'GenerateReportSuccess';
+  report: GqlReport;
+};
+
 export type GqlIdentity = {
   __typename?: 'Identity';
   createdAt?: Maybe<Scalars['Datetime']['output']>;
@@ -897,6 +919,7 @@ export type GqlMembershipsConnection = {
 
 export type GqlMutation = {
   __typename?: 'Mutation';
+  approveReport?: Maybe<GqlApproveReportPayload>;
   articleCreate?: Maybe<GqlArticleCreatePayload>;
   articleDelete?: Maybe<GqlArticleDeletePayload>;
   articleUpdateContent?: Maybe<GqlArticleUpdateContentPayload>;
@@ -904,6 +927,7 @@ export type GqlMutation = {
   communityDelete?: Maybe<GqlCommunityDeletePayload>;
   communityUpdateProfile?: Maybe<GqlCommunityUpdateProfilePayload>;
   evaluationBulkCreate?: Maybe<GqlEvaluationBulkCreatePayload>;
+  generateReport?: Maybe<GqlGenerateReportPayload>;
   identityCheckPhoneUser: GqlIdentityCheckPhoneUserPayload;
   incentiveGrantRetry?: Maybe<GqlIncentiveGrantRetryPayload>;
   linkPhoneAuth?: Maybe<GqlLinkPhoneAuthPayload>;
@@ -930,6 +954,8 @@ export type GqlMutation = {
   placeCreate?: Maybe<GqlPlaceCreatePayload>;
   placeDelete?: Maybe<GqlPlaceDeletePayload>;
   placeUpdate?: Maybe<GqlPlaceUpdatePayload>;
+  publishReport?: Maybe<GqlPublishReportPayload>;
+  rejectReport?: Maybe<GqlRejectReportPayload>;
   reservationAccept?: Maybe<GqlReservationSetStatusPayload>;
   reservationCancel?: Maybe<GqlReservationSetStatusPayload>;
   reservationCreate?: Maybe<GqlReservationCreatePayload>;
@@ -946,6 +972,7 @@ export type GqlMutation = {
   transactionIssueCommunityPoint?: Maybe<GqlTransactionIssueCommunityPointPayload>;
   transactionUpdateMetadata?: Maybe<GqlTransactionUpdateMetadataPayload>;
   updatePortalConfig: GqlCommunityPortalConfig;
+  updateReportTemplate?: Maybe<GqlUpdateReportTemplatePayload>;
   updateSignupBonusConfig: GqlCommunitySignupBonusConfig;
   userDeleteMe?: Maybe<GqlUserDeletePayload>;
   userSignUp?: Maybe<GqlCurrentUserPayload>;
@@ -981,6 +1008,11 @@ export type GqlMutation = {
    * gate / powerPolicy も同時に再設定可能。
    */
   voteTopicUpdate: GqlVoteTopicUpdatePayload;
+};
+
+
+export type GqlMutationApproveReportArgs = {
+  id: Scalars['ID']['input'];
 };
 
 
@@ -1023,6 +1055,12 @@ export type GqlMutationCommunityUpdateProfileArgs = {
 
 export type GqlMutationEvaluationBulkCreateArgs = {
   input: GqlEvaluationBulkCreateInput;
+  permission: GqlCheckCommunityPermissionInput;
+};
+
+
+export type GqlMutationGenerateReportArgs = {
+  input: GqlGenerateReportInput;
   permission: GqlCheckCommunityPermissionInput;
 };
 
@@ -1180,6 +1218,18 @@ export type GqlMutationPlaceUpdateArgs = {
 };
 
 
+export type GqlMutationPublishReportArgs = {
+  finalContent: Scalars['String']['input'];
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlMutationRejectReportArgs = {
+  id: Scalars['ID']['input'];
+  reason?: InputMaybe<Scalars['String']['input']>;
+};
+
+
 export type GqlMutationReservationAcceptArgs = {
   id: Scalars['ID']['input'];
   permission: GqlCheckOpportunityPermissionInput;
@@ -1275,6 +1325,13 @@ export type GqlMutationTransactionUpdateMetadataArgs = {
 export type GqlMutationUpdatePortalConfigArgs = {
   input: GqlCommunityPortalConfigInput;
   permission: GqlCheckCommunityPermissionInput;
+};
+
+
+export type GqlMutationUpdateReportTemplateArgs = {
+  communityId?: InputMaybe<Scalars['ID']['input']>;
+  input: GqlUpdateReportTemplateInput;
+  variant: GqlReportVariant;
 };
 
 
@@ -2057,6 +2114,13 @@ export type GqlPortfoliosConnection = {
   totalCount: Scalars['Int']['output'];
 };
 
+export type GqlPublishReportPayload = GqlPublishReportSuccess;
+
+export type GqlPublishReportSuccess = {
+  __typename?: 'PublishReportSuccess';
+  report: GqlReport;
+};
+
 export const GqlPublishStatus = {
   CommunityInternal: 'COMMUNITY_INTERNAL',
   Private: 'PRIVATE',
@@ -2104,6 +2168,9 @@ export type GqlQuery = {
   place?: Maybe<GqlPlace>;
   places: GqlPlacesConnection;
   portfolios?: Maybe<Array<GqlPortfolio>>;
+  report?: Maybe<GqlReport>;
+  reportTemplate?: Maybe<GqlReportTemplate>;
+  reports: GqlReportsConnection;
   reservation?: Maybe<GqlReservation>;
   reservationHistories: GqlReservationHistoriesConnection;
   reservationHistory?: Maybe<GqlReservationHistory>;
@@ -2343,6 +2410,27 @@ export type GqlQueryPortfoliosArgs = {
 };
 
 
+export type GqlQueryReportArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryReportTemplateArgs = {
+  communityId?: InputMaybe<Scalars['ID']['input']>;
+  variant: GqlReportVariant;
+};
+
+
+export type GqlQueryReportsArgs = {
+  communityId: Scalars['ID']['input'];
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  permission: GqlCheckCommunityPermissionInput;
+  status?: InputMaybe<GqlReportStatus>;
+  variant?: InputMaybe<GqlReportVariant>;
+};
+
+
 export type GqlQueryReservationArgs = {
   id: Scalars['ID']['input'];
 };
@@ -2513,6 +2601,91 @@ export type GqlQueryWalletsArgs = {
   filter?: InputMaybe<GqlWalletFilterInput>;
   first?: InputMaybe<Scalars['Int']['input']>;
   sort?: InputMaybe<GqlWalletSortInput>;
+};
+
+export type GqlRejectReportPayload = GqlRejectReportSuccess;
+
+export type GqlRejectReportSuccess = {
+  __typename?: 'RejectReportSuccess';
+  report: GqlReport;
+};
+
+export type GqlReport = {
+  __typename?: 'Report';
+  cacheReadTokens: Scalars['Int']['output'];
+  community: GqlCommunity;
+  createdAt: Scalars['Datetime']['output'];
+  finalContent?: Maybe<Scalars['String']['output']>;
+  generatedByUser?: Maybe<GqlUser>;
+  id: Scalars['ID']['output'];
+  inputTokens: Scalars['Int']['output'];
+  model: Scalars['String']['output'];
+  outputMarkdown: Scalars['String']['output'];
+  outputTokens: Scalars['Int']['output'];
+  parentRun?: Maybe<GqlReport>;
+  periodFrom: Scalars['Datetime']['output'];
+  periodTo: Scalars['Datetime']['output'];
+  publishedAt?: Maybe<Scalars['Datetime']['output']>;
+  publishedByUser?: Maybe<GqlUser>;
+  regenerateCount: Scalars['Int']['output'];
+  regenerations: Array<GqlReport>;
+  status: GqlReportStatus;
+  targetUser?: Maybe<GqlUser>;
+  template?: Maybe<GqlReportTemplate>;
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+  variant: Scalars['String']['output'];
+};
+
+export type GqlReportEdge = GqlEdge & {
+  __typename?: 'ReportEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlReport>;
+};
+
+export const GqlReportStatus = {
+  Approved: 'APPROVED',
+  Draft: 'DRAFT',
+  Published: 'PUBLISHED',
+  Rejected: 'REJECTED',
+  Superseded: 'SUPERSEDED'
+} as const;
+
+export type GqlReportStatus = typeof GqlReportStatus[keyof typeof GqlReportStatus];
+export type GqlReportTemplate = {
+  __typename?: 'ReportTemplate';
+  community?: Maybe<GqlCommunity>;
+  communityContext?: Maybe<Scalars['String']['output']>;
+  createdAt: Scalars['Datetime']['output'];
+  id: Scalars['ID']['output'];
+  isEnabled: Scalars['Boolean']['output'];
+  maxTokens: Scalars['Int']['output'];
+  model: Scalars['String']['output'];
+  scope: GqlReportTemplateScope;
+  stopSequences: Array<Scalars['String']['output']>;
+  systemPrompt: Scalars['String']['output'];
+  temperature: Scalars['Float']['output'];
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+  updatedByUser?: Maybe<GqlUser>;
+  userPromptTemplate: Scalars['String']['output'];
+  variant: Scalars['String']['output'];
+};
+
+export const GqlReportTemplateScope = {
+  Community: 'COMMUNITY',
+  System: 'SYSTEM'
+} as const;
+
+export type GqlReportTemplateScope = typeof GqlReportTemplateScope[keyof typeof GqlReportTemplateScope];
+export const GqlReportVariant = {
+  WeeklySummary: 'WEEKLY_SUMMARY'
+} as const;
+
+export type GqlReportVariant = typeof GqlReportVariant[keyof typeof GqlReportVariant];
+export type GqlReportsConnection = {
+  __typename?: 'ReportsConnection';
+  edges?: Maybe<Array<Maybe<GqlReportEdge>>>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
 };
 
 export type GqlReservation = {
@@ -3129,6 +3302,24 @@ export type GqlTransactionsConnection = {
   edges?: Maybe<Array<Maybe<GqlTransactionEdge>>>;
   pageInfo: GqlPageInfo;
   totalCount: Scalars['Int']['output'];
+};
+
+export type GqlUpdateReportTemplateInput = {
+  communityContext?: InputMaybe<Scalars['String']['input']>;
+  isEnabled?: InputMaybe<Scalars['Boolean']['input']>;
+  maxTokens: Scalars['Int']['input'];
+  model: Scalars['String']['input'];
+  stopSequences?: InputMaybe<Array<Scalars['String']['input']>>;
+  systemPrompt: Scalars['String']['input'];
+  temperature?: InputMaybe<Scalars['Float']['input']>;
+  userPromptTemplate: Scalars['String']['input'];
+};
+
+export type GqlUpdateReportTemplatePayload = GqlUpdateReportTemplateSuccess;
+
+export type GqlUpdateReportTemplateSuccess = {
+  __typename?: 'UpdateReportTemplateSuccess';
+  reportTemplate: GqlReportTemplate;
 };
 
 export type GqlUpdateSignupBonusConfigInput = {
@@ -3753,6 +3944,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 
 /** Mapping of union types */
 export type GqlResolversUnionTypes<_RefType extends Record<string, unknown>> = ResolversObject<{
+  ApproveReportPayload: ( Omit<GqlApproveReportSuccess, 'report'> & { report: _RefType['Report'] } );
   ArticleCreatePayload: ( Omit<GqlArticleCreateSuccess, 'article'> & { article: _RefType['Article'] } );
   ArticleDeletePayload: ( GqlArticleDeleteSuccess );
   ArticleUpdateContentPayload: ( Omit<GqlArticleUpdateContentSuccess, 'article'> & { article: _RefType['Article'] } );
@@ -3760,6 +3952,7 @@ export type GqlResolversUnionTypes<_RefType extends Record<string, unknown>> = R
   CommunityDeletePayload: ( GqlCommunityDeleteSuccess );
   CommunityUpdateProfilePayload: ( Omit<GqlCommunityUpdateProfileSuccess, 'community'> & { community: _RefType['Community'] } );
   EvaluationBulkCreatePayload: ( Omit<GqlEvaluationBulkCreateSuccess, 'evaluations'> & { evaluations: Array<_RefType['Evaluation']> } );
+  GenerateReportPayload: ( Omit<GqlGenerateReportSuccess, 'report'> & { report: _RefType['Report'] } );
   IncentiveGrantRetryPayload: ( Omit<GqlIncentiveGrantRetrySuccess, 'incentiveGrant' | 'transaction'> & { incentiveGrant: _RefType['IncentiveGrant'], transaction?: Maybe<_RefType['Transaction']> } );
   MembershipInvitePayload: ( Omit<GqlMembershipInviteSuccess, 'membership'> & { membership: _RefType['Membership'] } );
   MembershipRemovePayload: ( GqlMembershipRemoveSuccess );
@@ -3779,6 +3972,8 @@ export type GqlResolversUnionTypes<_RefType extends Record<string, unknown>> = R
   PlaceCreatePayload: ( Omit<GqlPlaceCreateSuccess, 'place'> & { place: _RefType['Place'] } );
   PlaceDeletePayload: ( GqlPlaceDeleteSuccess );
   PlaceUpdatePayload: ( Omit<GqlPlaceUpdateSuccess, 'place'> & { place: _RefType['Place'] } );
+  PublishReportPayload: ( Omit<GqlPublishReportSuccess, 'report'> & { report: _RefType['Report'] } );
+  RejectReportPayload: ( Omit<GqlRejectReportSuccess, 'report'> & { report: _RefType['Report'] } );
   ReservationCreatePayload: ( Omit<GqlReservationCreateSuccess, 'reservation'> & { reservation: _RefType['Reservation'] } );
   ReservationSetStatusPayload: ( Omit<GqlReservationSetStatusSuccess, 'reservation'> & { reservation: _RefType['Reservation'] } );
   TicketClaimPayload: ( Omit<GqlTicketClaimSuccess, 'tickets'> & { tickets: Array<_RefType['Ticket']> } );
@@ -3790,6 +3985,7 @@ export type GqlResolversUnionTypes<_RefType extends Record<string, unknown>> = R
   TransactionGrantCommunityPointPayload: ( Omit<GqlTransactionGrantCommunityPointSuccess, 'transaction'> & { transaction: _RefType['Transaction'] } );
   TransactionIssueCommunityPointPayload: ( Omit<GqlTransactionIssueCommunityPointSuccess, 'transaction'> & { transaction: _RefType['Transaction'] } );
   TransactionUpdateMetadataPayload: ( Omit<GqlTransactionUpdateMetadataSuccess, 'transaction'> & { transaction: _RefType['Transaction'] } );
+  UpdateReportTemplatePayload: ( Omit<GqlUpdateReportTemplateSuccess, 'reportTemplate'> & { reportTemplate: _RefType['ReportTemplate'] } );
   UserUpdateProfilePayload: ( Omit<GqlUserUpdateProfileSuccess, 'user'> & { user?: Maybe<_RefType['User']> } );
   UtilityCreatePayload: ( Omit<GqlUtilityCreateSuccess, 'utility'> & { utility: _RefType['Utility'] } );
   UtilityDeletePayload: ( GqlUtilityDeleteSuccess );
@@ -3803,13 +3999,15 @@ export type GqlResolversUnionTypes<_RefType extends Record<string, unknown>> = R
 
 /** Mapping of interface types */
 export type GqlResolversInterfaceTypes<_RefType extends Record<string, unknown>> = ResolversObject<{
-  Edge: ( Omit<GqlArticleEdge, 'node'> & { node?: Maybe<_RefType['Article']> } ) | ( Omit<GqlCityEdge, 'node'> & { node?: Maybe<_RefType['City']> } ) | ( Omit<GqlCommunityEdge, 'node'> & { node?: Maybe<_RefType['Community']> } ) | ( Omit<GqlEvaluationEdge, 'node'> & { node?: Maybe<_RefType['Evaluation']> } ) | ( Omit<GqlEvaluationHistoryEdge, 'node'> & { node?: Maybe<_RefType['EvaluationHistory']> } ) | ( Omit<GqlIncentiveGrantEdge, 'node'> & { node?: Maybe<_RefType['IncentiveGrant']> } ) | ( Omit<GqlMembershipEdge, 'node'> & { node?: Maybe<_RefType['Membership']> } ) | ( Omit<GqlNftInstanceEdge, 'node'> & { node: _RefType['NftInstance'] } ) | ( Omit<GqlNftTokenEdge, 'node'> & { node: _RefType['NftToken'] } ) | ( Omit<GqlOpportunityEdge, 'node'> & { node?: Maybe<_RefType['Opportunity']> } ) | ( Omit<GqlOpportunitySlotEdge, 'node'> & { node?: Maybe<_RefType['OpportunitySlot']> } ) | ( Omit<GqlParticipationEdge, 'node'> & { node?: Maybe<_RefType['Participation']> } ) | ( Omit<GqlParticipationStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['ParticipationStatusHistory']> } ) | ( Omit<GqlPlaceEdge, 'node'> & { node?: Maybe<_RefType['Place']> } ) | ( Omit<GqlPortfolioEdge, 'node'> & { node?: Maybe<_RefType['Portfolio']> } ) | ( Omit<GqlReservationEdge, 'node'> & { node?: Maybe<_RefType['Reservation']> } ) | ( Omit<GqlReservationHistoryEdge, 'node'> & { node?: Maybe<_RefType['ReservationHistory']> } ) | ( Omit<GqlStateEdge, 'node'> & { node?: Maybe<_RefType['State']> } ) | ( Omit<GqlTicketClaimLinkEdge, 'node'> & { node?: Maybe<_RefType['TicketClaimLink']> } ) | ( Omit<GqlTicketEdge, 'node'> & { node?: Maybe<_RefType['Ticket']> } ) | ( Omit<GqlTicketIssuerEdge, 'node'> & { node?: Maybe<_RefType['TicketIssuer']> } ) | ( Omit<GqlTicketStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['TicketStatusHistory']> } ) | ( Omit<GqlTransactionEdge, 'node'> & { node?: Maybe<_RefType['Transaction']> } ) | ( Omit<GqlUserEdge, 'node'> & { node?: Maybe<_RefType['User']> } ) | ( Omit<GqlUtilityEdge, 'node'> & { node?: Maybe<_RefType['Utility']> } ) | ( Omit<GqlVcIssuanceRequestEdge, 'node'> & { node?: Maybe<_RefType['VcIssuanceRequest']> } ) | ( Omit<GqlWalletEdge, 'node'> & { node?: Maybe<_RefType['Wallet']> } );
+  Edge: ( Omit<GqlArticleEdge, 'node'> & { node?: Maybe<_RefType['Article']> } ) | ( Omit<GqlCityEdge, 'node'> & { node?: Maybe<_RefType['City']> } ) | ( Omit<GqlCommunityEdge, 'node'> & { node?: Maybe<_RefType['Community']> } ) | ( Omit<GqlEvaluationEdge, 'node'> & { node?: Maybe<_RefType['Evaluation']> } ) | ( Omit<GqlEvaluationHistoryEdge, 'node'> & { node?: Maybe<_RefType['EvaluationHistory']> } ) | ( Omit<GqlIncentiveGrantEdge, 'node'> & { node?: Maybe<_RefType['IncentiveGrant']> } ) | ( Omit<GqlMembershipEdge, 'node'> & { node?: Maybe<_RefType['Membership']> } ) | ( Omit<GqlNftInstanceEdge, 'node'> & { node: _RefType['NftInstance'] } ) | ( Omit<GqlNftTokenEdge, 'node'> & { node: _RefType['NftToken'] } ) | ( Omit<GqlOpportunityEdge, 'node'> & { node?: Maybe<_RefType['Opportunity']> } ) | ( Omit<GqlOpportunitySlotEdge, 'node'> & { node?: Maybe<_RefType['OpportunitySlot']> } ) | ( Omit<GqlParticipationEdge, 'node'> & { node?: Maybe<_RefType['Participation']> } ) | ( Omit<GqlParticipationStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['ParticipationStatusHistory']> } ) | ( Omit<GqlPlaceEdge, 'node'> & { node?: Maybe<_RefType['Place']> } ) | ( Omit<GqlPortfolioEdge, 'node'> & { node?: Maybe<_RefType['Portfolio']> } ) | ( Omit<GqlReportEdge, 'node'> & { node?: Maybe<_RefType['Report']> } ) | ( Omit<GqlReservationEdge, 'node'> & { node?: Maybe<_RefType['Reservation']> } ) | ( Omit<GqlReservationHistoryEdge, 'node'> & { node?: Maybe<_RefType['ReservationHistory']> } ) | ( Omit<GqlStateEdge, 'node'> & { node?: Maybe<_RefType['State']> } ) | ( Omit<GqlTicketClaimLinkEdge, 'node'> & { node?: Maybe<_RefType['TicketClaimLink']> } ) | ( Omit<GqlTicketEdge, 'node'> & { node?: Maybe<_RefType['Ticket']> } ) | ( Omit<GqlTicketIssuerEdge, 'node'> & { node?: Maybe<_RefType['TicketIssuer']> } ) | ( Omit<GqlTicketStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['TicketStatusHistory']> } ) | ( Omit<GqlTransactionEdge, 'node'> & { node?: Maybe<_RefType['Transaction']> } ) | ( Omit<GqlUserEdge, 'node'> & { node?: Maybe<_RefType['User']> } ) | ( Omit<GqlUtilityEdge, 'node'> & { node?: Maybe<_RefType['Utility']> } ) | ( Omit<GqlVcIssuanceRequestEdge, 'node'> & { node?: Maybe<_RefType['VcIssuanceRequest']> } ) | ( Omit<GqlWalletEdge, 'node'> & { node?: Maybe<_RefType['Wallet']> } );
   TransactionChainParticipant: ( GqlTransactionChainCommunity ) | ( GqlTransactionChainUser );
 }>;
 
 /** Mapping between all available schema types and the resolvers types */
 export type GqlResolversTypes = ResolversObject<{
   AccumulatedPointView: ResolverTypeWrapper<AccumulatedPointView>;
+  ApproveReportPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['ApproveReportPayload']>;
+  ApproveReportSuccess: ResolverTypeWrapper<Omit<GqlApproveReportSuccess, 'report'> & { report: GqlResolversTypes['Report'] }>;
   Article: ResolverTypeWrapper<Article>;
   ArticleCategory: GqlArticleCategory;
   ArticleCreateInput: GqlArticleCreateInput;
@@ -3892,6 +4090,10 @@ export type GqlResolversTypes = ResolversObject<{
   EvaluationSortInput: GqlEvaluationSortInput;
   EvaluationStatus: GqlEvaluationStatus;
   EvaluationsConnection: ResolverTypeWrapper<Omit<GqlEvaluationsConnection, 'edges'> & { edges: Array<GqlResolversTypes['EvaluationEdge']> }>;
+  Float: ResolverTypeWrapper<Scalars['Float']['output']>;
+  GenerateReportInput: GqlGenerateReportInput;
+  GenerateReportPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['GenerateReportPayload']>;
+  GenerateReportSuccess: ResolverTypeWrapper<Omit<GqlGenerateReportSuccess, 'report'> & { report: GqlResolversTypes['Report'] }>;
   ID: ResolverTypeWrapper<Scalars['ID']['output']>;
   Identity: ResolverTypeWrapper<Omit<GqlIdentity, 'user'> & { user?: Maybe<GqlResolversTypes['User']> }>;
   IdentityCheckPhoneUserInput: GqlIdentityCheckPhoneUserInput;
@@ -4033,8 +4235,19 @@ export type GqlResolversTypes = ResolversObject<{
   PortfolioSortInput: GqlPortfolioSortInput;
   PortfolioSource: GqlPortfolioSource;
   PortfoliosConnection: ResolverTypeWrapper<Omit<GqlPortfoliosConnection, 'edges'> & { edges: Array<GqlResolversTypes['PortfolioEdge']> }>;
+  PublishReportPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['PublishReportPayload']>;
+  PublishReportSuccess: ResolverTypeWrapper<Omit<GqlPublishReportSuccess, 'report'> & { report: GqlResolversTypes['Report'] }>;
   PublishStatus: GqlPublishStatus;
   Query: ResolverTypeWrapper<{}>;
+  RejectReportPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['RejectReportPayload']>;
+  RejectReportSuccess: ResolverTypeWrapper<Omit<GqlRejectReportSuccess, 'report'> & { report: GqlResolversTypes['Report'] }>;
+  Report: ResolverTypeWrapper<Omit<GqlReport, 'community' | 'generatedByUser' | 'parentRun' | 'publishedByUser' | 'regenerations' | 'targetUser' | 'template'> & { community: GqlResolversTypes['Community'], generatedByUser?: Maybe<GqlResolversTypes['User']>, parentRun?: Maybe<GqlResolversTypes['Report']>, publishedByUser?: Maybe<GqlResolversTypes['User']>, regenerations: Array<GqlResolversTypes['Report']>, targetUser?: Maybe<GqlResolversTypes['User']>, template?: Maybe<GqlResolversTypes['ReportTemplate']> }>;
+  ReportEdge: ResolverTypeWrapper<Omit<GqlReportEdge, 'node'> & { node?: Maybe<GqlResolversTypes['Report']> }>;
+  ReportStatus: GqlReportStatus;
+  ReportTemplate: ResolverTypeWrapper<Omit<GqlReportTemplate, 'community' | 'updatedByUser'> & { community?: Maybe<GqlResolversTypes['Community']>, updatedByUser?: Maybe<GqlResolversTypes['User']> }>;
+  ReportTemplateScope: GqlReportTemplateScope;
+  ReportVariant: GqlReportVariant;
+  ReportsConnection: ResolverTypeWrapper<Omit<GqlReportsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['ReportEdge']>>> }>;
   Reservation: ResolverTypeWrapper<Omit<GqlReservation, 'createdByUser' | 'histories' | 'opportunitySlot' | 'participations'> & { createdByUser?: Maybe<GqlResolversTypes['User']>, histories?: Maybe<Array<GqlResolversTypes['ReservationHistory']>>, opportunitySlot?: Maybe<GqlResolversTypes['OpportunitySlot']>, participations?: Maybe<Array<GqlResolversTypes['Participation']>> }>;
   ReservationCancelInput: GqlReservationCancelInput;
   ReservationCreateInput: GqlReservationCreateInput;
@@ -4125,6 +4338,9 @@ export type GqlResolversTypes = ResolversObject<{
   TransactionUpdateMetadataSuccess: ResolverTypeWrapper<Omit<GqlTransactionUpdateMetadataSuccess, 'transaction'> & { transaction: GqlResolversTypes['Transaction'] }>;
   TransactionVerificationResult: ResolverTypeWrapper<GqlTransactionVerificationResult>;
   TransactionsConnection: ResolverTypeWrapper<Omit<GqlTransactionsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['TransactionEdge']>>> }>;
+  UpdateReportTemplateInput: GqlUpdateReportTemplateInput;
+  UpdateReportTemplatePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['UpdateReportTemplatePayload']>;
+  UpdateReportTemplateSuccess: ResolverTypeWrapper<Omit<GqlUpdateReportTemplateSuccess, 'reportTemplate'> & { reportTemplate: GqlResolversTypes['ReportTemplate'] }>;
   UpdateSignupBonusConfigInput: GqlUpdateSignupBonusConfigInput;
   Upload: ResolverTypeWrapper<Scalars['Upload']['output']>;
   User: ResolverTypeWrapper<User>;
@@ -4196,6 +4412,8 @@ export type GqlResolversTypes = ResolversObject<{
 /** Mapping between all available schema types and the resolvers parents */
 export type GqlResolversParentTypes = ResolversObject<{
   AccumulatedPointView: AccumulatedPointView;
+  ApproveReportPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['ApproveReportPayload'];
+  ApproveReportSuccess: Omit<GqlApproveReportSuccess, 'report'> & { report: GqlResolversParentTypes['Report'] };
   Article: Article;
   ArticleCreateInput: GqlArticleCreateInput;
   ArticleCreatePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['ArticleCreatePayload'];
@@ -4271,6 +4489,10 @@ export type GqlResolversParentTypes = ResolversObject<{
   EvaluationItem: GqlEvaluationItem;
   EvaluationSortInput: GqlEvaluationSortInput;
   EvaluationsConnection: Omit<GqlEvaluationsConnection, 'edges'> & { edges: Array<GqlResolversParentTypes['EvaluationEdge']> };
+  Float: Scalars['Float']['output'];
+  GenerateReportInput: GqlGenerateReportInput;
+  GenerateReportPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['GenerateReportPayload'];
+  GenerateReportSuccess: Omit<GqlGenerateReportSuccess, 'report'> & { report: GqlResolversParentTypes['Report'] };
   ID: Scalars['ID']['output'];
   Identity: Omit<GqlIdentity, 'user'> & { user?: Maybe<GqlResolversParentTypes['User']> };
   IdentityCheckPhoneUserInput: GqlIdentityCheckPhoneUserInput;
@@ -4396,7 +4618,15 @@ export type GqlResolversParentTypes = ResolversObject<{
   PortfolioFilterInput: GqlPortfolioFilterInput;
   PortfolioSortInput: GqlPortfolioSortInput;
   PortfoliosConnection: Omit<GqlPortfoliosConnection, 'edges'> & { edges: Array<GqlResolversParentTypes['PortfolioEdge']> };
+  PublishReportPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['PublishReportPayload'];
+  PublishReportSuccess: Omit<GqlPublishReportSuccess, 'report'> & { report: GqlResolversParentTypes['Report'] };
   Query: {};
+  RejectReportPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['RejectReportPayload'];
+  RejectReportSuccess: Omit<GqlRejectReportSuccess, 'report'> & { report: GqlResolversParentTypes['Report'] };
+  Report: Omit<GqlReport, 'community' | 'generatedByUser' | 'parentRun' | 'publishedByUser' | 'regenerations' | 'targetUser' | 'template'> & { community: GqlResolversParentTypes['Community'], generatedByUser?: Maybe<GqlResolversParentTypes['User']>, parentRun?: Maybe<GqlResolversParentTypes['Report']>, publishedByUser?: Maybe<GqlResolversParentTypes['User']>, regenerations: Array<GqlResolversParentTypes['Report']>, targetUser?: Maybe<GqlResolversParentTypes['User']>, template?: Maybe<GqlResolversParentTypes['ReportTemplate']> };
+  ReportEdge: Omit<GqlReportEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['Report']> };
+  ReportTemplate: Omit<GqlReportTemplate, 'community' | 'updatedByUser'> & { community?: Maybe<GqlResolversParentTypes['Community']>, updatedByUser?: Maybe<GqlResolversParentTypes['User']> };
+  ReportsConnection: Omit<GqlReportsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['ReportEdge']>>> };
   Reservation: Omit<GqlReservation, 'createdByUser' | 'histories' | 'opportunitySlot' | 'participations'> & { createdByUser?: Maybe<GqlResolversParentTypes['User']>, histories?: Maybe<Array<GqlResolversParentTypes['ReservationHistory']>>, opportunitySlot?: Maybe<GqlResolversParentTypes['OpportunitySlot']>, participations?: Maybe<Array<GqlResolversParentTypes['Participation']>> };
   ReservationCancelInput: GqlReservationCancelInput;
   ReservationCreateInput: GqlReservationCreateInput;
@@ -4478,6 +4708,9 @@ export type GqlResolversParentTypes = ResolversObject<{
   TransactionUpdateMetadataSuccess: Omit<GqlTransactionUpdateMetadataSuccess, 'transaction'> & { transaction: GqlResolversParentTypes['Transaction'] };
   TransactionVerificationResult: GqlTransactionVerificationResult;
   TransactionsConnection: Omit<GqlTransactionsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['TransactionEdge']>>> };
+  UpdateReportTemplateInput: GqlUpdateReportTemplateInput;
+  UpdateReportTemplatePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['UpdateReportTemplatePayload'];
+  UpdateReportTemplateSuccess: Omit<GqlUpdateReportTemplateSuccess, 'reportTemplate'> & { reportTemplate: GqlResolversParentTypes['ReportTemplate'] };
   UpdateSignupBonusConfigInput: GqlUpdateSignupBonusConfigInput;
   Upload: Scalars['Upload']['output'];
   User: User;
@@ -4556,6 +4789,15 @@ export type GqlRequireRoleDirectiveResolver<Result, Parent, ContextType = any, A
 export type GqlAccumulatedPointViewResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AccumulatedPointView'] = GqlResolversParentTypes['AccumulatedPointView']> = ResolversObject<{
   accumulatedPoint?: Resolver<GqlResolversTypes['BigInt'], ParentType, ContextType>;
   walletId?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlApproveReportPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ApproveReportPayload'] = GqlResolversParentTypes['ApproveReportPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'ApproveReportSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlApproveReportSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ApproveReportSuccess'] = GqlResolversParentTypes['ApproveReportSuccess']> = ResolversObject<{
+  report?: Resolver<GqlResolversTypes['Report'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -4810,7 +5052,7 @@ export type GqlDidIssuanceRequestResolvers<ContextType = any, ParentType extends
 }>;
 
 export type GqlEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Edge'] = GqlResolversParentTypes['Edge']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'ArticleEdge' | 'CityEdge' | 'CommunityEdge' | 'EvaluationEdge' | 'EvaluationHistoryEdge' | 'IncentiveGrantEdge' | 'MembershipEdge' | 'NftInstanceEdge' | 'NftTokenEdge' | 'OpportunityEdge' | 'OpportunitySlotEdge' | 'ParticipationEdge' | 'ParticipationStatusHistoryEdge' | 'PlaceEdge' | 'PortfolioEdge' | 'ReservationEdge' | 'ReservationHistoryEdge' | 'StateEdge' | 'TicketClaimLinkEdge' | 'TicketEdge' | 'TicketIssuerEdge' | 'TicketStatusHistoryEdge' | 'TransactionEdge' | 'UserEdge' | 'UtilityEdge' | 'VcIssuanceRequestEdge' | 'WalletEdge', ParentType, ContextType>;
+  __resolveType: TypeResolveFn<'ArticleEdge' | 'CityEdge' | 'CommunityEdge' | 'EvaluationEdge' | 'EvaluationHistoryEdge' | 'IncentiveGrantEdge' | 'MembershipEdge' | 'NftInstanceEdge' | 'NftTokenEdge' | 'OpportunityEdge' | 'OpportunitySlotEdge' | 'ParticipationEdge' | 'ParticipationStatusHistoryEdge' | 'PlaceEdge' | 'PortfolioEdge' | 'ReportEdge' | 'ReservationEdge' | 'ReservationHistoryEdge' | 'StateEdge' | 'TicketClaimLinkEdge' | 'TicketEdge' | 'TicketIssuerEdge' | 'TicketStatusHistoryEdge' | 'TransactionEdge' | 'UserEdge' | 'UtilityEdge' | 'VcIssuanceRequestEdge' | 'WalletEdge', ParentType, ContextType>;
   cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
 }>;
 
@@ -4877,6 +5119,15 @@ export type GqlEvaluationsConnectionResolvers<ContextType = any, ParentType exte
   edges?: Resolver<Array<GqlResolversTypes['EvaluationEdge']>, ParentType, ContextType>;
   pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
   totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlGenerateReportPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['GenerateReportPayload'] = GqlResolversParentTypes['GenerateReportPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'GenerateReportSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlGenerateReportSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['GenerateReportSuccess'] = GqlResolversParentTypes['GenerateReportSuccess']> = ResolversObject<{
+  report?: Resolver<GqlResolversTypes['Report'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -5033,6 +5284,7 @@ export type GqlMembershipsConnectionResolvers<ContextType = any, ParentType exte
 }>;
 
 export type GqlMutationResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Mutation'] = GqlResolversParentTypes['Mutation']> = ResolversObject<{
+  approveReport?: Resolver<Maybe<GqlResolversTypes['ApproveReportPayload']>, ParentType, ContextType, RequireFields<GqlMutationApproveReportArgs, 'id'>>;
   articleCreate?: Resolver<Maybe<GqlResolversTypes['ArticleCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationArticleCreateArgs, 'input' | 'permission'>>;
   articleDelete?: Resolver<Maybe<GqlResolversTypes['ArticleDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationArticleDeleteArgs, 'id' | 'permission'>>;
   articleUpdateContent?: Resolver<Maybe<GqlResolversTypes['ArticleUpdateContentPayload']>, ParentType, ContextType, RequireFields<GqlMutationArticleUpdateContentArgs, 'id' | 'input' | 'permission'>>;
@@ -5040,6 +5292,7 @@ export type GqlMutationResolvers<ContextType = any, ParentType extends GqlResolv
   communityDelete?: Resolver<Maybe<GqlResolversTypes['CommunityDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationCommunityDeleteArgs, 'id' | 'permission'>>;
   communityUpdateProfile?: Resolver<Maybe<GqlResolversTypes['CommunityUpdateProfilePayload']>, ParentType, ContextType, RequireFields<GqlMutationCommunityUpdateProfileArgs, 'id' | 'input' | 'permission'>>;
   evaluationBulkCreate?: Resolver<Maybe<GqlResolversTypes['EvaluationBulkCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationEvaluationBulkCreateArgs, 'input' | 'permission'>>;
+  generateReport?: Resolver<Maybe<GqlResolversTypes['GenerateReportPayload']>, ParentType, ContextType, RequireFields<GqlMutationGenerateReportArgs, 'input' | 'permission'>>;
   identityCheckPhoneUser?: Resolver<GqlResolversTypes['IdentityCheckPhoneUserPayload'], ParentType, ContextType, RequireFields<GqlMutationIdentityCheckPhoneUserArgs, 'input'>>;
   incentiveGrantRetry?: Resolver<Maybe<GqlResolversTypes['IncentiveGrantRetryPayload']>, ParentType, ContextType, RequireFields<GqlMutationIncentiveGrantRetryArgs, 'input' | 'permission'>>;
   linkPhoneAuth?: Resolver<Maybe<GqlResolversTypes['LinkPhoneAuthPayload']>, ParentType, ContextType, RequireFields<GqlMutationLinkPhoneAuthArgs, 'input' | 'permission'>>;
@@ -5066,6 +5319,8 @@ export type GqlMutationResolvers<ContextType = any, ParentType extends GqlResolv
   placeCreate?: Resolver<Maybe<GqlResolversTypes['PlaceCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationPlaceCreateArgs, 'input' | 'permission'>>;
   placeDelete?: Resolver<Maybe<GqlResolversTypes['PlaceDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationPlaceDeleteArgs, 'id' | 'permission'>>;
   placeUpdate?: Resolver<Maybe<GqlResolversTypes['PlaceUpdatePayload']>, ParentType, ContextType, RequireFields<GqlMutationPlaceUpdateArgs, 'id' | 'input' | 'permission'>>;
+  publishReport?: Resolver<Maybe<GqlResolversTypes['PublishReportPayload']>, ParentType, ContextType, RequireFields<GqlMutationPublishReportArgs, 'finalContent' | 'id'>>;
+  rejectReport?: Resolver<Maybe<GqlResolversTypes['RejectReportPayload']>, ParentType, ContextType, RequireFields<GqlMutationRejectReportArgs, 'id'>>;
   reservationAccept?: Resolver<Maybe<GqlResolversTypes['ReservationSetStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationReservationAcceptArgs, 'id' | 'permission'>>;
   reservationCancel?: Resolver<Maybe<GqlResolversTypes['ReservationSetStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationReservationCancelArgs, 'id' | 'input' | 'permission'>>;
   reservationCreate?: Resolver<Maybe<GqlResolversTypes['ReservationCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationReservationCreateArgs, 'input'>>;
@@ -5082,6 +5337,7 @@ export type GqlMutationResolvers<ContextType = any, ParentType extends GqlResolv
   transactionIssueCommunityPoint?: Resolver<Maybe<GqlResolversTypes['TransactionIssueCommunityPointPayload']>, ParentType, ContextType, RequireFields<GqlMutationTransactionIssueCommunityPointArgs, 'input' | 'permission'>>;
   transactionUpdateMetadata?: Resolver<Maybe<GqlResolversTypes['TransactionUpdateMetadataPayload']>, ParentType, ContextType, RequireFields<GqlMutationTransactionUpdateMetadataArgs, 'id' | 'input'>>;
   updatePortalConfig?: Resolver<GqlResolversTypes['CommunityPortalConfig'], ParentType, ContextType, RequireFields<GqlMutationUpdatePortalConfigArgs, 'input' | 'permission'>>;
+  updateReportTemplate?: Resolver<Maybe<GqlResolversTypes['UpdateReportTemplatePayload']>, ParentType, ContextType, RequireFields<GqlMutationUpdateReportTemplateArgs, 'input' | 'variant'>>;
   updateSignupBonusConfig?: Resolver<GqlResolversTypes['CommunitySignupBonusConfig'], ParentType, ContextType, RequireFields<GqlMutationUpdateSignupBonusConfigArgs, 'input' | 'permission'>>;
   userDeleteMe?: Resolver<Maybe<GqlResolversTypes['UserDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationUserDeleteMeArgs, 'permission'>>;
   userSignUp?: Resolver<Maybe<GqlResolversTypes['CurrentUserPayload']>, ParentType, ContextType, RequireFields<GqlMutationUserSignUpArgs, 'input'>>;
@@ -5485,6 +5741,15 @@ export type GqlPortfoliosConnectionResolvers<ContextType = any, ParentType exten
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type GqlPublishReportPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['PublishReportPayload'] = GqlResolversParentTypes['PublishReportPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'PublishReportSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlPublishReportSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['PublishReportSuccess'] = GqlResolversParentTypes['PublishReportSuccess']> = ResolversObject<{
+  report?: Resolver<GqlResolversTypes['Report'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type GqlQueryResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Query'] = GqlResolversParentTypes['Query']> = ResolversObject<{
   article?: Resolver<Maybe<GqlResolversTypes['Article']>, ParentType, ContextType, RequireFields<GqlQueryArticleArgs, 'id' | 'permission'>>;
   articles?: Resolver<GqlResolversTypes['ArticlesConnection'], ParentType, ContextType, Partial<GqlQueryArticlesArgs>>;
@@ -5519,6 +5784,9 @@ export type GqlQueryResolvers<ContextType = any, ParentType extends GqlResolvers
   place?: Resolver<Maybe<GqlResolversTypes['Place']>, ParentType, ContextType, RequireFields<GqlQueryPlaceArgs, 'id'>>;
   places?: Resolver<GqlResolversTypes['PlacesConnection'], ParentType, ContextType, Partial<GqlQueryPlacesArgs>>;
   portfolios?: Resolver<Maybe<Array<GqlResolversTypes['Portfolio']>>, ParentType, ContextType, Partial<GqlQueryPortfoliosArgs>>;
+  report?: Resolver<Maybe<GqlResolversTypes['Report']>, ParentType, ContextType, RequireFields<GqlQueryReportArgs, 'id'>>;
+  reportTemplate?: Resolver<Maybe<GqlResolversTypes['ReportTemplate']>, ParentType, ContextType, RequireFields<GqlQueryReportTemplateArgs, 'variant'>>;
+  reports?: Resolver<GqlResolversTypes['ReportsConnection'], ParentType, ContextType, RequireFields<GqlQueryReportsArgs, 'communityId' | 'permission'>>;
   reservation?: Resolver<Maybe<GqlResolversTypes['Reservation']>, ParentType, ContextType, RequireFields<GqlQueryReservationArgs, 'id'>>;
   reservationHistories?: Resolver<GqlResolversTypes['ReservationHistoriesConnection'], ParentType, ContextType, Partial<GqlQueryReservationHistoriesArgs>>;
   reservationHistory?: Resolver<Maybe<GqlResolversTypes['ReservationHistory']>, ParentType, ContextType, RequireFields<GqlQueryReservationHistoryArgs, 'id'>>;
@@ -5546,6 +5814,73 @@ export type GqlQueryResolvers<ContextType = any, ParentType extends GqlResolvers
   voteTopics?: Resolver<GqlResolversTypes['VoteTopicsConnection'], ParentType, ContextType, RequireFields<GqlQueryVoteTopicsArgs, 'communityId'>>;
   wallet?: Resolver<Maybe<GqlResolversTypes['Wallet']>, ParentType, ContextType, RequireFields<GqlQueryWalletArgs, 'id'>>;
   wallets?: Resolver<GqlResolversTypes['WalletsConnection'], ParentType, ContextType, Partial<GqlQueryWalletsArgs>>;
+}>;
+
+export type GqlRejectReportPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['RejectReportPayload'] = GqlResolversParentTypes['RejectReportPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'RejectReportSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlRejectReportSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['RejectReportSuccess'] = GqlResolversParentTypes['RejectReportSuccess']> = ResolversObject<{
+  report?: Resolver<GqlResolversTypes['Report'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReportResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Report'] = GqlResolversParentTypes['Report']> = ResolversObject<{
+  cacheReadTokens?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  community?: Resolver<GqlResolversTypes['Community'], ParentType, ContextType>;
+  createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  finalContent?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  generatedByUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  inputTokens?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  model?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  outputMarkdown?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  outputTokens?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  parentRun?: Resolver<Maybe<GqlResolversTypes['Report']>, ParentType, ContextType>;
+  periodFrom?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  periodTo?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  publishedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  publishedByUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  regenerateCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  regenerations?: Resolver<Array<GqlResolversTypes['Report']>, ParentType, ContextType>;
+  status?: Resolver<GqlResolversTypes['ReportStatus'], ParentType, ContextType>;
+  targetUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  template?: Resolver<Maybe<GqlResolversTypes['ReportTemplate']>, ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  variant?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReportEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReportEdge'] = GqlResolversParentTypes['ReportEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['Report']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReportTemplateResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReportTemplate'] = GqlResolversParentTypes['ReportTemplate']> = ResolversObject<{
+  community?: Resolver<Maybe<GqlResolversTypes['Community']>, ParentType, ContextType>;
+  communityContext?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  isEnabled?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  maxTokens?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  model?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  scope?: Resolver<GqlResolversTypes['ReportTemplateScope'], ParentType, ContextType>;
+  stopSequences?: Resolver<Array<GqlResolversTypes['String']>, ParentType, ContextType>;
+  systemPrompt?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  temperature?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  updatedByUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  userPromptTemplate?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  variant?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReportsConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReportsConnection'] = GqlResolversParentTypes['ReportsConnection']> = ResolversObject<{
+  edges?: Resolver<Maybe<Array<Maybe<GqlResolversTypes['ReportEdge']>>>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
 export type GqlReservationResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Reservation'] = GqlResolversParentTypes['Reservation']> = ResolversObject<{
@@ -5903,6 +6238,15 @@ export type GqlTransactionsConnectionResolvers<ContextType = any, ParentType ext
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type GqlUpdateReportTemplatePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['UpdateReportTemplatePayload'] = GqlResolversParentTypes['UpdateReportTemplatePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'UpdateReportTemplateSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlUpdateReportTemplateSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['UpdateReportTemplateSuccess'] = GqlResolversParentTypes['UpdateReportTemplateSuccess']> = ResolversObject<{
+  reportTemplate?: Resolver<GqlResolversTypes['ReportTemplate'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export interface GqlUploadScalarConfig extends GraphQLScalarTypeConfig<GqlResolversTypes['Upload'], any> {
   name: 'Upload';
 }
@@ -6196,6 +6540,8 @@ export type GqlWalletsConnectionResolvers<ContextType = any, ParentType extends 
 
 export type GqlResolvers<ContextType = any> = ResolversObject<{
   AccumulatedPointView?: GqlAccumulatedPointViewResolvers<ContextType>;
+  ApproveReportPayload?: GqlApproveReportPayloadResolvers<ContextType>;
+  ApproveReportSuccess?: GqlApproveReportSuccessResolvers<ContextType>;
   Article?: GqlArticleResolvers<ContextType>;
   ArticleCreatePayload?: GqlArticleCreatePayloadResolvers<ContextType>;
   ArticleCreateSuccess?: GqlArticleCreateSuccessResolvers<ContextType>;
@@ -6241,6 +6587,8 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   EvaluationHistory?: GqlEvaluationHistoryResolvers<ContextType>;
   EvaluationHistoryEdge?: GqlEvaluationHistoryEdgeResolvers<ContextType>;
   EvaluationsConnection?: GqlEvaluationsConnectionResolvers<ContextType>;
+  GenerateReportPayload?: GqlGenerateReportPayloadResolvers<ContextType>;
+  GenerateReportSuccess?: GqlGenerateReportSuccessResolvers<ContextType>;
   Identity?: GqlIdentityResolvers<ContextType>;
   IdentityCheckPhoneUserPayload?: GqlIdentityCheckPhoneUserPayloadResolvers<ContextType>;
   IncentiveGrant?: GqlIncentiveGrantResolvers<ContextType>;
@@ -6319,7 +6667,15 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   Portfolio?: GqlPortfolioResolvers<ContextType>;
   PortfolioEdge?: GqlPortfolioEdgeResolvers<ContextType>;
   PortfoliosConnection?: GqlPortfoliosConnectionResolvers<ContextType>;
+  PublishReportPayload?: GqlPublishReportPayloadResolvers<ContextType>;
+  PublishReportSuccess?: GqlPublishReportSuccessResolvers<ContextType>;
   Query?: GqlQueryResolvers<ContextType>;
+  RejectReportPayload?: GqlRejectReportPayloadResolvers<ContextType>;
+  RejectReportSuccess?: GqlRejectReportSuccessResolvers<ContextType>;
+  Report?: GqlReportResolvers<ContextType>;
+  ReportEdge?: GqlReportEdgeResolvers<ContextType>;
+  ReportTemplate?: GqlReportTemplateResolvers<ContextType>;
+  ReportsConnection?: GqlReportsConnectionResolvers<ContextType>;
   Reservation?: GqlReservationResolvers<ContextType>;
   ReservationCreatePayload?: GqlReservationCreatePayloadResolvers<ContextType>;
   ReservationCreateSuccess?: GqlReservationCreateSuccessResolvers<ContextType>;
@@ -6373,6 +6729,8 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   TransactionUpdateMetadataSuccess?: GqlTransactionUpdateMetadataSuccessResolvers<ContextType>;
   TransactionVerificationResult?: GqlTransactionVerificationResultResolvers<ContextType>;
   TransactionsConnection?: GqlTransactionsConnectionResolvers<ContextType>;
+  UpdateReportTemplatePayload?: GqlUpdateReportTemplatePayloadResolvers<ContextType>;
+  UpdateReportTemplateSuccess?: GqlUpdateReportTemplateSuccessResolvers<ContextType>;
   Upload?: GraphQLScalarType;
   User?: GqlUserResolvers<ContextType>;
   UserDeletePayload?: GqlUserDeletePayloadResolvers<ContextType>;


### PR DESCRIPTION
## Summary

AI レポート生成機能 Phase 1 MVP の **PR-D**。template 取得 → payload 生成 → LLM 呼び出し → DB 保存 の全フローと、admin ワークフロー (状態遷移 / template 管理) を実装。

**依存関係**: PR-A (#831) + PR-B (#835) + PR-C (#839) 全て merged 済。本 PR が merge されれば Phase 1 の GraphQL API は完成、PR-F (週次バッチ) のみ残る。

### GraphQL 表面 (8 endpoints)

**Query**:
- `reports(communityId, variant?, status?, cursor, first, permission)` — community manager+ / admin
- `report(id)` — admin only
- `reportTemplate(communityId?, variant)` — admin only

**Mutation**:
- `generateReport(input, permission)` — community manager+ / admin
- `updateReportTemplate(communityId?, variant, input)` — admin only (upsert semantics)
- `approveReport(id)` — admin only
- `publishReport(id, finalContent)` — admin only
- `rejectReport(id, reason?)` — admin only

### generateReport フロー

```
1. @authz(IsCommunityManager | IsAdmin)
2. Template 解決: findFirst(variant, community override → SYSTEM fallback)
   orderBy communityId ASC (PG default: NULLS LAST)
3. buildReportPayload(customContext: template.communityContext)
4. Prompt render: ${payload_json} → JSON.stringify(payload)
5. LLM call: @inject("LlmClient").complete() + 60s AbortController
6. DB tx (onlyBelongingCommunity):
   - 親 Report → SUPERSEDED (再生成時のみ、同 tx)
   - 新 Report INSERT (DRAFT, snapshots, token usage)
7. Presenter → GraphQL
```

### State machine

```
DRAFT → APPROVED | REJECTED | SUPERSEDED
APPROVED → PUBLISHED | REJECTED | SUPERSEDED
PUBLISHED → SUPERSEDED (再生成時のみ)
REJECTED / SUPERSEDED: terminal
```

再生成: `generateReport({parentRunId})` → 新 DRAFT + 親 auto-SUPERSEDED。`reports` query は default で `status != SUPERSEDED` filter。

### 認可 (二段構え)

| Action | GraphQL rule | UseCase issuer |
|---|---|---|
| generate / reports | `IsCommunityManager \| IsAdmin` | `onlyBelongingCommunity` |
| template / status | `IsAdmin` | `ctx.issuer.admin()` |
| report (single) | `IsAdmin` | `public()` |

### ファイル構成

**新規 8 ファイル**:
- `controller/resolver.ts` — Query / Mutation / Report field resolvers / ReportTemplate field resolvers / 5 Union __resolveType
- `controller/dataloader.ts` — report / reportTemplate / reportsByParentRunId loaders
- `data/type.ts` — Prisma select shapes (`reportSelect`, `reportTemplateSelect`)
- `data/converter.ts` — `GqlUpdateReportTemplateInput` → Prisma format
- `schema/query.graphql` / `schema/mutation.graphql` / `schema/type.graphql`
- `util/promptRenderer.ts` — `${payload_json}` 置換

**既存修正 7 ファイル**:
- `data/interface.ts` (+7 repo methods)
- `data/repository.ts` (+7 impl: findTemplate, upsertTemplate, createReport, findReportById, findReports, updateReportStatus, findReportsByParentRunId)
- `service.ts` (+state machine validation + template/report CRUD delegation)
- `usecase.ts` (+generateReport flow + browseReports + viewReport + viewReportTemplate + updateReportTemplate + approve/publish/reject)
- `presenter.ts` (+report / reportTemplate / reportsConnection mappers)
- `provider.ts` (ReportResolver 登録)
- `presentation/graphql/resolver.ts` + `dataloader/index.ts` (merge)

### Template 投入

PR-D merge 後、admin が以下を 1 回叩いて本番 prompt を投入:

```graphql
mutation {
  updateReportTemplate(
    variant: WEEKLY_SUMMARY
    input: {
      systemPrompt: "あなたはコミュニティの週次レポートを書く..."
      userPromptTemplate: "以下のデータを元にレポートを生成:\n${payload_json}"
      model: "claude-sonnet-4-6"
      maxTokens: 8192
    }
  ) {
    ... on UpdateReportTemplateSuccess { reportTemplate { id } }
  }
}
```

それまで `generateReport` は `template not found` で fail (意図通り)。

## Test plan

- [x] `npx tsc --noEmit` — 新規エラーなし
- [x] `pnpm gql:generate` — 成功、GQL types 生成
- [x] `pnpm test` (presenter 7 + anthropic 9) → 16/16 pass (回帰確認)
- [x] prettier applied
- [ ] dev 環境で `generateReport` mutation 実行 → Claude output 確認 (ANTHROPIC_API_KEY + template 設定後)
- [ ] `approveReport` → `publishReport(finalContent)` で PUBLISHED 遷移確認
- [ ] 再生成: 既存 run を `parentRunId` に渡して `generateReport` → 新 DRAFT + 親 SUPERSEDED
- [ ] non-admin で admin-only endpoint → 拒否確認

## 次の PR

- **PR-D2**: Feedback (submitReportFeedback / reportFeedbacks query) — admin QA signal
- **PR-F**: 週次バッチ (generateWeeklyReports.ts + batch.ts + Cloud Scheduler)

https://claude.ai/code/session_0113rnPuGjN67zbt8hDbzBay
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/841" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
