### PR TITLE
fix(report): make ReportTemplate.temperature nullable for Opus 4.7

### DIFF
--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -918,7 +918,7 @@ OTHER OTHER
     String user_prompt_template 
     String community_context "❓"
     String model 
-    Float temperature 
+    Float temperature "❓"
     Int maxTokens 
     String stopSequences 
     Boolean isEnabled 

--- a/docs/schema.dbml
+++ b/docs/schema.dbml
@@ -786,7 +786,7 @@ Table t_report_templates {
   userPromptTemplate String [not null]
   communityContext String
   model String [not null]
-  temperature Float [not null, default: 1]
+  temperature Float [default: 1]
   maxTokens Int [not null]
   stopSequences String[] [not null]
   isEnabled Boolean [not null, default: true]

--- a/src/infrastructure/prisma/factories/__generated__/index.ts
+++ b/src/infrastructure/prisma/factories/__generated__/index.ts
@@ -9329,7 +9329,7 @@ type ReportTemplateFactoryDefineInput = {
     userPromptTemplate?: string;
     communityContext?: string | null;
     model?: string;
-    temperature?: number;
+    temperature?: number | null;
     maxTokens?: number;
     stopSequences?: Prisma.ReportTemplateCreatestopSequencesInput | Array<string>;
     isEnabled?: boolean;

--- a/src/infrastructure/prisma/migrations/20260417074704_make_template_temperature_nullable/migration.sql
+++ b/src/infrastructure/prisma/migrations/20260417074704_make_template_temperature_nullable/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "t_report_templates" ALTER COLUMN "temperature" DROP NOT NULL;

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -1656,7 +1656,7 @@ model ReportTemplate {
   communityContext   String? @map("community_context") @db.Text
 
   model         String
-  temperature   Float    @default(1.0)
+  temperature   Float?   @default(1.0)
   maxTokens     Int      @map("max_tokens")
   stopSequences String[] @default([]) @map("stop_sequences")
   isEnabled     Boolean  @default(true) @map("is_enabled")


### PR DESCRIPTION
## Summary

`ReportTemplate.temperature` を nullable に変更 (Opus 4.7 対応)。

### 問題

`temperature Float @default(1.0)` (non-nullable) のため、usecase の `template.temperature !== null` ガードが常に `true` → temperature が必ず LLM に送られる。Opus 4.7 は temperature を受け取ると HTTP 400 を返すため、Opus 4.7 template では report 生成が必ず失敗する。

### 修正

```prisma
temperature   Float?   @default(1.0)  // nullable に変更
```

- `NULL` = LLM に temperature を送らない (Opus 4.7 / 将来の temperature 非対応モデル)
- 非 NULL = 指定値を送る (Sonnet 4.6 等)
- 既存行は `1.0` のまま (`DEFAULT` は維持)
- migration: `ALTER COLUMN "temperature" DROP NOT NULL` (1 行、`pnpm db:migrate` 生成)

## Test plan

- [x] `pnpm db:deploy` clean apply
- [x] `prisma migrate diff` → empty (drift 0)
- [x] `npx tsc --noEmit` clean
- [x] `pnpm test` 30/30 pass

https://claude.ai/code/session_0113rnPuGjN67zbt8hDbzBay
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
