### PR TITLE
Improve error handling and logging in report domain

### DIFF
--- a/src/__tests__/unit/report/templateSelector.test.ts
+++ b/src/__tests__/unit/report/templateSelector.test.ts
@@ -106,7 +106,7 @@ describe("ReportTemplateSelector", () => {
     expect(repository.findActiveTemplates).toHaveBeenCalledTimes(2);
   });
 
-  it("throws when there are no candidates at either scope", async () => {
+  it("throws a structured NotFoundError when there are no candidates at either scope", async () => {
     repository.findActiveTemplates.mockResolvedValue([]);
     await expect(
       selector.selectTemplate(
@@ -116,7 +116,10 @@ describe("ReportTemplateSelector", () => {
         "c-1",
         new Date("2026-04-17"),
       ),
-    ).rejects.toThrow(/No active template/);
+    ).rejects.toMatchObject({
+      name: "NotFoundError",
+      extensions: { code: "NOT_FOUND" },
+    });
   });
 
   it("returns a deterministic template for the same (communityId + week)", async () => {

--- a/src/application/domain/report/feedback/data/repository.ts
+++ b/src/application/domain/report/feedback/data/repository.ts
@@ -139,6 +139,14 @@ export default class ReportFeedbackRepository implements IReportFeedbackReposito
         }),
       ]);
 
+      // INNER JOIN on `t_report_feedbacks` is deliberate: Pearson's r
+      // requires *paired* observations, so a report with a `judgeScore`
+      // but no human feedback contributes no signal and must be
+      // dropped. Using LEFT JOIN and coercing missing ratings to 0 or
+      // NULL would either bias the correlation (0 is a real rating
+      // value) or blow up the coefficient (NULL averages propagate).
+      // See `JudgeFeedbackPairRow` in ./interface.ts for the same
+      // invariant expressed at the type layer.
       const pairRows = await tx.$queryRaw<
         { report_id: string; judge_score: number; avg_rating: number }[]
       >`

--- a/src/application/domain/report/feedback/usecase.ts
+++ b/src/application/domain/report/feedback/usecase.ts
@@ -122,8 +122,13 @@ export default class ReportFeedbackUseCase {
             reportId: input.reportId,
             userId,
             rating: input.rating,
+            // The GraphQL `ReportFeedbackType` and Prisma `FeedbackType`
+            // enums share identical member names by contract (Prisma's
+            // enum is the source of truth and the GraphQL schema mirrors
+            // it), so a plain assertion is enough — no `as unknown`
+            // intermediate needed.
             feedbackType: input.feedbackType
-              ? (input.feedbackType as unknown as FeedbackType)
+              ? (input.feedbackType as FeedbackType)
               : null,
             sectionKey: input.sectionKey ?? null,
             comment: input.comment ?? null,

--- a/src/application/domain/report/schema/type.graphql
+++ b/src/application/domain/report/schema/type.graphql
@@ -55,7 +55,12 @@ type Report {
 
   # Feedback (PR-F4). `feedbacks` is paginated for OWNER/MANAGER review;
   # `myFeedback` returns the caller's own submission (if any) so the UI
-  # can hide the rating button once submitted.
+  # can hide the rating button once submitted. Reachable today through
+  # the `reports` / `report` queries (MANAGER+/ADMIN) — MEMBER-level
+  # read access to `Report` is not yet exposed, so MEMBER clients rely
+  # on the `submitReportFeedback` mutation's response to learn their
+  # own submission state. Follow-up to open a MEMBER-accessible read
+  # path is tracked in PR-F5.
   feedbacks(first: Int, after: String): ReportFeedbacksConnection!
   myFeedback: ReportFeedback
 

--- a/src/application/domain/report/templateSelector.ts
+++ b/src/application/domain/report/templateSelector.ts
@@ -2,6 +2,7 @@ import { ReportTemplateKind } from "@prisma/client";
 import { inject, injectable } from "tsyringe";
 import { IContext } from "@/types/server";
 import logger from "@/infrastructure/logging";
+import { NotFoundError } from "@/errors/graphql";
 import { IReportRepository } from "@/application/domain/report/data/interface";
 import { PrismaReportTemplate } from "@/application/domain/report/data/type";
 import { truncateToJstDate } from "@/application/domain/report/util";
@@ -47,9 +48,12 @@ export default class ReportTemplateSelector {
         : await this.repository.findActiveTemplates(ctx, variant, kind, null);
 
     if (candidates.length === 0) {
-      throw new Error(
-        `No active template for variant=${variant}, kind=${kind}, communityId=${communityId}`,
-      );
+      // Surface as NOT_FOUND so the GraphQL boundary exposes a structured
+      // error code (rather than the opaque INTERNAL_SERVER_ERROR that a
+      // plain `Error` produces). Seed data always ships at least a SYSTEM
+      // template for every (variant, kind), so hitting this path means a
+      // deployment/config problem worth bubbling up clearly.
+      throw new NotFoundError("ReportTemplate", { variant, kind, communityId });
     }
 
     const selected =
@@ -57,19 +61,20 @@ export default class ReportTemplateSelector {
         ? candidates[0]
         : this.weightedRandom(candidates, communityId, referenceDate);
 
-    logger.info(
-      JSON.stringify({
-        event: "report.template.selected",
-        variant,
-        kind,
-        communityId,
-        selectedTemplateId: selected.id,
-        selectedVersion: selected.version,
-        selectedScope: selected.scope,
-        candidateCount: candidates.length,
-        isAbTest: candidates.length > 1,
-      }),
-    );
+    // Structured-meta form: winston's json() formatter promotes each field
+    // to a top-level key in Cloud Logging so queries like
+    // `jsonPayload.variant="WEEKLY_SUMMARY"` work. A single `JSON.stringify`
+    // would collapse everything into an opaque `message` string.
+    logger.info("report.template.selected", {
+      variant,
+      kind,
+      communityId,
+      selectedTemplateId: selected.id,
+      selectedVersion: selected.version,
+      selectedScope: selected.scope,
+      candidateCount: candidates.length,
+      isAbTest: candidates.length > 1,
+    });
 
     return selected;
   }

--- a/src/application/domain/report/templateSelector.ts
+++ b/src/application/domain/report/templateSelector.ts
@@ -53,6 +53,14 @@ export default class ReportTemplateSelector {
       // plain `Error` produces). Seed data always ships at least a SYSTEM
       // template for every (variant, kind), so hitting this path means a
       // deployment/config problem worth bubbling up clearly.
+      //
+      // `formatError` in presentation/graphql/server.ts only `logger.error`s
+      // codes of `INTERNAL_SERVER_ERROR` — a NOT_FOUND response would sail
+      // past that gate silently. Log explicitly here so this *server-side*
+      // misconfiguration still reaches Cloud Logging and any alerting
+      // subscribed to `report.template.missing`, even though the client
+      // sees a structured 4xx-style response.
+      logger.error("report.template.missing", { variant, kind, communityId });
       throw new NotFoundError("ReportTemplate", { variant, kind, communityId });
     }
 
@@ -64,8 +72,12 @@ export default class ReportTemplateSelector {
     // Structured-meta form: winston's json() formatter promotes each field
     // to a top-level key in Cloud Logging so queries like
     // `jsonPayload.variant="WEEKLY_SUMMARY"` work. A single `JSON.stringify`
-    // would collapse everything into an opaque `message` string.
+    // would collapse everything into an opaque `message` string. `event`
+    // is duplicated into the metadata so existing dashboards/alerts that
+    // match on `jsonPayload.event` continue to work regardless of how the
+    // log ingestion pipeline maps the winston `message` field.
     logger.info("report.template.selected", {
+      event: "report.template.selected",
       variant,
       kind,
       communityId,


### PR DESCRIPTION
## Summary
This PR improves error handling, logging, and code documentation in the report domain by surfacing structured GraphQL errors, adopting structured logging practices, and clarifying implementation invariants through comments.

## Key Changes

- **Error Handling**: Replace generic `Error` with `NotFoundError` when no active report templates are found, allowing GraphQL to surface a structured `NOT_FOUND` error code instead of `INTERNAL_SERVER_ERROR`

- **Structured Logging**: Refactor report template selection logging from `JSON.stringify()` to structured metadata format, enabling Cloud Logging queries on individual fields (e.g., `jsonPayload.variant="WEEKLY_SUMMARY"`)

- **Type Safety**: Simplify type assertion in `ReportFeedbackUseCase` from `as unknown as FeedbackType` to `as FeedbackType` with clarifying comment about enum contract between GraphQL and Prisma schemas

- **Documentation**: Add clarifying comments explaining:
  - Why `INNER JOIN` is used for Pearson correlation (requires paired observations)
  - Current scope of report feedback access (MANAGER+/ADMIN only, with MEMBER access tracked in PR-F5)
  - Rationale for structured error handling in template selection

- **Tests**: Update test expectations to verify structured `NotFoundError` with proper GraphQL error extensions instead of regex matching on error message

## Notable Implementation Details

The template selection error now properly distinguishes between deployment/configuration problems (missing seed data) and client errors by using the GraphQL error boundary, improving observability and client error handling.

https://claude.ai/code/session_012jXqCN5jo7i91AxLD3kUfu
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/883" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
