### PR TITLE
fix(deps): add graphql-armor-max-depth override (PR-α2.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
   },
   "pnpm": {
     "overrides": {
+      "@escape.tech/graphql-armor-max-depth": "^2.4.2",
       "ajv": "^6.12.6",
       "bn.js": ">=4.12.3",
       "diff": ">=4.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@escape.tech/graphql-armor-max-depth': ^2.4.2
   ajv: ^6.12.6
   bn.js: '>=4.12.3'
   diff: '>=4.0.4'
@@ -1576,8 +1577,8 @@ packages:
     resolution: {integrity: sha512-SDk7pAzY6gutsdZ3NlyY55RrytrCPxJJxSN/DBfIGKphTrfBvKQWTnioQ9OlLP9kPjCE6XM5UWwGt7uqbpKSYA==}
     engines: {node: '>=18.0.0'}
 
-  '@escape.tech/graphql-armor-max-depth@2.4.1':
-    resolution: {integrity: sha512-LTwNMSGEmRvpBxt25MmDpb9N/jyR66jEIDLaVJ3qDG2juyrdexhqxr98fLy4P26H7RKll9kyQ3AlhYaOjfy8cA==}
+  '@escape.tech/graphql-armor-max-depth@2.4.2':
+    resolution: {integrity: sha512-J9fbW1+W4u3GAcf19wwS0zrNGICCbWn/glvopCoC11Ga0reXvGwgr8EcyuHjTFLL7+pPvWAeVhP4qo6hybcB9w==}
     engines: {node: '>=18.0.0'}
 
   '@escape.tech/graphql-armor-max-directives@2.3.1':
@@ -10393,7 +10394,7 @@ snapshots:
       '@envelop/core': 5.3.0
       '@escape.tech/graphql-armor-types': 0.7.0
 
-  '@escape.tech/graphql-armor-max-depth@2.4.1':
+  '@escape.tech/graphql-armor-max-depth@2.4.2':
     dependencies:
       graphql: 16.10.0
     optionalDependencies:
@@ -10423,7 +10424,7 @@ snapshots:
       '@escape.tech/graphql-armor-block-field-suggestions': 3.0.1
       '@escape.tech/graphql-armor-cost-limit': 2.4.3
       '@escape.tech/graphql-armor-max-aliases': 2.6.2
-      '@escape.tech/graphql-armor-max-depth': 2.4.1
+      '@escape.tech/graphql-armor-max-depth': 2.4.2
       '@escape.tech/graphql-armor-max-directives': 2.3.1
       '@escape.tech/graphql-armor-max-tokens': 2.5.1
       graphql: 16.10.0


### PR DESCRIPTION
## Summary
GraphQL Armor max-depth plugin の bypass 脆弱性 2件(Moderate、runtime impact)を
`pnpm.overrides` で対処。現在 2.4.1 → 2.4.2 に強制 upgrade。

civicship-api は ApolloArmor を GraphQL 防御として直接使用中
(`src/presentation/graphql/plugins/armor.ts`)、fix 版適用は runtime security に
直接効く。

## Resolves

| Alert | GHSA | Summary |
|---|---|---|
| #20 | GHSA-hmfr-rx46-4jx2 | max-depth bypass via fragment caching |
| #21 | GHSA-224p-v68g-5g8f | max-depth bypass via Introspection Query Obfuscation |

Both: vulnerable range `<= 2.4.1`, first patched `2.4.2`.

## Changes

- `package.json`: add `"@escape.tech/graphql-armor-max-depth": "^2.4.2"` to `pnpm.overrides`
- `pnpm-lock.yaml`: regenerated, `2.4.1` → `2.4.2` across all resolution paths

## Verified

- `pnpm install` で override 期待通り適用(2.4.1 が lockfile から完全削除)
- 親 `@escape.tech/graphql-armor@3.1.6` も 2.4.2 を使うように解決(peer 制約突破確認)
- cooldown 違反なし(2.4.2 は 8ヶ月前 publish)

## Out of scope (deferred to later PRs)

- **protobufjs #124 (Critical)**: transitive only, 7.5.5 patched but within 3-day
  cooldown window. 実攻撃経路なし確認済み(`protobuf.Root.fromJSON` 未使用)、
  cooldown クリア後(~1日後)に PR-α2.6 で対応予定。
- **lodash-es #45/#104/#105**: devDependency only (mermaid → prisma-erd-generator)、
  runtime 影響なし、Phase 2 バックログで一括対応。
- **Runtime High alerts(node-forge / picomatch / path-to-regexp / jws 等)**:
  個別調査継続、次セッション以降。
- **Development deps 多数**: Phase 2 一括対応。

## Follow-up

merge 後、alert #20 / #21 が Dependabot 側で自動 close されるか確認。

https://claude.ai/code/session_0155Q7JBMiTV9NViLze67xwq
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
