### PR TITLE
Force IPv4 for fetch requests to fix Cloud Run Jobs egress (#905)

### DIFF
--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,4 +1,6 @@
 import fetch, { RequestInit, ResponseInit } from "node-fetch";
+import http from "http";
+import https from "https";
 
 export interface FetchOptions extends RequestInit {
   timeout?: number;
@@ -7,6 +9,22 @@ export interface FetchOptions extends RequestInit {
 const DEFAULT_HEADERS = {
   'User-Agent': 'civicship-api/1.0',
   'Accept': 'application/json',
+};
+
+// Cloud Run Jobs egress cannot reliably reach IPv6 endpoints; AAAA records
+// returned by DNS cause TCP SYN to time out (~5–6s ETIMEDOUT). Force IPv4.
+const ipv4HttpAgent = new http.Agent({ family: 4, keepAlive: true });
+const ipv4HttpsAgent = new https.Agent({ family: 4, keepAlive: true });
+
+const selectAgent = (url: string) => {
+  try {
+    const { protocol } = new URL(url);
+    if (protocol === "https:") return ipv4HttpsAgent;
+    if (protocol === "http:") return ipv4HttpAgent;
+  } catch {
+    // Malformed URL — let node-fetch surface its own error
+  }
+  return undefined;
 };
 
 function isAbortError(error: unknown): boolean {
@@ -36,6 +54,7 @@ export const fetchData = async <T = unknown>(
         ...init?.headers,
       },
       signal: controller.signal,
+      agent: init?.agent ?? selectAgent(url),
     });
 
     clearTimeout(timeoutId);


### PR DESCRIPTION
* fix(nft-wallet): force IPv4 for Blockscout fetch to avoid ETIMEDOUT

NFT metadata sync for specific wallets consistently times out with ETIMEDOUT at ~5-6s (below the 60s AbortController timeout). The error originates at the TLSSocket layer, indicating TCP SYN timeout — most likely because Cloud Run Jobs egress cannot reliably reach the IPv6 (AAAA) address returned by Blockscout's DNS.

Force IPv4 resolution by passing an http/https Agent with family: 4 to node-fetch. fetchData is only used for Blockscout API calls (verified via grep), so blast radius is limited to NFT sync.

https://claude.ai/code/session_01BwdgQRN8p7WdcAEjzrYDaa

* refactor(utils/fetch): enable keep-alive and use URL parsing for agent select

Address review feedback:
- Enable keepAlive on IPv4 agents to reuse connections within a batch run, reducing socket churn during sequential Blockscout calls.
- Replace url.startsWith with new URL() to correctly handle any case of protocol (per WHATWG URL normalization) and gracefully fall back on malformed URLs.

https://claude.ai/code/session_01BwdgQRN8p7WdcAEjzrYDaa

---------
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/906" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
