### PR TITLE
fix(report): allow null temperature through the API

### DIFF
--- a/src/application/domain/report/data/converter.ts
+++ b/src/application/domain/report/data/converter.ts
@@ -10,7 +10,7 @@ export default class ReportConverter {
       userPromptTemplate: input.userPromptTemplate,
       communityContext: input.communityContext ?? null,
       model: input.model,
-      temperature: input.temperature ?? 1.0,
+      temperature: input.temperature ?? null,
       maxTokens: input.maxTokens,
       stopSequences: input.stopSequences ?? [],
       isEnabled: input.isEnabled ?? true,


### PR DESCRIPTION
The converter's `input.temperature ?? 1.0` coerced null to 1.0, making it impossible to store a null temperature via updateReportTemplate. Change to `?? null` so admins can explicitly set temperature to null for models like Opus 4.7 that reject it.

https://claude.ai/code/session_0113rnPuGjN67zbt8hDbzBay
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/851" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
