### PR TITLE
ci: integrate test step with migrate deploy and dummy env (non-blocking)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,13 @@ jobs:
 
     env:
       DATABASE_URL: postgresql://civicship:civicship@localhost:5432/civicship_ci
+      # Test dummy values (production secret は注入しない、test は DI 通過が目的).
+      # ローカル CI 相当環境での実測で、dummy 値でも DI container 登録・初期化が
+      # pass することを確認済み。実 API call を行う test はステップ 3 で mock 化する。
+      ANTHROPIC_API_KEY: dummy-for-testing
+      FIREBASE_PROJECT_ID: test-project-id
+      FIREBASE_CLIENT_EMAIL: test@test-project.iam.gserviceaccount.com
+      FIREBASE_TOKEN_API_KEY: dummy-for-testing
 
     steps:
       - name: Harden runner
@@ -91,8 +98,13 @@ jobs:
       # - name: Lint
       #   run: pnpm lint
 
-      - name: Apply Prisma schema to CI database
-        run: pnpm prisma db push --skip-generate --schema src/infrastructure/prisma/schema.prisma
+      - name: Apply Prisma migrations to CI database
+        # `prisma db push` は schema.prisma のモデルのみ反映し、migration.sql を
+        # 実行しない。view (10 個) / materialized view (4 個) は migration.sql のみで
+        # 定義されているため、db push だと view/mv が作られず、それらに依存する test
+        # が構造的に fail する。`pnpm db:deploy` (= prisma migrate deploy) で migration
+        # を順次適用し、view/mv 含めた全スキーマを CI DB に反映する。
+        run: pnpm db:deploy
 
       - name: Generate Prisma client (with TypedSQL)
         run: pnpm db:generate
@@ -110,6 +122,30 @@ jobs:
             src/types/graphql.ts \
             docs/schema.graphql \
             src/infrastructure/prisma/schema.prisma
+
+      - name: Generate test JWT RSA key
+        # firebase-admin の内部 JWT 署名 (RS256) 用に、test 専用の使い捨て RSA 2048
+        # key を毎回生成する。repo / GitHub Secrets に commit しないことで rotation /
+        # 漏洩の懸念を排除。`openssl genpkey -algorithm RSA` の既定出力は PKCS#8
+        # (`-----BEGIN PRIVATE KEY-----`) なので追加フラグは不要。
+        run: |
+          openssl genpkey -algorithm RSA \
+            -out /tmp/test-firebase-key.pem \
+            -pkeyopt rsa_keygen_bits:2048
+          {
+            echo "FIREBASE_PRIVATE_KEY<<EOF"
+            cat /tmp/test-firebase-key.pem
+            echo "EOF"
+          } >> "$GITHUB_ENV"
+          rm /tmp/test-firebase-key.pem
+
+      - name: Run tests (non-blocking until debt is resolved)
+        # blocking 化条件: 残 27 件の実 debt 解消 (別途ステップ 3 で対応) +
+        # 運用上 flaky でないことの確認。全条件を満たしたら `continue-on-error` を
+        # 削除し、branch protection の required status check に本 step を追加する
+        # 別 PR を出す。
+        run: pnpm test
+        continue-on-error: true
 
       - name: Build (typecheck + emit)
         run: pnpm build


### PR DESCRIPTION
## 背景

civicship-api の CI は現状 build + generated-file diff check のみで、67 test suite / 620 test が一度も走っていない。ローカル CI 相当環境での jest フル実行の実測で、構造的問題(CI コマンド + env 不足)により 95 件が fail、残 27 件が実 debt と判明した。本 PR は 95 件を構造的に解消し、`pnpm test` step を non-blocking で先行導入する。

## 変更内容

1. **`prisma db push --skip-generate` → `pnpm db:deploy`(= `prisma migrate deploy`)**
   - `db push` は schema.prisma のモデルのみ反映し、`migration.sql` を実行しない
   - view (10 個) / materialized view (4 個) は `migration.sql` のみで定義
   - `migrate deploy` に切替で view/mv 依存 test の構造的 fail(実測 **59 件**)を解消
2. **test 用 dummy env を workflow に直接記述**
   - `ANTHROPIC_API_KEY`、`FIREBASE_PROJECT_ID`、`FIREBASE_CLIENT_EMAIL`、`FIREBASE_TOKEN_API_KEY`
   - DI container 初期化に必要なだけで、実 API call は行わない
   - production の Secret には一切触れない(本 PR は GitHub Secrets への追加・変更なし)
