### PR TITLE
chore(deps): override protobufjs to ^7.5.5 (GHSA-xq3m-2v4x-88gg, Critical)

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,8 @@
       "minimatch": ">=3.1.5",
       "node-forge": ">=1.3.2",
       "@smithy/config-resolver": ">=4.4.5",
-      "validator": ">=13.15.23"
+      "validator": ">=13.15.23",
+      "protobufjs": "^7.5.5"
     }
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,7 @@ overrides:
   node-forge: '>=1.3.2'
   '@smithy/config-resolver': '>=4.4.5'
   validator: '>=13.15.23'
+  protobufjs: ^7.5.5
 
 importers:
 
@@ -3471,9 +3472,6 @@ packages:
 
   '@types/node@22.16.5':
     resolution: {integrity: sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==}
-
-  '@types/node@22.18.0':
-    resolution: {integrity: sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==}
 
   '@types/node@22.19.11':
     resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
@@ -7194,8 +7192,8 @@ packages:
     resolution: {integrity: sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==}
     engines: {node: '>=14.0.0'}
 
-  protobufjs@7.5.3:
-    resolution: {integrity: sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==}
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -10605,7 +10603,7 @@ snapshots:
       fast-deep-equal: 3.1.3
       functional-red-black-tree: 1.0.1
       google-gax: 4.6.1
-      protobufjs: 7.5.3
+      protobufjs: 7.5.5
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -11313,14 +11311,14 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.3
+      protobufjs: 7.5.5
       yargs: 17.7.2
 
   '@grpc/proto-loader@0.8.0':
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.3
+      protobufjs: 7.5.5
       yargs: 17.7.2
 
   '@headlessui/react@2.2.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
@@ -11520,7 +11518,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.18.0
+      '@types/node': 22.19.11
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -11538,7 +11536,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 22.18.0
+      '@types/node': 22.19.11
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -11956,7 +11954,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.207.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
-      protobufjs: 7.5.3
+      protobufjs: 7.5.5
 
   '@opentelemetry/propagator-b3@2.2.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -12947,7 +12945,7 @@ snapshots:
 
   '@types/accepts@1.3.7':
     dependencies:
-      '@types/node': 22.16.3
+      '@types/node': 22.19.11
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -12998,7 +12996,7 @@ snapshots:
       '@types/connect': 3.4.38
       '@types/express': 4.17.23
       '@types/keygrip': 1.0.6
-      '@types/node': 22.16.3
+      '@types/node': 22.19.11
 
   '@types/cors@2.8.19':
     dependencies:
@@ -13153,7 +13151,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 22.18.0
+      '@types/node': 22.19.11
 
   '@types/graphql-upload@17.0.0':
     dependencies:
@@ -13245,10 +13243,6 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@22.18.0':
-    dependencies:
-      undici-types: 6.21.0
-
   '@types/node@22.19.11':
     dependencies:
       undici-types: 6.21.0
@@ -13263,7 +13257,7 @@ snapshots:
 
   '@types/readable-stream@4.0.21':
     dependencies:
-      '@types/node': 22.18.0
+      '@types/node': 22.19.11
 
   '@types/request@2.48.12':
     dependencies:
@@ -13312,7 +13306,7 @@ snapshots:
 
   '@types/tunnel@0.0.3':
     dependencies:
-      '@types/node': 22.18.0
+      '@types/node': 22.19.11
 
   '@types/unist@2.0.11': {}
 
@@ -13332,7 +13326,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 22.18.0
+      '@types/node': 22.19.11
     optional: true
 
   '@typescript-eslint/eslint-plugin@8.36.0(@typescript-eslint/parser@8.36.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)':
@@ -15442,7 +15436,7 @@ snapshots:
       node-fetch: 2.7.0
       object-hash: 3.0.0
       proto3-json-serializer: 2.0.2
-      protobufjs: 7.5.3
+      protobufjs: 7.5.5
       retry-request: 7.0.2
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -16009,7 +16003,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.18.0
+      '@types/node': 22.19.11
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.6.0
@@ -16118,7 +16112,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.18.0
+      '@types/node': 22.19.11
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -16167,7 +16161,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.18.0
+      '@types/node': 22.19.11
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -16304,7 +16298,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 22.18.0
+      '@types/node': 22.19.11
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -17558,9 +17552,9 @@ snapshots:
 
   proto3-json-serializer@2.0.2:
     dependencies:
