### PR TITLE
ci: enable blocking tests, split jobs, and shard test by category (#880)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,8 @@ jobs:
     strategy:
       fail-fast: false
       # test ディレクトリ単位で job 並列化。jest の `--shard` (hash 分散) ではなく
-      # `--testPathPattern` で category split することで、job 名が
+      # matrix.path を positional 引数として渡してテスト対象を絞り込む
+      # (Jest の testPathPattern 相当) ことで、job 名が
       # unit / integration / e2e / auth という意味的ラベルになり、失敗した
       # カテゴリが一目で分かる。各 job は独立 Postgres service を持ち、job 内は
       # --runInBand で直列 (DB race 安全)、job 間は並列で高速化する。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,134 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  ci:
+  lint:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 5
     permissions:
       contents: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+          disable-sudo: true
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Lint GitHub Actions workflows (actionlint 1.7.7)
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/repo:ro" \
+            --workdir /repo \
+            rhysd/actionlint@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9 \
+            -color
+        # Image: rhysd/actionlint:1.7.7 (Docker Hub, multi-arch index digest)
+        # shellcheck / pyflakes are bundled in the image.
+
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    # Postgres is required because `pnpm db:generate` uses `prisma generate --sql`
+    # (TypedSQL). --sql introspects `src/infrastructure/prisma/sql/*.sql` against
+    # a live DB to type the `@prisma/client/sql` exports which are imported by
+    # src (e.g. refreshMaterializedViewCurrentPoints). Without DB, generate fails
+    # and typecheck breaks at import resolution.
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: civicship
+          POSTGRES_PASSWORD: civicship
+          POSTGRES_DB: civicship_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://civicship:civicship@localhost:5432/civicship_ci
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+          disable-sudo: true
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies (lockfile integrity check)
+        run: pnpm install --frozen-lockfile
+
+      - name: Audit (non-blocking)
+        run: pnpm audit --audit-level=high
+        continue-on-error: true
+
+      - name: Apply Prisma migrations to CI database
+        # TypedSQL (`--sql`) は DB 接続を必要とするため、db:generate の前に
+        # migration を当ててスキーマを用意する。view / materialized view も
+        # migration.sql 経由でのみ作成される。
+        run: pnpm db:deploy
+
+      - name: Generate Prisma client (with TypedSQL)
+        run: pnpm db:generate
+
+      - name: Generate GraphQL types
+        run: pnpm gql:generate
+
+      # Detect uncommitted regenerations of tracked generated files.
+      # Note: this workflow's name ("CI") will be referenced by downstream
+      # deploy workflows via `workflow_run` triggers in PR-β (not yet
+      # implemented). Renaming after PR-β lands will require updating those.
+      - name: Check generated files are up to date
+        run: |
+          git diff --exit-code \
+            src/types/graphql.ts \
+            docs/schema.graphql \
+            src/infrastructure/prisma/schema.prisma
+
+      - name: Build (typecheck + emit)
+        run: pnpm build
+
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      # test ディレクトリ単位で job 並列化。jest の `--shard` (hash 分散) ではなく
+      # `--testPathPattern` で category split することで、job 名が
+      # unit / integration / e2e / auth という意味的ラベルになり、失敗した
+      # カテゴリが一目で分かる。各 job は独立 Postgres service を持ち、job 内は
+      # --runInBand で直列 (DB race 安全)、job 間は並列で高速化する。
+      matrix:
+        include:
+          - name: unit
+            path: src/__tests__/unit
+          - name: integration
+            path: src/__tests__/integration
+          - name: e2e
+            path: src/__tests__/e2e
+          - name: auth
+            path: src/__tests__/auth
 
     services:
       postgres:
@@ -44,6 +167,13 @@ jobs:
       FIREBASE_PROJECT_ID: test-project-id
       FIREBASE_CLIENT_EMAIL: test@test-project.iam.gserviceaccount.com
       FIREBASE_TOKEN_API_KEY: dummy-for-testing
+      # PointVerifyClient (src/infrastructure/libs/point-verify/client.ts)
+      # は constructor で IDENTUS_API_URL が未設定 / example URL の場合に throw
+      # する。DI resolve 時に auth test が graphql schema 全体を
+      # container.resolve(...) で構築するため、env が無いと全 auth test が fail
+      # する。CI では "example URL でない任意の URL" であれば pass する。
+      IDENTUS_API_URL: http://ci-dummy.invalid
+      IDENTUS_API_KEY: dummy-for-testing
 
     steps:
       - name: Harden runner
@@ -51,22 +181,9 @@ jobs:
         with:
           egress-policy: audit
           disable-sudo: true
-          # TODO (Phase 2): move to block mode and populate allowed-endpoints
-          # based on audit baseline observed in StepSecurity dashboard.
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Lint GitHub Actions workflows (actionlint 1.7.7)
-        run: |
-          docker run --rm \
-            -v "${{ github.workspace }}:/repo:ro" \
-            --workdir /repo \
-            rhysd/actionlint@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9 \
-            -color
-        # Image: rhysd/actionlint:1.7.7 (Docker Hub, multi-arch index digest)
-        # shellcheck / pyflakes are bundled in the image.
-        # Digest pin: manual update until PR-β.1e adds `docker` ecosystem to dependabot.yml.
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
@@ -79,24 +196,6 @@ jobs:
 
       - name: Install dependencies (lockfile integrity check)
         run: pnpm install --frozen-lockfile
-
-      - name: Audit (non-blocking)
-        run: pnpm audit --audit-level=high
-        continue-on-error: true
-
-      # TODO (PR-ε): Re-enable after ESLint lint-debt cleanup.
-      # Disabled in PR-α because the ajv override fix (commit d9dab51) unblocked
-      # `pnpm lint`, which then revealed 763 pre-existing errors:
-      # - 575 in generated files (src/types/graphql.ts, factories/__generated__/)
-      #   — root cause: flat config (ESLint 9) ignores .eslintignore; eslint.config.mjs
-      #     needs an `ignores` array.
-      # - 188 in source/test code — real debt requiring rule review.
-      # Additionally, the `pnpm lint` npm script uses `eslint --fix && prettier --write`,
-      # which silently auto-corrects. PR-ε should introduce a `lint:check` variant
-      # (`eslint src/` + `prettier --check src/`) for CI to actually fail on violations.
-      # See docs/dependabot-playbook.md Case 5 and Section 10.
-      # - name: Lint
-      #   run: pnpm lint
 
       - name: Apply Prisma migrations to CI database
         # `prisma db push` は schema.prisma のモデルのみ反映し、migration.sql を
@@ -111,17 +210,6 @@ jobs:
 
       - name: Generate GraphQL types
         run: pnpm gql:generate
-
-      # Detect uncommitted regenerations of tracked generated files.
-      # Note: this workflow's name ("CI") will be referenced by downstream
-      # deploy workflows via `workflow_run` triggers in PR-β (not yet
-      # implemented). Renaming after PR-β lands will require updating those.
-      - name: Check generated files are up to date
-        run: |
-          git diff --exit-code \
-            src/types/graphql.ts \
-            docs/schema.graphql \
-            src/infrastructure/prisma/schema.prisma
 
       - name: Generate test JWT RSA key
         # firebase-admin の内部 JWT 署名 (RS256) 用に、test 専用の使い捨て RSA 2048
@@ -139,13 +227,37 @@ jobs:
           } >> "$GITHUB_ENV"
           rm /tmp/test-firebase-key.pem
 
