### PR TITLE
ci(security): PR-β.2 remove unused SERVICE_ACCOUNT_CREDENTIAL_JSON env from deploy workflows

### DIFF
--- a/.github/workflows/deploy-external-api-dev.yml
+++ b/.github/workflows/deploy-external-api-dev.yml
@@ -22,7 +22,6 @@ jobs:
     env:
       STAGE: dev
       GCP_REGION: ${{ secrets.GCP_REGION }}
-      SERVICE_ACCOUNT_CREDENTIAL_JSON: ${{ secrets.SERVICE_ACCOUNT_CREDENTIAL_JSON }}
       DB_USER: ${{ secrets.DB_USER }}
       DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
       DB_NAME: ${{ secrets.DB_NAME }}

--- a/.github/workflows/deploy-external-api-prd.yml
+++ b/.github/workflows/deploy-external-api-prd.yml
@@ -22,7 +22,6 @@ jobs:
     env:
       STAGE: prd
       GCP_REGION: ${{ secrets.GCP_REGION }}
-      SERVICE_ACCOUNT_CREDENTIAL_JSON: ${{ secrets.SERVICE_ACCOUNT_CREDENTIAL_JSON }}
       DB_USER: ${{ secrets.DB_USER }}
       DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
       DB_NAME: ${{ secrets.DB_NAME }}

--- a/.github/workflows/deploy-to-cloud-run-dev.yml
+++ b/.github/workflows/deploy-to-cloud-run-dev.yml
@@ -24,8 +24,6 @@ jobs:
       STAGE: dev
       # GCP settings
       GCP_REGION: ${{ secrets.GCP_REGION }}
-      # GCP service account credentials
-      SERVICE_ACCOUNT_CREDENTIAL_JSON: ${{ secrets.SERVICE_ACCOUNT_CREDENTIAL_JSON }}
       # DB credentials
       DB_USER: ${{ secrets.DB_USER }}
       DB_PASSWORD: ${{ secrets.DB_PASSWORD }}

--- a/.github/workflows/deploy-to-cloud-run-prd.yml
+++ b/.github/workflows/deploy-to-cloud-run-prd.yml
@@ -24,8 +24,6 @@ jobs:
       STAGE: prd
       # GCP settings
       GCP_REGION: ${{ secrets.GCP_REGION }}
-      # GCP service account credentials
-      SERVICE_ACCOUNT_CREDENTIAL_JSON: ${{ secrets.SERVICE_ACCOUNT_CREDENTIAL_JSON }}
       # DB credentials
       DB_USER: ${{ secrets.DB_USER }}
       DB_PASSWORD: ${{ secrets.DB_PASSWORD }}


### PR DESCRIPTION
## 背景

4 deploy workflow の top-level `env:` に定義されている
`SERVICE_ACCOUNT_CREDENTIAL_JSON` は、2025-12-05 の WIF 移行
(commit `7f1b6f5`, "chore: Switch GCP authentication to Workload Identity Federation and update workflows")
以降、参照する step が全て削除された状態で env 定義のみ残置されていた。

約 4.5 ヶ月間、参照ゼロの secret が runtime 環境変数として展開され続けており、
PR-β.1 で指摘した mutable tag compromise 時の漏洩対象(具体的には
`SERVICE_ACCOUNT_CREDENTIAL_JSON`)はこの残置が原因。本 PR で env 定義を削除
することで runtime 露出を解消する。

## 変更内容

4 deploy workflow から `SERVICE_ACCOUNT_CREDENTIAL_JSON: ${{ secrets.SERVICE_ACCOUNT_CREDENTIAL_JSON }}`
を削除:

- `.github/workflows/deploy-to-cloud-run-dev.yml`
- `.github/workflows/deploy-to-cloud-run-prd.yml`
- `.github/workflows/deploy-external-api-dev.yml`
- `.github/workflows/deploy-external-api-prd.yml`

`deploy-richmenu.yml` は元から定義なし、対象外。

### コメント同時削除について

`deploy-to-cloud-run-{dev,prd}.yml` では削除対象 env 直前の
`# GCP service account credentials` コメントが、削除した env 1 行のみを
指す説明コメントだった。env 削除後に orphan 化すると直後の `# DB credentials`
セクションの誤読源になるため、コメントも同時削除した
(`deploy-external-api-*.yml` には同コメントなし、env 1 行のみ削除)。

差分合計 6 deletions(env 4 行 + orphan コメント 2 行)。

## 事前確認(実測)

- `SERVICE_ACCOUNT_CREDENTIAL_JSON` への step 参照: **0 件**
  (`${{ env.* }}` / `$X` / `${X}` 全形式、repo 全体)
- `credentials_json` 参照: **0 件**(`.github/` 配下)
- WIF 経由 auth が 5 workflow 全てで稼働中
  (`google-github-actions/auth@8254fb75… v2.1.6`、
   `workload_identity_provider` + `service_account` 方式)
- 類似命名の dead env 検出なし
  (`SA_CREDENTIAL` / `GCP_SA_KEY` / `GOOGLE_CREDENTIALS` / `GOOGLE_APPLICATION_CREDENTIALS` 全 0 件)

## 検証

- `python3 yaml.safe_load`: OK(4 ファイル全て)
- `actionlint 1.7.7` + `shellcheck 0.9.0`: **0 error / 0 warning**
  (`.github/workflows/*.yml` 全ワークフロー)

## 後処理(本 PR 外、admin action)

merge 後に GitHub Secrets から `SERVICE_ACCOUNT_CREDENTIAL_JSON` 自体を
削除(sakata-san 実施)。secret 参照がゼロになった状態で削除すれば、
どの workflow にも影響しない。

## ロールバック

単一 commit、`git revert` で一括戻し可能。
ただし secret 側を先行削除した場合でも、revert 後は
`secrets.SERVICE_ACCOUNT_CREDENTIAL_JSON` が undefined で空文字として展開
されるのみで、参照 step がないため動作影響なし。

## Test plan

- [x] `python3 yaml.safe_load` pass(4 ファイル)
- [x] `actionlint 1.7.7` 0 error / 0 warning
- [ ] CI workflow run 成功確認
- [ ] merge 後の dev deploy 動作確認(次回 develop push 時)
- [ ] merge 後の prd deploy 動作確認(次回 master push 時)
- [ ] secret 削除(admin action、sakata-san)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/866" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
