### PR TITLE
ci(security): PR-β.1 SHA-pin actions, deploy concurrency, dependabot align, actionlint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,16 @@
 # Dependabot configuration for civicship-api.
-# Strategy: cooldown + grouping (方針B). Rationale captured in
-# docs/dependabot-playbook.md section 1.
+# Strategy: cooldown + grouping + intentional pinning (方針B).
+# Applied uniformly to both `npm` and `github-actions` ecosystems.
+# Rationale captured in docs/dependabot-playbook.md section 1.
 # - Weekly Monday 06:00 JST aligns with the dependency review routine.
 # - Cooldown windows (patch 5d / minor 10d / major 14d) are api-conservative;
 #   security updates bypass cooldown and are opened immediately by Dependabot.
-# - Grouping: production patch + all dev deps (minor/patch) are grouped;
-#   majors (dev and prod) open as individual PRs for breaking-change review.
+# - Grouping: minor+patch updates are grouped to reduce PR noise, while
+#   majors open as individual PRs for breaking-change review.
+#   - npm: production-patch and dev (minor+patch) grouped; majors individual.
+#   - github-actions: all actions (minor+patch) grouped; majors individual.
+# - Pinning: workflows reference actions by 40-char commit SHA with a
+#   `# vX.Y.Z` comment. Dependabot preserves this style across bumps.
 version: 2
 updates:
   - package-ecosystem: "npm"
@@ -49,10 +54,15 @@ updates:
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 5
     cooldown:
-      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 10
+      semver-patch-days: 5
     groups:
-      actions:
+      actions-minor-patch:
         patterns: ["*"]
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
       - "github-actions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Lint GitHub Actions workflows (actionlint 1.7.7)
         run: |
           docker run --rm \
-            -v "${{ github.workspace }}:/repo" \
+            -v "${{ github.workspace }}:/repo:ro" \
             --workdir /repo \
             rhysd/actionlint@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9 \
             -color

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Lint GitHub Actions workflows (actionlint 1.7.7)
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/repo" \
+            --workdir /repo \
+            rhysd/actionlint@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9 \
+            -color
+        # Image: rhysd/actionlint:1.7.7 (Docker Hub, multi-arch index digest)
+        # shellcheck / pyflakes are bundled in the image.
+        # Digest pin: manual update until PR-β.1e adds `docker` ecosystem to dependabot.yml.
+
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 

--- a/.github/workflows/deploy-external-api-dev.yml
+++ b/.github/workflows/deploy-external-api-dev.yml
@@ -70,7 +70,7 @@ jobs:
           --quiet -- -N -L 5432:localhost:5432 &
         SSH_PID=$!
         sleep 60
-        for i in {1..5}; do
+        for _ in {1..5}; do
           pg_isready -h localhost -p 5432 -d ${{ env.DB_NAME }} && break
           sleep 60
         done