-      - name: Run tests (non-blocking until debt is resolved)
-        # blocking 化条件: 残 27 件の実 debt 解消 (別途ステップ 3 で対応) +
-        # 運用上 flaky でないことの確認。全条件を満たしたら `continue-on-error` を
-        # 削除し、branch protection の required status check に本 step を追加する
-        # 別 PR を出す。
-        run: pnpm test
-        continue-on-error: true
+      - name: Run tests (${{ matrix.name }})
+        # pnpm test (= jest --runInBand) に `--` 越しで `--testPathPattern=...`
+        # を渡すと、pnpm が `--` を保持したまま jest に forward し、jest 側では
+        # `--` 以降が全て positional 扱いとなるため `--testPathPattern=...`
+        # 文字列そのものが pattern として解釈され 0 match になる。
+        # jest の最初の positional 引数が testPathPattern として扱われる仕様を
+        # 利用し、path を positional で渡す。
+        run: pnpm test -- "${{ matrix.path }}"
 
-      - name: Build (typecheck + emit)
-        run: pnpm build
+  # Aggregator job: branch protection の required status check として
+  # `ci` を維持したまま、実体は lint / build / test の複合結果を集約する。
+  # 分割した各 job を required check として列挙すると、matrix の shard 数を
+  # 変えるたびに branch protection 設定を更新する必要が出るため、aggregator
+  # 1 個に集約することで将来の shard 数変更に branch protection 無変更で追従
+  # できる。
+  ci:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    needs: [lint, build, test]
+    if: always()
+    permissions:
+      contents: read
+    steps:
+      - name: Verify all required jobs passed
+        run: |
+          lint='${{ needs.lint.result }}'
+          build='${{ needs.build.result }}'
+          test='${{ needs.test.result }}'
+          echo "lint=$lint build=$build test=$test"
+          if [ "$lint" != "success" ] || [ "$build" != "success" ] || [ "$test" != "success" ]; then
+            echo "::error::One or more required jobs failed"
+            exit 1
+          fi
+          echo "All required jobs passed"

