### PR TITLE
fix(report): make GraphQL ReportTemplate.temperature nullable

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -1740,7 +1740,7 @@ type ReportTemplate {
   scope: ReportTemplateScope!
   stopSequences: [String!]!
   systemPrompt: String!
-  temperature: Float!
+  temperature: Float
   updatedAt: Datetime
   updatedByUser: User
   userPromptTemplate: String!

--- a/src/application/domain/report/schema/type.graphql
+++ b/src/application/domain/report/schema/type.graphql
@@ -62,7 +62,7 @@ type ReportTemplate {
   userPromptTemplate: String!
   communityContext: String
   model: String!
-  temperature: Float!
+  temperature: Float
   maxTokens: Int!
   stopSequences: [String!]!
   isEnabled: Boolean!

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -2662,7 +2662,7 @@ export type GqlReportTemplate = {
   scope: GqlReportTemplateScope;
   stopSequences: Array<Scalars['String']['output']>;
   systemPrompt: Scalars['String']['output'];
-  temperature: Scalars['Float']['output'];
+  temperature?: Maybe<Scalars['Float']['output']>;
   updatedAt?: Maybe<Scalars['Datetime']['output']>;
   updatedByUser?: Maybe<GqlUser>;
   userPromptTemplate: Scalars['String']['output'];
@@ -5871,7 +5871,7 @@ export type GqlReportTemplateResolvers<ContextType = any, ParentType extends Gql
   scope?: Resolver<GqlResolversTypes['ReportTemplateScope'], ParentType, ContextType>;
   stopSequences?: Resolver<Array<GqlResolversTypes['String']>, ParentType, ContextType>;
   systemPrompt?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
-  temperature?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  temperature?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
   updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
   updatedByUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
   userPromptTemplate?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;


### PR DESCRIPTION
## Summary

PR #848 で Prisma の `temperature` を nullable にしたが、GraphQL schema の `ReportTemplate.temperature` が `Float!` のまま残っていた。null temperature の template を query すると Apollo が non-null violation を throw する。

`Float!` → `Float` に変更。

## Test plan

- [x] `pnpm gql:generate` 成功
- [x] `npx tsc --noEmit` clean

https://claude.ai/code/session_0113rnPuGjN67zbt8hDbzBay
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/850" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
