### PR TITLE
fix(graphql): tighten Apollo Armor limits to portal-aligned BACKEND_LIMITS

### DIFF
--- a/src/presentation/graphql/plugins/armor.ts
+++ b/src/presentation/graphql/plugins/armor.ts
@@ -1,29 +1,37 @@
 import { ApolloArmor } from "@escape.tech/graphql-armor";
 import { GraphQLArmorConfig } from "@escape.tech/graphql-armor-types/dist/declarations/src";
 
+// Limits below are aligned with civicship-portal's measurement engine
+// (@escape.tech/graphql-armor-* shared with this server). Portal sets
+// CLIENT_LIMITS at its observed max usage and BACKEND_LIMITS = CLIENT × 1.2,
+// giving 20% headroom and a layered defense where build-time client checks
+// fire before backend rejection. Cost formula parameters
+// (objectCost / scalarCost / depthCostFactor) are kept at the GraphQL Armor
+// defaults so portal's measurements remain bit-equivalent to backend
+// enforcement.
 const config: GraphQLArmorConfig = {
   costLimit: {
     enabled: true,
-    maxCost: 7500, // GraphQL Armor plugin default
-    objectCost: 2, // GraphQL Armor plugin default
-    scalarCost: 1, // GraphQL Armor plugin default
-    depthCostFactor: 1.5, // GraphQL Armor plugin default
+    maxCost: 3000, // portal-aligned (CLIENT 2500 × 1.2)
+    objectCost: 2, // GraphQL Armor plugin default - keep parity with portal measurement
+    scalarCost: 1, // GraphQL Armor plugin default - keep parity with portal measurement
+    depthCostFactor: 1.5, // GraphQL Armor plugin default - keep parity with portal measurement
   },
   maxDepth: {
     enabled: true,
-    n: 12, // Keep portal-aligned value for depth limit
+    n: 13, // portal-aligned (CLIENT 11 × 1.2 ≒ 13)
   },
   maxAliases: {
     enabled: true,
-    n: 15, // GraphQL Armor plugin default
+    n: 4, // portal-aligned (CLIENT 3 × 1.2 ≒ 4)
   },
   maxDirectives: {
     enabled: true,
-    n: 50, // GraphQL Armor plugin default
+    n: 9, // portal-aligned (CLIENT 7 × 1.2 ≒ 9)
   },
   maxTokens: {
     enabled: true,
-    n: 1000, // GraphQL Armor plugin default
+    n: 480, // portal-aligned (CLIENT 400 × 1.2)
   },
   blockFieldSuggestion: {
     enabled: true, // Keep field suggestion blocking enabled


### PR DESCRIPTION
## Summary
Apollo Armor の閾値を civicship-portal の measurement engine と parity を取った `BACKEND_LIMITS` に絞り込む。portal 側 PR(`@escape.tech/graphql-armor-*` 経由で BE と同一計算ロジックの計測を build-time で実施)と対の改修。

設計思想: portal が CLIENT_LIMITS で build-time 検知 → BE が CLIENT × 1.2 の BACKEND_LIMITS で runtime enforce、という layered defense。

## Changes

`src/presentation/graphql/plugins/armor.ts` のみ(+16/-8、コメント追加と数値 5 箇所)。

| metric | before | after | 由来 |
|---|---|---|---|
| maxDepth | 12 | **13** | CLIENT 11(GetCurrentUserProfile)× 1.2 |
| maxAliases | 15 | **4** | CLIENT 3(検知用、現状実 alias は 0) |
| maxDirectives | 50 | **9** | CLIENT 7(GetUserFlexible)× 1.2 |
| maxTokens | 1000 | **480** | CLIENT 400(GetUserFlexible)× 1.2 |
| maxCost | 7500 | **3000** | CLIENT 2500(GetArticle)× 1.2 |

cost formula 計算 params(`objectCost: 2` / `scalarCost: 1` / `depthCostFactor: 1.5`)は **GraphQL Armor default のまま変更なし**。これらを変えると portal の measurement と差が出るため、pin する必要がある。

## Risk assessment

### 影響範囲

- **civicship-portal**: portal 側で CLIENT_LIMITS(BACKEND の 1/1.2)以下に bound されてる、20% headroom 確保済み → 影響なし
- **`src/external-api.ts`**: REST のみ、GraphQL 経路なし → 影響なし
- **その他 production GraphQL consumer**: リポジトリ調査の限り存在せず

### Risk: 「未知の consumer」が新限界に引っかかる

タイト化で発生しうる唯一のリスク。dev observation window で検出可能、rollback は 1 metric ずつ独立 revert 可能。

### Risk: Armor の挙動変化

PR #852(graphql-armor-max-depth 2.4.1 → 2.4.2)で bypass 修正済み。本 PR は閾値変更のみで plugin 挙動は不変。

## Verified

- diff は armor.ts の閾値 5 箇所 + コメント追加のみ
- cost params は不変、portal の measurement と parity 維持
- TypeScript compile / runtime ロジックは GraphQL Armor が処理(PR #852 で更新済み)

## Deploy considerations

- develop merge → kyoso-dev Cloud Run 自動 deploy
- dev 観察(portal メイン導線で `GraphQLError: ... too deep / too many tokens / too many aliases / too many directives / cost too high` の error log を監視)
- 問題なければ develop → master 統合 PR、本番自動 deploy
- 業務時間 merge 推奨、PR-β で workflow_dispatch 化されるまでは引き続き慎重運用

### Merge 順序(portal PR との関係)

BE 先 / portal 後 の順が安全:
- BE merge:閾値が緩い(現状 7500 等)→ 厳しい(3000 等)に変化、portal は影響なし
- portal merge: CLIENT_LIMITS による build-time 検知を確立

逆順(portal 先 / BE 後)でも portal の build-time 検知は CLIENT(=BE より厳しい)で動くので機能的に問題ないが、**BE が緩い間に portal の CI が「OK」を出した実装が後の BE タイト化で reject される**可能性は理論上ある。BE 先のほうが整合性高い。

## Out of scope

- portal 側 measurement infra(別 PR)
- shared config への切り出し(現状は数値 hardcode、portal 側の `CLIENT_LIMITS` / `BACKEND_LIMITS` 単一ソース化は将来検討)

## Rollback

該当 metric の数値を 1 行戻す revert commit で即可能。例: cost が突然多発したら `maxCost: 3000` → `7500` に戻すだけ。

https://claude.ai/code/session_0155Q7JBMiTV9NViLze67xwq
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/856" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
