### PR TITLE
test: resolve all 27 CI test debt items (100% pass rate) (#875)

### DIFF
--- a/src/__tests__/e2e/userJourney.test.ts
+++ b/src/__tests__/e2e/userJourney.test.ts
@@ -10,6 +10,25 @@ import { registerProductionDependencies } from "@/application/provider";
 import { PrismaClientIssuer } from "@/infrastructure/prisma/client";
 import { GqlCurrentPrefecture, GqlIdentityPlatform } from "@/types/graphql";
 
+// firebase-admin の `auth.tenantManager().createTenant()` 等は実 Google OAuth2
+// API への token exchange を行う。有効な RSA key を与えても存在しない service
+// account のため `invalid_grant: account not found` で失敗する。本リポの運用方針
+// として「e2e の境界は DB + usecase chain、Google API は production のみ」と
+// 定めており、test レイヤーでは community.service.test.ts の unit と同様に
+// targeted mock する (sakata-san 判断 7.2 撤回後の改訂方針)。
+jest.mock("@/infrastructure/libs/firebase", () => ({
+  __esModule: true,
+  auth: {
+    tenantManager: jest.fn(() => ({
+      createTenant: jest.fn().mockResolvedValue({ tenantId: "mock-tenant-id" }),
+      deleteTenant: jest.fn().mockResolvedValue(undefined),
+      authForTenant: jest.fn(() => ({
+        deleteUser: jest.fn().mockResolvedValue(undefined),
+      })),
+    })),
+  },
+}));
+
 describe("End-to-End User Journey Integration Tests", () => {
   let identityUseCase: IdentityUseCase;
   let transactionUseCase: TransactionUseCase;
@@ -82,6 +101,15 @@ describe("End-to-End User Journey Integration Tests", () => {
       name: "Second User",
       slug: `second-user-${uniqueId}`,
       currentPrefecture: CurrentPrefecture.KAGAWA,
+    });
+
+    // donation (member-to-member) は receiver wallet の auto-create をしないため
+    // (usecase.ts:192 findMemberWalletOrThrow)、事前に明示 seed する
+    // (sakata-san 判断 7.4)。
+    await TestDataSourceHelper.createWallet({
+      type: WalletType.MEMBER,
+      community: { connect: { id: community.id } },
+      user: { connect: { id: secondUser.id } },
     });
 
     await transactionUseCase.userDonateSelfPointToAnother(grantCtx, {

--- a/src/__tests__/integration/pointTransfer/donateSelfPoint.error.test.ts
+++ b/src/__tests__/integration/pointTransfer/donateSelfPoint.error.test.ts
@@ -115,6 +115,15 @@ describe("Point Donation Error Handling Tests", () => {
       user: { connect: { id: user1.id } },
     });
 
+    // donation は receiver wallet の事前存在が前提。insufficient balance を検証する
+    // には wallet not found で落ちる前に balance validator に到達させる必要がある
+    // (sakata-san 判断 7.4)。
+    await TestDataSourceHelper.createWallet({
+      type: WalletType.MEMBER,
+      community: { connect: { id: community.id } },
+      user: { connect: { id: user2.id } },
+    });
+
     await TestDataSourceHelper.createTransaction({
       toWallet: { connect: { id: user1Wallet.id } },
       toPointChange: 30,

--- a/src/__tests__/integration/pointTransfer/evaluatePassParticipation.test.ts
+++ b/src/__tests__/integration/pointTransfer/evaluatePassParticipation.test.ts
@@ -339,21 +339,25 @@ describe("Point Reward Tests", () => {
     const vcRequest = vcRequests[0];
     const claims = vcRequest.claims as any;
 
+    // EvaluationCredentialClaim 型 (vcIssuanceRequest/data/type.ts:3-21) に沿って assert。
+    // type 上で claims.id は evaluation.id を格納する (converter.ts:38)。
+    // participationId / comment / opportunity.pointsToEarn は現時点の spec には
+    // 含まれない (VC claim 拡張は別 scope の spec 議論で扱う)。
     expect(claims.type).toBe("EvaluationCredential");
     expect(claims.score).toBe("PASSED");
-    expect(claims.participationId).toBe(participationId);
-    expect(claims.evaluationId).toBeDefined();
-    expect(claims.comment).toBe(testSetup.comment);
-    
+    expect(claims.id).toBeDefined();
+
     expect(claims.evaluator.id).toBe(opportunityOwnerUserId);
-    expect(claims.evaluator.name).toBe("Manager");
-    
+    // fixture では opportunityOwner も participation user も `testSetup.userName` を共有する
+    expect(claims.evaluator.name).toBe(testSetup.userName);
+
     expect(claims.participant.id).toBe(participationUserId);
     expect(claims.participant.name).toBeDefined();
-    
+
     expect(claims.opportunity.id).toBeDefined();
     expect(claims.opportunity.title).toBe("opportunity");
-    expect(claims.opportunity.pointsToEarn).toBe(testSetup.pointsToEarn);
+    expect(claims.opportunity.startsAt).toBeDefined();
+    expect(claims.opportunity.endsAt).toBeDefined();
   });
 
   it("creates multiple VC issuance requests for bulk evaluations", async () => {

--- a/src/__tests__/integration/walletCreation/donateSelfPoint.test.ts
+++ b/src/__tests__/integration/walletCreation/donateSelfPoint.test.ts
@@ -31,7 +31,11 @@ describe("Transaction DonateSelfPoint Integration Tests", () => {
     await TestDataSourceHelper.disconnect();
   });
 
-  it("should create member wallet if not exists when donate self points", async () => {
+  // donate のフローでは receiver の member wallet は事前存在が前提
+  // (usecase.ts:192 findMemberWalletOrThrow)。grant 経由は createIfNeeded だが、
+  // donation は member-to-member なので auto-create しない。
+  // fixture で明示 create することで test の意図を可視化する (sakata-san 判断 7.4)。
+  it("should donate self points to another existing member wallet", async () => {
     const name = "John Doe";
     const slug = "user-1-slug";
     const createUserInput = {
@@ -77,6 +81,13 @@ describe("Transaction DonateSelfPoint Integration Tests", () => {
     );
     const fromMemberWalletId = fromMemberWalletInserted.id;
 
+    // receiver 側も事前に member wallet を seed
+    await TestDataSourceHelper.createWallet({
+      type: WalletType.MEMBER,
+      community: { connect: { id: communityId } },
+      user: { connect: { id: toUserId } },
+    });
+
     const createTransactionInput = {
       to: fromMemberWalletId,
       toPointChange: 100,
@@ -95,7 +106,7 @@ describe("Transaction DonateSelfPoint Integration Tests", () => {
       transferPoints: donatedPoints,
     };
 
-    await useCase.userDonateSelfPointToAnother(ctx, { 
+    await useCase.userDonateSelfPointToAnother(ctx, {
       input,
       permission: { userId: ctx.currentUser!.id }
     });

--- a/src/__tests__/integration/walletCreation/reserveParticipation.error.test.ts
+++ b/src/__tests__/integration/walletCreation/reserveParticipation.error.test.ts
@@ -165,8 +165,9 @@ describe("Reservation Error Handling Tests", () => {
       paymentMethod: GqlReservationPaymentMethod.Ticket,
     };
 
+    // 実装 (utils.ts:10 AuthorizationError) は "User must be logged in" を投げる
     await expect(
       useCase.userReserveParticipation({ input }, ctx)
-    ).rejects.toThrow(/not authenticated/i);
+    ).rejects.toThrow(/User must be logged in/i);
   });
 });

--- a/src/__tests__/integration/walletCreation/reserveParticipation.test.ts
+++ b/src/__tests__/integration/walletCreation/reserveParticipation.test.ts
@@ -11,6 +11,31 @@ import { PrismaClientIssuer } from "@/infrastructure/prisma/client";
 describe("Reservation Integration Tests", () => {
   jest.setTimeout(30_000);
 
+  // reservation/validator.ts の validateSlotAdvanceBookingThreshold は
+  // now と endOfDay(subDays(startsAt, DEFAULT_ADVANCE_BOOKING_DAYS=2)) を比較する。
+  // 実時刻では test 実行の微細なずれで境界越えが発生しうるため、Date のみ固定する
+  // fake timers で安定化する (sakata-san 判断 7.3)。nextTick/setImmediate/setTimeout
+  // 等は Prisma/async 処理が依存するので fake 対象から除外。
+  const FIXED_NOW = new Date("2026-06-01T00:00:00.000Z");
+
+  beforeAll(() => {
+    jest.useFakeTimers({
+      doNotFake: [
+        "nextTick",
+        "setImmediate",
+        "setTimeout",
+        "setInterval",
+        "clearTimeout",
+        "clearInterval",
+      ],
+      now: FIXED_NOW,
+    });
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   let useCase: ReservationUseCase;
   let issuer: PrismaClientIssuer;
   let startsAt: Date;
@@ -18,9 +43,10 @@ describe("Reservation Integration Tests", () => {
 
   beforeEach(async () => {
     await TestDataSourceHelper.deleteAll();
-    const now = new Date();
-    startsAt = new Date(now.getTime() + 25 * 60 * 60 * 1000); // 25 hours in the future
-    endsAt = new Date(now.getTime() + 26 * 60 * 60 * 1000); // 26 hours in the future
+    // FIXED_NOW から 4 日後を slot の startsAt に設定。
+    // DEFAULT_ADVANCE_BOOKING_DAYS=2 の threshold に対して余裕を持たせる。
+    startsAt = new Date(FIXED_NOW.getTime() + 4 * 24 * 60 * 60 * 1000);
+    endsAt = new Date(FIXED_NOW.getTime() + 4 * 24 * 60 * 60 * 1000 + 60 * 60 * 1000);
 
     container.reset();
     registerProductionDependencies();

--- a/src/__tests__/unit/account/community.service.test.ts
+++ b/src/__tests__/unit/account/community.service.test.ts
@@ -117,7 +117,7 @@ describe("CommunityService", () => {
         ctxWithUser,
         {
           ...converted.data,
-          image: { create: converted.image },
+          image: undefined,
         },
         expect.anything(),
       );

--- a/src/__tests__/unit/experience/opportunity.service.test.ts
+++ b/src/__tests__/unit/experience/opportunity.service.test.ts
@@ -128,7 +128,9 @@ describe("OpportunityService", () => {
         "opportunity-1",
         expect.objectContaining({
           title: "Updated Opportunity",
+          // service.ts:102 で uploadedImages 有り時は既存画像を deleteMany で全消去してから create
           images: {
+            deleteMany: {},
             create: [{ id: "uploaded-1" }, { id: "uploaded-2" }],
           },
         }),

--- a/src/__tests__/unit/experience/opportunitySlot.service.test.ts
+++ b/src/__tests__/unit/experience/opportunitySlot.service.test.ts
@@ -21,6 +21,8 @@ class MockOpportunitySlotConverter {
   sort = jest.fn();
   createMany = jest.fn();
   update = jest.fn();
+  // service.ts:75 setOpportunitySlotHostingStatus は converter.setStatus(input) を呼ぶ
+  setStatus = jest.fn();
 }
 
 describe("OpportunitySlotService", () => {
@@ -46,6 +48,13 @@ describe("OpportunitySlotService", () => {
   describe("setOpportunitySlotHostingStatus", () => {
     it("should set hosting status after finding the slot", async () => {
       mockRepository.find.mockResolvedValue({ id: "slot-1" });
+      // service.ts:75 が converter.setStatus(input) を呼び、その戻り値を repository.setHostingStatus
+      // の第3引数として渡すため、mock に戻り値を設定しないと undefined が流れる。
+      mockConverter.setStatus.mockReturnValue({
+        status: OpportunitySlotHostingStatus.SCHEDULED,
+        capacity: 20,
+        comment: "任意コメント",
+      });
       mockRepository.setHostingStatus.mockResolvedValue({
         id: "slot-1",
         status: OpportunitySlotHostingStatus.SCHEDULED,

--- a/src/__tests__/unit/experience/participation.service.test.ts
+++ b/src/__tests__/unit/experience/participation.service.test.ts
@@ -86,7 +86,8 @@ describe("ParticipationService", () => {
 
       const result = await service.deleteParticipation(mockCtx, "p1", mockTx);
 
-      expect(mockRepository.find).toHaveBeenCalledWith(mockCtx, "p1");
+      // findParticipationOrThrow は tx を渡さずに repository.find(ctx, id, undefined) を呼ぶ
+      expect(mockRepository.find).toHaveBeenCalledWith(mockCtx, "p1", undefined);
       expect(mockRepository.delete).toHaveBeenCalledWith(mockCtx, "p1", mockTx);
       expect(result).toEqual({ id: "p1" });
     });

--- a/src/__tests__/unit/experience/reservation.service.test.ts
+++ b/src/__tests__/unit/experience/reservation.service.test.ts
@@ -79,8 +79,9 @@ describe("ReservationService", () => {
         participantCount,
         userIdsIfExists,
         reservationStatuses,
-        undefined,
+        undefined, // comment
         communityId,
+        undefined, // participantCountWithPoints (service.ts:74)
       );
       expect(mockRepository.create).toHaveBeenCalledWith(mockCtx, createdData, mockTx);
       expect(result).toEqual({ id: "reservation-1" });

--- a/src/__tests__/unit/middleware/bot-blocker.test.ts
+++ b/src/__tests__/unit/middleware/bot-blocker.test.ts
@@ -8,7 +8,14 @@ function makeReq(userAgent: string | undefined): Partial<Request> {
   };
 }
 
-function makeRes(): { res: Partial<Response>; statusCode: number | undefined; body: unknown } {
+function makeRes(): {
+  res: Partial<Response>;
+  ctx: { statusCode: number | undefined; body: unknown };
+} {
+  // ctx を参照ごと返すことで、mock が後から書き込んだ値を呼出側が観測できる。
+  // 以前は `return { res, ...ctx }` で spread していたが、spread は call 時点の
+  // 値をコピーするため、mock の `ctx.statusCode = code` 更新が届かず、
+  // destructure した `statusCode` は常に初期値 undefined のままだった。
   const ctx: { statusCode: number | undefined; body: unknown } = {
     statusCode: undefined,
     body: undefined,
@@ -23,7 +30,7 @@ function makeRes(): { res: Partial<Response>; statusCode: number | undefined; bo
       return res;
     }),
   };
-  return { res, ...ctx };
+  return { res, ctx };
 }
 
 describe("botBlocker", () => {
@@ -47,14 +54,14 @@ describe("botBlocker", () => {
 
     test.each(botUAs)("UA=%s → 403 を返し next() を呼ばない", (ua) => {
       const req = makeReq(ua);
-      const { res, statusCode } = makeRes();
+      const { res, ctx } = makeRes();
 
       botBlocker(req as Request, res as Response, next);
 
       expect(res.status).toHaveBeenCalledWith(403);
       expect(res.json).toHaveBeenCalledWith({ error: "Bot access blocked" });
       expect(next).not.toHaveBeenCalled();
-      expect(statusCode).toBe(403);
+      expect(ctx.statusCode).toBe(403);
     });
   });
 

--- a/src/__tests__/unit/transaction.service.test.ts
+++ b/src/__tests__/unit/transaction.service.test.ts
@@ -72,7 +72,6 @@ describe("TransactionService", () => {
 
       mockConverter.issueCommunityPoint.mockReturnValue(convertedData);
       mockRepository.create.mockResolvedValue(mockTransaction);
-      mockRepository.refreshCurrentPoints.mockResolvedValue(undefined);
 
       const result = await mockService.issueCommunityPoint(
         mockCtx,
@@ -84,7 +83,6 @@ describe("TransactionService", () => {
 
       expect(mockConverter.issueCommunityPoint).toHaveBeenCalledWith(walletId, transferPoints, "test-user-id", comment, undefined);
       expect(mockRepository.create).toHaveBeenCalledWith(mockCtx, convertedData, mockTx);
-      expect(mockRepository.refreshCurrentPoints).toHaveBeenCalledWith(mockCtx, mockTx);
       expect(result).toBe(mockTransaction);
     });
   });
@@ -108,7 +106,6 @@ describe("TransactionService", () => {
 
       mockConverter.grantCommunityPoint.mockReturnValue(convertedData);
       mockRepository.create.mockResolvedValue(mockTransaction);
-      mockRepository.refreshCurrentPoints.mockResolvedValue(undefined);
 
       const result = await mockService.grantCommunityPoint(
         mockCtx,
@@ -128,7 +125,6 @@ describe("TransactionService", () => {
         undefined,
       );
       expect(mockRepository.create).toHaveBeenCalledWith(mockCtx, convertedData, mockTx);
-      expect(mockRepository.refreshCurrentPoints).toHaveBeenCalledWith(mockCtx, mockTx);
       expect(result).toBe(mockTransaction);
     });
   });
@@ -152,7 +148,6 @@ describe("TransactionService", () => {
 
       mockConverter.donateSelfPoint.mockReturnValue(convertedData);
       mockRepository.create.mockResolvedValue(mockTransaction);
-      mockRepository.refreshCurrentPoints.mockResolvedValue(undefined);
 
       const result = await mockService.donateSelfPoint(
         mockCtx,
@@ -170,8 +165,8 @@ describe("TransactionService", () => {
         transferPoints,
         "test-user-id",
         comment,
-        undefined, // parentTxId (null → undefined)
-        1,         // chainDepth (no parent → 1)
+        undefined, // parentTxId (no parent)
+        undefined, // chainDepth (no parent → undefined, per service.ts:89)
         undefined, // uploadedImages
       );
       expect(mockRepository.create).toHaveBeenCalledWith(mockCtx, convertedData, mockTx);
@@ -243,7 +238,6 @@ describe("TransactionService", () => {
 
       mockConverter.giveRewardPoint.mockReturnValue(convertedData);
       mockRepository.create.mockResolvedValue(mockTransaction);
-      mockRepository.refreshCurrentPoints.mockResolvedValue(undefined);
 
       const result = await mockService.giveRewardPoint(
         mockCtx,
@@ -261,8 +255,8 @@ describe("TransactionService", () => {
         participationId,
         transferPoints,
         "test-user-id",
-        undefined, // parentTxId (null → undefined)
-        1,         // chainDepth (no parent → 1)
+        undefined, // parentTxId (no parent)
+        undefined, // chainDepth (no parent → undefined, per service.ts:119)
       );
       expect(mockRepository.create).toHaveBeenCalledWith(mockCtx, convertedData, mockTx);
       expect(result).toBe(mockTransaction);
@@ -332,7 +326,6 @@ describe("TransactionService", () => {
 
       mockConverter.purchaseTicket.mockReturnValue(convertedData);
       mockRepository.create.mockResolvedValue(mockTransaction);
-      mockRepository.refreshCurrentPoints.mockResolvedValue(undefined);
 
       const result = await mockService.purchaseTicket(
         mockCtx,
@@ -344,7 +337,6 @@ describe("TransactionService", () => {
 
       expect(mockConverter.purchaseTicket).toHaveBeenCalledWith(walletId, walletId, transferPoints, "test-user-id");
       expect(mockRepository.create).toHaveBeenCalledWith(mockCtx, convertedData, mockTx);
-      expect(mockRepository.refreshCurrentPoints).toHaveBeenCalledWith(mockCtx, mockTx);
       expect(result).toBe(mockTransaction);
     });
   });
@@ -368,7 +360,6 @@ describe("TransactionService", () => {
 
       mockConverter.refundTicket.mockReturnValue(convertedData);
       mockRepository.create.mockResolvedValue(mockTransaction);
-      mockRepository.refreshCurrentPoints.mockResolvedValue(undefined);
 
       const result = await mockService.refundTicket(
         mockCtx,
@@ -380,7 +371,6 @@ describe("TransactionService", () => {
 
       expect(mockConverter.refundTicket).toHaveBeenCalledWith(walletId, walletId, transferPoints, "test-user-id");
       expect(mockRepository.create).toHaveBeenCalledWith(mockCtx, convertedData, mockTx);
-      expect(mockRepository.refreshCurrentPoints).toHaveBeenCalledWith(mockCtx, mockTx);
       expect(result).toBe(mockTransaction);
     });
   });


### PR DESCRIPTION
* test(transaction): align mock expectations with current service signature

service 実装の現状に合わせて test 期待値を修正。以下 6 ケース全てで fail していた。

1. issueCommunityPoint / grantCommunityPoint / purchaseTicket / refundTicket (4件) `mockRepository.refreshCurrentPoints` の assertion を削除。 service.ts の該当 method は repository.refreshCurrentPoints を呼ばず、 呼び出しは usecase.ts:112 / 161 / 218 の 3 箇所に集約されている。 service 単体の unit test で refresh を assert するのは layer 違反なので、 setup (`mockResolvedValue`) ごと削除した。緩和ではなく責務の再配置。

2. donateSelfPoint / giveRewardPoint (2件、親 tx 無しケース) chainDepth 期待値を `1` → `undefined` に修正。 service.ts:89 / 119 の実装は `parentTx ? (parentTx.chainDepth ?? 0) + 1 : undefined` で、親 tx が無い場合は `undefined` を返す。親有りケース (chainDepth: 2 → 3 / 3 → 4) は現状維持。

service 実装は一切変更していない (禁止事項遵守)。

検証: pnpm test --testPathPattern='transaction.service.test.ts' → 8/8 pass

https://claude.ai/code/session_01Qo2eL3Jw7BRV1fPupba9Xu

* test(bot-blocker): fix makeRes helper to return ctx by reference

既知 Bot UA 8 件の全 fail は `makeRes()` helper の closure バグが原因。

修正前:
```
function makeRes(): { res; statusCode; body } {
  const ctx = { statusCode: undefined, body: undefined };
  const res = { status: jest.fn().mockImplementation(code => { ctx.statusCode = code; ... }), ... };
  return { res, ...ctx };  // ← spread が call 時点の undefined をコピー
}
const { res, statusCode } = makeRes();  // statusCode は const primitive 固定
```

mock 実行時の `ctx.statusCode = code` は ctx object を mutate するが、 呼出側で destructure された `statusCode` は primitive snapshot で、以後の mutation を観測できない。結果 `expect(statusCode).toBe(403)` が常に undefined 比較。

修正後:
```
return { res, ctx };                    // ctx を参照ごと返す
const { res, ctx } = makeRes();
expect(ctx.statusCode).toBe(403);       // mock 更新後の値が読める
```

実装 `src/presentation/middleware/bot-blocker.ts` は変更なし (禁止事項遵守)。 実装は `res.status(403).json(...)` を正しく呼び出しており、問題は test helper のみ。

検証: pnpm test --testPathPattern='bot-blocker.test.ts' → 14/14 pass (既存 6 + 修正 8)

https://claude.ai/code/session_01Qo2eL3Jw7BRV1fPupba9Xu

* test(services): align mock expectations with current signatures

Small 群 5 件を解消。いずれも test 側のみの修正で、実装 (service / converter / repository / errors) は一切変更していない。

1. community.service createCommunityAndJoinAsOwner service.ts:73 は `image: uploadedImageData ? { create: ... } : undefined` で、画像なし時は `image: undefined` を返す。test の期待 `image: { create: undefined }` を `image: undefined` に修正。

2. participation.service deleteParticipation service.ts:92 `findParticipationOrThrow(ctx, id)` が内部で `this.repository.find(ctx, id, tx)` を呼ぶが tx を渡さないため undefined が 第3引数に入る。test の `toHaveBeenCalledWith(mockCtx, "p1")` を `(mockCtx, "p1", undefined)` に修正。

3. reservation.service createReservation service.ts:66-75 の converter.create 呼出は 8 引数 (..., comment, communityId, participantCountWithPoints)。test は 7 引数で 最後の participantCountWithPoints (=undefined) が欠落。追加。

4. opportunity.service updateOpportunityContent (uploaded images) service.ts:99-106 で uploadedImages 有り時は `images: { deleteMany: {}, create: uploadedImages }` を生成する。 test の期待に `deleteMany: {}` を追加。

5. reserveParticipation.error "not authenticated" 実装 `utils.ts:10 AuthorizationError` は "User must be logged in" を throw。 test 側の regex を `/not authenticated/i` → `/User must be logged in/i` に修正。 実装側の文言変更はしない。

検証: 対象 5 suite 単体で 50/50 pass。

https://claude.ai/code/session_01Qo2eL3Jw7BRV1fPupba9Xu

* test(opportunitySlot): add missing converter.setStatus mock method and return value

setOpportunitySlotHostingStatus の test 失敗 2 段。

1. `TypeError: this.converter.setStatus is not a function` service.ts:75 は `this.converter.setStatus(input)` を呼ぶが、 MockOpportunitySlotConverter クラスに setStatus プロパティが無かった。 `setStatus = jest.fn()` を追加。

2. 戻り値 undefined が repository に渡る mock に mockReturnValue を設定しないと service.ts:76 `repository.setHostingStatus(ctx, slotId, data, tx)` の data が undefined と なり、test 期待 `expect.any(Object)` に合わない。`mockConverter.setStatus.mockReturnValue({...})` を追加。

実装 (service / converter) は一切変更していない。test のみ。

検証: pnpm test --testPathPattern='opportunitySlot.service.test.ts$' → 8/8 pass

残 VC issuance テストは sakata-san 判断待ちのため別 commit で対応予定。

https://claude.ai/code/session_01Qo2eL3Jw7BRV1fPupba9Xu

* test(evaluation): align VC claims assertions with EvaluationCredentialClaim type

`creates VC issuance request with correct claims structure` test 失敗の原因は seed 順序ではなく、test 期待値が現状の型定義 (vcIssuanceRequest/data/type.ts:3-21) および converter 実装 (vcIssuanceRequest/data/converter.ts:31-55) と乖離していた。

EvaluationCredentialClaim 型は以下 7 field のみ保持する:
- type: "EvaluationCredential"
- score: EvaluationStatus
- id: string (evaluation.id を格納)
- evaluator: { id, name }
- participant: { id?, name? }
- opportunity: { id?, title?, startsAt?, endsAt? }

修正前の test 期待に含まれていた非存在 field を削除/リネーム:

1. `claims.participationId` → 型に存在しない (削除)
2. `claims.evaluationId` → 型に存在しない (converter は `claims.id` に evaluation.id を格納)。assertion を `claims.id` に変更
3. `claims.comment` → 型に存在しない (削除)
4. `claims.opportunity.pointsToEarn` → 型に存在しない。opportunity 下には `startsAt` / `endsAt` のみ。これらの assertion に置換
5. `claims.evaluator.name` expected "Manager" → fixture (testSetup.userName) は "Jane Doe" を使用。`testSetup.userName` 参照に変更

sakata-san 判断 (option A): type 定義を source of truth とし、VC claim 拡張 (participationId / comment / pointsToEarn 等の追加) は別 scope の spec 議論で扱う。

実装 (converter / type) は一切変更していない。test のみ。

検証: pnpm test --testPathPattern='evaluatePassParticipation.test.ts$' → 9/9 pass

https://claude.ai/code/session_01Qo2eL3Jw7BRV1fPupba9Xu

* test(seed): explicitly create receiver member wallets for donation flows

donation (member-to-member) は `TransactionUseCase.userDonateSelfPointToAnother` で `walletService.findMemberWalletOrThrow` を使うため receiver の member wallet の 事前存在が必須 (usecase.ts:192)。`createIfNeeded` フラグ (validator.ts:27) は `reason === GRANT` のときだけ true となり、donation では false。

seed fixture で明示的に receiver wallet を create することで、 `NotFoundError: Member wallet not found` を回避し本来の test 意図を通す。 実装 (usecase / service / validator) は一切変更していない (sakata-san 判断 7.4)。

修正箇所 3 件:

1. walletCreation/donateSelfPoint.test.ts `should create member wallet if not exists when donate self points` は auto-create 動作を assert していたが、実装は auto-create しない設計。 seed で receiver wallet を明示 create し、test 名を `should donate self points to another existing member wallet` に変更。 元の assertion (toMemberWalletActual がある, transaction.to が wallet.id と一致) は seed された wallet に対しても成立する。

2. e2e/userJourney.test.ts "signup -> receive points -> donate points" secondUser は TestDataSourceHelper.createUser で作成され、member wallet は 付かない。donate の前に明示 create する。

3. pointTransfer/donateSelfPoint.error.test.ts "insufficient balance" user2 の wallet が未 seed のため、balance validator に到達する前に `Member wallet not found` が出て `/insufficient.*balance/i` regex と不一致。 user2 の wallet を seed することで validator.ts:103 の `InsufficientBalanceError` ("Insufficient balance: current balance 30 is less than requested amount 50") に到達させる。

検証: 3 suite 単体で 5/6 pass (userJourney の multi-user は P6 RS256 で未解消、 commit 7 で対応)。

https://claude.ai/code/session_01Qo2eL3Jw7BRV1fPupba9Xu

* test(reservation): stabilize date-dependent fixtures with fake timers

reservation/validator.ts:97 `validateSlotAdvanceBookingThreshold` は `endOfDay(subDays(startsAt, DEFAULT_ADVANCE_BOOKING_DAYS=2))` と `new Date()` を 比較する。test 実行時の微細な時刻ずれで境界越えが起きうる構造。

修正前: `startsAt = now + 25h` は config.ts の 2 日要件 (deadline = endOfDay(startsAt
- 2days)) に対して不十分。25h は subDays(..., 2) で 23h 過去になり、endOfDay で 当日終わりまで拡張されるが、実時刻では必ず過去になるため threshold を超過する。

修正後: sakata-san 判断 7.3 に従い `jest.useFakeTimers` で Date のみ固定。
- `FIXED_NOW = 2026-06-01T00:00:00Z` を beforeAll で set
- startsAt = FIXED_NOW + 4 日 → deadline = endOfDay(FIXED_NOW + 2日) > FIXED_NOW で安定 pass
- nextTick / setImmediate / setTimeout / setInterval は fake 対象外にし、 Prisma / async 処理を妨げない

実装 (validator / config) は一切変更していない。

検証: pnpm test --testPathPattern='walletCreation/reserveParticipation.test' → 2/2 pass

他 date-dependent test への fake timers 展開は別 scope (PR 本文の debt 残に記録)。

https://claude.ai/code/session_01Qo2eL3Jw7BRV1fPupba9Xu

* test(e2e): mock firebase-admin in userJourney to avoid real Google API call

当初 sakata-san 判断 7.2「test 用 RSA helper 方式で e2e coverage 維持」は 実測で不十分であると判明したため撤回、targeted mock 方式に差替える。

実測事実:
- 有効な RSA 2048 key を FIREBASE_PRIVATE_KEY に注入し jwt 署名は通す
- firebase-admin は続けて `https://accounts.google.com/o/oauth2/token` に JWT を 送信して access token を取得しようとする (AuthHttpClient.getToken)
- test 用 service account は Google 側に存在しないため `invalid_grant: account not found` で拒否される
- RSA key 単独では test は通らない

本リポの運用方針:
- e2e の境界は "DB + usecase chain の統合動作検証"
- Google API 接続は production key でのみ行う
- test 用 service account を Google に作るのは別 scope

解決策:
community.service.test.ts で既採用の targeted mock pattern を userJourney.test.ts 冒頭に適用:

  jest.mock("@/infrastructure/libs/firebase", () => ({
    __esModule: true,
    auth: {
      tenantManager: jest.fn(() => ({
        createTenant: jest.fn().mockResolvedValue({ tenantId: "mock-tenant-id" }),
        deleteTenant: jest.fn().mockResolvedValue(undefined),
        authForTenant: jest.fn(() => ({
          deleteUser: jest.fn().mockResolvedValue(undefined),
        })),
      })),
    },
  }));

mock 粒度:
- firebase-admin 全面 mock ではなく `@/infrastructure/libs/firebase` の薄い wrapper のみ
- createTenant / deleteTenant / authForTenant を stub し、他のフロー (DB / usecase) は real 実行
- e2e の価値は維持、Google API 部分だけ諦める

実装コード (community.service.ts / identity/service.ts) は一切変更していない。

Handoff 記録:
- ci.yml の "Generate test JWT RSA key" step (PR #872) は残置。将来 step 整理 PR で必要性を再評価する。本 PR では触らない。
- firebase-admin を使う test の emulator 移行は別 scope。

検証: pnpm test --testPathPattern='userJourney' → 2/2 pass

https://claude.ai/code/session_01Qo2eL3Jw7BRV1fPupba9Xu

---------
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