-      protobufjs: 7.5.3
+      protobufjs: 7.5.5
 
-  protobufjs@7.5.3:
+  protobufjs@7.5.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -17572,7 +17566,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 22.16.3
+      '@types/node': 22.19.11
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -18396,7 +18390,7 @@ snapshots:
       '@azure/identity': 4.10.2
       '@azure/keyvault-keys': 4.10.0
       '@js-joda/core': 5.6.5
-      '@types/node': 22.18.0
+      '@types/node': 22.19.11
       bl: 6.1.0
       iconv-lite: 0.6.3
       js-md4: 0.3.2


### PR DESCRIPTION
## 背景

Dependabot alert #124: protobufjs に Critical 脆弱性 (CVSS 9.4, ACE)。

- **GHSA**: [GHSA-xq3m-2v4x-88gg](https://github.com/advisories/GHSA-xq3m-2v4x-88gg)
- **公開**: 2026-04-16
- **攻撃ベクター**: Network / Low complexity / No auth / No UI
- **原因**: protobuf 定義の `type` field 経由で JS code injection、decode 時に実行

現在 `protobufjs@7.5.3` 使用、4 ルートの transitive 経由 (direct 依存なし):

- `@google-cloud/firestore` → `firebase-admin` (direct)
- `@grpc/proto-loader` → `@grpc/grpc-js` → 複数 direct dep
- `google-gax` → `@google-cloud/logging-winston` (direct)
- `@opentelemetry/otlp-transformer` (direct)

## 解消方針

`pnpm.overrides` に `protobufjs: "^7.5.5"` を追加。

**判断理由**:
- 4 ルート全てを単一 override で遮断可能
- 7.5.5 は同 major の patch release、drop-in safe
- `^7.5.5` で 7.x 系に固定(8.x への意図せぬ昇格を防ぐ)
- 既存 `pnpm.overrides` 14 件と同パターン(運用実績あり)
- Dependabot の PR 待ちより先回りで Critical を即解消

**却下した選択肢**:
- (a) 親 package 全 update: 4 親 × major bump、breaking 懸念、overkill
- (c) patch-package: upstream に 7.5.5 patch 済み、不要

## 検証

ローカル環境で確認済み:

```
$ pnpm why protobufjs
protobufjs@7.5.5
├─┬ @google-cloud/firestore@7.11.2
├─┬ @grpc/proto-loader@0.7.15
├─┬ @grpc/proto-loader@0.8.0
├─┬ @opentelemetry/otlp-transformer@0.207.0
├── google-gax@4.6.1 [deduped]
└─┬ proto3-json-serializer@2.0.2
Found 1 version of protobufjs
```

- `pnpm install` で lock 反映
- `pnpm list protobufjs --depth=0` で 7.5.5 昇格確認 (全 4 ルート)
- `pnpm-lock.yaml` も `protobufjs@7.5.5` に更新

**build / test について**:
ローカル環境では `@prisma/client/sql` (TypedSQL) の生成に live Postgres が必要なため、`pnpm build` / `pnpm test` のフル実行は環境制約でスキップ。これらは protobufjs 変更と無関係の Prisma 生成側の制約。CI 側で検証する。

## Dependabot PR との関係

cooldown 明けで Dependabot が自動 PR を立てる想定。本 PR merge 後、その PR は close する(overrides で解消済みのため不要)。

## Admin action

不要。PR merge で完結。

## Checklist

- [x] `package.json` pnpm.overrides に 1 行追加のみ
- [x] 既存 overrides entry は変更なし
- [x] 7.5.5 未満の version 指定なし
- [x] 8.x 系 override なし (`^7.5.5` で 7.x 系に固定)
- [x] direct dep 追加なし (transitive override 方針)
- [x] 2 commit 構成 (package.json / pnpm-lock.yaml)

https://claude.ai/code/session_01HrYj9zExZ6Yp9HDKSWHawR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/881" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