--- a/.github/workflows/deploy-external-api-dev.yml
+++ b/.github/workflows/deploy-external-api-dev.yml
@@ -7,6 +7,10 @@ on:
       - hotfix/**
       - epic/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -53,7 +57,7 @@ jobs:
         service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
 
     - name: Set up gcloud SDK
-      uses: google-github-actions/setup-gcloud@v2
+      uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
 
     - name: pnpm db:generate
       env:
@@ -95,7 +99,7 @@ jobs:
 
     - name: Deploy External API to Cloud Run
       id: 'deploy'
-      uses: 'google-github-actions/deploy-cloudrun@v2' # v2.8.1
+      uses: 'google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522' # v2.7.6
       with:
         service: ${{ env.EXTERNAL_API_NAME }}
         image: ${{ env.ARTIFACT_REGISTRY }}/${{ env.EXTERNAL_API_NAME }}:latest

--- a/.github/workflows/deploy-external-api-dev.yml
+++ b/.github/workflows/deploy-external-api-dev.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - develop
-      - hotfix/**
-      - epic/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/deploy-external-api-prd.yml
+++ b/.github/workflows/deploy-external-api-prd.yml
@@ -68,7 +68,7 @@ jobs:
           --quiet -- -N -L 5432:localhost:5432 &
         SSH_PID=$!
         sleep 60
-        for i in {1..5}; do
+        for _ in {1..5}; do
           pg_isready -h localhost -p 5432 -d ${{ env.DB_NAME }} && break
           sleep 60
         done
@@ -117,8 +117,8 @@ jobs:
         git config user.name "github-actions"
         git config user.email "github-actions@github.com"
         
-        git tag $TAG_NAME
-        git push origin $TAG_NAME
+        git tag "$TAG_NAME"
+        git push origin "$TAG_NAME"
 
     - name: Cleanup SSH Key
       if: always()

--- a/.github/workflows/deploy-external-api-prd.yml
+++ b/.github/workflows/deploy-external-api-prd.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -51,7 +55,7 @@ jobs:
         service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
 
     - name: Set up gcloud SDK
-      uses: google-github-actions/setup-gcloud@v2
+      uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
 
     - name: pnpm db:generate
       env:
@@ -93,7 +97,7 @@ jobs:
 
     - name: Deploy External API to Cloud Run
       id: 'deploy'
-      uses: 'google-github-actions/deploy-cloudrun@v2' # v2.8.1
+      uses: 'google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522' # v2.7.6
       with:
         service: ${{ env.EXTERNAL_API_NAME }}
         image: ${{ env.ARTIFACT_REGISTRY }}/${{ env.EXTERNAL_API_NAME }}:latest

--- a/.github/workflows/deploy-to-cloud-run-dev.yml
+++ b/.github/workflows/deploy-to-cloud-run-dev.yml
@@ -7,6 +7,10 @@ on:
       - hotfix/**
       - epic/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -65,7 +69,7 @@ jobs:
         service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
 
     - name: Set up gcloud SDK
-      uses: google-github-actions/setup-gcloud@v2
+      uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
 
     - name: pnpm db:generate
       env:
@@ -118,7 +122,7 @@ jobs:
 
     - name: Deploy Internal API to Cloud Run
       id: 'deploy'
-      uses: 'google-github-actions/deploy-cloudrun@v2' # v2.8.1
+      uses: 'google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522' # v2.7.6
       with:
         service: ${{ env.APPLICATION_NAME }}
         image: ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest

--- a/.github/workflows/deploy-to-cloud-run-dev.yml
+++ b/.github/workflows/deploy-to-cloud-run-dev.yml
@@ -82,7 +82,7 @@ jobs:
           --quiet -- -N -L 5432:localhost:5432 &
         SSH_PID=$!
         sleep 60
-        for i in {1..5}; do
+        for _ in {1..5}; do
           pg_isready -h localhost -p 5432 -d ${{ env.DB_NAME }} && break
           sleep 60
         done

--- a/.github/workflows/deploy-to-cloud-run-dev.yml
+++ b/.github/workflows/deploy-to-cloud-run-dev.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - develop
-      - hotfix/**
-      - epic/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/deploy-to-cloud-run-prd.yml
+++ b/.github/workflows/deploy-to-cloud-run-prd.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -63,7 +67,7 @@ jobs:
         service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
 
     - name: Set up gcloud SDK
-      uses: google-github-actions/setup-gcloud@v2
+      uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
 
     - name: pnpm db:generate
       env:
@@ -116,7 +120,7 @@ jobs:
 
     - name: Deploy Internal API to Cloud Run
       id: 'deploy'
-      uses: 'google-github-actions/deploy-cloudrun@v2' # v2.8.1
+      uses: 'google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522' # v2.7.6
       with:
         service: ${{ env.APPLICATION_NAME }}
         image: ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest

--- a/.github/workflows/deploy-to-cloud-run-prd.yml
+++ b/.github/workflows/deploy-to-cloud-run-prd.yml
@@ -80,7 +80,7 @@ jobs:
           --quiet -- -N -L 5432:localhost:5432 &
         SSH_PID=$!
         sleep 60
-        for i in {1..5}; do
+        for _ in {1..5}; do
           pg_isready -h localhost -p 5432 -d ${{ env.DB_NAME }} && break
           sleep 60
         done
@@ -160,8 +160,8 @@ jobs:
         git config user.email "github-actions@github.com"
         
         # Create and push tag
-        git tag $TAG_NAME
-        git push origin $TAG_NAME
+        git tag "$TAG_NAME"
+        git push origin "$TAG_NAME"
 
     - name: Cleanup SSH Key
       if: always()


### PR DESCRIPTION
## 背景

本 PR は deploy workflow 群の「品質 baseline 整備」を目的に、
security / operational / CI 検証の 3 軸を一括で強化する。

### Security 軸(mutable tag 問題)
`google-github-actions/setup-gcloud@v2` / `deploy-cloudrun@v2` は mutable tag のため、
上流 compromise 時に deploy 権限で任意コード実行のリスクがある。具体的な
漏洩対象: WIF 経由の Cloud Run revision 差替え、env 経由の `DB_PASSWORD` /
`APOLLO_KEY` / `SERVICE_ACCOUNT_CREDENTIAL_JSON` 等。

### Operational 軸(並列 deploy 問題)
4 deploy workflow に concurrency 設定がなく、並列 merge 時に `:latest` tag race が
発生し「古いコードが latest revision として deploy」される可能性あり。
特に master への連続 merge 時に prd で顕在化しやすい。

### Dependabot 整合軸
dependabot.yml の github-actions 設定が方針B(cooldown + grouping + 意図的 pinning)の
npm 側と粒度不整合。major が patch と同 PR 混入しうる。

### CI 検証軸
CI に workflow 構文検証(actionlint)がなく、workflow 変更時の syntax / schema 問題を
検知できない。本 PR で SHA pin / concurrency を追加した workflow 群を恒久的に
保護するため、同 PR で actionlint step を導入する。

## 変更内容

### 1. SHA pin(8 箇所)
- `setup-gcloud@v2` → `@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1`(4 箇所)
- `deploy-cloudrun@v2` → `@251330ba9a8a34bfbc1622895f42e1d53fd14522 # v2.7.6`(4 箇所)
- richmenu workflow は運用判断で scope 外

### 2. concurrency 追加(4 deploy workflow)
各 workflow の `jobs:` 直前に:
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: false
```
- `cancel-in-progress: false` は Cloud Run deploy 途中 cancel 回避の重要設計判断

### 3. dependabot.yml github-actions を npm 方針に align
- cooldown: `default-days: 7` → `semver-major-days: 14 / semver-minor-days: 10 / semver-patch-days: 5`
- groups: 単一 `actions` → `actions-minor-patch`(minor+patch 限定、majors は個別 PR 化)
- 冒頭コメント: 両 ecosystem に適用される方針B 宣言に刷新

### 4. ci.yml に actionlint step 追加
- `rhysd/actionlint@sha256:887a259a...`(multi-arch index digest)
- Checkout 直後の配置、最速 fail
- shellcheck / pyflakes は image 内蔵、別途 install 不要
- blocking 運用

### 5. 追加修正(shellcheck 警告対応)

ci.yml に追加した actionlint step 導入により、既存 deploy workflow の
bash script に潜んでいた shellcheck 警告 8 件が検出された。本 PR の
scope 内(同 4 deploy workflow を既に触っているため)として同梱修正。

- SC2034(`i appears unused`)4 箇所: `for i in {1..5}` → `for _ in {1..5}`
  (db:generate step の jumpbox readiness loop、本体で `$i` 未使用、
  semantics 不変)
- SC2086(quote 不足)4 箇所: `git tag $TAG_NAME` / `git push origin $TAG_NAME`
  の変数展開にダブルクォート追加。TAG_NAME は `date +"%Y%m%d%H%M%S"` 由来の
  deterministic 文字列で空白・glob 含まず、挙動不変

事前検証環境の問題記録:
- 当初 `/tmp/actionlint` 単体配置で shellcheck 未 install のため「全 pass」
  と報告していたが、CI 実環境(rhysd/actionlint image)は shellcheck 内蔵で
  rule 有効化。ローカル検証環境と CI 環境の rule セット差分を事前に潰せて
  いなかった。次回以降は shellcheck install 済み env での事前検証を必須化。

### 追加修正(bot review 対応)

Copilot PR review の指摘を受けて 2 commit を追加:

1. actionlint docker run mount を `:ro` に変更
   - actionlint は read-only で完結、image 側 compromise に対する defense-in-depth
   - commit: `d0d0817`

2. dev workflow の `hotfix/**` / `epic/**` trigger を削除
   - 実運用は PR merge 中心、直 push は形骸化していた
   - `:latest` race 問題の構造的解消(concurrency 対処療法より根本対処)
   - commit: `a5c499e`

## 既存誤記の修正

既存の deploy-cloudrun 4 箇所に `# v2.8.1` コメントが存在したが、
`google-github-actions/deploy-cloudrun` には v2.8.x tag が存在しない(v2 系最新は v2.7.6、
次は v3.0.0)。過去のどこかで混入した誤記と判断、本 PR で `# v2.7.6` に修正。
silent 修正ではなく本 description に明記。

## scope 外(backlog 化)

- **v3 系への移行**: setup-gcloud / deploy-cloudrun ともに v3.0.1 存在、
  breaking change 検証が必要なため別 PR(PR-γ.2 予定)で対応
- **dependabot docker ecosystem 追加**: 本 PR で追加した actionlint digest の
  自動更新化のため、別 PR(PR-β.1e 予定)で追加予定
- **docs/dependabot-playbook.md 本文更新**: PR-α3(Playbook 書き下し)で対応

## 事前検証

- 事前調査で mutable tag 9 箇所 → richmenu 除外で 8 箇所、concurrency 未設定 4 workflow、
  dependabot.yml 粒度不整合を実測確認済み
- actionlint 1.7.7 + shellcheck 0.9.0 install 済み env で再検証、error 0 / warning 0
- python3 yaml.safe_load pass
- multi-arch index digest 採用(将来 arm64 runner でも追従)
- image config blob から shellcheck / pyflakes 内蔵確認済み

## 既知の懸念

- actionlint docker image の user が `guest`。万一 permission issue 発生時は
  `--user $(id -u):$(id -g)` 追加が fallback。Playbook に記録予定。

## commit 構成(5 commit)

| # | commit | 内容 |
|---|---|---|
| 1 | `4f85da7` | SHA-pin + concurrency + dependabot align |
| 2 | `6b060fc` | add actionlint step to CI |
| 3 | `3ddc6b4` | fix existing shellcheck warnings |
| 4 | `d0d0817` | add `:ro` mount to actionlint docker run |
| 5 | `a5c499e` | remove formal-only `hotfix/**` and `epic/**` triggers |

## ロールバック

- `git revert` で commit 単位 or 一括戻し可能
- 挙動変化: 並列 deploy が queue 待機(機能退化なし)+ CI に actionlint step 追加
  (現時点で全 pass、workflow 変更時に即 fail)+ dev deploy の trigger が
  `develop` のみに絞られる(直 push 経路の形骸化を反映、PR merge 経由は不変)

https://claude.ai/code/session_0147sR8CQKMq8WMV92Rk3CgB