### PR TITLE
Migrate CI/CD to Workload Identity Federation

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -21,7 +21,6 @@ FIREBASE_AUTH_TENANT_ID=your_tenant_id
 GCS_SERVICE_ACCOUNT_BASE64=base64_encoded_service_account_json
 GCS_BUCKET_NAME=your_storage_bucket_name
 GCP_PROJECT_ID=your_gcp_project_id
-GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 
 # Security & CORS
 ALLOWED_ORIGINS=http://localhost:3000,https://localhost:3000

--- a/docs/handbook/DEPLOYMENT.md
+++ b/docs/handbook/DEPLOYMENT.md
@@ -176,73 +176,36 @@ Features:
 
 ### GitHub Actions Workflow
 
-**Configuration File:** `.github/workflows/deploy-to-cloud-run-dev.yml`
+**Configuration Files:**
+- `.github/workflows/deploy-to-cloud-run-dev.yml` (develop → Cloud Run dev)
+- `.github/workflows/deploy-to-cloud-run-prd.yml` (master → Cloud Run prd)
+- `.github/workflows/deploy-external-api-dev.yml` / `deploy-external-api-prd.yml` (External API)
+- `.github/workflows/deploy-richmenu.yml` (LINE rich menu, manual dispatch)
+- `.github/workflows/ci.yml` (lint / build / generated-file check)
 
