### PR TITLE
feat(report): copilot fixes + 5 variant expansion + weekly batch

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -1713,7 +1713,7 @@ type Report {
   targetUser: User
   template: ReportTemplate
   updatedAt: Datetime
-  variant: String!
+  variant: ReportVariant!
 }
 
 type ReportEdge implements Edge {
@@ -1744,7 +1744,7 @@ type ReportTemplate {
   updatedAt: Datetime
   updatedByUser: User
   userPromptTemplate: String!
-  variant: String!
+  variant: ReportVariant!
 }
 
 enum ReportTemplateScope {
@@ -1753,6 +1753,10 @@ enum ReportTemplateScope {
 }
 
 enum ReportVariant {
+  GRANT_APPLICATION
+  MEDIA_PR
+  MEMBER_NEWSLETTER
+  PERSONAL_RECAP
   WEEKLY_SUMMARY
 }
 

--- a/src/__tests__/unit/report/service.test.ts
+++ b/src/__tests__/unit/report/service.test.ts
@@ -1,0 +1,63 @@
+import "reflect-metadata";
+import { ReportStatus } from "@prisma/client";
+import { container } from "tsyringe";
+import ReportService from "@/application/domain/report/service";
+
+class MockReportRepository {
+  findDailySummaries = jest.fn();
+  findDailyActiveUsers = jest.fn();
+  findTopUsersByTotalPoints = jest.fn();
+  findCommentsByDateRange = jest.fn();
+  findUserProfiles = jest.fn();
+  findCommunityContext = jest.fn();
+  findDeepestChain = jest.fn();
+  refreshTransactionSummaryDaily = jest.fn();
+  refreshUserTransactionDaily = jest.fn();
+  findTemplate = jest.fn();
+  upsertTemplate = jest.fn();
+  createReport = jest.fn();
+  findReportById = jest.fn();
+  findReports = jest.fn();
+  updateReportStatus = jest.fn();
+  findReportsByParentRunId = jest.fn();
+}
+
+describe("ReportService", () => {
+  let service: ReportService;
+
+  beforeEach(() => {
+    container.reset();
+    container.register("ReportRepository", { useValue: new MockReportRepository() });
+    service = container.resolve(ReportService);
+  });
+
+  describe("assertStatusTransition", () => {
+    const validTransitions: [ReportStatus, ReportStatus][] = [
+      [ReportStatus.DRAFT, ReportStatus.APPROVED],
+      [ReportStatus.DRAFT, ReportStatus.REJECTED],
+      [ReportStatus.DRAFT, ReportStatus.SUPERSEDED],
+      [ReportStatus.APPROVED, ReportStatus.PUBLISHED],
+      [ReportStatus.APPROVED, ReportStatus.REJECTED],
+      [ReportStatus.APPROVED, ReportStatus.SUPERSEDED],
+      [ReportStatus.PUBLISHED, ReportStatus.SUPERSEDED],
+    ];
+
+    it.each(validTransitions)("allows %s → %s", (from, to) => {
+      expect(() => service.assertStatusTransition(from, to)).not.toThrow();
+    });
+
+    const invalidTransitions: [ReportStatus, ReportStatus][] = [
+      [ReportStatus.REJECTED, ReportStatus.DRAFT],
+      [ReportStatus.REJECTED, ReportStatus.APPROVED],
+      [ReportStatus.SUPERSEDED, ReportStatus.DRAFT],
+      [ReportStatus.SUPERSEDED, ReportStatus.APPROVED],
+      [ReportStatus.PUBLISHED, ReportStatus.APPROVED],
+      [ReportStatus.PUBLISHED, ReportStatus.DRAFT],
+      [ReportStatus.DRAFT, ReportStatus.PUBLISHED],
+    ];
+
+    it.each(invalidTransitions)("rejects %s → %s", (from, to) => {
+      expect(() => service.assertStatusTransition(from, to)).toThrow(/Invalid status transition/);
+    });
+  });
+});

--- a/src/application/domain/report/controller/resolver.ts
+++ b/src/application/domain/report/controller/resolver.ts
@@ -54,8 +54,10 @@ export default class ReportResolver {
   Report = {
     community: (parent: PrismaReport, _: unknown, ctx: IContext) =>
       ctx.loaders.community.load(parent.communityId),
-    template: (parent: PrismaReport, _: unknown, ctx: IContext) =>
-      parent.templateId ? ctx.loaders.reportTemplate.load(parent.templateId) : null,
+    template: (parent: PrismaReport, _: unknown, ctx: IContext) => {
+      if (!(ctx.isAdmin || ctx.currentUser?.sysRole === "SYS_ADMIN")) return null;
+      return parent.templateId ? ctx.loaders.reportTemplate.load(parent.templateId) : null;
+    },
     generatedByUser: (parent: PrismaReport, _: unknown, ctx: IContext) =>
       parent.generatedBy ? ctx.loaders.user.load(parent.generatedBy) : null,
     publishedByUser: (parent: PrismaReport, _: unknown, ctx: IContext) =>

--- a/src/application/domain/report/schema/type.graphql
+++ b/src/application/domain/report/schema/type.graphql
@@ -4,6 +4,10 @@
 
 enum ReportVariant {
   WEEKLY_SUMMARY
+  GRANT_APPLICATION
+  MEDIA_PR
+  PERSONAL_RECAP
+  MEMBER_NEWSLETTER
 }
 
 enum ReportStatus {
@@ -22,7 +26,7 @@ enum ReportTemplateScope {
 type Report {
   id: ID!
   community: Community!
-  variant: String!
+  variant: ReportVariant!
   periodFrom: Datetime!
   periodTo: Datetime!
   template: ReportTemplate
@@ -51,7 +55,7 @@ type Report {
 
 type ReportTemplate {
   id: ID!
-  variant: String!
+  variant: ReportVariant!
   scope: ReportTemplateScope!
   community: Community
   systemPrompt: String!

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -130,10 +130,7 @@ export default class ReportUseCase {
     ctx: IContext,
   ): Promise<GqlGenerateReportPayload> {
     if (permission.communityId !== input.communityId) {
-      throw new ValidationError(
-        "communityId in input does not match permission.communityId",
-        [],
-      );
+      throw new ValidationError("communityId in input does not match permission.communityId", []);
     }
     const communityId = permission.communityId;
     const template = await this.service.getTemplate(ctx, input.variant, communityId);
@@ -143,7 +140,19 @@ export default class ReportUseCase {
       );
     }
 
+    if (input.periodFrom > input.periodTo) {
+      throw new ValidationError("periodFrom must be on or before periodTo", [
+        "periodFrom",
+        "periodTo",
+      ]);
+    }
     const windowDays = daysBetweenJst(input.periodFrom, input.periodTo) + 1;
+    if (windowDays > MAX_WINDOW_DAYS) {
+      throw new ValidationError(
+        `Report window cannot exceed ${MAX_WINDOW_DAYS} days (requested ${windowDays})`,
+        ["periodFrom", "periodTo"],
+      );
+    }
     const payload = await this.buildReportPayload(ctx, {
       communityId,
       referenceDate: input.periodTo,
@@ -261,7 +270,14 @@ export default class ReportUseCase {
     ctx: IContext,
   ): Promise<GqlUpdateReportTemplatePayload> {
     const template = await ctx.issuer.admin(ctx, (tx) =>
-      this.service.upsertTemplate(ctx, variant, communityId ?? null, input, ctx.currentUser!.id, tx),
+      this.service.upsertTemplate(
+        ctx,
+        variant,
+        communityId ?? null,
+        input,
+        ctx.currentUser!.id,
+        tx,
+      ),
     );
     return {
       __typename: "UpdateReportTemplateSuccess",

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -140,7 +140,7 @@ export default class ReportUseCase {
       );
     }
 
-    if (input.periodFrom > input.periodTo) {
+    if (daysBetweenJst(input.periodFrom, input.periodTo) < 0) {
       throw new ValidationError("periodFrom must be on or before periodTo", [
         "periodFrom",
         "periodTo",

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -140,13 +140,16 @@ export default class ReportUseCase {
       );
     }
 
-    if (daysBetweenJst(input.periodFrom, input.periodTo) < 0) {
+    const periodFrom = truncateToJstDate(input.periodFrom);
+    const periodTo = truncateToJstDate(input.periodTo);
+
+    if (daysBetweenJst(periodFrom, periodTo) < 0) {
       throw new ValidationError("periodFrom must be on or before periodTo", [
         "periodFrom",
         "periodTo",
       ]);
     }
-    const windowDays = daysBetweenJst(input.periodFrom, input.periodTo) + 1;
+    const windowDays = daysBetweenJst(periodFrom, periodTo) + 1;
     if (windowDays > MAX_WINDOW_DAYS) {
       throw new ValidationError(
         `Report window cannot exceed ${MAX_WINDOW_DAYS} days (requested ${windowDays})`,
@@ -155,7 +158,7 @@ export default class ReportUseCase {
     }
     const payload = await this.buildReportPayload(ctx, {
       communityId,
-      referenceDate: input.periodTo,
+      referenceDate: periodTo,
       windowDays,
       customContext: template.communityContext ?? undefined,
     });
@@ -207,8 +210,8 @@ export default class ReportUseCase {
         {
           communityId,
           variant: input.variant,
-          periodFrom: input.periodFrom,
-          periodTo: input.periodTo,
+          periodFrom,
+          periodTo,
           templateId: template.id,
           inputPayload: payload as object,
           outputMarkdown: llmResult.text,

--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -31,7 +31,6 @@ import IdentityUseCase from "@/application/domain/account/identity/usecase";
 import { NmkrClient } from "@/infrastructure/libs/nmkr/api/client";
 import { CardanoShopifyAppClient } from "@/infrastructure/libs/cardanoShopifyApp/api/client";
 import { AnthropicLlmClient } from "@/infrastructure/libs/llm";
-import ReportResolver from "@/application/domain/report/controller/resolver";
 import IdentityRepository from "@/application/domain/account/identity/data/repository";
 import IdentityConverter from "@/application/domain/account/identity/data/converter";
 import DIDIssuanceRequestRepository from "@/application/domain/account/identity/didIssuanceRequest/data/repository";
@@ -352,7 +351,6 @@ export function registerProductionDependencies() {
   container.register("ReportRepository", { useClass: ReportRepository });
   container.register("ReportService", { useClass: ReportService });
   container.register("ReportUseCase", { useClass: ReportUseCase });
-  container.register("ReportResolver", { useClass: ReportResolver });
   container.register("LlmClient", { useClass: AnthropicLlmClient });
 
   // ------------------------------

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -7,6 +7,7 @@ import { requestDIDVC } from "@/presentation/batch/requestDIDVC";
 import { syncNftMetadata } from "@/presentation/batch/syncNftMetadata";
 import { refreshPointViews } from "@/presentation/batch/refreshPointViews";
 import { refreshReportViews } from "@/presentation/batch/refreshReportViews";
+import { generateWeeklyReports } from "@/presentation/batch/generateWeeklyReports";
 
 export async function batchProcess() {
   switch (process.env.BATCH_PROCESS_NAME) {
@@ -33,6 +34,9 @@ export async function batchProcess() {
       return;
     case "refresh-report-views":
       await refreshReportViews();
+      return;
+    case "generate-weekly-reports":
+      await generateWeeklyReports();
       return;
     default:
       logger.error("Invalid batch process called.");

--- a/src/presentation/batch/generateWeeklyReports.ts
+++ b/src/presentation/batch/generateWeeklyReports.ts
@@ -35,7 +35,7 @@ export async function generateWeeklyReports() {
           variant: "WEEKLY_SUMMARY",
           periodFrom: weekAgo,
           periodTo: yesterday,
-          status: { not: ReportStatus.REJECTED },
+          status: { notIn: [ReportStatus.REJECTED, ReportStatus.SUPERSEDED] },
         },
         select: { id: true },
       });

--- a/src/presentation/batch/generateWeeklyReports.ts
+++ b/src/presentation/batch/generateWeeklyReports.ts
@@ -1,0 +1,71 @@
+import "reflect-metadata";
+import "@/application/provider";
+import { container } from "tsyringe";
+import { ReportStatus } from "@prisma/client";
+import { PrismaClientIssuer, prismaClient } from "@/infrastructure/prisma/client";
+import logger from "@/infrastructure/logging";
+import ReportUseCase from "@/application/domain/report/usecase";
+import { IContext } from "@/types/server";
+import { addDays, truncateToJstDate } from "@/application/domain/report/util";
+
+export async function generateWeeklyReports() {
+  const issuer = container.resolve<PrismaClientIssuer>("PrismaClientIssuer");
+  const reportUseCase = container.resolve<ReportUseCase>("ReportUseCase");
+
+  logger.debug("Starting weekly report generation batch...");
+
+  const communities = await prismaClient.community.findMany({
+    select: { id: true },
+  });
+
+  const yesterday = addDays(truncateToJstDate(new Date()), -1);
+  const weekAgo = addDays(yesterday, -6);
+
+  const ctx = { issuer, isAdmin: true } as IContext;
+
+  let successCount = 0;
+  let skipCount = 0;
+  let errorCount = 0;
+
+  for (const community of communities) {
+    try {
+      const existing = await prismaClient.report.findFirst({
+        where: {
+          communityId: community.id,
+          variant: "WEEKLY_SUMMARY",
+          periodFrom: weekAgo,
+          periodTo: yesterday,
+          status: { not: ReportStatus.REJECTED },
+        },
+        select: { id: true },
+      });
+      if (existing) {
+        logger.debug(`Skipping community ${community.id} — report already exists`);
+        skipCount++;
+        continue;
+      }
+
+      await reportUseCase.generateReport(
+        {
+          input: {
+            communityId: community.id,
+            variant: "WEEKLY_SUMMARY" as never,
+            periodFrom: weekAgo,
+            periodTo: yesterday,
+          },
+          permission: { communityId: community.id },
+        },
+        ctx,
+      );
+      successCount++;
+      logger.debug(`Generated weekly report for community ${community.id}`);
+    } catch (error) {
+      errorCount++;
+      logger.error(`Failed to generate weekly report for community ${community.id}:`, error);
+    }
+  }
+
+  logger.debug(
+    `Weekly report batch completed: ${successCount} generated, ${skipCount} skipped, ${errorCount} errors`,
+  );
+}

--- a/src/presentation/batch/generateWeeklyReports.ts
+++ b/src/presentation/batch/generateWeeklyReports.ts
@@ -30,6 +30,10 @@ export async function generateWeeklyReports() {
 
   for (const community of communities) {
     try {
+      // Intentionally skip only DRAFT/APPROVED/PUBLISHED reports.
+      // REJECTED reports are treated as "not existing" so the batch
+      // retries generation after an admin rejection. SUPERSEDED
+      // reports are also excluded since they've been replaced.
       const existing = await issuer.internal((tx) =>
         tx.report.findFirst({
           where: {

--- a/src/presentation/batch/generateWeeklyReports.ts
+++ b/src/presentation/batch/generateWeeklyReports.ts
@@ -2,10 +2,11 @@ import "reflect-metadata";
 import "@/application/provider";
 import { container } from "tsyringe";
 import { ReportStatus } from "@prisma/client";
-import { PrismaClientIssuer, prismaClient } from "@/infrastructure/prisma/client";
+import { PrismaClientIssuer } from "@/infrastructure/prisma/client";
 import logger from "@/infrastructure/logging";
 import ReportUseCase from "@/application/domain/report/usecase";
 import { IContext } from "@/types/server";
+import { GqlReportVariant } from "@/types/graphql";
 import { addDays, truncateToJstDate } from "@/application/domain/report/util";
 
 export async function generateWeeklyReports() {
@@ -14,14 +15,14 @@ export async function generateWeeklyReports() {
 
   logger.debug("Starting weekly report generation batch...");
 
-  const communities = await prismaClient.community.findMany({
-    select: { id: true },
-  });
+  const ctx = { issuer, isAdmin: true } as IContext;
+
+  const communities = await issuer.internal((tx) =>
+    tx.community.findMany({ select: { id: true } }),
+  );
 
   const yesterday = addDays(truncateToJstDate(new Date()), -1);
   const weekAgo = addDays(yesterday, -6);
-
-  const ctx = { issuer, isAdmin: true } as IContext;
 
   let successCount = 0;
   let skipCount = 0;
@@ -29,16 +30,18 @@ export async function generateWeeklyReports() {
 
   for (const community of communities) {
     try {
-      const existing = await prismaClient.report.findFirst({
-        where: {
-          communityId: community.id,
-          variant: "WEEKLY_SUMMARY",
-          periodFrom: weekAgo,
-          periodTo: yesterday,
-          status: { notIn: [ReportStatus.REJECTED, ReportStatus.SUPERSEDED] },
-        },
-        select: { id: true },
-      });
+      const existing = await issuer.internal((tx) =>
+        tx.report.findFirst({
+          where: {
+            communityId: community.id,
+            variant: GqlReportVariant.WeeklySummary,
+            periodFrom: weekAgo,
+            periodTo: yesterday,
+            status: { notIn: [ReportStatus.REJECTED, ReportStatus.SUPERSEDED] },
+          },
+          select: { id: true },
+        }),
+      );
       if (existing) {
         logger.debug(`Skipping community ${community.id} — report already exists`);
         skipCount++;
@@ -49,7 +52,7 @@ export async function generateWeeklyReports() {
         {
           input: {
             communityId: community.id,
-            variant: "WEEKLY_SUMMARY" as never,
+            variant: GqlReportVariant.WeeklySummary,
             periodFrom: weekAgo,
             periodTo: yesterday,
           },

--- a/src/presentation/graphql/dataloader/domain/report.ts
+++ b/src/presentation/graphql/dataloader/domain/report.ts
@@ -1,0 +1,1 @@
+export { createReportLoaders } from "@/application/domain/report/controller/dataloader";

--- a/src/presentation/graphql/dataloader/index.ts
+++ b/src/presentation/graphql/dataloader/index.ts
@@ -6,7 +6,7 @@ import { createContentLoaders } from "@/presentation/graphql/dataloader/domain/c
 import { createTransactionLoaders } from "@/presentation/graphql/dataloader/domain/transaction";
 import { createLocationLoaders } from "@/presentation/graphql/dataloader/domain/location";
 import { createVoteLoaders } from "@/presentation/graphql/dataloader/domain/vote";
-import { createReportLoaders } from "@/application/domain/report/controller/dataloader";
+import { createReportLoaders } from "@/presentation/graphql/dataloader/domain/report";
 
 export function createLoaders(prisma: PrismaClient) {
   return {

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -2632,7 +2632,7 @@ export type GqlReport = {
   targetUser?: Maybe<GqlUser>;
   template?: Maybe<GqlReportTemplate>;
   updatedAt?: Maybe<Scalars['Datetime']['output']>;
-  variant: Scalars['String']['output'];
+  variant: GqlReportVariant;
 };
 
 export type GqlReportEdge = GqlEdge & {
@@ -2666,7 +2666,7 @@ export type GqlReportTemplate = {
   updatedAt?: Maybe<Scalars['Datetime']['output']>;
   updatedByUser?: Maybe<GqlUser>;
   userPromptTemplate: Scalars['String']['output'];
-  variant: Scalars['String']['output'];
+  variant: GqlReportVariant;
 };
 
 export const GqlReportTemplateScope = {
@@ -2676,6 +2676,10 @@ export const GqlReportTemplateScope = {
 
 export type GqlReportTemplateScope = typeof GqlReportTemplateScope[keyof typeof GqlReportTemplateScope];
 export const GqlReportVariant = {
+  GrantApplication: 'GRANT_APPLICATION',
+  MediaPr: 'MEDIA_PR',
+  MemberNewsletter: 'MEMBER_NEWSLETTER',
+  PersonalRecap: 'PERSONAL_RECAP',
   WeeklySummary: 'WEEKLY_SUMMARY'
 } as const;
 
@@ -5846,7 +5850,7 @@ export type GqlReportResolvers<ContextType = any, ParentType extends GqlResolver
   targetUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
   template?: Resolver<Maybe<GqlResolversTypes['ReportTemplate']>, ParentType, ContextType>;
   updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
-  variant?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  variant?: Resolver<GqlResolversTypes['ReportVariant'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -5871,7 +5875,7 @@ export type GqlReportTemplateResolvers<ContextType = any, ParentType extends Gql
   updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
   updatedByUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
   userPromptTemplate?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
-  variant?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  variant?: Resolver<GqlResolversTypes['ReportVariant'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 


### PR DESCRIPTION
## Summary

PR-D (#841) の Copilot review 対応 + 全 5 variant 展開 + 週次バッチ。

### 変更内容 (8 項目)

1. **Period validation** — `periodFrom > periodTo` / 90 日超を `ValidationError` で明示的に弾く
2. **Variant 型修正** — `Report.variant` / `ReportTemplate.variant` を `String!` → `ReportVariant!` に統一
3. **Template field security** — `Report.template` field resolver で admin チェック。community manager が prompt を読めなくなる
4. **DataLoader import path** — `presentation/graphql/dataloader/domain/report.ts` wrapper で既存パターンに統一
5. **Provider cleanup** — 未使用の `"ReportResolver"` string-token 登録を削除
6. **Variant 全展開** — `WEEKLY_SUMMARY` / `GRANT_APPLICATION` / `MEDIA_PR` / `PERSONAL_RECAP` / `MEMBER_NEWSLETTER`
7. **週次バッチ** — `generateWeeklyReports.ts` (sequential / idempotent / `isAdmin: true` context)
8. **Unit tests** — `assertStatusTransition` 14 ケース (7 valid + 7 invalid)

### 検証

- [x] `pnpm gql:generate` 成功
- [x] `npx tsc --noEmit` clean
- [x] `pnpm test` 30/30 pass (既存 16 + 新規 14)
- [ ] dev 環境 variant 切替テスト (admin が各 variant の template seed → generateReport)
- [ ] バッチ: `BATCH_PROCESS_NAME=generate-weekly-reports` で dev 実行

https://claude.ai/code/session_0113rnPuGjN67zbt8hDbzBay
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
