### PR TITLE
Add report feedback collection and template A/B testing (PR-F3/F4) (#…

### DIFF
--- a/docs/schema.dbml
+++ b/docs/schema.dbml
@@ -861,6 +861,10 @@ Table t_report_feedbacks {
   sectionKey String
   comment String
   createdAt DateTime [default: `now()`, not null]
+
+  indexes {
+    (reportId, userId) [unique]
+  }
 }
 
 Table t_report_golden_cases {

--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -876,6 +876,7 @@ type Mutation {
   reservationJoin(id: ID!): ReservationSetStatusPayload
   reservationReject(id: ID!, input: ReservationRejectInput!, permission: CheckOpportunityPermissionInput!): ReservationSetStatusPayload
   storePhoneAuthToken(input: StorePhoneAuthTokenInput!, permission: CheckIsSelfPermissionInput!): StorePhoneAuthTokenPayload
+  submitReportFeedback(input: SubmitReportFeedbackInput!, permission: CheckCommunityPermissionInput!): SubmitReportFeedbackPayload
   ticketClaim(input: TicketClaimInput!): TicketClaimPayload
   ticketIssue(input: TicketIssueInput!, permission: CheckCommunityPermissionInput!): TicketIssuePayload
   ticketPurchase(input: TicketPurchaseInput!, permission: CheckCommunityPermissionInput!): TicketPurchasePayload
@@ -1640,6 +1641,7 @@ type Query {
   portfolios(filter: PortfolioFilterInput, first: Int, sort: PortfolioSortInput): [Portfolio!]
   report(id: ID!): Report
   reportTemplate(communityId: ID, variant: ReportVariant!): ReportTemplate
+  reportTemplateStats(variant: ReportVariant!, version: Int): ReportTemplateStats!
   reports(communityId: ID!, cursor: String, first: Int, permission: CheckCommunityPermissionInput!, status: ReportStatus, variant: ReportVariant): ReportsConnection!
   reservation(id: ID!): Reservation
   reservationHistories(cursor: String, filter: ReservationHistoryFilterInput, first: Int, sort: ReservationHistorySortInput): ReservationHistoriesConnection!
@@ -1695,11 +1697,13 @@ type Report {
   cacheReadTokens: Int
   community: Community!
   createdAt: Datetime!
+  feedbacks(after: String, first: Int): ReportFeedbacksConnection!
   finalContent: String
   generatedByUser: User
   id: ID!
   inputTokens: Int
   model: String
+  myFeedback: ReportFeedback
   outputMarkdown: String
   outputTokens: Int
   parentRun: Report
@@ -1722,6 +1726,36 @@ type ReportEdge implements Edge {
   node: Report
 }
 
+type ReportFeedback {
+  comment: String
+  createdAt: Datetime!
+  feedbackType: ReportFeedbackType
+  id: ID!
+  rating: Int!
+  reportId: ID!
+  sectionKey: String
+  user: User!
+}
+
+type ReportFeedbackEdge implements Edge {
+  cursor: String!
+  node: ReportFeedback
+}
+
+enum ReportFeedbackType {
+  ACCURACY
+  OTHER
+  QUALITY
+  STRUCTURE
+  TONE
+}
+
+type ReportFeedbacksConnection {
+  edges: [ReportFeedbackEdge]
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
 enum ReportStatus {
   APPROVED
   DRAFT
@@ -1735,7 +1769,9 @@ type ReportTemplate {
   community: Community
   communityContext: String
   createdAt: Datetime!
+  experimentKey: String
   id: ID!
+  isActive: Boolean!
   isEnabled: Boolean!
   maxTokens: Int!
   model: String!
@@ -1743,15 +1779,27 @@ type ReportTemplate {
   stopSequences: [String!]!
   systemPrompt: String!
   temperature: Float
+  trafficWeight: Int!
   updatedAt: Datetime
   updatedByUser: User
   userPromptTemplate: String!
   variant: ReportVariant!
+  version: Int!
 }
 
 enum ReportTemplateScope {
   COMMUNITY
   SYSTEM
+}
+
+type ReportTemplateStats {
+  avgJudgeScore: Float
+  avgRating: Float
+  correlationWarning: Boolean!
+  feedbackCount: Int!
+  judgeHumanCorrelation: Float
+  variant: ReportVariant!
+  version: Int
 }
 
 enum ReportVariant {
@@ -1931,6 +1979,20 @@ input StorePhoneAuthTokenInput {
 type StorePhoneAuthTokenPayload {
   expiresAt: Datetime
   success: Boolean!
+}
+
+input SubmitReportFeedbackInput {
+  comment: String
+  feedbackType: ReportFeedbackType
+  rating: Int!
+  reportId: ID!
+  sectionKey: String
+}
+
+union SubmitReportFeedbackPayload = SubmitReportFeedbackSuccess
+
+type SubmitReportFeedbackSuccess {
+  feedback: ReportFeedback!
 }
 
 enum SysRole {
@@ -2340,12 +2402,15 @@ type TransactionsConnection {
 
 input UpdateReportTemplateInput {
   communityContext: String
+  experimentKey: String
+  isActive: Boolean
   isEnabled: Boolean
   maxTokens: Int!
   model: String!
   stopSequences: [String!]
   systemPrompt: String!
   temperature: Float
+  trafficWeight: Int
   userPromptTemplate: String!
 }
 

--- a/src/__tests__/unit/report/feedback/feedbackService.test.ts
+++ b/src/__tests__/unit/report/feedback/feedbackService.test.ts
@@ -1,0 +1,128 @@
+import "reflect-metadata";
+import { container } from "tsyringe";
+import ReportFeedbackService, {
+  pearsonCorrelation,
+  JUDGE_HUMAN_CORRELATION_WARNING_THRESHOLD,
+} from "@/application/domain/report/feedback/service";
+import type { IContext } from "@/types/server";
+
+describe("ReportFeedbackService.getTemplateStats", () => {
+  const fakeCtx = {} as IContext;
+
+  let repository: {
+    createFeedback: jest.Mock;
+    findFeedbackByReportAndUser: jest.Mock;
+    findFeedbacksByReport: jest.Mock;
+    findFeedbacksByReportIds: jest.Mock;
+    getTemplateFeedbackAggregates: jest.Mock;
+  };
+  let service: ReportFeedbackService;
+
+  beforeEach(() => {
+    container.reset();
+    repository = {
+      createFeedback: jest.fn(),
+      findFeedbackByReportAndUser: jest.fn(),
+      findFeedbacksByReport: jest.fn(),
+      findFeedbacksByReportIds: jest.fn(),
+      getTemplateFeedbackAggregates: jest.fn(),
+    };
+    container.register("ReportFeedbackRepository", { useValue: repository });
+    service = container.resolve(ReportFeedbackService);
+  });
+
+  it("returns null correlation + no warning when there is no feedback", async () => {
+    repository.getTemplateFeedbackAggregates.mockResolvedValue({
+      feedbackCount: 0,
+      avgRating: null,
+      avgJudgeScore: null,
+      pairs: [],
+      version: 1,
+    });
+
+    const result = await service.getTemplateStats(fakeCtx, "WEEKLY_SUMMARY", 1);
+    expect(result.avgRating).toBeNull();
+    expect(result.feedbackCount).toBe(0);
+    expect(result.judgeHumanCorrelation).toBeNull();
+    expect(result.correlationWarning).toBe(false);
+  });
+
+  it("computes Pearson's r when judge + rating pairs exist", async () => {
+    // Perfectly correlated series (judgeScore rises linearly with rating)
+    // → r = 1, safely above the 0.7 warning threshold.
+    repository.getTemplateFeedbackAggregates.mockResolvedValue({
+      feedbackCount: 5,
+      avgRating: 3.0,
+      avgJudgeScore: 75,
+      pairs: [
+        { reportId: "r1", judgeScore: 60, avgRating: 2 },
+        { reportId: "r2", judgeScore: 70, avgRating: 3 },
+        { reportId: "r3", judgeScore: 80, avgRating: 4 },
+        { reportId: "r4", judgeScore: 90, avgRating: 5 },
+      ],
+      version: 1,
+    });
+
+    const result = await service.getTemplateStats(fakeCtx, "WEEKLY_SUMMARY", 1);
+    expect(result.judgeHumanCorrelation).not.toBeNull();
+    expect(result.judgeHumanCorrelation!).toBeGreaterThan(0.99);
+    expect(result.correlationWarning).toBe(false);
+  });
+
+  it("flags correlationWarning when r falls below the threshold", async () => {
+    // Anti-correlated series (higher judgeScore ↔ lower rating) → r ≈ -1,
+    // well below 0.7.
+    repository.getTemplateFeedbackAggregates.mockResolvedValue({
+      feedbackCount: 4,
+      avgRating: 3.5,
+      avgJudgeScore: 75,
+      pairs: [
+        { reportId: "r1", judgeScore: 90, avgRating: 2 },
+        { reportId: "r2", judgeScore: 80, avgRating: 3 },
+        { reportId: "r3", judgeScore: 70, avgRating: 4 },
+        { reportId: "r4", judgeScore: 60, avgRating: 5 },
+      ],
+      version: 1,
+    });
+
+    const result = await service.getTemplateStats(fakeCtx, "WEEKLY_SUMMARY", 1);
+    expect(result.judgeHumanCorrelation).toBeLessThan(
+      JUDGE_HUMAN_CORRELATION_WARNING_THRESHOLD,
+    );
+    expect(result.correlationWarning).toBe(true);
+  });
+});
+
+describe("pearsonCorrelation", () => {
+  it("returns null when the pair count is below the minimum", () => {
+    expect(pearsonCorrelation([])).toBeNull();
+    expect(pearsonCorrelation([{ reportId: "r1", judgeScore: 70, avgRating: 3 }])).toBeNull();
+    expect(
+      pearsonCorrelation([
+        { reportId: "r1", judgeScore: 70, avgRating: 3 },
+        { reportId: "r2", judgeScore: 80, avgRating: 4 },
+      ]),
+    ).toBeNull();
+  });
+
+  it("returns null when either series has zero variance", () => {
+    // All judgeScores identical → denX = 0 → division-by-zero → null.
+    const result = pearsonCorrelation([
+      { reportId: "r1", judgeScore: 70, avgRating: 2 },
+      { reportId: "r2", judgeScore: 70, avgRating: 4 },
+      { reportId: "r3", judgeScore: 70, avgRating: 3 },
+    ]);
+    expect(result).toBeNull();
+  });
+
+  it("returns a value between -1 and 1 (inclusive)", () => {
+    const r = pearsonCorrelation([
+      { reportId: "r1", judgeScore: 50, avgRating: 2 },
+      { reportId: "r2", judgeScore: 75, avgRating: 3 },
+      { reportId: "r3", judgeScore: 100, avgRating: 5 },
+    ]);
+    expect(r).not.toBeNull();
+    expect(r!).toBeGreaterThanOrEqual(-1);
+    expect(r!).toBeLessThanOrEqual(1);
+  });
+});

--- a/src/__tests__/unit/report/feedback/feedbackUsecase.test.ts
+++ b/src/__tests__/unit/report/feedback/feedbackUsecase.test.ts
@@ -1,0 +1,172 @@
+import "reflect-metadata";
+import { Prisma } from "@prisma/client";
+import { container } from "tsyringe";
+import ReportFeedbackUseCase from "@/application/domain/report/feedback/usecase";
+import type { IContext } from "@/types/server";
+import { GqlReportFeedbackType } from "@/types/graphql";
+
+/**
+ * `submitReportFeedback` sits at the top of a short pipeline:
+ * validate → lookup report → check duplicate → insert. These tests
+ * exercise each gate and the success path; the repository is stubbed so
+ * no Prisma / DB is involved.
+ */
+describe("ReportFeedbackUseCase.submitReportFeedback", () => {
+  const communityId = "kibotcha";
+  const reportId = "report-1";
+  const userId = "user-1";
+
+  const fakeCtx = {
+    currentUser: { id: userId, sysRole: "USER" },
+    issuer: {
+      // Pass-through both variants: the usecase wraps the whole
+      // check-then-write in `issuer.public`, while other call sites in
+      // the domain still reach for `onlyBelongingCommunity`.
+      public: (_ctx: IContext, fn: (tx: unknown) => Promise<unknown>) => fn({} as never),
+      onlyBelongingCommunity: (_ctx: IContext, fn: (tx: unknown) => Promise<unknown>) =>
+        fn({} as never),
+    },
+  } as unknown as IContext;
+
+  let feedbackService: {
+    createFeedback: jest.Mock;
+    getExistingFeedback: jest.Mock;
+    listFeedbacksByReport: jest.Mock;
+    listFeedbacksByReportIds: jest.Mock;
+    getTemplateStats: jest.Mock;
+  };
+  let reportService: { getReportById: jest.Mock };
+  let usecase: ReportFeedbackUseCase;
+
+  beforeEach(() => {
+    container.reset();
+    feedbackService = {
+      createFeedback: jest.fn(),
+      getExistingFeedback: jest.fn().mockResolvedValue(null),
+      listFeedbacksByReport: jest.fn(),
+      listFeedbacksByReportIds: jest.fn(),
+      getTemplateStats: jest.fn(),
+    };
+    reportService = {
+      getReportById: jest
+        .fn()
+        .mockResolvedValue({ id: reportId, communityId, variant: "WEEKLY_SUMMARY" }),
+    };
+
+    container.register("ReportFeedbackService", { useValue: feedbackService });
+    container.register("ReportService", { useValue: reportService });
+    usecase = container.resolve(ReportFeedbackUseCase);
+  });
+
+  function defaultInput() {
+    return {
+      input: {
+        reportId,
+        rating: 4,
+        feedbackType: GqlReportFeedbackType.Quality,
+        comment: "great summary",
+      },
+      permission: { communityId },
+    };
+  }
+
+  it("inserts a feedback row on the happy path", async () => {
+    feedbackService.createFeedback.mockResolvedValue({
+      id: "feedback-1",
+      reportId,
+      userId,
+      rating: 4,
+      feedbackType: "QUALITY",
+      sectionKey: null,
+      comment: "great summary",
+      createdAt: new Date(),
+    });
+
+    const result = await usecase.submitReportFeedback(defaultInput(), fakeCtx);
+
+    expect(feedbackService.createFeedback).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ reportId, userId, rating: 4 }),
+      expect.anything(), // tx propagated through the atomic wrapper
+    );
+    expect(result.__typename).toBe("SubmitReportFeedbackSuccess");
+  });
+
+  it.each([0, 6, 3.5, Number.NaN, -1])(
+    "rejects rating=%s with ValidationError (out of 1..5 or not an integer)",
+    async (rating) => {
+      const args = defaultInput();
+      args.input.rating = rating as number;
+      await expect(usecase.submitReportFeedback(args, fakeCtx)).rejects.toThrow(/rating/);
+      expect(feedbackService.createFeedback).not.toHaveBeenCalled();
+    },
+  );
+
+  it("throws when the report does not exist", async () => {
+    reportService.getReportById.mockResolvedValue(null);
+    await expect(usecase.submitReportFeedback(defaultInput(), fakeCtx)).rejects.toThrow(
+      /Report not found/,
+    );
+    expect(feedbackService.createFeedback).not.toHaveBeenCalled();
+  });
+
+  it("throws when the report belongs to a different community (cross-community probe)", async () => {
+    reportService.getReportById.mockResolvedValue({
+      id: reportId,
+      communityId: "other-community",
+      variant: "WEEKLY_SUMMARY",
+    });
+    // NotFoundError — not an AuthorizationError — to avoid leaking the
+    // existence of the report to non-members.
+    await expect(usecase.submitReportFeedback(defaultInput(), fakeCtx)).rejects.toThrow(
+      /Report not found/,
+    );
+    expect(feedbackService.createFeedback).not.toHaveBeenCalled();
+  });
+
+  it("throws when the user has already submitted for this report", async () => {
+    feedbackService.getExistingFeedback.mockResolvedValue({
+      id: "feedback-0",
+      reportId,
+      userId,
+      rating: 5,
+    });
+    await expect(usecase.submitReportFeedback(defaultInput(), fakeCtx)).rejects.toThrow(
+      /already submitted/,
+    );
+    expect(feedbackService.createFeedback).not.toHaveBeenCalled();
+  });
+
+  it("rejects an over-long comment", async () => {
+    const args = defaultInput();
+    args.input.comment = "x".repeat(3000);
+    await expect(usecase.submitReportFeedback(args, fakeCtx)).rejects.toThrow(/comment/);
+    expect(feedbackService.createFeedback).not.toHaveBeenCalled();
+  });
+
+  it("throws AuthenticationError when there is no current user", async () => {
+    const anonCtx = {
+      ...fakeCtx,
+      currentUser: null,
+    } as unknown as IContext;
+    await expect(usecase.submitReportFeedback(defaultInput(), anonCtx)).rejects.toThrow(
+      /logged in/,
+    );
+  });
+
+  it("translates a racing P2002 into the same ValidationError as the pre-check", async () => {
+    // Simulate a second writer landing between our duplicate check and
+    // the insert: pre-check sees no row, but Prisma raises P2002 on
+    // write. The usecase must surface the same error code as the
+    // pre-check path so clients get a consistent message.
+    feedbackService.createFeedback.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+        code: "P2002",
+        clientVersion: "test",
+      }),
+    );
+    await expect(usecase.submitReportFeedback(defaultInput(), fakeCtx)).rejects.toThrow(
+      /already submitted/,
+    );
+  });
+});

--- a/src/__tests__/unit/report/service.test.ts
+++ b/src/__tests__/unit/report/service.test.ts
@@ -17,6 +17,11 @@ class MockReportRepository {
   refreshTransactionSummaryDaily = jest.fn();
   refreshUserTransactionDaily = jest.fn();
   findTemplate = jest.fn();
+  findActiveTemplates = jest.fn();
+  findJudgeTemplate = jest.fn();
+  updateReportJudgeResult = jest.fn();
+  findGoldenCases = jest.fn();
+  upsertGoldenCase = jest.fn();
   upsertTemplate = jest.fn();
   createReport = jest.fn();
   findReportById = jest.fn();

--- a/src/__tests__/unit/report/templateSelector.test.ts
+++ b/src/__tests__/unit/report/templateSelector.test.ts
@@ -1,0 +1,230 @@
+import "reflect-metadata";
+import { ReportTemplateKind } from "@prisma/client";
+import { container } from "tsyringe";
+import ReportTemplateSelector, {
+  cyrb53,
+} from "@/application/domain/report/templateSelector";
+import type { IContext } from "@/types/server";
+import type { PrismaReportTemplate } from "@/application/domain/report/data/type";
+
+/**
+ * `ReportTemplateSelector` covers three behaviour invariants:
+ *
+ *   1. COMMUNITY-scope candidates shadow SYSTEM — if any community row
+ *      exists, the SYSTEM fallback is not consulted.
+ *   2. The weighted draw is deterministic per (communityId + week), so a
+ *      manager regenerating mid-week sees the same template.
+ *   3. Weights govern the distribution across *different* communities —
+ *      feeding different seeds to a 50/50 split converges on the
+ *      intended ratio.
+ *
+ * Repository methods are mocked via the DI container.
+ */
+describe("ReportTemplateSelector", () => {
+  const fakeCtx = {} as IContext;
+
+  function makeTemplate(overrides: Partial<PrismaReportTemplate>): PrismaReportTemplate {
+    return {
+      id: overrides.id ?? "tpl-a",
+      variant: "WEEKLY_SUMMARY",
+      scope: overrides.scope ?? "SYSTEM",
+      kind: "GENERATION",
+      communityId: overrides.communityId ?? null,
+      systemPrompt: "sys",
+      userPromptTemplate: "user",
+      communityContext: null,
+      model: "claude-sonnet-4-6",
+      temperature: 0.7,
+      maxTokens: 8192,
+      stopSequences: [],
+      isEnabled: true,
+      version: 1,
+      isActive: true,
+      experimentKey: null,
+      trafficWeight: 100,
+      notes: null,
+      updatedBy: null,
+      createdAt: new Date("2026-04-17"),
+      updatedAt: null,
+      ...overrides,
+    } as PrismaReportTemplate;
+  }
+
+  let repository: {
+    findActiveTemplates: jest.Mock;
+  };
+  let selector: ReportTemplateSelector;
+
+  beforeEach(() => {
+    container.reset();
+    repository = { findActiveTemplates: jest.fn() };
+    container.register("ReportRepository", { useValue: repository });
+    selector = container.resolve(ReportTemplateSelector);
+  });
+
+  it("prefers COMMUNITY scope over SYSTEM when any community row exists", async () => {
+    const communityTpl = makeTemplate({
+      id: "community-1",
+      scope: "COMMUNITY",
+      communityId: "c-1",
+    });
+    repository.findActiveTemplates.mockImplementation(
+      async (_ctx, _variant, _kind, communityId) =>
+        communityId === "c-1" ? [communityTpl] : [makeTemplate({ id: "system-1" })],
+    );
+
+    const result = await selector.selectTemplate(
+      fakeCtx,
+      "WEEKLY_SUMMARY",
+      ReportTemplateKind.GENERATION,
+      "c-1",
+      new Date("2026-04-17"),
+    );
+
+    expect(result).toBe(communityTpl);
+    // Second call (SYSTEM fallback) must NOT happen when community has
+    // its own candidates — otherwise we'd be paying for a wasted round
+    // trip every generation.
+    expect(repository.findActiveTemplates).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to SYSTEM when the community has no candidates", async () => {
+    const systemTpl = makeTemplate({ id: "system-1" });
+    repository.findActiveTemplates.mockImplementation(
+      async (_ctx, _variant, _kind, communityId) => (communityId ? [] : [systemTpl]),
+    );
+
+    const result = await selector.selectTemplate(
+      fakeCtx,
+      "WEEKLY_SUMMARY",
+      ReportTemplateKind.GENERATION,
+      "c-1",
+      new Date("2026-04-17"),
+    );
+
+    expect(result).toBe(systemTpl);
+    expect(repository.findActiveTemplates).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws when there are no candidates at either scope", async () => {
+    repository.findActiveTemplates.mockResolvedValue([]);
+    await expect(
+      selector.selectTemplate(
+        fakeCtx,
+        "WEEKLY_SUMMARY",
+        ReportTemplateKind.GENERATION,
+        "c-1",
+        new Date("2026-04-17"),
+      ),
+    ).rejects.toThrow(/No active template/);
+  });
+
+  it("returns a deterministic template for the same (communityId + week)", async () => {
+    const a = makeTemplate({ id: "a", trafficWeight: 50 });
+    const b = makeTemplate({ id: "b", trafficWeight: 50 });
+    repository.findActiveTemplates.mockImplementation(async (_ctx, _v, _k, communityId) =>
+      communityId ? [] : [a, b],
+    );
+
+    // Two calls within the same JST ISO week on the same community must
+    // resolve to the same template — crucial for managers who regenerate
+    // mid-week.
+    const first = await selector.selectTemplate(
+      fakeCtx,
+      "WEEKLY_SUMMARY",
+      ReportTemplateKind.GENERATION,
+      "c-1",
+      new Date("2026-04-15T10:00:00Z"),
+    );
+    const second = await selector.selectTemplate(
+      fakeCtx,
+      "WEEKLY_SUMMARY",
+      ReportTemplateKind.GENERATION,
+      "c-1",
+      new Date("2026-04-17T23:00:00Z"),
+    );
+    expect(second.id).toBe(first.id);
+  });
+
+  it("distributes roughly 50/50 across many communities with equal weights", async () => {
+    const a = makeTemplate({ id: "a", trafficWeight: 50 });
+    const b = makeTemplate({ id: "b", trafficWeight: 50 });
+    repository.findActiveTemplates.mockImplementation(async (_ctx, _v, _k, communityId) =>
+      communityId ? [] : [a, b],
+    );
+
+    const counts = { a: 0, b: 0 };
+    // 500 distinct community seeds. cyrb53 is deterministic, so this
+    // test itself is reproducible — but the distribution should be close
+    // to the 50/50 weights. Use a wide 40..60 window so chi-square
+    // fluctuations don't flake the test.
+    for (let i = 0; i < 500; i++) {
+      const picked = await selector.selectTemplate(
+        fakeCtx,
+        "WEEKLY_SUMMARY",
+        ReportTemplateKind.GENERATION,
+        `community-${i}`,
+        new Date("2026-04-17"),
+      );
+      counts[picked.id as "a" | "b"]++;
+    }
+    expect(counts.a).toBeGreaterThan(200);
+    expect(counts.a).toBeLessThan(300);
+    expect(counts.a + counts.b).toBe(500);
+  });
+
+  it("respects unequal weights (90/10)", async () => {
+    const a = makeTemplate({ id: "a", trafficWeight: 90 });
+    const b = makeTemplate({ id: "b", trafficWeight: 10 });
+    repository.findActiveTemplates.mockImplementation(async (_ctx, _v, _k, communityId) =>
+      communityId ? [] : [a, b],
+    );
+
+    const counts = { a: 0, b: 0 };
+    for (let i = 0; i < 500; i++) {
+      const picked = await selector.selectTemplate(
+        fakeCtx,
+        "WEEKLY_SUMMARY",
+        ReportTemplateKind.GENERATION,
+        `community-${i}`,
+        new Date("2026-04-17"),
+      );
+      counts[picked.id as "a" | "b"]++;
+    }
+    // The expected split is 450/50; allow ±70 slack for PRNG variance.
+    expect(counts.a).toBeGreaterThan(380);
+    expect(counts.b).toBeLessThan(120);
+  });
+
+  it("logs a structured selection event", async () => {
+    const a = makeTemplate({ id: "a", trafficWeight: 50 });
+    const b = makeTemplate({ id: "b", trafficWeight: 50 });
+    repository.findActiveTemplates.mockImplementation(async (_ctx, _v, _k, communityId) =>
+      communityId ? [] : [a, b],
+    );
+
+    // The selector logs via the infrastructure logger (winston-style).
+    // Rather than mock that, we just confirm a selection succeeds —
+    // the log call is purely observational and failing a test on its
+    // absence would couple unit tests to the logger.
+    const result = await selector.selectTemplate(
+      fakeCtx,
+      "WEEKLY_SUMMARY",
+      ReportTemplateKind.GENERATION,
+      "c-1",
+      new Date("2026-04-17"),
+    );
+    expect([a.id, b.id]).toContain(result.id);
+  });
+});
+
+describe("cyrb53", () => {
+  it("is deterministic for the same input", () => {
+    expect(cyrb53("community-1-2026-04-13")).toBe(cyrb53("community-1-2026-04-13"));
+  });
+
+  it("produces different hashes for different inputs", () => {
+    expect(cyrb53("community-1-2026-04-13")).not.toBe(cyrb53("community-2-2026-04-13"));
+    expect(cyrb53("community-1-2026-04-13")).not.toBe(cyrb53("community-1-2026-04-20"));
+  });
+});

--- a/src/__tests__/unit/report/templateSelector.test.ts
+++ b/src/__tests__/unit/report/templateSelector.test.ts
@@ -106,7 +106,7 @@ describe("ReportTemplateSelector", () => {
     expect(repository.findActiveTemplates).toHaveBeenCalledTimes(2);
   });
 
-  it("throws when there are no candidates at either scope", async () => {
+  it("throws a structured NotFoundError when there are no candidates at either scope", async () => {
     repository.findActiveTemplates.mockResolvedValue([]);
     await expect(
       selector.selectTemplate(
@@ -116,7 +116,10 @@ describe("ReportTemplateSelector", () => {
         "c-1",
         new Date("2026-04-17"),
       ),
-    ).rejects.toThrow(/No active template/);
+    ).rejects.toMatchObject({
+      name: "NotFoundError",
+      extensions: { code: "NOT_FOUND" },
+    });
   });
 
   it("returns a deterministic template for the same (communityId + week)", async () => {

--- a/src/__tests__/unit/report/usecase.test.ts
+++ b/src/__tests__/unit/report/usecase.test.ts
@@ -174,9 +174,18 @@ describe("ReportUseCase.generateReport", () => {
       executeJudge: jest.fn(),
     };
 
+    // Minimal ReportTemplateSelector mock: returns the canonical
+    // stubTemplate regardless of inputs. Selector logic (A/B weighting,
+    // community hash) lives in templateSelector.test.ts so the usecase
+    // suite can stay focused on orchestration.
+    const templateSelector = {
+      selectTemplate: jest.fn().mockResolvedValue(stubTemplate),
+    };
+
     container.register("ReportService", { useValue: service });
     container.register("LlmClient", { useValue: llmClient });
     container.register("ReportJudgeService", { useValue: judgeService });
+    container.register("ReportTemplateSelector", { useValue: templateSelector });
 
     usecase = container.resolve(ReportUseCase);
 
@@ -353,5 +362,86 @@ describe("ReportUseCase.generateReport", () => {
       expect(result.report.status).toBe(ReportStatus.DRAFT);
       expect(result.report.outputMarkdown).toBe(llmResult.text);
     }
+  });
+});
+
+describe("ReportUseCase.updateReportTemplate trafficWeight validation (PR-F3)", () => {
+  // The DB has a CHECK constraint on trafficWeight BETWEEN 0 AND 100, but
+  // a constraint violation surfaces as an opaque PrismaClientKnownRequestError
+  // at the admin UI. These tests pin down the app-layer guard that turns
+  // a bad value into a structured ValidationError *before* the Prisma call.
+  const fakeCtx = {
+    currentUser: { id: "admin-1", sysRole: "SYS_ADMIN" },
+    issuer: {
+      admin: (_ctx: IContext, fn: (tx: unknown) => Promise<unknown>) => fn({} as never),
+    },
+  } as unknown as IContext;
+
+  function makeUseCase() {
+    container.reset();
+    const service = {
+      upsertTemplate: jest.fn().mockResolvedValue({ id: "tpl-1" }),
+    };
+    container.register("ReportService", { useValue: service });
+    container.register("LlmClient", { useValue: { complete: jest.fn() } });
+    container.register("ReportJudgeService", {
+      useValue: { selectJudgeTemplate: jest.fn(), executeJudge: jest.fn() },
+    });
+    container.register("ReportTemplateSelector", {
+      useValue: { selectTemplate: jest.fn() },
+    });
+    return { service, usecase: container.resolve(ReportUseCase) };
+  }
+
+  const baseInput = {
+    systemPrompt: "sys",
+    userPromptTemplate: "user ${payload_json}",
+    communityContext: null,
+    model: "claude-sonnet-4-6",
+    temperature: 0.5,
+    maxTokens: 8192,
+    stopSequences: [],
+    isEnabled: true,
+  };
+
+  it.each([-1, 101, 3.5])(
+    "rejects trafficWeight=%s with ValidationError",
+    async (trafficWeight) => {
+      const { usecase, service } = makeUseCase();
+      await expect(
+        usecase.updateReportTemplate(
+          {
+            variant: GqlReportVariant.WeeklySummary,
+            input: { ...baseInput, trafficWeight } as never,
+          },
+          fakeCtx,
+        ),
+      ).rejects.toThrow(/trafficWeight/);
+      expect(service.upsertTemplate).not.toHaveBeenCalled();
+    },
+  );
+
+  it("accepts trafficWeight in 0..100", async () => {
+    const { usecase, service } = makeUseCase();
+    await usecase.updateReportTemplate(
+      {
+        variant: GqlReportVariant.WeeklySummary,
+        input: { ...baseInput, trafficWeight: 50 } as never,
+      },
+      fakeCtx,
+    );
+    expect(service.upsertTemplate).toHaveBeenCalled();
+  });
+
+  it("accepts an omitted trafficWeight (leaves server default)", async () => {
+    const { usecase, service } = makeUseCase();
+    await usecase.updateReportTemplate(
+      {
+        variant: GqlReportVariant.WeeklySummary,
+        input: baseInput as never,
+      },
+      fakeCtx,
+    );
+    expect(service.upsertTemplate).toHaveBeenCalled();
   });
 });

--- a/src/application/domain/report/controller/dataloader.ts
+++ b/src/application/domain/report/controller/dataloader.ts
@@ -1,6 +1,7 @@
 import { PrismaClient } from "@prisma/client";
 import {
   createLoaderById,
+  createLoaderByCompositeKey,
   createHasManyLoaderByKey,
 } from "@/presentation/graphql/dataloader/utils";
 import {
@@ -9,8 +10,13 @@ import {
   PrismaReport,
   PrismaReportTemplate,
 } from "@/application/domain/report/data/type";
+import {
+  reportFeedbackSelect,
+  PrismaReportFeedback,
+} from "@/application/domain/report/feedback/data/type";
 import ReportPresenter from "@/application/domain/report/presenter";
-import { GqlReport, GqlReportTemplate } from "@/types/graphql";
+import ReportFeedbackPresenter from "@/application/domain/report/feedback/presenter";
+import { GqlReport, GqlReportFeedback, GqlReportTemplate } from "@/types/graphql";
 
 export function createReportLoader(prisma: PrismaClient) {
   return createLoaderById<PrismaReport, GqlReport>(
@@ -47,10 +53,48 @@ export function createReportsByParentRunIdLoader(prisma: PrismaClient) {
   );
 }
 
+/**
+ * Resolves `Report.myFeedback` for the *caller* — the per-Report
+ * "did this user already rate this?" lookup. Keyed by
+ * `{ reportId, userId }` rather than just `reportId` so the same
+ * loader instance correctly handles resolver chains that mix users
+ * (e.g. an admin field that materialises another user's session). In
+ * the common case every key in a given request shares the same
+ * userId, and the batch fan-out is one query per distinct userId.
+ *
+ * The loader closure carries no auth state itself: the resolver
+ * passes `ctx.currentUser.id` at load time. That keeps the loader
+ * factory pure (it runs before auth in the request lifecycle) and
+ * matches the rest of the dataloader catalogue, which is also
+ * constructed from `prisma` alone.
+ */
+export function createMyReportFeedbackLoader(prisma: PrismaClient) {
+  type Key = { reportId: string; userId: string };
+  return createLoaderByCompositeKey<Key, PrismaReportFeedback, GqlReportFeedback>(
+    async (keys) => {
+      // Collapse all (reportId, userId) pairs into a single `findMany`
+      // using an OR of exact pairs. This avoids both the per-user
+      // round-trip a group-by-userId loop would do and the over-fetch
+      // a naive `IN (userIds) AND IN (reportIds)` Cartesian query would
+      // cause. The `@@unique([reportId, userId])` index makes each OR
+      // branch a direct index lookup.
+      return prisma.reportFeedback.findMany({
+        where: {
+          OR: keys.map((k) => ({ reportId: k.reportId, userId: k.userId })),
+        },
+        select: reportFeedbackSelect,
+      });
+    },
+    (record) => ({ reportId: record.reportId, userId: record.userId }),
+    ReportFeedbackPresenter.feedback,
+  );
+}
+
 export function createReportLoaders(prisma: PrismaClient) {
   return {
     report: createReportLoader(prisma),
     reportTemplate: createReportTemplateLoader(prisma),
     reportsByParentRunId: createReportsByParentRunIdLoader(prisma),
+    myReportFeedback: createMyReportFeedbackLoader(prisma),
   };
 }

--- a/src/application/domain/report/data/converter.ts
+++ b/src/application/domain/report/data/converter.ts
@@ -14,6 +14,19 @@ export default class ReportConverter {
       maxTokens: input.maxTokens,
       stopSequences: input.stopSequences ?? [],
       isEnabled: input.isEnabled ?? true,
+      // A/B selection fields (PR-F3). The Prisma defaults are applied on
+      // CREATE (isActive=true, trafficWeight=100, experimentKey=null) so we
+      // only forward values the caller explicitly provided; on UPDATE the
+      // explicit values overwrite any prior state.
+      ...(input.isActive !== undefined && input.isActive !== null
+        ? { isActive: input.isActive }
+        : {}),
+      ...(input.trafficWeight !== undefined && input.trafficWeight !== null
+        ? { trafficWeight: input.trafficWeight }
+        : {}),
+      ...(input.experimentKey !== undefined
+        ? { experimentKey: input.experimentKey }
+        : {}),
     };
   }
 

--- a/src/application/domain/report/data/interface.ts
+++ b/src/application/domain/report/data/interface.ts
@@ -1,4 +1,10 @@
-import { Prisma, TransactionReason, Role, ReportStatus } from "@prisma/client";
+import {
+  Prisma,
+  TransactionReason,
+  Role,
+  ReportStatus,
+  ReportTemplateKind,
+} from "@prisma/client";
 import { IContext } from "@/types/server";
 import {
   PrismaReport,
@@ -190,6 +196,22 @@ export interface IReportRepository {
     variant: string,
     communityId: string | null,
   ): Promise<PrismaReportTemplate | null>;
+
+  /**
+   * Resolve every active candidate template for a given
+   * (variant, kind, communityId) triple. Scoped strictly to the
+   * `communityId` argument — SYSTEM fallback is the caller's job, so the
+   * selector can tell "community has its own overrides" apart from
+   * "community falls back to SYSTEM". Only `isEnabled=true AND
+   * isActive=true` rows are returned, ordered by `id` for a stable draw
+   * in the weighted selection.
+   */
+  findActiveTemplates(
+    ctx: IContext,
+    variant: string,
+    kind: ReportTemplateKind,
+    communityId: string | null,
+  ): Promise<PrismaReportTemplate[]>;
 
   /**
    * Resolve the active SYSTEM-scope JUDGE template for a variant. Returns

--- a/src/application/domain/report/data/repository.ts
+++ b/src/application/domain/report/data/repository.ts
@@ -372,6 +372,36 @@ export default class ReportRepository implements IReportRepository {
   }
 
   /**
+   * Active candidates for (variant, kind, communityId). Unlike `findTemplate`
+   * this does NOT fall back to SYSTEM when `communityId` is non-null — the
+   * caller (the selector) must issue a separate SYSTEM query when the
+   * community-scoped query returns empty, because it needs to distinguish
+   * "community has its own A/B set" from "community uses SYSTEM". Only
+   * `isEnabled=true AND isActive=true` rows are returned so deprecated /
+   * rolled-back candidates never enter the weighted draw.
+   */
+  async findActiveTemplates(
+    ctx: IContext,
+    variant: string,
+    kind: ReportTemplateKind,
+    communityId: string | null,
+  ): Promise<PrismaReportTemplate[]> {
+    return ctx.issuer.public(ctx, (tx) =>
+      tx.reportTemplate.findMany({
+        where: {
+          variant,
+          kind,
+          communityId,
+          isEnabled: true,
+          isActive: true,
+        },
+        orderBy: { id: "asc" },
+        select: reportTemplateSelect,
+      }),
+    );
+  }
+
+  /**
    * Resolve the active SYSTEM-scope JUDGE template for a variant.
    * Filters on `isEnabled` AND `isActive` so the F1 versioning bookkeeping
    * also gates judge selection — a JUDGE row marked inactive (e.g. a

--- a/src/application/domain/report/feedback/controller/resolver.ts
+++ b/src/application/domain/report/feedback/controller/resolver.ts
@@ -1,0 +1,63 @@
+import { inject, injectable } from "tsyringe";
+import { IContext } from "@/types/server";
+import ReportFeedbackUseCase from "@/application/domain/report/feedback/usecase";
+import {
+  GqlMutationSubmitReportFeedbackArgs,
+  GqlQueryReportTemplateStatsArgs,
+} from "@/types/graphql";
+import { PrismaReport } from "@/application/domain/report/data/type";
+import { PrismaReportFeedback } from "@/application/domain/report/feedback/data/type";
+
+@injectable()
+export default class ReportFeedbackResolver {
+  constructor(@inject("ReportFeedbackUseCase") private readonly useCase: ReportFeedbackUseCase) {}
+
+  Query = {
+    reportTemplateStats: (_: unknown, args: GqlQueryReportTemplateStatsArgs, ctx: IContext) => {
+      return this.useCase.viewReportTemplateStats(args, ctx);
+    },
+  };
+
+  Mutation = {
+    submitReportFeedback: (
+      _: unknown,
+      args: GqlMutationSubmitReportFeedbackArgs,
+      ctx: IContext,
+    ) => {
+      return this.useCase.submitReportFeedback(args, ctx);
+    },
+  };
+
+  /**
+   * Field resolvers grafted onto the existing `Report` type. Extending
+   * the resolver map in a separate file means the main report resolver
+   * does not grow a feedback dependency — the GraphQL runtime merges
+   * the two `Report` resolver objects when the schema is assembled.
+   *
+   * `myFeedback` is routed through the per-request DataLoader so a
+   * `reports { myFeedback }` query collapses to one Prisma round trip
+   * per distinct caller userId rather than one per Report. The loader
+   * key is `{ reportId, userId }`; we pass the caller's userId at load
+   * time because the loader factory runs before auth in the request
+   * lifecycle.
+   */
+  Report = {
+    feedbacks: (
+      parent: PrismaReport,
+      args: { first?: number | null; after?: string | null },
+      ctx: IContext,
+    ) => this.useCase.listFeedbacksForReport(ctx, parent.id, args),
+    myFeedback: (parent: PrismaReport, _: unknown, ctx: IContext) => {
+      const userId = ctx.currentUser?.id;
+      if (!userId) return null;
+      return ctx.loaders.myReportFeedback.load({ reportId: parent.id, userId });
+    },
+  };
+
+  ReportFeedback = {
+    user: (parent: PrismaReportFeedback, _: unknown, ctx: IContext) =>
+      ctx.loaders.user.load(parent.userId),
+  };
+
+  SubmitReportFeedbackPayload = { __resolveType: (obj: { __typename: string }) => obj.__typename };
+}

--- a/src/application/domain/report/feedback/data/interface.ts
+++ b/src/application/domain/report/feedback/data/interface.ts
@@ -1,0 +1,72 @@
+import { Prisma, FeedbackType } from "@prisma/client";
+import { IContext } from "@/types/server";
+import { PrismaReportFeedback } from "@/application/domain/report/feedback/data/type";
+
+export interface CreateReportFeedbackInput {
+  reportId: string;
+  userId: string;
+  rating: number;
+  feedbackType?: FeedbackType | null;
+  sectionKey?: string | null;
+  comment?: string | null;
+}
+
+/**
+ * Paired (judgeScore, avgFeedbackRating) rows used by the service to
+ * compute Pearson's r between the two series. A report is eligible to
+ * appear here only when both signals exist — reports with no feedback are
+ * skipped upstream rather than contributing a 0 that would bias the
+ * correlation.
+ */
+export interface JudgeFeedbackPairRow {
+  reportId: string;
+  judgeScore: number;
+  avgRating: number;
+}
+
+export interface IReportFeedbackRepository {
+  createFeedback(
+    ctx: IContext,
+    data: CreateReportFeedbackInput,
+    tx?: Prisma.TransactionClient,
+  ): Promise<PrismaReportFeedback>;
+
+  findFeedbackByReportAndUser(
+    ctx: IContext,
+    reportId: string,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<PrismaReportFeedback | null>;
+
+  findFeedbacksByReport(
+    ctx: IContext,
+    reportId: string,
+    params: { first: number; cursor?: string | null },
+  ): Promise<{ items: PrismaReportFeedback[]; totalCount: number }>;
+
+  findFeedbacksByReportIds(
+    ctx: IContext,
+    reportIds: string[],
+  ): Promise<PrismaReportFeedback[]>;
+
+  /**
+   * Aggregate feedback across reports that used a given (variant, version).
+   * Returns feedbackCount / avgRating at the (variant, version) level, and
+   * the full (judgeScore, avgRating) pair set so the service can compute
+   * correlation in-process (Postgres' `corr()` is not wired to Prisma
+   * `$queryRaw` types as cleanly as the plain aggregate). `version` in the
+   * return is the caller's argument echoed back, or null when the caller
+   * requested a roll-up across every version.
+   */
+  getTemplateFeedbackAggregates(
+    ctx: IContext,
+    variant: string,
+    version?: number,
+  ): Promise<{
+    feedbackCount: number;
+    avgRating: number | null;
+    avgJudgeScore: number | null;
+    pairs: JudgeFeedbackPairRow[];
+    version: number | null;
+  }>;
+}

--- a/src/application/domain/report/feedback/data/repository.ts
+++ b/src/application/domain/report/feedback/data/repository.ts
@@ -139,6 +139,14 @@ export default class ReportFeedbackRepository implements IReportFeedbackReposito
         }),
       ]);
 
+      // INNER JOIN on `t_report_feedbacks` is deliberate: Pearson's r
+      // requires *paired* observations, so a report with a `judgeScore`
+      // but no human feedback contributes no signal and must be
+      // dropped. Using LEFT JOIN and coercing missing ratings to 0 or
+      // NULL would either bias the correlation (0 is a real rating
+      // value) or blow up the coefficient (NULL averages propagate).
+      // See `JudgeFeedbackPairRow` in ./interface.ts for the same
+      // invariant expressed at the type layer.
       const pairRows = await tx.$queryRaw<
         { report_id: string; judge_score: number; avg_rating: number }[]
       >`

--- a/src/application/domain/report/feedback/data/repository.ts
+++ b/src/application/domain/report/feedback/data/repository.ts
@@ -1,0 +1,178 @@
+import { Prisma } from "@prisma/client";
+import { injectable } from "tsyringe";
+import { IContext } from "@/types/server";
+import {
+  CreateReportFeedbackInput,
+  IReportFeedbackRepository,
+  JudgeFeedbackPairRow,
+} from "@/application/domain/report/feedback/data/interface";
+import {
+  PrismaReportFeedback,
+  reportFeedbackSelect,
+} from "@/application/domain/report/feedback/data/type";
+
+@injectable()
+export default class ReportFeedbackRepository implements IReportFeedbackRepository {
+  async createFeedback(
+    ctx: IContext,
+    data: CreateReportFeedbackInput,
+    tx?: Prisma.TransactionClient,
+  ): Promise<PrismaReportFeedback> {
+    const doCreate = (client: Prisma.TransactionClient) =>
+      client.reportFeedback.create({
+        data: {
+          reportId: data.reportId,
+          userId: data.userId,
+          rating: data.rating,
+          feedbackType: data.feedbackType ?? null,
+          sectionKey: data.sectionKey ?? null,
+          comment: data.comment ?? null,
+        },
+        select: reportFeedbackSelect,
+      });
+
+    if (tx) return doCreate(tx);
+    return ctx.issuer.public(ctx, doCreate);
+  }
+
+  async findFeedbackByReportAndUser(
+    ctx: IContext,
+    reportId: string,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<PrismaReportFeedback | null> {
+    const doFind = (client: Prisma.TransactionClient) =>
+      client.reportFeedback.findUnique({
+        where: { reportId_userId: { reportId, userId } },
+        select: reportFeedbackSelect,
+      });
+
+    if (tx) return doFind(tx);
+    return ctx.issuer.public(ctx, doFind);
+  }
+
+  async findFeedbacksByReport(
+    ctx: IContext,
+    reportId: string,
+    params: { first: number; cursor?: string | null },
+  ): Promise<{ items: PrismaReportFeedback[]; totalCount: number }> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      const [items, totalCount] = await Promise.all([
+        tx.reportFeedback.findMany({
+          where: { reportId },
+          select: reportFeedbackSelect,
+          // `id` as a secondary key turns the ordering into a total order —
+          // without it, two rows sharing a `createdAt` (possible when a
+          // seed script bulk-inserts, or under high write concurrency)
+          // can reshuffle between pages and either duplicate or skip
+          // rows across cursor boundaries.
+          orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+          take: params.first + 1,
+          ...(params.cursor ? { skip: 1, cursor: { id: params.cursor } } : {}),
+        }),
+        tx.reportFeedback.count({ where: { reportId } }),
+      ]);
+      return { items, totalCount };
+    });
+  }
+
+  async findFeedbacksByReportIds(
+    ctx: IContext,
+    reportIds: string[],
+  ): Promise<PrismaReportFeedback[]> {
+    if (reportIds.length === 0) return [];
+    return ctx.issuer.public(ctx, (tx) =>
+      tx.reportFeedback.findMany({
+        where: { reportId: { in: reportIds } },
+        select: reportFeedbackSelect,
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      }),
+    );
+  }
+
+  /**
+   * Aggregate feedback stats for templates matching (variant, version?).
+   * When `version` is omitted, the query rolls up across every version of
+   * that variant — useful for a "how is WEEKLY_SUMMARY doing overall?"
+   * snapshot. When present, it scopes tightly to a single prompt revision.
+   *
+   * The three-way roll-up is run as two round trips:
+   *   1. `avgRating` / `feedbackCount` / `avgJudgeScore` via Prisma
+   *      aggregates on the related Reports.
+   *   2. Per-report (judgeScore, avgRating) pairs via a grouped raw query
+   *      so the service can compute Pearson's r on the paired series.
+   *
+   * The `version` in the return reflects the value passed in — the caller
+   * passes the exact revision they want displayed, and the stats row
+   * mirrors that back so consumers need not re-derive it.
+   */
+  async getTemplateFeedbackAggregates(
+    ctx: IContext,
+    variant: string,
+    version?: number,
+  ): Promise<{
+    feedbackCount: number;
+    avgRating: number | null;
+    avgJudgeScore: number | null;
+    pairs: JudgeFeedbackPairRow[];
+    version: number | null;
+  }> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      // Report → Template join: template.variant matches, and if `version`
+      // was specified, template.version matches too.
+      const reportWhere: Prisma.ReportWhereInput = {
+        template: {
+          variant,
+          ...(version !== undefined ? { version } : {}),
+        },
+      };
+
+      const [feedbackAgg, judgeAgg] = await Promise.all([
+        tx.reportFeedback.aggregate({
+          where: { report: reportWhere },
+          _avg: { rating: true },
+          _count: { _all: true },
+        }),
+        tx.report.aggregate({
+          where: { ...reportWhere, judgeScore: { not: null } },
+          _avg: { judgeScore: true },
+        }),
+      ]);
+
+      const pairRows = await tx.$queryRaw<
+        { report_id: string; judge_score: number; avg_rating: number }[]
+      >`
+        SELECT
+          r."id" AS "report_id",
+          r."judge_score"::float AS "judge_score",
+          AVG(f."rating")::float AS "avg_rating"
+        FROM "t_reports" r
+        INNER JOIN "t_report_templates" t ON t."id" = r."template_id"
+        INNER JOIN "t_report_feedbacks" f ON f."report_id" = r."id"
+        WHERE t."variant" = ${variant}
+          ${version !== undefined ? Prisma.sql`AND t."version" = ${version}` : Prisma.empty}
+          AND r."judge_score" IS NOT NULL
+        GROUP BY r."id", r."judge_score"
+      `;
+
+      const pairs: JudgeFeedbackPairRow[] = pairRows.map((p) => ({
+        reportId: p.report_id,
+        judgeScore: Number(p.judge_score),
+        avgRating: Number(p.avg_rating),
+      }));
+
+      return {
+        feedbackCount: feedbackAgg._count._all,
+        avgRating: feedbackAgg._avg.rating ?? null,
+        avgJudgeScore: judgeAgg._avg.judgeScore ?? null,
+        pairs,
+        // Mirror the caller's `version` argument: a concrete value means
+        // the stats are scoped to that revision; null signals a roll-up
+        // across every version of the variant. GraphQL exposes `version`
+        // as nullable so consumers can tell the two cases apart without
+        // relying on a magic sentinel.
+        version: version ?? null,
+      };
+    });
+  }
+}

--- a/src/application/domain/report/feedback/data/type.ts
+++ b/src/application/domain/report/feedback/data/type.ts
@@ -1,0 +1,38 @@
+import { Prisma } from "@prisma/client";
+
+export const reportFeedbackSelect = Prisma.validator<Prisma.ReportFeedbackSelect>()({
+  id: true,
+  reportId: true,
+  userId: true,
+  rating: true,
+  feedbackType: true,
+  sectionKey: true,
+  comment: true,
+  createdAt: true,
+});
+
+export type PrismaReportFeedback = Prisma.ReportFeedbackGetPayload<{
+  select: typeof reportFeedbackSelect;
+}>;
+
+/**
+ * Per-(variant, version) aggregate row powering the `reportTemplateStats`
+ * admin query. `feedbackCount` counts ReportFeedback rows joined on the
+ * Report(s) that used the template. `judgeHumanCorrelation` is Pearson's
+ * r across the paired (judgeScore, averageFeedbackRating) series per
+ * report; null when the series is too short (< 3 reports with both
+ * signals) to compute a meaningful correlation — two points always
+ * produce ±1 under the classical formula and carry no signal.
+ *
+ * `version` is null when the caller did not pin the query to a specific
+ * template revision — the row then represents a roll-up across every
+ * version of the variant.
+ */
+export interface ReportTemplateStatsRow {
+  variant: string;
+  version: number | null;
+  avgRating: number | null;
+  feedbackCount: number;
+  avgJudgeScore: number | null;
+  judgeHumanCorrelation: number | null;
+}

--- a/src/application/domain/report/feedback/presenter.ts
+++ b/src/application/domain/report/feedback/presenter.ts
@@ -1,0 +1,59 @@
+import {
+  GqlReportFeedback,
+  GqlReportFeedbacksConnection,
+  GqlReportTemplateStats,
+  GqlReportVariant,
+} from "@/types/graphql";
+import {
+  PrismaReportFeedback,
+  ReportTemplateStatsRow,
+} from "@/application/domain/report/feedback/data/type";
+
+export default class ReportFeedbackPresenter {
+  // `user` is resolved by a field resolver via the existing user
+  // DataLoader, so the Prisma select shape omits it. The cast bridges
+  // the type gap until ReportFeedback is added to codegen.yaml mappers.
+  static feedback(f: PrismaReportFeedback): GqlReportFeedback {
+    return f as unknown as GqlReportFeedback;
+  }
+
+  static connection(
+    items: PrismaReportFeedback[],
+    totalCount: number,
+    requestedFirst: number,
+  ): GqlReportFeedbacksConnection {
+    const hasNextPage = items.length > requestedFirst;
+    const page = hasNextPage ? items.slice(0, requestedFirst) : items;
+    return {
+      edges: page.map((f) => ({
+        cursor: f.id,
+        node: ReportFeedbackPresenter.feedback(f),
+      })),
+      pageInfo: {
+        hasNextPage,
+        hasPreviousPage: false,
+        startCursor: page[0]?.id ?? null,
+        endCursor: page[page.length - 1]?.id ?? null,
+      },
+      totalCount,
+    };
+  }
+
+  static templateStats(
+    row: ReportTemplateStatsRow & { correlationWarning: boolean },
+  ): GqlReportTemplateStats {
+    return {
+      // Upstream only accepts `ReportVariant!` as the query argument, so
+      // the row's `variant` is always one of the enum members — the cast
+      // just narrows the service's `string` return to the codegen enum
+      // without an extra runtime check.
+      variant: row.variant as GqlReportVariant,
+      version: row.version,
+      avgRating: row.avgRating,
+      feedbackCount: row.feedbackCount,
+      avgJudgeScore: row.avgJudgeScore,
+      judgeHumanCorrelation: row.judgeHumanCorrelation,
+      correlationWarning: row.correlationWarning,
+    };
+  }
+}

--- a/src/application/domain/report/feedback/service.ts
+++ b/src/application/domain/report/feedback/service.ts
@@ -1,0 +1,135 @@
+import { Prisma } from "@prisma/client";
+import { inject, injectable } from "tsyringe";
+import { IContext } from "@/types/server";
+import {
+  CreateReportFeedbackInput,
+  IReportFeedbackRepository,
+  JudgeFeedbackPairRow,
+} from "@/application/domain/report/feedback/data/interface";
+import {
+  PrismaReportFeedback,
+  ReportTemplateStatsRow,
+} from "@/application/domain/report/feedback/data/type";
+
+/**
+ * Threshold below which judge scores are no longer a reliable proxy for
+ * perceived quality. Flagged via `correlationWarning=true` in the stats
+ * response so ops can re-calibrate the judge prompt. The number is not
+ * sacred — pulled from the design doc — but kept as a named constant so
+ * every layer (service, test) shares one source of truth.
+ */
+export const JUDGE_HUMAN_CORRELATION_WARNING_THRESHOLD = 0.7;
+
+/**
+ * Minimum number of (judgeScore, rating) pairs required before Pearson's
+ * r is computed. Fewer than two pairs has no variance; with only two
+ * points the correlation is always ±1 and carries no signal. Return null
+ * below this threshold rather than emitting misleading values.
+ */
+const MIN_PAIRS_FOR_CORRELATION = 3;
+
+@injectable()
+export default class ReportFeedbackService {
+  constructor(
+    @inject("ReportFeedbackRepository") private readonly repository: IReportFeedbackRepository,
+  ) {}
+
+  async createFeedback(
+    ctx: IContext,
+    data: CreateReportFeedbackInput,
+    tx?: Prisma.TransactionClient,
+  ): Promise<PrismaReportFeedback> {
+    return this.repository.createFeedback(ctx, data, tx);
+  }
+
+  async getExistingFeedback(
+    ctx: IContext,
+    reportId: string,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<PrismaReportFeedback | null> {
+    return this.repository.findFeedbackByReportAndUser(ctx, reportId, userId, tx);
+  }
+
+  async listFeedbacksByReport(
+    ctx: IContext,
+    reportId: string,
+    params: { first: number; cursor?: string | null },
+  ): Promise<{ items: PrismaReportFeedback[]; totalCount: number }> {
+    return this.repository.findFeedbacksByReport(ctx, reportId, params);
+  }
+
+  async listFeedbacksByReportIds(
+    ctx: IContext,
+    reportIds: string[],
+  ): Promise<PrismaReportFeedback[]> {
+    return this.repository.findFeedbacksByReportIds(ctx, reportIds);
+  }
+
+  /**
+   * Assemble the stats row for `reportTemplateStats`:
+   *   - Forward the aggregates straight from the repository.
+   *   - Compute Pearson's r over the paired (judgeScore, avgRating) series.
+   *   - Return `correlationWarning=true` iff we have a correlation and it
+   *     sits below the recalibration threshold.
+   */
+  async getTemplateStats(
+    ctx: IContext,
+    variant: string,
+    version?: number,
+  ): Promise<ReportTemplateStatsRow & { correlationWarning: boolean }> {
+    const agg = await this.repository.getTemplateFeedbackAggregates(ctx, variant, version);
+    const correlation = pearsonCorrelation(agg.pairs);
+    const correlationWarning =
+      correlation !== null && correlation < JUDGE_HUMAN_CORRELATION_WARNING_THRESHOLD;
+
+    return {
+      variant,
+      // `agg.version` is null iff the caller did not pin to a revision —
+      // mirror that through to the GraphQL layer where the field is
+      // nullable to encode "roll-up across all versions".
+      version: agg.version,
+      avgRating: agg.avgRating,
+      feedbackCount: agg.feedbackCount,
+      avgJudgeScore: agg.avgJudgeScore,
+      judgeHumanCorrelation: correlation,
+      correlationWarning,
+    };
+  }
+}
+
+/**
+ * Pearson's product-moment correlation coefficient for a paired
+ * (judgeScore, avgRating) series. Returns `null` when the series is too
+ * short or either axis has zero variance (both produce a division by zero
+ * in the classical formula — null is safer than NaN at the GraphQL
+ * boundary). Exported for unit-test coverage; consumers should go through
+ * `getTemplateStats`.
+ */
+export function pearsonCorrelation(pairs: JudgeFeedbackPairRow[]): number | null {
+  if (pairs.length < MIN_PAIRS_FOR_CORRELATION) return null;
+
+  const n = pairs.length;
+  const meanX = pairs.reduce((s, p) => s + p.judgeScore, 0) / n;
+  const meanY = pairs.reduce((s, p) => s + p.avgRating, 0) / n;
+
+  let num = 0;
+  let denX = 0;
+  let denY = 0;
+  for (const p of pairs) {
+    const dx = p.judgeScore - meanX;
+    const dy = p.avgRating - meanY;
+    num += dx * dy;
+    denX += dx * dx;
+    denY += dy * dy;
+  }
+  const denom = Math.sqrt(denX * denY);
+  if (denom === 0) return null;
+
+  const r = num / denom;
+  // Clamp to [-1, 1]; rounding error can push a mathematically ±1 series
+  // over the boundary by ~1e-16, which is ugly in the response.
+  if (r > 1) return 1;
+  if (r < -1) return -1;
+  return r;
+}

--- a/src/application/domain/report/feedback/usecase.ts
+++ b/src/application/domain/report/feedback/usecase.ts
@@ -122,8 +122,13 @@ export default class ReportFeedbackUseCase {
             reportId: input.reportId,
             userId,
             rating: input.rating,
+            // The GraphQL `ReportFeedbackType` and Prisma `FeedbackType`
+            // enums share identical member names by contract (Prisma's
+            // enum is the source of truth and the GraphQL schema mirrors
+            // it), so a plain assertion is enough — no `as unknown`
+            // intermediate needed.
             feedbackType: input.feedbackType
-              ? (input.feedbackType as unknown as FeedbackType)
+              ? (input.feedbackType as FeedbackType)
               : null,
             sectionKey: input.sectionKey ?? null,
             comment: input.comment ?? null,

--- a/src/application/domain/report/feedback/usecase.ts
+++ b/src/application/domain/report/feedback/usecase.ts
@@ -1,0 +1,212 @@
+import { inject, injectable } from "tsyringe";
+import { Prisma, FeedbackType } from "@prisma/client";
+import { IContext } from "@/types/server";
+import { AuthenticationError, NotFoundError, ValidationError } from "@/errors/graphql";
+import ReportService from "@/application/domain/report/service";
+import ReportFeedbackService from "@/application/domain/report/feedback/service";
+import ReportFeedbackPresenter from "@/application/domain/report/feedback/presenter";
+import {
+  GqlMutationSubmitReportFeedbackArgs,
+  GqlSubmitReportFeedbackPayload,
+  GqlQueryReportTemplateStatsArgs,
+  GqlReportTemplateStats,
+} from "@/types/graphql";
+
+const MAX_FEEDBACKS_PER_PAGE = 100;
+const DEFAULT_FEEDBACKS_PER_PAGE = 20;
+const MAX_COMMENT_LENGTH = 2000;
+const MAX_SECTION_KEY_LENGTH = 128;
+
+@injectable()
+export default class ReportFeedbackUseCase {
+  constructor(
+    @inject("ReportFeedbackService") private readonly feedbackService: ReportFeedbackService,
+    @inject("ReportService") private readonly reportService: ReportService,
+  ) {}
+
+  /**
+   * Submit a feedback row for a report. Validation is layered:
+   *   1. `rating` fits 1..5 (DB has the same CHECK but we want a
+   *      structured ValidationError rather than a PrismaClientKnownRequestError).
+   *   2. Optional `comment` / `sectionKey` respect length caps so a
+   *      misbehaving client can't push multi-MB rows.
+   *   3. The target `Report` exists and belongs to the community the
+   *      caller already passed authz for — the `@authz IsCommunityMember`
+   *      rule checks `permission.communityId`, but we still need to
+   *      confirm the `reportId` is actually from that community; otherwise
+   *      a member of community A could rate a report of community B by
+   *      forging the report id.
+   *   4. One submit per (report, user). Pre-checked here so the client
+   *      gets a structured ValidationError before the DB raises P2002 —
+   *      friendlier message, same invariant. The @@unique([reportId, userId])
+   *      index is still the authoritative tiebreaker under concurrent
+   *      submits, and the raw P2002 is caught and re-thrown as the same
+   *      ValidationError so racing clients receive a consistent error
+   *      code regardless of which arm of the check they lost to.
+   *
+   * The whole sequence (existence check → duplicate check → insert)
+   * runs inside a single `ctx.issuer.public` transaction so the three
+   * steps are atomic — without this the report could be deleted or a
+   * second submit could land between the checks and the write.
+   */
+  async submitReportFeedback(
+    { input, permission }: GqlMutationSubmitReportFeedbackArgs,
+    ctx: IContext,
+  ): Promise<GqlSubmitReportFeedbackPayload> {
+    const userId = ctx.currentUser?.id;
+    if (!userId) {
+      throw new AuthenticationError("User must be logged in to submit feedback");
+    }
+
+    if (!Number.isInteger(input.rating) || input.rating < 1 || input.rating > 5) {
+      throw new ValidationError("rating must be an integer between 1 and 5", ["rating"]);
+    }
+    if (input.comment && input.comment.length > MAX_COMMENT_LENGTH) {
+      throw new ValidationError(
+        `comment cannot exceed ${MAX_COMMENT_LENGTH} characters`,
+        ["comment"],
+      );
+    }
+    if (input.sectionKey && input.sectionKey.length > MAX_SECTION_KEY_LENGTH) {
+      throw new ValidationError(
+        `sectionKey cannot exceed ${MAX_SECTION_KEY_LENGTH} characters`,
+        ["sectionKey"],
+      );
+    }
+
+    // `ctx.issuer.public` is used here deliberately — `t_report_feedbacks`
+    // ships with a single `community_bypass_policy` RLS rule
+    // (`app.rls_bypass='on'` required), inherited from F1 when the table
+    // was admin-only. Switching to `onlyBelongingCommunity` without first
+    // adding a MEMBER-write RLS policy would flip `rls_bypass='off'` for
+    // non-admin callers and block every legitimate INSERT. Authorization
+    // is already enforced in two places:
+    //   1. `@authz IsCommunityMember` on the GraphQL mutation rejects
+    //      non-members before the resolver is entered.
+    //   2. The explicit `report.communityId === permission.communityId`
+    //      check below stops a member of community A from forging a
+    //      `reportId` belonging to community B.
+    // If we later want defence-in-depth via RLS, a follow-up PR can add
+    // the member-write policy and swap this for `onlyBelongingCommunity`
+    // — entry tracked in the PR description.
+    const feedback = await ctx.issuer.public(ctx, async (tx) => {
+      const report = await this.reportService.getReportById(ctx, input.reportId, tx);
+      if (!report) {
+        throw new NotFoundError("Report", { id: input.reportId });
+      }
+      if (report.communityId !== permission.communityId) {
+        // We return a NotFoundError rather than AuthorizationError here
+        // so a non-member can't probe existence of other communities'
+        // reports by watching the error code. The authz rule already
+        // verified membership of `permission.communityId`.
+        throw new NotFoundError("Report", { id: input.reportId });
+      }
+
+      const existing = await this.feedbackService.getExistingFeedback(
+        ctx,
+        input.reportId,
+        userId,
+        tx,
+      );
+      if (existing) {
+        throw new ValidationError(
+          "Feedback already submitted for this report",
+          ["reportId"],
+        );
+      }
+
+      try {
+        return await this.feedbackService.createFeedback(
+          ctx,
+          {
+            reportId: input.reportId,
+            userId,
+            rating: input.rating,
+            feedbackType: input.feedbackType
+              ? (input.feedbackType as unknown as FeedbackType)
+              : null,
+            sectionKey: input.sectionKey ?? null,
+            comment: input.comment ?? null,
+          },
+          tx,
+        );
+      } catch (e) {
+        // Even inside a transaction the unique index can still flag a
+        // concurrent submit from another session that committed between
+        // the duplicate check and the insert. Translate the opaque
+        // P2002 into the same ValidationError the pre-check would have
+        // thrown so clients see one error code for the invariant.
+        if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
+          throw new ValidationError(
+            "Feedback already submitted for this report",
+            ["reportId"],
+          );
+        }
+        throw e;
+      }
+    });
+
+    return {
+      __typename: "SubmitReportFeedbackSuccess",
+      feedback: ReportFeedbackPresenter.feedback(feedback),
+    };
+  }
+
+  /**
+   * Aggregates over a single (variant, version) pair for the platform
+   * admin dashboard. Authorization is enforced upstream by the
+   * `@authz IsAdmin` rule on the GraphQL query — the usecase trusts the
+   * directive and does not re-check.
+   */
+  async viewReportTemplateStats(
+    { variant, version }: GqlQueryReportTemplateStatsArgs,
+    ctx: IContext,
+  ): Promise<GqlReportTemplateStats> {
+    const row = await this.feedbackService.getTemplateStats(
+      ctx,
+      variant,
+      version ?? undefined,
+    );
+    return ReportFeedbackPresenter.templateStats(row);
+  }
+
+  // Field-resolver helper used by `Report.feedbacks`. `Report.myFeedback`
+  // is wired directly to a DataLoader in the resolver to keep the per-
+  // Report lookup batched (see `createMyReportFeedbackLoader`).
+
+  async listFeedbacksForReport(
+    ctx: IContext,
+    reportId: string,
+    params: { first?: number | null; after?: string | null },
+  ) {
+    const first = validateInt(
+      params.first ?? DEFAULT_FEEDBACKS_PER_PAGE,
+      1,
+      MAX_FEEDBACKS_PER_PAGE,
+      "first",
+    );
+    const result = await this.feedbackService.listFeedbacksByReport(ctx, reportId, {
+      first,
+      cursor: params.after ?? null,
+    });
+    return ReportFeedbackPresenter.connection(result.items, result.totalCount, first);
+  }
+}
+
+/**
+ * Match `ReportUseCase`'s pagination bounds behaviour: reject out-of-range
+ * input with a structured ValidationError rather than silently clamping.
+ * A silent clamp can mask a real client bug (asking for 10000 items and
+ * getting 100 without warning), and `RangeError` would surface at the
+ * GraphQL boundary as an INTERNAL_SERVER_ERROR — not what callers expect
+ * for a validation failure on a user-supplied argument.
+ */
+function validateInt(value: number, min: number, max: number, name: string): number {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new ValidationError(
+      `${name} must be an integer between ${min} and ${max}, got ${value}`,
+      [name],
+    );
+  }
+  return value;
+}

--- a/src/application/domain/report/schema/mutation.graphql
+++ b/src/application/domain/report/schema/mutation.graphql
@@ -18,6 +18,23 @@ input UpdateReportTemplateInput {
   maxTokens: Int!
   stopSequences: [String!]
   isEnabled: Boolean
+  # A/B selection controls (PR-F3). Omitted = leave unchanged on update,
+  # default on create (`isActive=true`, `trafficWeight=100`, null key).
+  isActive: Boolean
+  experimentKey: String
+  trafficWeight: Int
+}
+
+input SubmitReportFeedbackInput {
+  reportId: ID!
+  rating: Int!
+  # Optional category for the feedback — defaults to a plain rating
+  # when omitted. `sectionKey` is the identifier of a sub-section of the
+  # report (e.g. "top_users", "highlights") and is only meaningful
+  # alongside a section-specific rating.
+  feedbackType: ReportFeedbackType
+  sectionKey: String
+  comment: String
 }
 
 extend type Mutation {
@@ -37,4 +54,13 @@ extend type Mutation {
   publishReport(id: ID!, finalContent: String!): PublishReportPayload @authz(rules: [IsAdmin])
 
   rejectReport(id: ID!): RejectReportPayload @authz(rules: [IsAdmin])
+
+  # PR-F4: Anyone in the target community (MEMBER or higher) may submit
+  # a rating. The usecase additionally verifies that `input.reportId`
+  # belongs to `permission.communityId` — otherwise a member of
+  # community A could rate a report of community B by forging the id.
+  submitReportFeedback(
+    input: SubmitReportFeedbackInput!
+    permission: CheckCommunityPermissionInput!
+  ): SubmitReportFeedbackPayload @authz(compositeRules: [{ or: [IsCommunityMember, IsAdmin] }])
 }

--- a/src/application/domain/report/schema/query.graphql
+++ b/src/application/domain/report/schema/query.graphql
@@ -14,4 +14,11 @@ extend type Query {
   report(id: ID!): Report @authz(rules: [IsAdmin])
 
   reportTemplate(communityId: ID, variant: ReportVariant!): ReportTemplate @authz(rules: [IsAdmin])
+
+  # PR-F4: SYS_ADMIN-only snapshot of how a (variant, version) is
+  # performing — avg feedback rating, avg judge score, and Pearson's
+  # correlation between them. Used to decide when the judge prompt
+  # needs re-calibration (correlation < 0.7 → flagged).
+  reportTemplateStats(variant: ReportVariant!, version: Int): ReportTemplateStats!
+    @authz(rules: [IsAdmin])
 }

--- a/src/application/domain/report/schema/type.graphql
+++ b/src/application/domain/report/schema/type.graphql
@@ -53,6 +53,12 @@ type Report {
   targetUser: User
   generatedByUser: User
 
+  # Feedback (PR-F4). `feedbacks` is paginated for OWNER/MANAGER review;
+  # `myFeedback` returns the caller's own submission (if any) so the UI
+  # can hide the rating button once submitted.
+  feedbacks(first: Int, after: String): ReportFeedbacksConnection!
+  myFeedback: ReportFeedback
+
   createdAt: Datetime!
   updatedAt: Datetime
 }
@@ -70,6 +76,13 @@ type ReportTemplate {
   maxTokens: Int!
   stopSequences: [String!]!
   isEnabled: Boolean!
+  # Versioning + A/B control fields (PR-F3). Exposed on the read type so
+  # the admin UI can display and round-trip the current values — they
+  # are writable via `UpdateReportTemplateInput` on the mutation side.
+  version: Int!
+  isActive: Boolean!
+  experimentKey: String
+  trafficWeight: Int!
   updatedByUser: User
   createdAt: Datetime!
   updatedAt: Datetime
@@ -119,3 +132,65 @@ type RejectReportSuccess {
 }
 
 union RejectReportPayload = RejectReportSuccess
+
+# ------------------------------
+# Feedback (PR-F4)
+# ------------------------------
+
+enum ReportFeedbackType {
+  QUALITY
+  ACCURACY
+  TONE
+  STRUCTURE
+  OTHER
+}
+
+type ReportFeedback {
+  id: ID!
+  reportId: ID!
+  user: User!
+  rating: Int!
+  feedbackType: ReportFeedbackType
+  sectionKey: String
+  comment: String
+  createdAt: Datetime!
+}
+
+type ReportFeedbackEdge implements Edge {
+  cursor: String!
+  node: ReportFeedback
+}
+
+type ReportFeedbacksConnection {
+  edges: [ReportFeedbackEdge]
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type SubmitReportFeedbackSuccess {
+  feedback: ReportFeedback!
+}
+
+union SubmitReportFeedbackPayload = SubmitReportFeedbackSuccess
+
+# Aggregate snapshot of feedback / judge signal for a (variant, version)
+# pair. Admin-only. `judgeHumanCorrelation` is Pearson's r across
+# per-report (judgeScore, avgFeedbackRating) pairs; null when too few
+# pairs (< 3) exist to compute a meaningful correlation.
+# `correlationWarning` is true iff the correlation is present AND below
+# the recalibration threshold (0.7) — a signal that the judge prompt
+# needs re-tuning.
+#
+# `version` is null when the caller did not pin the query to a specific
+# revision — the row then rolls up stats across every version of the
+# variant. Consumers should branch on null vs. concrete number rather
+# than treating them the same.
+type ReportTemplateStats {
+  variant: ReportVariant!
+  version: Int
+  avgRating: Float
+  feedbackCount: Int!
+  avgJudgeScore: Float
+  judgeHumanCorrelation: Float
+  correlationWarning: Boolean!
+}

--- a/src/application/domain/report/schema/type.graphql
+++ b/src/application/domain/report/schema/type.graphql
@@ -55,7 +55,12 @@ type Report {
 
   # Feedback (PR-F4). `feedbacks` is paginated for OWNER/MANAGER review;
   # `myFeedback` returns the caller's own submission (if any) so the UI
-  # can hide the rating button once submitted.
+  # can hide the rating button once submitted. Reachable today through
+  # the `reports` / `report` queries (MANAGER+/ADMIN) — MEMBER-level
+  # read access to `Report` is not yet exposed, so MEMBER clients rely
+  # on the `submitReportFeedback` mutation's response to learn their
+  # own submission state. Follow-up to open a MEMBER-accessible read
+  # path is tracked in PR-F5.
   feedbacks(first: Int, after: String): ReportFeedbacksConnection!
   myFeedback: ReportFeedback
 

--- a/src/application/domain/report/templateSelector.ts
+++ b/src/application/domain/report/templateSelector.ts
@@ -2,6 +2,7 @@ import { ReportTemplateKind } from "@prisma/client";
 import { inject, injectable } from "tsyringe";
 import { IContext } from "@/types/server";
 import logger from "@/infrastructure/logging";
+import { NotFoundError } from "@/errors/graphql";
 import { IReportRepository } from "@/application/domain/report/data/interface";
 import { PrismaReportTemplate } from "@/application/domain/report/data/type";
 import { truncateToJstDate } from "@/application/domain/report/util";
@@ -47,9 +48,20 @@ export default class ReportTemplateSelector {
         : await this.repository.findActiveTemplates(ctx, variant, kind, null);
 
     if (candidates.length === 0) {
-      throw new Error(
-        `No active template for variant=${variant}, kind=${kind}, communityId=${communityId}`,
-      );
+      // Surface as NOT_FOUND so the GraphQL boundary exposes a structured
+      // error code (rather than the opaque INTERNAL_SERVER_ERROR that a
+      // plain `Error` produces). Seed data always ships at least a SYSTEM
+      // template for every (variant, kind), so hitting this path means a
+      // deployment/config problem worth bubbling up clearly.
+      //
+      // `formatError` in presentation/graphql/server.ts only `logger.error`s
+      // codes of `INTERNAL_SERVER_ERROR` — a NOT_FOUND response would sail
+      // past that gate silently. Log explicitly here so this *server-side*
+      // misconfiguration still reaches Cloud Logging and any alerting
+      // subscribed to `report.template.missing`, even though the client
+      // sees a structured 4xx-style response.
+      logger.error("report.template.missing", { variant, kind, communityId });
+      throw new NotFoundError("ReportTemplate", { variant, kind, communityId });
     }
 
     const selected =
@@ -57,19 +69,24 @@ export default class ReportTemplateSelector {
         ? candidates[0]
         : this.weightedRandom(candidates, communityId, referenceDate);
 
-    logger.info(
-      JSON.stringify({
-        event: "report.template.selected",
-        variant,
-        kind,
-        communityId,
-        selectedTemplateId: selected.id,
-        selectedVersion: selected.version,
-        selectedScope: selected.scope,
-        candidateCount: candidates.length,
-        isAbTest: candidates.length > 1,
-      }),
-    );
+    // Structured-meta form: winston's json() formatter promotes each field
+    // to a top-level key in Cloud Logging so queries like
+    // `jsonPayload.variant="WEEKLY_SUMMARY"` work. A single `JSON.stringify`
+    // would collapse everything into an opaque `message` string. `event`
+    // is duplicated into the metadata so existing dashboards/alerts that
+    // match on `jsonPayload.event` continue to work regardless of how the
+    // log ingestion pipeline maps the winston `message` field.
+    logger.info("report.template.selected", {
+      event: "report.template.selected",
+      variant,
+      kind,
+      communityId,
+      selectedTemplateId: selected.id,
+      selectedVersion: selected.version,
+      selectedScope: selected.scope,
+      candidateCount: candidates.length,
+      isAbTest: candidates.length > 1,
+    });
 
     return selected;
   }

--- a/src/application/domain/report/templateSelector.ts
+++ b/src/application/domain/report/templateSelector.ts
@@ -1,0 +1,144 @@
+import { ReportTemplateKind } from "@prisma/client";
+import { inject, injectable } from "tsyringe";
+import { IContext } from "@/types/server";
+import logger from "@/infrastructure/logging";
+import { IReportRepository } from "@/application/domain/report/data/interface";
+import { PrismaReportTemplate } from "@/application/domain/report/data/type";
+import { truncateToJstDate } from "@/application/domain/report/util";
+
+/**
+ * Resolves a `ReportTemplate` for a (variant, kind, community) triple with
+ * support for concurrent A/B candidates.
+ *
+ * Selection order:
+ *   1. COMMUNITY-scope candidates (isEnabled=true AND isActive=true), if any.
+ *   2. Otherwise, SYSTEM-scope candidates with the same filter.
+ *
+ * When more than one candidate matches, the winner is chosen by a
+ * `trafficWeight`-weighted draw whose seed is derived from
+ * `${communityId}-${isoWeekStartJst}`. This keeps the selection
+ * *deterministic within a given community + ISO week* — a manager regenerating
+ * their weekly report mid-week sees the same variant, not a fresh coin flip —
+ * while still rotating candidates week-over-week so the distribution
+ * converges on the intended `trafficWeight` split over time.
+ */
+@injectable()
+export default class ReportTemplateSelector {
+  constructor(
+    @inject("ReportRepository") private readonly repository: IReportRepository,
+  ) {}
+
+  async selectTemplate(
+    ctx: IContext,
+    variant: string,
+    kind: ReportTemplateKind,
+    communityId: string,
+    referenceDate: Date,
+  ): Promise<PrismaReportTemplate> {
+    const communityCandidates = await this.repository.findActiveTemplates(
+      ctx,
+      variant,
+      kind,
+      communityId,
+    );
+    const candidates =
+      communityCandidates.length > 0
+        ? communityCandidates
+        : await this.repository.findActiveTemplates(ctx, variant, kind, null);
+
+    if (candidates.length === 0) {
+      throw new Error(
+        `No active template for variant=${variant}, kind=${kind}, communityId=${communityId}`,
+      );
+    }
+
+    const selected =
+      candidates.length === 1
+        ? candidates[0]
+        : this.weightedRandom(candidates, communityId, referenceDate);
+
+    logger.info(
+      JSON.stringify({
+        event: "report.template.selected",
+        variant,
+        kind,
+        communityId,
+        selectedTemplateId: selected.id,
+        selectedVersion: selected.version,
+        selectedScope: selected.scope,
+        candidateCount: candidates.length,
+        isAbTest: candidates.length > 1,
+      }),
+    );
+
+    return selected;
+  }
+
+  /**
+   * Weighted draw over `templates` using `trafficWeight`. The seed is
+   * `cyrb53(${communityId}-${isoWeekStartJst})`, so the *same* community
+   * resolves to the *same* template for every call within a given JST ISO
+   * week — even across regenerations. Templates are first sorted by id so the
+   * weight-accumulation order is stable regardless of DB result order
+   * (otherwise a row re-ordering in Postgres could flip the selection for the
+   * same seed).
+   */
+  private weightedRandom(
+    templates: PrismaReportTemplate[],
+    communityId: string,
+    referenceDate: Date,
+  ): PrismaReportTemplate {
+    const weekStart = isoWeekStartJst(referenceDate);
+    const seed = cyrb53(`${communityId}-${weekStart.toISOString().slice(0, 10)}`);
+
+    const sorted = [...templates].sort((a, b) => a.id.localeCompare(b.id));
+    const weights = sorted.map((t) => (t.trafficWeight > 0 ? t.trafficWeight : 0));
+    const total = weights.reduce((s, w) => s + w, 0);
+
+    // Degenerate: every candidate has weight 0. Fall back to the first
+    // (deterministic by id) rather than erroring — the situation is
+    // recoverable by fixing seed data, and the caller still gets a valid
+    // template snapshot.
+    if (total === 0) return sorted[0];
+
+    let rand = seed % total;
+    for (let i = 0; i < sorted.length; i++) {
+      if (rand < weights[i]) return sorted[i];
+      rand -= weights[i];
+    }
+    return sorted[sorted.length - 1];
+  }
+}
+
+/**
+ * Monday (00:00 JST) of the ISO week containing `d`, encoded as a
+ * UTC-midnight Date whose year/month/day match the JST calendar date (the
+ * same convention used by `truncateToJstDate`).
+ */
+function isoWeekStartJst(d: Date): Date {
+  const jstDay = truncateToJstDate(d);
+  const dow = jstDay.getUTCDay(); // 0=Sun..6=Sat
+  const daysSinceMonday = (dow + 6) % 7;
+  return new Date(jstDay.getTime() - daysSinceMonday * 24 * 60 * 60 * 1000);
+}
+
+/**
+ * cyrb53: a fast, non-cryptographic 53-bit string hash. Used only as a
+ * deterministic PRNG seed for weighted A/B selection — no security
+ * properties relied on. Lifted verbatim from the canonical reference
+ * (bryc/code-snippets on GitHub, public domain).
+ */
+export function cyrb53(str: string, seed = 0): number {
+  let h1 = 0xdeadbeef ^ seed;
+  let h2 = 0x41c6ce57 ^ seed;
+  for (let i = 0; i < str.length; i++) {
+    const ch = str.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+  }
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507);
+  h1 ^= Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507);
+  h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+  return 4294967296 * (2097151 & h2) + (h1 >>> 0);
+}

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -1,9 +1,10 @@
-import { Prisma, ReportStatus } from "@prisma/client";
+import { Prisma, ReportStatus, ReportTemplateKind } from "@prisma/client";
 import { inject, injectable } from "tsyringe";
 import { IContext } from "@/types/server";
 import { ValidationError } from "@/errors/graphql";
 import ReportService from "@/application/domain/report/service";
 import ReportJudgeService, { JudgeParseError } from "@/application/domain/report/judgeService";
+import ReportTemplateSelector from "@/application/domain/report/templateSelector";
 import ReportPresenter from "@/application/domain/report/presenter";
 import { WeeklyReportPayload } from "@/application/domain/report/types";
 import { addDays, daysBetweenJst, truncateToJstDate } from "@/application/domain/report/util";
@@ -46,6 +47,7 @@ export default class ReportUseCase {
     @inject("ReportService") private readonly service: ReportService,
     @inject("LlmClient") private readonly llmClient: LlmClient,
     @inject("ReportJudgeService") private readonly judgeService: ReportJudgeService,
+    @inject("ReportTemplateSelector") private readonly templateSelector: ReportTemplateSelector,
   ) {}
 
   /**
@@ -137,12 +139,6 @@ export default class ReportUseCase {
       throw new ValidationError("communityId in input does not match permission.communityId", []);
     }
     const communityId = permission.communityId;
-    const template = await this.service.getTemplate(ctx, input.variant, communityId);
-    if (!template) {
-      throw new Error(
-        `No enabled template found for variant=${input.variant}, communityId=${communityId}`,
-      );
-    }
 
     const periodFrom = truncateToJstDate(input.periodFrom);
     const periodTo = truncateToJstDate(input.periodTo);
@@ -160,6 +156,18 @@ export default class ReportUseCase {
         ["periodFrom", "periodTo"],
       );
     }
+
+    // Select the generation template via the A/B-aware selector. The
+    // reference date is `periodTo`, which — combined with the selector's
+    // `${communityId}-${isoWeekStartJst}` seed — pins a regenerate within
+    // the same ISO week to the same template as the original run.
+    const template = await this.templateSelector.selectTemplate(
+      ctx,
+      input.variant,
+      ReportTemplateKind.GENERATION,
+      communityId,
+      periodTo,
+    );
     const payload = await this.buildReportPayload(ctx, {
       communityId,
       referenceDate: periodTo,
@@ -517,6 +525,24 @@ export default class ReportUseCase {
     { communityId, variant, input }: GqlMutationUpdateReportTemplateArgs,
     ctx: IContext,
   ): Promise<GqlUpdateReportTemplatePayload> {
+    // App-layer bounds check on trafficWeight. The DB already enforces the
+    // same invariant via `t_report_templates_traffic_weight_check`, but a
+    // CHECK-constraint violation surfaces as an opaque
+    // PrismaClientKnownRequestError — we want the admin UI to see a
+    // structured ValidationError with an attribution to the offending
+    // field instead.
+    if (input.trafficWeight !== undefined && input.trafficWeight !== null) {
+      if (
+        !Number.isInteger(input.trafficWeight) ||
+        input.trafficWeight < 0 ||
+        input.trafficWeight > 100
+      ) {
+        throw new ValidationError("trafficWeight must be an integer between 0 and 100", [
+          "trafficWeight",
+        ]);
+      }
+    }
+
     const template = await ctx.issuer.admin(ctx, (tx) =>
       this.service.upsertTemplate(
         ctx,

--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -7,6 +7,10 @@ import ReportRepository from "@/application/domain/report/data/repository";
 import ReportService from "@/application/domain/report/service";
 import ReportUseCase from "@/application/domain/report/usecase";
 import ReportJudgeService from "@/application/domain/report/judgeService";
+import ReportTemplateSelector from "@/application/domain/report/templateSelector";
+import ReportFeedbackRepository from "@/application/domain/report/feedback/data/repository";
+import ReportFeedbackService from "@/application/domain/report/feedback/service";
+import ReportFeedbackUseCase from "@/application/domain/report/feedback/usecase";
 import ICommunityRepository from "@/application/domain/account/community/data/repository";
 import TransactionService from "@/application/domain/transaction/service";
 import MembershipService from "@/application/domain/account/membership/service";
@@ -353,6 +357,10 @@ export function registerProductionDependencies() {
   container.register("ReportService", { useClass: ReportService });
   container.register("ReportUseCase", { useClass: ReportUseCase });
   container.register("ReportJudgeService", { useClass: ReportJudgeService });
+  container.register("ReportTemplateSelector", { useClass: ReportTemplateSelector });
+  container.register("ReportFeedbackRepository", { useClass: ReportFeedbackRepository });
+  container.register("ReportFeedbackService", { useClass: ReportFeedbackService });
+  container.register("ReportFeedbackUseCase", { useClass: ReportFeedbackUseCase });
   container.register("LlmClient", { useClass: AnthropicLlmClient });
 
   // ------------------------------

--- a/src/infrastructure/prisma/migrations/20260418120000_add_report_feedback_unique/migration.sql
+++ b/src/infrastructure/prisma/migrations/20260418120000_add_report_feedback_unique/migration.sql
@@ -1,0 +1,12 @@
+-- Enforce one feedback per (report, user). Required by PR-F4's
+-- `submitReportFeedback` mutation, which refuses second submits and
+-- relies on the unique index both as an app-layer fast path (via a
+-- pre-check) and as the last line of defence against racing writers.
+--
+-- Pre-existing duplicate rows would block this migration. t_report_feedbacks
+-- had no expose-path in F1/F2/F3, so no production duplicates are expected;
+-- if any environment somehow accumulated them, resolve the duplicates
+-- manually before re-running this migration — an automated dedupe here would
+-- silently discard ratings, which is worse than a loud failure.
+CREATE UNIQUE INDEX "t_report_feedbacks_report_id_user_id_key"
+    ON "t_report_feedbacks"("report_id", "user_id");

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -1826,6 +1826,13 @@ model ReportFeedback {
 
   createdAt DateTime @default(now()) @map("created_at")
 
+  // One feedback per (report, user). Duplicate submissions are rejected
+  // by this unique index; the `submitReportFeedback` mutation surfaces
+  // the violation as a `ValidationError` (both as a pre-check before the
+  // INSERT and as a translation of any racing P2002 into the same error
+  // code). An edit / partial-submit flow is deferred to a later PR — for
+  // now the mutation refuses second submits outright.
+  @@unique([reportId, userId])
   @@index([reportId])
   @@index([userId])
   @@map("t_report_feedbacks")

--- a/src/presentation/graphql/resolver.ts
+++ b/src/presentation/graphql/resolver.ts
@@ -28,6 +28,7 @@ import NftInstanceResolver from "@/application/domain/account/nft-instance/contr
 import NftTokenResolver from "@/application/domain/account/nft-token/controller/resolver";
 import VoteResolver from "@/application/domain/vote/controller/resolver";
 import ReportResolver from "@/application/domain/report/controller/resolver";
+import ReportFeedbackResolver from "@/application/domain/report/feedback/controller/resolver";
 import scalarResolvers from "@/presentation/graphql/scalar";
 
 const identity = container.resolve(IdentityResolver);
@@ -63,6 +64,7 @@ const transactionVerification = container.resolve(TransactionVerificationResolve
 const incentiveGrant = container.resolve(IncentiveGrantResolver);
 const vote = container.resolve(VoteResolver);
 const report = container.resolve(ReportResolver);
+const reportFeedback = container.resolve(ReportFeedbackResolver);
 
 const resolvers = {
   Query: {
@@ -93,6 +95,7 @@ const resolvers = {
     ...incentiveGrant.Query,
     ...vote.Query,
     ...report.Query,
+    ...reportFeedback.Query,
   },
   Mutation: {
     ...identity.Mutation,
@@ -112,6 +115,7 @@ const resolvers = {
     ...incentiveGrant.Mutation,
     ...vote.Mutation,
     ...report.Mutation,
+    ...reportFeedback.Mutation,
   },
   Identity: identity.Identity,
   User: user.User,
@@ -147,13 +151,15 @@ const resolvers = {
   VotePowerPolicy: vote.VotePowerPolicy,
   VoteBallot: vote.VoteBallot,
 
-  Report: report.Report,
+  Report: { ...report.Report, ...reportFeedback.Report },
   ReportTemplate: report.ReportTemplate,
+  ReportFeedback: reportFeedback.ReportFeedback,
   GenerateReportPayload: report.GenerateReportPayload,
   UpdateReportTemplatePayload: report.UpdateReportTemplatePayload,
   ApproveReportPayload: report.ApproveReportPayload,
   PublishReportPayload: report.PublishReportPayload,
   RejectReportPayload: report.RejectReportPayload,
+  SubmitReportFeedbackPayload: reportFeedback.SubmitReportFeedbackPayload,
 
   ...scalarResolvers,
 };

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -962,6 +962,7 @@ export type GqlMutation = {
   reservationJoin?: Maybe<GqlReservationSetStatusPayload>;
   reservationReject?: Maybe<GqlReservationSetStatusPayload>;
   storePhoneAuthToken?: Maybe<GqlStorePhoneAuthTokenPayload>;
+  submitReportFeedback?: Maybe<GqlSubmitReportFeedbackPayload>;
   ticketClaim?: Maybe<GqlTicketClaimPayload>;
   ticketIssue?: Maybe<GqlTicketIssuePayload>;
   ticketPurchase?: Maybe<GqlTicketPurchasePayload>;
@@ -1262,6 +1263,12 @@ export type GqlMutationReservationRejectArgs = {
 export type GqlMutationStorePhoneAuthTokenArgs = {
   input: GqlStorePhoneAuthTokenInput;
   permission: GqlCheckIsSelfPermissionInput;
+};
+
+
+export type GqlMutationSubmitReportFeedbackArgs = {
+  input: GqlSubmitReportFeedbackInput;
+  permission: GqlCheckCommunityPermissionInput;
 };
 
 
@@ -2169,6 +2176,7 @@ export type GqlQuery = {
   portfolios?: Maybe<Array<GqlPortfolio>>;
   report?: Maybe<GqlReport>;
   reportTemplate?: Maybe<GqlReportTemplate>;
+  reportTemplateStats: GqlReportTemplateStats;
   reports: GqlReportsConnection;
   reservation?: Maybe<GqlReservation>;
   reservationHistories: GqlReservationHistoriesConnection;
@@ -2420,6 +2428,12 @@ export type GqlQueryReportTemplateArgs = {
 };
 
 
+export type GqlQueryReportTemplateStatsArgs = {
+  variant: GqlReportVariant;
+  version?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
 export type GqlQueryReportsArgs = {
   communityId: Scalars['ID']['input'];
   cursor?: InputMaybe<Scalars['String']['input']>;
@@ -2614,11 +2628,13 @@ export type GqlReport = {
   cacheReadTokens?: Maybe<Scalars['Int']['output']>;
   community: GqlCommunity;
   createdAt: Scalars['Datetime']['output'];
+  feedbacks: GqlReportFeedbacksConnection;
   finalContent?: Maybe<Scalars['String']['output']>;
   generatedByUser?: Maybe<GqlUser>;
   id: Scalars['ID']['output'];
   inputTokens?: Maybe<Scalars['Int']['output']>;
   model?: Maybe<Scalars['String']['output']>;
+  myFeedback?: Maybe<GqlReportFeedback>;
   outputMarkdown?: Maybe<Scalars['String']['output']>;
   outputTokens?: Maybe<Scalars['Int']['output']>;
   parentRun?: Maybe<GqlReport>;
@@ -2636,10 +2652,50 @@ export type GqlReport = {
   variant: GqlReportVariant;
 };
 
+
+export type GqlReportFeedbacksArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+};
+
 export type GqlReportEdge = GqlEdge & {
   __typename?: 'ReportEdge';
   cursor: Scalars['String']['output'];
   node?: Maybe<GqlReport>;
+};
+
+export type GqlReportFeedback = {
+  __typename?: 'ReportFeedback';
+  comment?: Maybe<Scalars['String']['output']>;
+  createdAt: Scalars['Datetime']['output'];
+  feedbackType?: Maybe<GqlReportFeedbackType>;
+  id: Scalars['ID']['output'];
+  rating: Scalars['Int']['output'];
+  reportId: Scalars['ID']['output'];
+  sectionKey?: Maybe<Scalars['String']['output']>;
+  user: GqlUser;
+};
+
+export type GqlReportFeedbackEdge = GqlEdge & {
+  __typename?: 'ReportFeedbackEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlReportFeedback>;
+};
+
+export const GqlReportFeedbackType = {
+  Accuracy: 'ACCURACY',
+  Other: 'OTHER',
+  Quality: 'QUALITY',
+  Structure: 'STRUCTURE',
+  Tone: 'TONE'
+} as const;
+
+export type GqlReportFeedbackType = typeof GqlReportFeedbackType[keyof typeof GqlReportFeedbackType];
+export type GqlReportFeedbacksConnection = {
+  __typename?: 'ReportFeedbacksConnection';
+  edges?: Maybe<Array<Maybe<GqlReportFeedbackEdge>>>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
 };
 
 export const GqlReportStatus = {
@@ -2657,7 +2713,9 @@ export type GqlReportTemplate = {
   community?: Maybe<GqlCommunity>;
   communityContext?: Maybe<Scalars['String']['output']>;
   createdAt: Scalars['Datetime']['output'];
+  experimentKey?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
+  isActive: Scalars['Boolean']['output'];
   isEnabled: Scalars['Boolean']['output'];
   maxTokens: Scalars['Int']['output'];
   model: Scalars['String']['output'];
@@ -2665,10 +2723,12 @@ export type GqlReportTemplate = {
   stopSequences: Array<Scalars['String']['output']>;
   systemPrompt: Scalars['String']['output'];
   temperature?: Maybe<Scalars['Float']['output']>;
+  trafficWeight: Scalars['Int']['output'];
   updatedAt?: Maybe<Scalars['Datetime']['output']>;
   updatedByUser?: Maybe<GqlUser>;
   userPromptTemplate: Scalars['String']['output'];
   variant: GqlReportVariant;
+  version: Scalars['Int']['output'];
 };
 
 export const GqlReportTemplateScope = {
@@ -2677,6 +2737,17 @@ export const GqlReportTemplateScope = {
 } as const;
 
 export type GqlReportTemplateScope = typeof GqlReportTemplateScope[keyof typeof GqlReportTemplateScope];
+export type GqlReportTemplateStats = {
+  __typename?: 'ReportTemplateStats';
+  avgJudgeScore?: Maybe<Scalars['Float']['output']>;
+  avgRating?: Maybe<Scalars['Float']['output']>;
+  correlationWarning: Scalars['Boolean']['output'];
+  feedbackCount: Scalars['Int']['output'];
+  judgeHumanCorrelation?: Maybe<Scalars['Float']['output']>;
+  variant: GqlReportVariant;
+  version?: Maybe<Scalars['Int']['output']>;
+};
+
 export const GqlReportVariant = {
   GrantApplication: 'GRANT_APPLICATION',
   MediaPr: 'MEDIA_PR',
@@ -2873,6 +2944,21 @@ export type GqlStorePhoneAuthTokenPayload = {
   __typename?: 'StorePhoneAuthTokenPayload';
   expiresAt?: Maybe<Scalars['Datetime']['output']>;
   success: Scalars['Boolean']['output'];
+};
+
+export type GqlSubmitReportFeedbackInput = {
+  comment?: InputMaybe<Scalars['String']['input']>;
+  feedbackType?: InputMaybe<GqlReportFeedbackType>;
+  rating: Scalars['Int']['input'];
+  reportId: Scalars['ID']['input'];
+  sectionKey?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type GqlSubmitReportFeedbackPayload = GqlSubmitReportFeedbackSuccess;
+
+export type GqlSubmitReportFeedbackSuccess = {
+  __typename?: 'SubmitReportFeedbackSuccess';
+  feedback: GqlReportFeedback;
 };
 
 export const GqlSysRole = {
@@ -3311,12 +3397,15 @@ export type GqlTransactionsConnection = {
 
 export type GqlUpdateReportTemplateInput = {
   communityContext?: InputMaybe<Scalars['String']['input']>;
+  experimentKey?: InputMaybe<Scalars['String']['input']>;
+  isActive?: InputMaybe<Scalars['Boolean']['input']>;
   isEnabled?: InputMaybe<Scalars['Boolean']['input']>;
   maxTokens: Scalars['Int']['input'];
   model: Scalars['String']['input'];
   stopSequences?: InputMaybe<Array<Scalars['String']['input']>>;
   systemPrompt: Scalars['String']['input'];
   temperature?: InputMaybe<Scalars['Float']['input']>;
+  trafficWeight?: InputMaybe<Scalars['Int']['input']>;
   userPromptTemplate: Scalars['String']['input'];
 };
 
@@ -3981,6 +4070,7 @@ export type GqlResolversUnionTypes<_RefType extends Record<string, unknown>> = R
   RejectReportPayload: ( Omit<GqlRejectReportSuccess, 'report'> & { report: _RefType['Report'] } );
   ReservationCreatePayload: ( Omit<GqlReservationCreateSuccess, 'reservation'> & { reservation: _RefType['Reservation'] } );
   ReservationSetStatusPayload: ( Omit<GqlReservationSetStatusSuccess, 'reservation'> & { reservation: _RefType['Reservation'] } );
+  SubmitReportFeedbackPayload: ( Omit<GqlSubmitReportFeedbackSuccess, 'feedback'> & { feedback: _RefType['ReportFeedback'] } );
   TicketClaimPayload: ( Omit<GqlTicketClaimSuccess, 'tickets'> & { tickets: Array<_RefType['Ticket']> } );
   TicketIssuePayload: ( Omit<GqlTicketIssueSuccess, 'issue'> & { issue: _RefType['TicketIssuer'] } );
   TicketPurchasePayload: ( Omit<GqlTicketPurchaseSuccess, 'ticket'> & { ticket: _RefType['Ticket'] } );
@@ -4004,7 +4094,7 @@ export type GqlResolversUnionTypes<_RefType extends Record<string, unknown>> = R
 
 /** Mapping of interface types */
 export type GqlResolversInterfaceTypes<_RefType extends Record<string, unknown>> = ResolversObject<{
-  Edge: ( Omit<GqlArticleEdge, 'node'> & { node?: Maybe<_RefType['Article']> } ) | ( Omit<GqlCityEdge, 'node'> & { node?: Maybe<_RefType['City']> } ) | ( Omit<GqlCommunityEdge, 'node'> & { node?: Maybe<_RefType['Community']> } ) | ( Omit<GqlEvaluationEdge, 'node'> & { node?: Maybe<_RefType['Evaluation']> } ) | ( Omit<GqlEvaluationHistoryEdge, 'node'> & { node?: Maybe<_RefType['EvaluationHistory']> } ) | ( Omit<GqlIncentiveGrantEdge, 'node'> & { node?: Maybe<_RefType['IncentiveGrant']> } ) | ( Omit<GqlMembershipEdge, 'node'> & { node?: Maybe<_RefType['Membership']> } ) | ( Omit<GqlNftInstanceEdge, 'node'> & { node: _RefType['NftInstance'] } ) | ( Omit<GqlNftTokenEdge, 'node'> & { node: _RefType['NftToken'] } ) | ( Omit<GqlOpportunityEdge, 'node'> & { node?: Maybe<_RefType['Opportunity']> } ) | ( Omit<GqlOpportunitySlotEdge, 'node'> & { node?: Maybe<_RefType['OpportunitySlot']> } ) | ( Omit<GqlParticipationEdge, 'node'> & { node?: Maybe<_RefType['Participation']> } ) | ( Omit<GqlParticipationStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['ParticipationStatusHistory']> } ) | ( Omit<GqlPlaceEdge, 'node'> & { node?: Maybe<_RefType['Place']> } ) | ( Omit<GqlPortfolioEdge, 'node'> & { node?: Maybe<_RefType['Portfolio']> } ) | ( Omit<GqlReportEdge, 'node'> & { node?: Maybe<_RefType['Report']> } ) | ( Omit<GqlReservationEdge, 'node'> & { node?: Maybe<_RefType['Reservation']> } ) | ( Omit<GqlReservationHistoryEdge, 'node'> & { node?: Maybe<_RefType['ReservationHistory']> } ) | ( Omit<GqlStateEdge, 'node'> & { node?: Maybe<_RefType['State']> } ) | ( Omit<GqlTicketClaimLinkEdge, 'node'> & { node?: Maybe<_RefType['TicketClaimLink']> } ) | ( Omit<GqlTicketEdge, 'node'> & { node?: Maybe<_RefType['Ticket']> } ) | ( Omit<GqlTicketIssuerEdge, 'node'> & { node?: Maybe<_RefType['TicketIssuer']> } ) | ( Omit<GqlTicketStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['TicketStatusHistory']> } ) | ( Omit<GqlTransactionEdge, 'node'> & { node?: Maybe<_RefType['Transaction']> } ) | ( Omit<GqlUserEdge, 'node'> & { node?: Maybe<_RefType['User']> } ) | ( Omit<GqlUtilityEdge, 'node'> & { node?: Maybe<_RefType['Utility']> } ) | ( Omit<GqlVcIssuanceRequestEdge, 'node'> & { node?: Maybe<_RefType['VcIssuanceRequest']> } ) | ( Omit<GqlWalletEdge, 'node'> & { node?: Maybe<_RefType['Wallet']> } );
+  Edge: ( Omit<GqlArticleEdge, 'node'> & { node?: Maybe<_RefType['Article']> } ) | ( Omit<GqlCityEdge, 'node'> & { node?: Maybe<_RefType['City']> } ) | ( Omit<GqlCommunityEdge, 'node'> & { node?: Maybe<_RefType['Community']> } ) | ( Omit<GqlEvaluationEdge, 'node'> & { node?: Maybe<_RefType['Evaluation']> } ) | ( Omit<GqlEvaluationHistoryEdge, 'node'> & { node?: Maybe<_RefType['EvaluationHistory']> } ) | ( Omit<GqlIncentiveGrantEdge, 'node'> & { node?: Maybe<_RefType['IncentiveGrant']> } ) | ( Omit<GqlMembershipEdge, 'node'> & { node?: Maybe<_RefType['Membership']> } ) | ( Omit<GqlNftInstanceEdge, 'node'> & { node: _RefType['NftInstance'] } ) | ( Omit<GqlNftTokenEdge, 'node'> & { node: _RefType['NftToken'] } ) | ( Omit<GqlOpportunityEdge, 'node'> & { node?: Maybe<_RefType['Opportunity']> } ) | ( Omit<GqlOpportunitySlotEdge, 'node'> & { node?: Maybe<_RefType['OpportunitySlot']> } ) | ( Omit<GqlParticipationEdge, 'node'> & { node?: Maybe<_RefType['Participation']> } ) | ( Omit<GqlParticipationStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['ParticipationStatusHistory']> } ) | ( Omit<GqlPlaceEdge, 'node'> & { node?: Maybe<_RefType['Place']> } ) | ( Omit<GqlPortfolioEdge, 'node'> & { node?: Maybe<_RefType['Portfolio']> } ) | ( Omit<GqlReportEdge, 'node'> & { node?: Maybe<_RefType['Report']> } ) | ( Omit<GqlReportFeedbackEdge, 'node'> & { node?: Maybe<_RefType['ReportFeedback']> } ) | ( Omit<GqlReservationEdge, 'node'> & { node?: Maybe<_RefType['Reservation']> } ) | ( Omit<GqlReservationHistoryEdge, 'node'> & { node?: Maybe<_RefType['ReservationHistory']> } ) | ( Omit<GqlStateEdge, 'node'> & { node?: Maybe<_RefType['State']> } ) | ( Omit<GqlTicketClaimLinkEdge, 'node'> & { node?: Maybe<_RefType['TicketClaimLink']> } ) | ( Omit<GqlTicketEdge, 'node'> & { node?: Maybe<_RefType['Ticket']> } ) | ( Omit<GqlTicketIssuerEdge, 'node'> & { node?: Maybe<_RefType['TicketIssuer']> } ) | ( Omit<GqlTicketStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['TicketStatusHistory']> } ) | ( Omit<GqlTransactionEdge, 'node'> & { node?: Maybe<_RefType['Transaction']> } ) | ( Omit<GqlUserEdge, 'node'> & { node?: Maybe<_RefType['User']> } ) | ( Omit<GqlUtilityEdge, 'node'> & { node?: Maybe<_RefType['Utility']> } ) | ( Omit<GqlVcIssuanceRequestEdge, 'node'> & { node?: Maybe<_RefType['VcIssuanceRequest']> } ) | ( Omit<GqlWalletEdge, 'node'> & { node?: Maybe<_RefType['Wallet']> } );
   TransactionChainParticipant: ( GqlTransactionChainCommunity ) | ( GqlTransactionChainUser );
 }>;
 
@@ -4246,11 +4336,16 @@ export type GqlResolversTypes = ResolversObject<{
   Query: ResolverTypeWrapper<{}>;
   RejectReportPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['RejectReportPayload']>;
   RejectReportSuccess: ResolverTypeWrapper<Omit<GqlRejectReportSuccess, 'report'> & { report: GqlResolversTypes['Report'] }>;
-  Report: ResolverTypeWrapper<Omit<GqlReport, 'community' | 'generatedByUser' | 'parentRun' | 'publishedByUser' | 'regenerations' | 'targetUser' | 'template'> & { community: GqlResolversTypes['Community'], generatedByUser?: Maybe<GqlResolversTypes['User']>, parentRun?: Maybe<GqlResolversTypes['Report']>, publishedByUser?: Maybe<GqlResolversTypes['User']>, regenerations: Array<GqlResolversTypes['Report']>, targetUser?: Maybe<GqlResolversTypes['User']>, template?: Maybe<GqlResolversTypes['ReportTemplate']> }>;
+  Report: ResolverTypeWrapper<Omit<GqlReport, 'community' | 'feedbacks' | 'generatedByUser' | 'myFeedback' | 'parentRun' | 'publishedByUser' | 'regenerations' | 'targetUser' | 'template'> & { community: GqlResolversTypes['Community'], feedbacks: GqlResolversTypes['ReportFeedbacksConnection'], generatedByUser?: Maybe<GqlResolversTypes['User']>, myFeedback?: Maybe<GqlResolversTypes['ReportFeedback']>, parentRun?: Maybe<GqlResolversTypes['Report']>, publishedByUser?: Maybe<GqlResolversTypes['User']>, regenerations: Array<GqlResolversTypes['Report']>, targetUser?: Maybe<GqlResolversTypes['User']>, template?: Maybe<GqlResolversTypes['ReportTemplate']> }>;
   ReportEdge: ResolverTypeWrapper<Omit<GqlReportEdge, 'node'> & { node?: Maybe<GqlResolversTypes['Report']> }>;
+  ReportFeedback: ResolverTypeWrapper<Omit<GqlReportFeedback, 'user'> & { user: GqlResolversTypes['User'] }>;
+  ReportFeedbackEdge: ResolverTypeWrapper<Omit<GqlReportFeedbackEdge, 'node'> & { node?: Maybe<GqlResolversTypes['ReportFeedback']> }>;
+  ReportFeedbackType: GqlReportFeedbackType;
+  ReportFeedbacksConnection: ResolverTypeWrapper<Omit<GqlReportFeedbacksConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['ReportFeedbackEdge']>>> }>;
   ReportStatus: GqlReportStatus;
   ReportTemplate: ResolverTypeWrapper<Omit<GqlReportTemplate, 'community' | 'updatedByUser'> & { community?: Maybe<GqlResolversTypes['Community']>, updatedByUser?: Maybe<GqlResolversTypes['User']> }>;
   ReportTemplateScope: GqlReportTemplateScope;
+  ReportTemplateStats: ResolverTypeWrapper<GqlReportTemplateStats>;
   ReportVariant: GqlReportVariant;
   ReportsConnection: ResolverTypeWrapper<Omit<GqlReportsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['ReportEdge']>>> }>;
   Reservation: ResolverTypeWrapper<Omit<GqlReservation, 'createdByUser' | 'histories' | 'opportunitySlot' | 'participations'> & { createdByUser?: Maybe<GqlResolversTypes['User']>, histories?: Maybe<Array<GqlResolversTypes['ReservationHistory']>>, opportunitySlot?: Maybe<GqlResolversTypes['OpportunitySlot']>, participations?: Maybe<Array<GqlResolversTypes['Participation']>> }>;
@@ -4282,6 +4377,9 @@ export type GqlResolversTypes = ResolversObject<{
   StorePhoneAuthTokenInput: GqlStorePhoneAuthTokenInput;
   StorePhoneAuthTokenPayload: ResolverTypeWrapper<GqlStorePhoneAuthTokenPayload>;
   String: ResolverTypeWrapper<Scalars['String']['output']>;
+  SubmitReportFeedbackInput: GqlSubmitReportFeedbackInput;
+  SubmitReportFeedbackPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['SubmitReportFeedbackPayload']>;
+  SubmitReportFeedbackSuccess: ResolverTypeWrapper<Omit<GqlSubmitReportFeedbackSuccess, 'feedback'> & { feedback: GqlResolversTypes['ReportFeedback'] }>;
   SysRole: GqlSysRole;
   Ticket: ResolverTypeWrapper<Ticket>;
   TicketClaimInput: GqlTicketClaimInput;
@@ -4628,9 +4726,13 @@ export type GqlResolversParentTypes = ResolversObject<{
   Query: {};
   RejectReportPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['RejectReportPayload'];
   RejectReportSuccess: Omit<GqlRejectReportSuccess, 'report'> & { report: GqlResolversParentTypes['Report'] };
-  Report: Omit<GqlReport, 'community' | 'generatedByUser' | 'parentRun' | 'publishedByUser' | 'regenerations' | 'targetUser' | 'template'> & { community: GqlResolversParentTypes['Community'], generatedByUser?: Maybe<GqlResolversParentTypes['User']>, parentRun?: Maybe<GqlResolversParentTypes['Report']>, publishedByUser?: Maybe<GqlResolversParentTypes['User']>, regenerations: Array<GqlResolversParentTypes['Report']>, targetUser?: Maybe<GqlResolversParentTypes['User']>, template?: Maybe<GqlResolversParentTypes['ReportTemplate']> };
+  Report: Omit<GqlReport, 'community' | 'feedbacks' | 'generatedByUser' | 'myFeedback' | 'parentRun' | 'publishedByUser' | 'regenerations' | 'targetUser' | 'template'> & { community: GqlResolversParentTypes['Community'], feedbacks: GqlResolversParentTypes['ReportFeedbacksConnection'], generatedByUser?: Maybe<GqlResolversParentTypes['User']>, myFeedback?: Maybe<GqlResolversParentTypes['ReportFeedback']>, parentRun?: Maybe<GqlResolversParentTypes['Report']>, publishedByUser?: Maybe<GqlResolversParentTypes['User']>, regenerations: Array<GqlResolversParentTypes['Report']>, targetUser?: Maybe<GqlResolversParentTypes['User']>, template?: Maybe<GqlResolversParentTypes['ReportTemplate']> };
   ReportEdge: Omit<GqlReportEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['Report']> };
+  ReportFeedback: Omit<GqlReportFeedback, 'user'> & { user: GqlResolversParentTypes['User'] };
+  ReportFeedbackEdge: Omit<GqlReportFeedbackEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['ReportFeedback']> };
+  ReportFeedbacksConnection: Omit<GqlReportFeedbacksConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['ReportFeedbackEdge']>>> };
   ReportTemplate: Omit<GqlReportTemplate, 'community' | 'updatedByUser'> & { community?: Maybe<GqlResolversParentTypes['Community']>, updatedByUser?: Maybe<GqlResolversParentTypes['User']> };
+  ReportTemplateStats: GqlReportTemplateStats;
   ReportsConnection: Omit<GqlReportsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['ReportEdge']>>> };
   Reservation: Omit<GqlReservation, 'createdByUser' | 'histories' | 'opportunitySlot' | 'participations'> & { createdByUser?: Maybe<GqlResolversParentTypes['User']>, histories?: Maybe<Array<GqlResolversParentTypes['ReservationHistory']>>, opportunitySlot?: Maybe<GqlResolversParentTypes['OpportunitySlot']>, participations?: Maybe<Array<GqlResolversParentTypes['Participation']>> };
   ReservationCancelInput: GqlReservationCancelInput;
@@ -4656,6 +4758,9 @@ export type GqlResolversParentTypes = ResolversObject<{
   StorePhoneAuthTokenInput: GqlStorePhoneAuthTokenInput;
   StorePhoneAuthTokenPayload: GqlStorePhoneAuthTokenPayload;
   String: Scalars['String']['output'];
+  SubmitReportFeedbackInput: GqlSubmitReportFeedbackInput;
+  SubmitReportFeedbackPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['SubmitReportFeedbackPayload'];
+  SubmitReportFeedbackSuccess: Omit<GqlSubmitReportFeedbackSuccess, 'feedback'> & { feedback: GqlResolversParentTypes['ReportFeedback'] };
   Ticket: Ticket;
   TicketClaimInput: GqlTicketClaimInput;
   TicketClaimLink: TicketClaimLink;
@@ -5057,7 +5162,7 @@ export type GqlDidIssuanceRequestResolvers<ContextType = any, ParentType extends
 }>;
 
 export type GqlEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Edge'] = GqlResolversParentTypes['Edge']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'ArticleEdge' | 'CityEdge' | 'CommunityEdge' | 'EvaluationEdge' | 'EvaluationHistoryEdge' | 'IncentiveGrantEdge' | 'MembershipEdge' | 'NftInstanceEdge' | 'NftTokenEdge' | 'OpportunityEdge' | 'OpportunitySlotEdge' | 'ParticipationEdge' | 'ParticipationStatusHistoryEdge' | 'PlaceEdge' | 'PortfolioEdge' | 'ReportEdge' | 'ReservationEdge' | 'ReservationHistoryEdge' | 'StateEdge' | 'TicketClaimLinkEdge' | 'TicketEdge' | 'TicketIssuerEdge' | 'TicketStatusHistoryEdge' | 'TransactionEdge' | 'UserEdge' | 'UtilityEdge' | 'VcIssuanceRequestEdge' | 'WalletEdge', ParentType, ContextType>;
+  __resolveType: TypeResolveFn<'ArticleEdge' | 'CityEdge' | 'CommunityEdge' | 'EvaluationEdge' | 'EvaluationHistoryEdge' | 'IncentiveGrantEdge' | 'MembershipEdge' | 'NftInstanceEdge' | 'NftTokenEdge' | 'OpportunityEdge' | 'OpportunitySlotEdge' | 'ParticipationEdge' | 'ParticipationStatusHistoryEdge' | 'PlaceEdge' | 'PortfolioEdge' | 'ReportEdge' | 'ReportFeedbackEdge' | 'ReservationEdge' | 'ReservationHistoryEdge' | 'StateEdge' | 'TicketClaimLinkEdge' | 'TicketEdge' | 'TicketIssuerEdge' | 'TicketStatusHistoryEdge' | 'TransactionEdge' | 'UserEdge' | 'UtilityEdge' | 'VcIssuanceRequestEdge' | 'WalletEdge', ParentType, ContextType>;
   cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
 }>;
 
@@ -5332,6 +5437,7 @@ export type GqlMutationResolvers<ContextType = any, ParentType extends GqlResolv
   reservationJoin?: Resolver<Maybe<GqlResolversTypes['ReservationSetStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationReservationJoinArgs, 'id'>>;
   reservationReject?: Resolver<Maybe<GqlResolversTypes['ReservationSetStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationReservationRejectArgs, 'id' | 'input' | 'permission'>>;
   storePhoneAuthToken?: Resolver<Maybe<GqlResolversTypes['StorePhoneAuthTokenPayload']>, ParentType, ContextType, RequireFields<GqlMutationStorePhoneAuthTokenArgs, 'input' | 'permission'>>;
+  submitReportFeedback?: Resolver<Maybe<GqlResolversTypes['SubmitReportFeedbackPayload']>, ParentType, ContextType, RequireFields<GqlMutationSubmitReportFeedbackArgs, 'input' | 'permission'>>;
   ticketClaim?: Resolver<Maybe<GqlResolversTypes['TicketClaimPayload']>, ParentType, ContextType, RequireFields<GqlMutationTicketClaimArgs, 'input'>>;
   ticketIssue?: Resolver<Maybe<GqlResolversTypes['TicketIssuePayload']>, ParentType, ContextType, RequireFields<GqlMutationTicketIssueArgs, 'input' | 'permission'>>;
   ticketPurchase?: Resolver<Maybe<GqlResolversTypes['TicketPurchasePayload']>, ParentType, ContextType, RequireFields<GqlMutationTicketPurchaseArgs, 'input' | 'permission'>>;
@@ -5791,6 +5897,7 @@ export type GqlQueryResolvers<ContextType = any, ParentType extends GqlResolvers
   portfolios?: Resolver<Maybe<Array<GqlResolversTypes['Portfolio']>>, ParentType, ContextType, Partial<GqlQueryPortfoliosArgs>>;
   report?: Resolver<Maybe<GqlResolversTypes['Report']>, ParentType, ContextType, RequireFields<GqlQueryReportArgs, 'id'>>;
   reportTemplate?: Resolver<Maybe<GqlResolversTypes['ReportTemplate']>, ParentType, ContextType, RequireFields<GqlQueryReportTemplateArgs, 'variant'>>;
+  reportTemplateStats?: Resolver<GqlResolversTypes['ReportTemplateStats'], ParentType, ContextType, RequireFields<GqlQueryReportTemplateStatsArgs, 'variant'>>;
   reports?: Resolver<GqlResolversTypes['ReportsConnection'], ParentType, ContextType, RequireFields<GqlQueryReportsArgs, 'communityId' | 'permission'>>;
   reservation?: Resolver<Maybe<GqlResolversTypes['Reservation']>, ParentType, ContextType, RequireFields<GqlQueryReservationArgs, 'id'>>;
   reservationHistories?: Resolver<GqlResolversTypes['ReservationHistoriesConnection'], ParentType, ContextType, Partial<GqlQueryReservationHistoriesArgs>>;
@@ -5834,11 +5941,13 @@ export type GqlReportResolvers<ContextType = any, ParentType extends GqlResolver
   cacheReadTokens?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
   community?: Resolver<GqlResolversTypes['Community'], ParentType, ContextType>;
   createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  feedbacks?: Resolver<GqlResolversTypes['ReportFeedbacksConnection'], ParentType, ContextType, Partial<GqlReportFeedbacksArgs>>;
   finalContent?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   generatedByUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
   id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
   inputTokens?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
   model?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  myFeedback?: Resolver<Maybe<GqlResolversTypes['ReportFeedback']>, ParentType, ContextType>;
   outputMarkdown?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   outputTokens?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
   parentRun?: Resolver<Maybe<GqlResolversTypes['Report']>, ParentType, ContextType>;
@@ -5863,11 +5972,38 @@ export type GqlReportEdgeResolvers<ContextType = any, ParentType extends GqlReso
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type GqlReportFeedbackResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReportFeedback'] = GqlResolversParentTypes['ReportFeedback']> = ResolversObject<{
+  comment?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  feedbackType?: Resolver<Maybe<GqlResolversTypes['ReportFeedbackType']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  rating?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  reportId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  sectionKey?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  user?: Resolver<GqlResolversTypes['User'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReportFeedbackEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReportFeedbackEdge'] = GqlResolversParentTypes['ReportFeedbackEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['ReportFeedback']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReportFeedbacksConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReportFeedbacksConnection'] = GqlResolversParentTypes['ReportFeedbacksConnection']> = ResolversObject<{
+  edges?: Resolver<Maybe<Array<Maybe<GqlResolversTypes['ReportFeedbackEdge']>>>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type GqlReportTemplateResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReportTemplate'] = GqlResolversParentTypes['ReportTemplate']> = ResolversObject<{
   community?: Resolver<Maybe<GqlResolversTypes['Community']>, ParentType, ContextType>;
   communityContext?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  experimentKey?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  isActive?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
   isEnabled?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
   maxTokens?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   model?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
@@ -5875,10 +6011,23 @@ export type GqlReportTemplateResolvers<ContextType = any, ParentType extends Gql
   stopSequences?: Resolver<Array<GqlResolversTypes['String']>, ParentType, ContextType>;
   systemPrompt?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
   temperature?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  trafficWeight?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
   updatedByUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
   userPromptTemplate?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
   variant?: Resolver<GqlResolversTypes['ReportVariant'], ParentType, ContextType>;
+  version?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReportTemplateStatsResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReportTemplateStats'] = GqlResolversParentTypes['ReportTemplateStats']> = ResolversObject<{
+  avgJudgeScore?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  avgRating?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  correlationWarning?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  feedbackCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  judgeHumanCorrelation?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  variant?: Resolver<GqlResolversTypes['ReportVariant'], ParentType, ContextType>;
+  version?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -5979,6 +6128,15 @@ export type GqlStatesConnectionResolvers<ContextType = any, ParentType extends G
 export type GqlStorePhoneAuthTokenPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['StorePhoneAuthTokenPayload'] = GqlResolversParentTypes['StorePhoneAuthTokenPayload']> = ResolversObject<{
   expiresAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
   success?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlSubmitReportFeedbackPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SubmitReportFeedbackPayload'] = GqlResolversParentTypes['SubmitReportFeedbackPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'SubmitReportFeedbackSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlSubmitReportFeedbackSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SubmitReportFeedbackSuccess'] = GqlResolversParentTypes['SubmitReportFeedbackSuccess']> = ResolversObject<{
+  feedback?: Resolver<GqlResolversTypes['ReportFeedback'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -6680,7 +6838,11 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   RejectReportSuccess?: GqlRejectReportSuccessResolvers<ContextType>;
   Report?: GqlReportResolvers<ContextType>;
   ReportEdge?: GqlReportEdgeResolvers<ContextType>;
+  ReportFeedback?: GqlReportFeedbackResolvers<ContextType>;
+  ReportFeedbackEdge?: GqlReportFeedbackEdgeResolvers<ContextType>;
+  ReportFeedbacksConnection?: GqlReportFeedbacksConnectionResolvers<ContextType>;
   ReportTemplate?: GqlReportTemplateResolvers<ContextType>;
+  ReportTemplateStats?: GqlReportTemplateStatsResolvers<ContextType>;
   ReportsConnection?: GqlReportsConnectionResolvers<ContextType>;
   Reservation?: GqlReservationResolvers<ContextType>;
   ReservationCreatePayload?: GqlReservationCreatePayloadResolvers<ContextType>;
@@ -6696,6 +6858,8 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   StateEdge?: GqlStateEdgeResolvers<ContextType>;
   StatesConnection?: GqlStatesConnectionResolvers<ContextType>;
   StorePhoneAuthTokenPayload?: GqlStorePhoneAuthTokenPayloadResolvers<ContextType>;
+  SubmitReportFeedbackPayload?: GqlSubmitReportFeedbackPayloadResolvers<ContextType>;
+  SubmitReportFeedbackSuccess?: GqlSubmitReportFeedbackSuccessResolvers<ContextType>;
   Ticket?: GqlTicketResolvers<ContextType>;
   TicketClaimLink?: GqlTicketClaimLinkResolvers<ContextType>;
   TicketClaimLinkEdge?: GqlTicketClaimLinkEdgeResolvers<ContextType>;


### PR DESCRIPTION
…877)

* A/Bテンプレート選択とReportFeedback APIを追加

PR-F3: 既存の isActive=true 1件取得ロジックを、コミュニティハッシュベースの
重み付き選択に置き換え。同じ (communityId, ISO週) では同じテンプレートが
選ばれるため、マネージャーが週途中に再生成しても出力が変わらない。
trafficWeight は 0..100 のアプリ層バリデーションを追加（DB CHECK と両方）。

PR-F4: ReportFeedback entity を GraphQL に expose。MEMBER 以上が rating (1-5) と任意のコメントを submit 可能。OWNER/MANAGER は Report.feedbacks で 一覧、本人は Report.myFeedback で自分の分のみ参照できる。管理画面向けに
reportTemplateStats クエリで (variant, version) 単位の avgRating / avgJudgeScore / Pearson's r を返し、相関が 0.7 未満の場合は
correlationWarning=true を立てる。@@unique([reportId, userId]) を DB に 追加して重複 submit を防止。

* PR #877 レビュー指摘に対応

gemini / copilot / devin のレビューコメントから以下を反映:

- submitReportFeedback を ctx.issuer.public 単一トランザクションでラップし、 existence check → duplicate check → insert をアトミック化。racing P2002 も同じ ValidationError に翻訳してクライアントから見たエラー コードを一貫させる（#2 #4-atomicity）
- findFeedbacksByReport(Ids) の orderBy に id 副キーを追加し、 createdAt 同値時のカーソルページング順序を全順序化（#1 #10）
- listFeedbacksForReport の clampInt を ValidationError を throw する validateInt に置換。RangeError → INTERNAL_SERVER_ERROR を避ける（#3 #7 #8）
- ReportTemplateStats.version を nullable 化し、0 埋めマジック値を廃止。 未指定時の roll-up を null で明示（#11）
- ReportTemplateStats.variant を String! → ReportVariant! enum 化（#12）
- ReportTemplate output 型に version / isActive / experimentKey / trafficWeight を expose し、管理画面からの read-after-write を可能に（#13）
- schema.prisma / usecase / type.ts の誤 JSDoc を修正 （ConflictError → ValidationError、< 2 → < 3 pairs、架空の ReportFeedbackAlreadyExistsError を削除）（#5 #6 #9）
- feedbackUsecase.test.ts に P2002 race ケースを追加（81 テスト通過）

残: #4 devin 指摘の「onlyBelongingCommunity でラップ + RLS ポリシー追加」 は t_report_feedbacks の RLS 設計変更（F1 では admin-only だったが F4 で member write を開放）を伴うため、追加マイグレーションの是非を別途確認する。

https://claude.ai/code/session_01BcD9iYBieK94PUe1PHc4TK

* Report.myFeedback の N+1 を DataLoader 化

devin レビュー指摘: `reports { myFeedback }` を select すると Report 件数分の ctx.issuer.public トランザクションが走り、RLS セットアップごと N 回繰り返
されていた。

createMyReportFeedbackLoader を追加し、`{ reportId, userId }` の合成キーで バッチ。findFeedbacksByReportIds と同様に1リクエストで distinct userId ごとに1クエリへ集約する（通常は同一リクエスト内で userId は1つ）。

Loader factory はリクエストライフサイクル上 auth より前に実行されるため、
userId は load 時点で resolver から渡す方式とした（factory 引数は prisma のまま、他の loader と一貫）。

ReportFeedbackUseCase.getMyFeedback は使用箇所がなくなったので削除。

https://claude.ai/code/session_01BcD9iYBieK94PUe1PHc4TK

* submitReportFeedback の issuer.public 選択理由をコメント化

devin レビューが「onlyBelongingCommunity を使うべき」と再指摘してきたが、 実際には切り替えると非admin MEMBER の INSERT が既存RLSポリシー
(community_bypass_policy のみ) に弾かれて即機能不全になる。F4 では
F1 の admin-only 設計を維持したまま @authz + アプリ層チェック二段で
認可している。将来 defence-in-depth で RLS を増やす場合は別PRで
member-write ポリシー追加 + onlyBelongingCommunity 化、とする想定を usecase に明記した。ロジック変更なし。

https://claude.ai/code/session_01BcD9iYBieK94PUe1PHc4TK

* myReportFeedback DataLoader を OR ペアの単一クエリに変更

gemini review 指摘対応。userId ごとにループして findMany を回す実装は 1 リクエスト内で複数 userId が混在すると N+1 に退化する。(reportId, userId) ペアを OR で束ねた単一 findMany に置き換え、@@unique([reportId, userId]) インデックスでペアごとに直接ルックアップさせる。Cartesian 過取得もなし。

既存テスト (18件) グリーンのまま。

https://claude.ai/code/session_01BcD9iYBieK94PUe1PHc4TK

---------
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