3. **`Generate test JWT RSA key` step を追加**
   - firebase-admin の内部 JWT 署名 (RS256) 用に、test 専用 RSA 2048 key を毎回 on-the-fly で生成し `$GITHUB_ENV` に注入
   - repo / GitHub Secrets に key を保存しないため rotation / 漏洩リスクゼロ
4. **`pnpm test` step を `continue-on-error: true` で追加**
   - 残 27 件の実 debt があるため non-blocking で先行導入
   - debt 解消後に別 PR で `continue-on-error` 削除 + branch protection 更新

### 実装メモ(指示書との差分 1 件)

指示書の openssl コマンドに含まれていた `-pkcs8` フラグは `openssl genpkey` の有効 option ではなく、実行環境(OpenSSL 3.0.13)で `Unknown cipher: pkcs8` となり実行不可能だったため削除した。`openssl genpkey -algorithm RSA` の既定出力は既に PKCS#8(`-----BEGIN PRIVATE KEY-----`)で、要件(RSA 2048, PKCS#8)を満たす。挙動は等価。

## 実測結果(本 PR 適用前後の比較)

ローカル CI 相当環境(PostgreSQL 16、Node 22、pnpm 10.33.0)での `pnpm test --runInBand` 実測:

| 指標 | 適用前 | 適用後 | 削減 |
|---|---|---|---|
| Test Suites failed | 28 / 67 | 13 / 67 | -15 |
| Tests failed | 115 / 620 | 27 / 620 | **-88** |
| Pass rate | 81.5% | **95.6%** | +14.1pt |
| 所要時間 | 286.7 s | 92.1 s | -194.6 s |

fail カテゴリ削減内訳:

| カテゴリ | 適用前 | 適用後 | 解消手段 |
|---|---|---|---|
| A. Missing matview(`mv_current_points` 等) | 56 | 0 | migrate deploy |
| B. DI: `llmClient`(ANTHROPIC_API_KEY 不足) | 35 | 0 | dummy env |
| C. Missing view(`v_slot_remaining_capacity`) | 3 | 0 | migrate deploy |
| D. JWT RS256 key 不足(e2e) | 1 | 1 | on-the-fly key(残 1 件は test が実 Firebase 呼ぶ設計、mock 化は step 3) |
| E. `toHaveBeenCalledWith` mock mismatch | 10 | 10 | 本 PR 対象外(step 3) |
| F. 一般 assertion mismatch | 9 | 11 | 本 PR 対象外(step 3) |
| G. Other | 1 | 5 | 本 PR 対象外(step 3) |

※ E/F/G の一部増加は、B カテゴリの DI 失敗で suite レベル fail していた test が走るようになり個別 assertion 失敗が顕在化したもの。

## Admin action: 不要

本 PR は workflow と config のみの変更で完結する。GitHub Secrets への追加・変更・削除は発生しない。PR merge のみで CI test 統合が有効化される。

## blocking 化の条件(次ステップ)

- 残 27 件の実 debt 解消(step 3 で別 issue 化予定)
- 運用上 test step が flaky でないことの確認
- 全条件を満たしたら、`continue-on-error: true` を削除し、branch protection の required status check に本 step を追加する別 PR を出す

## 検証

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` pass
- `actionlint 1.7.7`(shellcheck 0.9.0 同梱)で全 workflow error 0 / warning 0 維持
- `openssl genpkey -algorithm RSA -out ... -pkeyopt rsa_keygen_bits:2048` 動作確認(OpenSSL 3.0.13)
- 変更箇所以外の ci.yml は無編集(38 insertions, 2 deletions、全 14 step)
- ローカル CI 相当環境で pass rate 95.6% 実測

## ロールバック

単一 commit、`git revert` で一括戻し可能。test step は non-blocking のため、仮に全 test fail しても merge blocker にならず、CI 全体の機能退化なし。

## Test plan

- [x] YAML syntax 検証(`python3 yaml.safe_load`)
- [x] actionlint + shellcheck 検証
- [x] ローカル CI 相当環境で `migrate deploy` 後 view/mv 作成確認(view 10 / matview 4)
- [x] ローカルで全 test 実行 → 593 pass / 27 fail 確認
- [ ] CI run 実走行で pass rate 95.6% 近辺 / test step `continue-on-error` で job 全体 success
- [ ] test step の fail 内訳がローカル実測 27 件と同等であることの確認

https://claude.ai/code/session_01Qo2eL3Jw7BRV1fPupba9Xu
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/872" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
