### PR TITLE
Refactor report template seeding with type safety and transactions

### DIFF
--- a/src/infrastructure/prisma/seeds/reportTemplates.ts
+++ b/src/infrastructure/prisma/seeds/reportTemplates.ts
@@ -1,8 +1,9 @@
 import { prismaClient } from "@/infrastructure/prisma/client";
 import { ReportTemplateScope } from "@prisma/client";
+import { GqlReportVariant } from "@/types/graphql";
 
 interface TemplateDefinition {
-  variant: string;
+  variant: GqlReportVariant;
   systemPrompt: string;
   userPromptTemplate: string;
   model: string;
@@ -12,7 +13,7 @@ interface TemplateDefinition {
 
 const TEMPLATES: TemplateDefinition[] = [
   {
-    variant: "WEEKLY_SUMMARY",
+    variant: GqlReportVariant.WeeklySummary,
     model: "claude-sonnet-4-6",
     maxTokens: 8192,
     temperature: 0.5,
@@ -47,7 +48,7 @@ const TEMPLATES: TemplateDefinition[] = [
 \${payload_json}`,
   },
   {
-    variant: "GRANT_APPLICATION",
+    variant: GqlReportVariant.GrantApplication,
     model: "claude-sonnet-4-6",
     maxTokens: 8192,
     temperature: 0.5,
@@ -81,7 +82,7 @@ const TEMPLATES: TemplateDefinition[] = [
 \${payload_json}`,
   },
   {
-    variant: "MEDIA_PR",
+    variant: GqlReportVariant.MediaPr,
     model: "claude-sonnet-4-6",
     maxTokens: 8192,
     temperature: 0.7,
@@ -115,7 +116,7 @@ note記事やプレスリリースとして公開できるレベルの読み物�
 \${payload_json}`,
   },
   {
-    variant: "MEMBER_NEWSLETTER",
+    variant: GqlReportVariant.MemberNewsletter,
     model: "claude-sonnet-4-6",
     maxTokens: 4096,
     temperature: 0.7,
@@ -152,41 +153,43 @@ LINE配信やコミュニティ掲示板への投稿を想定しています。�
 ];
 
 export async function seedReportTemplates() {
-  for (const tmpl of TEMPLATES) {
-    const existing = await prismaClient.reportTemplate.findFirst({
-      where: { variant: tmpl.variant, communityId: null },
-      select: { id: true },
-    });
+  await prismaClient.$transaction(async (tx) => {
+    for (const tmpl of TEMPLATES) {
+      const existing = await tx.reportTemplate.findFirst({
+        where: { variant: tmpl.variant, communityId: null },
+        select: { id: true },
+      });
 
-    if (existing) {
-      await prismaClient.reportTemplate.update({
-        where: { id: existing.id },
-        data: {
-          systemPrompt: tmpl.systemPrompt,
-          userPromptTemplate: tmpl.userPromptTemplate,
-          model: tmpl.model,
-          maxTokens: tmpl.maxTokens,
-          temperature: tmpl.temperature,
-          stopSequences: [],
-          isEnabled: true,
-        },
-      });
-      console.info(`  Updated SYSTEM template: ${tmpl.variant}`);
-    } else {
-      await prismaClient.reportTemplate.create({
-        data: {
-          variant: tmpl.variant,
-          scope: ReportTemplateScope.SYSTEM,
-          systemPrompt: tmpl.systemPrompt,
-          userPromptTemplate: tmpl.userPromptTemplate,
-          model: tmpl.model,
-          maxTokens: tmpl.maxTokens,
-          temperature: tmpl.temperature,
-          stopSequences: [],
-          isEnabled: true,
-        },
-      });
-      console.info(`  Created SYSTEM template: ${tmpl.variant}`);
+      if (existing) {
+        await tx.reportTemplate.update({
+          where: { id: existing.id },
+          data: {
+            systemPrompt: tmpl.systemPrompt,
+            userPromptTemplate: tmpl.userPromptTemplate,
+            model: tmpl.model,
+            maxTokens: tmpl.maxTokens,
+            temperature: tmpl.temperature,
+            stopSequences: [],
+            isEnabled: true,
+          },
+        });
+        console.info(`  Updated SYSTEM template: ${tmpl.variant}`);
+      } else {
+        await tx.reportTemplate.create({
+          data: {
+            variant: tmpl.variant,
+            scope: ReportTemplateScope.SYSTEM,
+            systemPrompt: tmpl.systemPrompt,
+            userPromptTemplate: tmpl.userPromptTemplate,
+            model: tmpl.model,
+            maxTokens: tmpl.maxTokens,
+            temperature: tmpl.temperature,
+            stopSequences: [],
+            isEnabled: true,
+          },
+        });
+        console.info(`  Created SYSTEM template: ${tmpl.variant}`);
+      }
     }
-  }
+  });
 }


### PR DESCRIPTION
## Summary
This PR improves the report template seeding logic by adding type safety for report variants and wrapping the seeding operation in a database transaction for data consistency.

## Key Changes
- **Type Safety**: Changed `variant` field from `string` to `GqlReportVariant` enum type in the `TemplateDefinition` interface
- **Enum Usage**: Updated all template variant definitions to use `GqlReportVariant` enum values (`WeeklySummary`, `GrantApplication`, `MediaPr`, `MemberNewsletter`) instead of string literals
- **Transaction Wrapper**: Wrapped the entire seeding loop in a Prisma transaction (`$transaction`) to ensure all template operations succeed or fail atomically
- **Client Consistency**: Updated all Prisma client calls within the transaction to use the transaction client (`tx`) instead of the global `prismaClient`

## Implementation Details
- The transaction ensures that if any template creation or update fails, all changes are rolled back, maintaining database integrity
- Type safety prevents accidental typos or invalid variant values at compile time
- The seeding logic remains functionally equivalent while being more robust and type-safe

https://claude.ai/code/session_012XpS5xmqg5UvZFuSV2LhxQ
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/858" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