-```yaml
-name: Deploy to Cloud Run (Development)
+**Authentication:** Workload Identity Federation (WIF). Service account JSON keys
+are no longer used — workflows authenticate via
+`google-github-actions/auth` with `workload_identity_provider` +
+`service_account` secrets. See each workflow file for the concrete step
+definitions. Actions are pinned to 40-char commit SHAs.
 
-on:
-push:
-branches: [ develop ]
-pull_request:
-branches: [ develop ]
+**Required repo-level secrets (as of the post-β.2 cleanup):**
 
-jobs:
-test:
-runs-on: ubuntu-latest
-steps:
-- uses: actions/checkout@v4
-- name: Setup Node.js 20
-uses: actions/setup-node@v4
-with:
-node-version: '20'
-cache: 'pnpm'
+| Secret | Used by |
+| --- | --- |
+| `GCP_WIF_PROVIDER` | all deploy workflows (WIF auth) |
+| `GCP_SERVICE_ACCOUNT_EMAIL` | all deploy workflows (WIF auth) |
+| `GCP_REGION` | all deploy workflows |
+| `ARTIFACT_REGISTRY` / `BATCH_ARTIFACT_REGISTRY` | Cloud Run image push |
+| `APPLICATION_NAME` / `BATCH_NAME` / `EXTERNAL_API_NAME` | Cloud Run service/job names |
+| `CLOUD_SQL_CONNECTION_NAME` | Cloud Run → Cloud SQL |
+| `DB_USER` / `DB_PASSWORD` / `DB_NAME` | Prisma generate via jumpbox |
+| `JUMPBOX_INSTANCE_NAME` / `JUMPBOX_ZONE` | IAP tunnel for jumpbox |
+| `APOLLO_KEY` | Rover schema publish |
 
-- name: Install dependencies
-run: pnpm install
-
-- name: Run tests
-run: pnpm test
-
-- name: Run lint
-run: pnpm lint
-
-build-and-deploy:
-needs: test
-runs-on: ubuntu-latest 
-if: github.ref == 'refs/heads/develop' 
-
-steps: 
-- uses: actions/checkout@v4 
-
-- name: Setup Google Cloud CLI 
-uses: google-github-actions/setup-gcloud@v1 
-with: 
-service_account_key: ${{ secrets.GCP_SA_KEY }} 
-project_id: ${{ secrets.GCP_PROJECT_ID }} 
-
-- name: Configure Docker 
-run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev 
-
-- name: Build Docker images 
-run: | 
-docker build -t asia-northeast1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/civicship-api/civicship-api:${{ github.sha }} . 
-docker build -f Dockerfile.external -t asia-northeast1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/civicship-api/civicship-api-external:${{ github.sha }} . 
-docker build -f Dockerfile.batch -t asia-northeast1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/civicship-api/civicship-api-batch:${{ github.sha }} . 
-
-- name: Push to Container Registry 
-run: | 
-docker push asia-northeast1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/civicship-api/civicship-api:${{ github.sha }} 
-docker push asia-northeast1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/civicship-api/civicship-api-external:${{ github.sha }} 
-docker push asia-northeast1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/civicship-api/civicship-api-batch:${{ github.sha }} 
-
-- name: Deploy to Cloud Run 
-run: | 
-gcloud run deploy civicship-api-internal \ 
---image asia-northeast1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/civicship-api/civicship-api:${{ github.sha }} \ 
---platform managed \ 
---region asia-northeast1 \ --allow-unauthenticated
-```
+Runtime-only secrets (`DATABASE_URL`, `FIREBASE_*`) are supplied to Cloud Run
+from **GCP Secret Manager**, not from GitHub Secrets. See
+[Environment Variable Management](#environment-variable-management) below.
 
 ### Multi-Environment Deployment
 

--- a/docs/handbook/DEPLOYMENT.md
+++ b/docs/handbook/DEPLOYMENT.md
@@ -185,9 +185,10 @@ Features:
 
 **Authentication:** Workload Identity Federation (WIF). Service account JSON keys
 are no longer used — workflows authenticate via
-`google-github-actions/auth` with `workload_identity_provider` +
-`service_account` secrets. See each workflow file for the concrete step
-definitions. Actions are pinned to 40-char commit SHAs.
+`google-github-actions/auth`, whose `workload_identity_provider` and
+`service_account` inputs are sourced from the `GCP_WIF_PROVIDER` and
+`GCP_SERVICE_ACCOUNT_EMAIL` secrets respectively. See each workflow file for
+the concrete step definitions. Actions are pinned to 40-char commit SHAs.
 
 **Required repo-level secrets (as of the post-β.2 cleanup):**
 
@@ -222,7 +223,7 @@ from **GCP Secret Manager**, not from GitHub Secrets. See
 - **Domain:** `staging-api.civicship.com`
 
 #### Production Environment
-- **Branch:** `main`
+- **Branch:** `master`
 - **Manual Approval:** Required
 - **Database:** Production PostgreSQL
 - **Domain:** `api.civicship.com`

--- a/docs/handbook/ENVIRONMENT.md
+++ b/docs/handbook/ENVIRONMENT.md
@@ -36,8 +36,11 @@ FIREBASE_AUDIENCE=your_project_id
 GCS_SERVICE_ACCOUNT_BASE64=base64_encoded_service_account_json
 GCS_BUCKET_NAME=your_storage_bucket_name
 GCP_PROJECT_ID=your_gcp_project_id
-GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 ```
+
+> `GOOGLE_APPLICATION_CREDENTIALS` is not used by this project. CI/CD uses
+> Workload Identity Federation, and runtime uses `GCS_SERVICE_ACCOUNT_BASE64`
+> for GCS access. Do not set it.
 
 ### Security/CORS
 
@@ -107,7 +110,6 @@ cp .env.test .env.test.local
 - `GCS_SERVICE_ACCOUNT_BASE64`: Base64-encoded service account JSON.
 - `GCS_BUCKET_NAME`: Name of the storage bucket to upload files to
 - `GCP_PROJECT_ID`: Google Cloud project ID
-- `GOOGLE_APPLICATION_CREDENTIALS`: Path to the service account JSON
 
 ### LINE Integration-Related Variables
 - The rich menu ID is stored in the database and configured in the admin panel.


### PR DESCRIPTION
## Summary
Updated deployment documentation and environment configuration to reflect migration from service account JSON keys to Workload Identity Federation (WIF) for GitHub Actions authentication. Removed references to `GOOGLE_APPLICATION_CREDENTIALS` environment variable which is no longer used.

## Key Changes

- **DEPLOYMENT.md**: Replaced detailed GitHub Actions workflow YAML example with a summary of workflow files and updated authentication approach
  - Documented WIF-based authentication via `google-github-actions/auth` action
  - Added comprehensive table of required repo-level secrets for CI/CD pipelines
  - Clarified that runtime secrets (`DATABASE_URL`, `FIREBASE_*`) are sourced from GCP Secret Manager, not GitHub Secrets
  - Listed all workflow files: dev/prd deployments, external API, rich menu, and CI checks

- **ENVIRONMENT.md**: Removed `GOOGLE_APPLICATION_CREDENTIALS` from environment variable documentation
  - Added clarification note explaining that WIF is used for CI/CD and `GCS_SERVICE_ACCOUNT_BASE64` is used for runtime GCS access
  - Removed `GOOGLE_APPLICATION_CREDENTIALS` from the GCP-related variables section

- **.env.sample**: Removed `GOOGLE_APPLICATION_CREDENTIALS` line to reflect that this variable is not needed

## Implementation Details

The changes document a security improvement where:
- GitHub Actions workflows now authenticate to GCP using Workload Identity Federation instead of service account JSON keys
- Service account keys are no longer stored as GitHub Secrets
- Runtime GCS access continues to use base64-encoded service account JSON via `GCS_SERVICE_ACCOUNT_BASE64`
- All GitHub Actions are pinned to 40-character commit SHAs for reproducibility

https://claude.ai/code/session_018db4pRGuygK6BKQoZnjaB5
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/868" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
