### PR TITLE
Add communityId support to NFT instances and tokens

### DIFF
--- a/src/application/domain/account/nft-instance/data/interface.ts
+++ b/src/application/domain/account/nft-instance/data/interface.ts
@@ -45,6 +45,7 @@ export default interface INftInstanceRepository {
       json: Record<string, unknown>;
       nftWalletId: string;
       nftTokenId: string;
+      communityId?: string | null;
     },
     nftTokenId: string,
     tx: Prisma.TransactionClient,

--- a/src/application/domain/account/nft-instance/data/repository.ts
+++ b/src/application/domain/account/nft-instance/data/repository.ts
@@ -112,6 +112,7 @@ export default class NftInstanceRepository implements INftInstanceRepository {
       json: unknown;
       nftWalletId: string;
       nftTokenId: string;
+      communityId?: string | null;
     },
     nftTokenId: string,
     tx: Prisma.TransactionClient,
@@ -128,6 +129,7 @@ export default class NftInstanceRepository implements INftInstanceRepository {
         description: data.description,
         imageUrl: data.imageUrl,
         json: data.json,
+        communityId: data.communityId ?? null,
       },
       create: {
         instanceId: data.instanceId,
@@ -137,6 +139,7 @@ export default class NftInstanceRepository implements INftInstanceRepository {
         json: data.json,
         nftWalletId: data.nftWalletId,
         nftTokenId: data.nftTokenId,
+        communityId: data.communityId ?? null,
       },
       select: {
         id: true,

--- a/src/application/domain/account/nft-instance/data/repository.ts
+++ b/src/application/domain/account/nft-instance/data/repository.ts
@@ -129,7 +129,7 @@ export default class NftInstanceRepository implements INftInstanceRepository {
         description: data.description,
         imageUrl: data.imageUrl,
         json: data.json,
-        communityId: data.communityId ?? null,
+        communityId: data.communityId,
       },
       create: {
         instanceId: data.instanceId,
@@ -139,7 +139,7 @@ export default class NftInstanceRepository implements INftInstanceRepository {
         json: data.json,
         nftWalletId: data.nftWalletId,
         nftTokenId: data.nftTokenId,
-        communityId: data.communityId ?? null,
+        communityId: data.communityId,
       },
       select: {
         id: true,

--- a/src/application/domain/account/nft-token/data/interface.ts
+++ b/src/application/domain/account/nft-token/data/interface.ts
@@ -13,7 +13,7 @@ export interface INftTokenRepository {
       json?: Record<string, unknown>;
     },
     tx: Prisma.TransactionClient,
-  ): Promise<{ id: string; address: string }>;
+  ): Promise<{ id: string; address: string; communityId: string | null }>;
 
   findByAddress(
     ctx: IContext,

--- a/src/application/domain/account/nft-token/data/repository.ts
+++ b/src/application/domain/account/nft-token/data/repository.ts
@@ -66,6 +66,7 @@ export default class NftTokenRepository implements INftTokenRepository {
       select: {
         id: true,
         address: true,
+        communityId: true,
       },
     });
   }

--- a/src/application/domain/account/nft-wallet/service.ts
+++ b/src/application/domain/account/nft-wallet/service.ts
@@ -312,6 +312,7 @@ export default class NFTWalletService {
           json: item,
           nftWalletId: wallet.id,
           nftTokenId: nftToken.id,
+          communityId: nftToken.communityId ?? null,
         },
         nftToken.id,
         tx,


### PR DESCRIPTION
## Summary
This PR adds support for tracking `communityId` associations with NFT instances and tokens throughout the domain layer. The changes enable NFT instances to be linked to specific communities while maintaining backward compatibility with nullable values.

## Key Changes
- **NFT Instance Repository**: Added `communityId` field to the `upsertInstance` method's data parameter and update/create operations
- **NFT Token Repository**: Extended the return type of `upsertToken` to include `communityId` and added it to the select clause
- **NFT Token Interface**: Updated `upsertToken` return type to include `communityId: string | null`
- **NFT Instance Interface**: Added optional `communityId?: string | null` parameter to the `upsertInstance` data object
- **NFT Wallet Service**: Propagated `communityId` from the NFT token to the instance during the upsert operation

## Implementation Details
- The `communityId` field is optional in the input data and defaults to `null` using the nullish coalescing operator (`??`)
- The field is properly threaded through the upsert operations, allowing both updates and creates to handle community associations
- Changes maintain backward compatibility by making the field optional and nullable

https://claude.ai/code/session_01FFFj8Gc15QbnWzKDg4NZ8K
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