--- a/src/infrastructure/logging/index.ts
+++ b/src/infrastructure/logging/index.ts
@@ -8,7 +8,12 @@ import { traceContext } from "./formats/traceContext";
 // LOCAL_DEV is injected by `pnpm dev*` scripts so that running locally against
 // a remote env (`dev:https:dev` / `dev:https:prd`) still uses console logging
 // instead of shipping logs to Cloud Logging.
-const isLocal = process.env.ENV === "LOCAL" || process.env.LOCAL_DEV === "true";
+// NODE_ENV === "test" も含めることで、CI / jest 実行時に LoggingWinston が
+// import 時点で GCP Project 自動検出を試みて失敗する事象を防ぐ (credential 不在)。
+const isLocal =
+  process.env.ENV === "LOCAL" ||
+  process.env.LOCAL_DEV === "true" ||
+  process.env.NODE_ENV === "test";
 const isProduction = process.env.NODE_ENV === "production";
 
 const baseFormats: winston.Logform.Format[] = [


### PR DESCRIPTION
* ci: enable blocking test step (remove continue-on-error)

PR #872 で CI に test step を non-blocking で導入、PR #875 で debt 27 件完遂 (100% pass 達成)。本 commit で test step を blocking 化し、CI の品質ゲート 機能を回復する。

- `continue-on-error: true` 削除
- step name から "(non-blocking until debt is resolved)" 削除
- blocking 化の追跡コメント削除 (既に blocking になるため不要)

branch protection 側の JSON update は不要。`ci` check は既に required status check として設定済みのため、test 内の fail で `ci` check 全体が FAILURE になり、 merge blocker として機能する。

https://claude.ai/code/session_01QB2cg6MAj1Sad42ust6GA7

* ci: set ENV=LOCAL to bypass LoggingWinston GCP project detection

blocking 化 (PR #880 の commit 78da477) で CI 実行時に test 全体が unhandled error で落ちる problem が顕在化。原因は src/infrastructure/logging/index.ts の logger 初期化で ENV=LOCAL / LOCAL_DEV=true でない場合に
@google-cloud/logging-winston の LoggingWinston transport が instantiate され、GCP credential / project 不在の CI で Project Id 検出に失敗していた (PR #872 の continue-on-error: true で隠蔽されていた実 debt)。

CI env block に ENV=LOCAL を追加して Console transport に切り替え、 既存コードの意図 (local / CI は Console、dev/prd は LoggingWinston) に 沿った fix とする。ローカルは .env.test.local の ENV=LOCAL で同値。

https://claude.ai/code/session_01QB2cg6MAj1Sad42ust6GA7

* fix(logging): treat NODE_ENV=test as local (revert CI ENV=LOCAL hack)

直前 commit (605a5a1) で CI env に ENV=LOCAL を追加したのは workaround。 根本原因は src/infrastructure/logging/index.ts の isLocal 条件が "LOCAL" / LOCAL_DEV のみで NODE_ENV=test を考慮していなかったため、 test 実行時 (jest が NODE_ENV=test を自動設定) に LoggingWinston が module import 時点で GCP Project 自動検出を試みて fail していた。

修正:
- logging/index.ts: isLocal 条件に `process.env.NODE_ENV === "test"` を追加。 これにより CI / jest では常に Console transport を選択。
- ci.yml: ENV=LOCAL を revert (CI 環境が "LOCAL" を自称する歪みを解消)。

local も jest が NODE_ENV=test を set するので挙動等価。既存の dev/prd で logging が変わることはない (ENV / NODE_ENV が異なるため)。

https://claude.ai/code/session_01QB2cg6MAj1Sad42ust6GA7

* ci: split into lint/build/test(4 shards)/ci(aggregator) for parallel speedup

CI の wall-clock を短縮するため、単一 job を 4 つに分割。test step は jest --shard=M/4 で 4 並列。branch protection は `ci` aggregator job が required status check として機能し、既存設定を無変更で維持。

構成:
- lint: actionlint のみ (~30秒、DB 不要)
- build: install + pnpm audit + prisma/gql generate + generated files 差分 check + typecheck + build (~2-3分、DB 不要)
- test: matrix [1,2,3,4] で 4 並列、各 shard 独立 Postgres service、 `pnpm test -- --shard=M/4` で jest 標準 shard 分散、各 shard 内は --runInBand 維持 (race 安全)
- ci: aggregator、needs: [lint, build, test]、全 result が success か検証

効果見込み: 現状 ~8 分直列 → ~2-3 分並列 (test shard が critical path、 build/lint は並列で隠蔽)。

branch protection 無変更: required_status_checks.contexts = ["ci", ...] は `ci` aggregator job を指すため、shard 数を変更しても影響なし。

https://claude.ai/code/session_01QB2cg6MAj1Sad42ust6GA7

* fix(ci): add Postgres service to build job for TypedSQL generation

直前 commit (9ea2552) の build job 分離で Postgres service を外したが、 `pnpm db:generate` は `prisma generate --sql` (TypedSQL) で src/infrastructure/prisma/sql/*.sql を DB に対して introspect し、 @prisma/client/sql の型を生成する。これを src (transaction, report domain の repository 等) が import しているため、DB 無しでは generate が失敗し typecheck が import 解決で落ちる。

build job にも test job と同等の Postgres service + db:deploy を追加。 test job との分離自体は維持 (test 並列化の恩恵は変わらず)、build は追加
~30-60s 程度の DB 起動 + migration コストを許容。

https://claude.ai/code/session_01QB2cg6MAj1Sad42ust6GA7

* ci(test): split test matrix by directory category (unit/integration/e2e/auth)

test matrix を jest --shard (hash 分散、数字のみ) からディレクトリ単位 --testPathPattern に変更。job 名が `test (unit)` `test (integration)` `test (e2e)` `test (auth)` となり、失敗したカテゴリが一目で分かる。

各 job は独立 Postgres service を持ち、job 内は --runInBand で直列 (DB race 安全)、job 間は並列実行で高速化する。

分布 (test files):
- unit: 37
- integration: 30
- e2e: 2
- auth: 2

critical path は unit or integration のいずれか。将来、偏りが問題に なれば、大きい dir を更に細分化する余地あり (別 PR)。

https://claude.ai/code/session_01QB2cg6MAj1Sad42ust6GA7

* fix(ci): pass test path as positional arg to jest (drop --testPathPattern flag)

直前 commit (cc4ff98) の `pnpm test -- --testPathPattern=x` は、pnpm が `--` を保持したまま jest script へ forward するため、jest 側では `--` 以降が positional 扱いになり `--testPathPattern=src/__tests__/unit` 文字列自体が test path pattern として解釈され 0 match で fail していた:

  > jest --runInBand -- --testPathPattern=src/__tests__/unit
  No tests found, exiting with code 1
  Pattern: --testPathPattern=src/__tests__/unit - 0 matches

jest の最初の positional 引数が testPathPattern として扱われる仕様を利用し、 path を positional で渡す:

  pnpm test -- "src/__tests__/unit"
  # → jest --runInBand -- src/__tests__/unit
  # → testPathPattern = "src/__tests__/unit" (正しく match)

https://claude.ai/code/session_01QB2cg6MAj1Sad42ust6GA7

* fix(ci): inject dummy IDENTUS env vars for test job DI resolution

auth test (src/__tests__/auth/*.test.ts) は test server 生成時に src/presentation/graphql/resolver.ts の container.resolve(...) で schema 全体を構築する。その DI chain で
TransactionVerificationResolver → TransactionVerificationUseCase → TransactionVerificationService → PointVerifyClient と解決され、 PointVerifyClient の constructor は IDENTUS_API_URL が未設定 or example URL の場合 throw する仕様:

  // src/infrastructure/libs/point-verify/client.ts
  if (!this.baseUrl || this.baseUrl === "https://kyoso-identus-api.example.com") {
    throw new Error("[PointVerifyClient] IDENTUS_API_URL is not configured.");
  }

CI では env 未設定のため fallback (example URL) が使われ、35 test 全て DI resolution 失敗で fail していた。test env block に dummy URL を注入。

https://claude.ai/code/session_01QB2cg6MAj1Sad42ust6GA7

---------
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
