### PR TITLE
docker: establish supply chain integrity baseline (PR-β')

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,19 @@
 # Node.js dependencies
+#
+# node_modules is intentionally NOT excluded from the build context.
+#
+# The current Dockerfile relies on the CI/CD runner having pre-built
+# node_modules (including Prisma TypedSQL generated types at
+# @prisma/client/sql/*.d.ts) that are copied into the image via
+# `COPY . ./`. This is because `prisma generate --sql` requires
+# database connectivity (via jumpbox tunnel) which is not available
+# during `docker build`.
+#
+# This is intentional tech debt. A multi-stage build with CI artifact
+# injection is the proper fix - see the git log around this file and
+# the associated PR description for context. Do NOT re-enable the
+# `node_modules` exclusion below without first resolving the build
+# flow (runner-dependent -> self-contained).
 # node_modules
 npm-debug.log*
 yarn-debug.log*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:20
 WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-RUN npm install -g pnpm
-RUN pnpm install
+RUN npm install -g pnpm@10.33.0
+RUN pnpm install --frozen-lockfile
 COPY . ./
 RUN pnpm build
 CMD ["pnpm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:20
 WORKDIR /app
-COPY package*.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN npm install -g pnpm
 RUN pnpm install
 COPY . ./

--- a/Dockerfile.batch
+++ b/Dockerfile.batch
@@ -1,8 +1,8 @@
 FROM node:20
 WORKDIR /tmp
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-RUN npm install -g pnpm
-RUN pnpm install
+RUN npm install -g pnpm@10.33.0
+RUN pnpm install --frozen-lockfile
 COPY . ./
 RUN pnpm build
 CMD ["node", "dist/index.js"]

--- a/Dockerfile.batch
+++ b/Dockerfile.batch
@@ -1,6 +1,6 @@
 FROM node:20
 WORKDIR /tmp
-COPY package*.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN npm install -g pnpm
 RUN pnpm install
 COPY . ./

--- a/Dockerfile.external
+++ b/Dockerfile.external
@@ -1,8 +1,8 @@
 FROM node:20
 WORKDIR /tmp
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-RUN npm install -g pnpm
-RUN pnpm install
+RUN npm install -g pnpm@10.33.0
+RUN pnpm install --frozen-lockfile
 COPY . ./
 RUN pnpm build
 CMD ["node", "dist/external-api.js"]

--- a/Dockerfile.external
+++ b/Dockerfile.external
@@ -1,6 +1,6 @@
 FROM node:20
 WORKDIR /tmp
-COPY package*.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN npm install -g pnpm
 RUN pnpm install
 COPY . ./


### PR DESCRIPTION
## Summary
PR-α で設定した supply chain 防御(`minimumReleaseAge`)を本番 Docker build に届かせる。3 commit で lockfile integrity と pnpm version pin を確立。

## Changes
- commit 1: COPY に pnpm-lock.yaml / pnpm-workspace.yaml 追加(3 Dockerfiles)
- commit 2: pnpm を 10.33.0 に pin、`pnpm install --frozen-lockfile` 化
- commit 3: `.dockerignore` に意図的 node_modules 非除外の理由を明記

## Design decision: node_modules leak is retained

最初の実装では `.dockerignore` で `node_modules` を除外したが、結果として `docker build` が `pnpm build`(tsc)で大量の型エラーを起こして fail。

根本原因: `pnpm db:generate`(= `prisma generate --sql`)は `src/infrastructure/prisma/sql/` の SQL ファイル type 検証のため DB 接続必須。Docker build には DB アクセスがない。

現行 build flow:
1. CI/CD runner で `pnpm install` + `pnpm db:generate`(jumpbox 経由で DB tunnel)
2. `docker build` が runner の pre-built `node_modules` を `COPY . ./` で image に取り込む
3. image は runner で生成された TypedSQL 型を使って `pnpm build` を通す

この leak は **意図的**で、`.dockerignore` にコメントとして明記した。

## Verified
- ローカルで `pnpm install --frozen-lockfile` が cooldown を bypass する挙動を確認(50.9s で完走)
- **ローカル docker build 成功(574.6s, image: `civicship-api:pr-beta-prime-test`)**
  - 全 12 step 通過、`pnpm build` 33.8s
  - 事前に `pnpm db:generate:local` 実行、develop 最新 schema の Prisma TypedSQL 型を生成した node_modules を runner leak 経由で image に取り込む構造
  - 本番 CI/CD と同等の build flow(runner で db:generate → docker build が runner の node_modules を leak で取り込む)で動作確認
- 本番 CI/CD 条件での最終検証は dev 環境の Cloud Build で実施(dev merge 時に自動 trigger)

## Out of scope (recorded for future PRs)

### PR-β''(TBD): Multi-stage build with CI artifact injection
現在の設計は CI runner が暗黙の build 一部になってる。Prisma 生成物を input artifact として明示的に受け取る multi-stage build にすれば:
- node_modules leak 解消
- image build が source + artifact から再現可能に
- cross-platform dev build 可能(現状 Mac ARM → Linux x86_64 で壊れる)

deploy workflow と Dockerfile の協調変更が必要、独立した設計議論として PR-β'' に委譲。

### WORKDIR /tmp(Dockerfile.batch / Dockerfile.external)
current git history が squash 起点で `/tmp` 採用の元の意図を追跡不可。動作実績あり、外部設定(Cloud Run volume 等)への依存可能性もあるため PR-β' では触らず、別 PR(PR-ζ 仮称)で runtime 検証込みで判断。

### base image digest pin(`node:20` moving tag)
再現性強化の対象、別 PR の管理対象。

### Single-stage build / devDependencies in production image
Multi-stage refactor(PR-β'')と関連、同 PR で扱う想定。

## Playbook
PR-α3 で Section 12 に本 PR の背景 + シナリオB 発見 + 選択肢α 採用判断 + Case 7(TypedSQL + node_modules leak、ローカル検証手順含む)を記録予定。

https://claude.ai/code/session_0155Q7JBMiTV9NViLze67xwq
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/849" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
