### PR TITLE
feat(sysadmin): プラットフォーム運営者向けダッシュボード + コミュニティ詳細 (#911)

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -1649,6 +1649,23 @@ type Query {
   reservations(cursor: String, filter: ReservationFilterInput, first: Int, sort: ReservationSortInput): ReservationsConnection!
   signupBonusConfig(communityId: ID!): CommunitySignupBonusConfig
   states(cursor: String, filter: StatesInput, first: Int): StatesConnection!
+
+  """
+  L2 detail for a single community: summary card, stage distribution,
+  trailing-window trends, cohort retention, and a paginated member list.
+  Intended for answering "what are kibotcha's numbers?" in an external
+  report conversation.
+  """
+  sysAdminCommunityDetail(input: SysAdminCommunityDetailInput!): SysAdminCommunityDetailPayload!
+
+  """
+  L1 overview: platform totals plus one row per community. Intended for
+  the "is any community stalling?" scan. Community fan-out is served
+  with N in-process calls (acceptable at today's community count —
+  switch to a GROUP BY implementation once the platform exceeds ~20
+  communities).
+  """
+  sysAdminDashboard(input: SysAdminDashboardInput): SysAdminDashboardPayload!
   ticket(id: ID!): Ticket
   ticketClaimLink(id: ID!): TicketClaimLink
   ticketClaimLinks(cursor: String, filter: TicketClaimLinkFilterInput, first: Int, sort: TicketClaimLinkSortInput): TicketClaimLinksConnection!
@@ -1993,6 +2010,551 @@ union SubmitReportFeedbackPayload = SubmitReportFeedbackSuccess
 
 type SubmitReportFeedbackSuccess {
   feedback: ReportFeedback!
+}
+
+"""One entry-month cohort's retention curve."""
+type SysAdminCohortRetentionPoint {
+  """Entry month, first day JST (e.g. 2025-10-01T00:00+09:00)."""
+  cohortMonth: Datetime!
+
+  """Cohort size at entry (status='JOINED' joiners in the month)."""
+  cohortSize: Int!
+
+  """
+  Fraction of the cohort with a DONATION out in the SECOND month after
+  entry (m+1). null for an empty cohort or a cohort too recent to have
+  a completed m+1 window.
+  """
+  retentionM1: Float
+
+  """Fraction active in m+3."""
+  retentionM3: Float
+
+  """Fraction active in m+6."""
+  retentionM6: Float
+}
+
+"""
+API-side alert flags. Boolean only: the server owns the cross-field
+judgement, the client just renders the badge.
+"""
+type SysAdminCommunityAlerts {
+  """Month-over-month communityActivityRate change <= -20%."""
+  activeDrop: Boolean!
+
+  """Latest-week churned_senders > retained_senders."""
+  churnSpike: Boolean!
+
+  """
+  No t_memberships.created_at rows (status='JOINED') in the last 14 days.
+  """
+  noNewMembers: Boolean!
+}
+
+input SysAdminCommunityDetailInput {
+  """As-of timestamp (see SysAdminDashboardInput.asOf)."""
+  asOf: Datetime
+
+  """Target community id."""
+  communityId: ID!
+
+  """
+  Opaque cursor for pagination. Internally a base64-encoded offset of
+  the prior page's position. Treat as opaque — pass back the cursor
+  returned by the previous response unchanged.
+  """
+  cursor: String
+
+  """Member list page size (default 50, max 200)."""
+  limit: Int = 50
+
+  """Stage-count thresholds for the stage distribution and tier counts."""
+  segmentThresholds: SysAdminSegmentThresholdsInput
+
+  """Member list filter. Defaults to `minSendRate = 0.7` (habitual only)."""
+  userFilter: SysAdminUserListFilter
+
+  """Member list sort. Defaults to SEND_RATE DESC."""
+  userSort: SysAdminUserListSort
+
+  """
+  How many trailing JST months to include in the trend / cohort arrays.
+  Default 10.
+  """
+  windowMonths: Int = 10
+}
+
+"""Root payload for sysAdminCommunityDetail (L2)."""
+type SysAdminCommunityDetailPayload {
+  """Alert flags (same structure as L1, evaluated for this community)."""
+  alerts: SysAdminCommunityAlerts!
+
+  """As-of timestamp echoed back."""
+  asOf: Datetime!
+
+  """
+  One entry per entry month (length <= windowMonths), newest last.
+  `retentionM*` fields are null when the cohort is empty or too recent.
+  """
+  cohortRetention: [SysAdminCohortRetentionPoint!]!
+
+  """Community id."""
+  communityId: ID!
+
+  """Community display name."""
+  communityName: String!
+
+  """Paginated member list — see type doc."""
+  memberList: SysAdminMemberList!
+
+  """
+  One entry per month (length <= windowMonths), newest last. Older
+  months with no MV data are omitted rather than zero-padded.
+  """
+  monthlyActivityTrend: [SysAdminMonthlyActivityPoint!]!
+
+  """
+  One entry per ISO week, newest last. Length approximates
+  `windowMonths * ~4.3` weeks; sparse weeks with no activity still emit
+  a row with zero counters.
+  """
+  retentionTrend: [SysAdminRetentionTrendPoint!]!
+
+  """
+  Stage distribution, classified server-side with the request's
+  thresholds. Computed over ALL members (independent of member-list
+  filter).
+  """
+  stages: SysAdminStageDistribution!
+
+  """Summary card — see type doc."""
+  summary: SysAdminCommunitySummaryCard!
+
+  """Trailing window length in JST months (echoed back)."""
+  windowMonths: Int!
+}
+
+"""
+One row of the L1 all-community table. See the module docstring for the
+distinction between `communityActivityRate` (this type) and
+`userSendRate` (SysAdminMemberRow).
+"""
+type SysAdminCommunityOverview {
+  """Alert flags (see SysAdminCommunityAlerts)."""
+  alerts: SysAdminCommunityAlerts!
+
+  """
+  Community activity rate for the JST calendar month containing asOf:
+  unique DONATION senders in that month / month-end total_members.
+  0.0–1.0. NOT the individual-level userSendRate.
+  """
+  communityActivityRate: Float!
+
+  """Community id."""
+  communityId: ID!
+
+  """Community display name (t_communities.name)."""
+  communityName: String!
+
+  """
+  Month-over-month % change in communityActivityRate.
+  Returned as a fraction (e.g. -0.2 == -20%). null when the prior month
+  has no data to compare against.
+  """
+  growthRateActivity: Float
+
+  """
+  Retention rate of the most recent completed cohort (members who joined
+  in asOf's previous JST month) measured in the month after joining.
+  null when that cohort is empty.
+  """
+  latestCohortRetentionM1: Float
+
+  """
+  Direct member count for the "latent" stage (never donated).
+  Convenience field (== segmentCounts.passiveCount).
+  """
+  passiveCount: Int!
+
+  """Stage counts under the supplied thresholds (cumulative, see type doc)."""
+  segmentCounts: SysAdminSegmentCounts!
+
+  """
+  Direct member count for the "habitual" stage (userSendRate >= tier1).
+  Convenience field (== segmentCounts.tier1Count).
+  """
+  tier1Count: Int!
+
+  """
+  Direct member count for the "regular+habitual" stage
+  (userSendRate >= tier2). Convenience field (== segmentCounts.tier2Count).
+  """
+  tier2Count: Int!
+
+  """Total status='JOINED' members at asOf."""
+  totalMembers: Int!
+}
+
+"""
+Summary card for a single community. Fronts the L2 detail screen and
+answers "is this community improving?" in one row of numbers.
+"""
+type SysAdminCommunitySummaryCard {
+  """
+  Latest-month communityActivityRate (PRIMARY indicator — see module
+  docstring for the distinction vs userSendRate).
+  """
+  communityActivityRate: Float!
+
+  """
+  3-month trailing average of communityActivityRate, ending at the JST
+  calendar month containing asOf (inclusive). null when fewer than 3
+  months of data exist.
+  """
+  communityActivityRate3mAvg: Float
+
+  """Community id."""
+  communityId: ID!
+
+  """Community display name."""
+  communityName: String!
+
+  """Oldest date with MV data for this community (JST calendar)."""
+  dataFrom: Datetime
+
+  """Newest date with MV data for this community (JST calendar)."""
+  dataTo: Datetime
+
+  """
+  Month-over-month % change in communityActivityRate (fraction, e.g.
+  -0.2 == -20%). null when the prior month has no data.
+  """
+  growthRateActivity: Float
+
+  """
+  Maximum chain depth observed in any DONATION, all-time. null when
+  no chained transactions exist.
+  """
+  maxChainDepthAllTime: Int
+
+  """Cumulative members in tier2 or above under the supplied thresholds."""
+  tier2Count: Int!
+
+  """tier2Count / totalMembers (0.0–1.0)."""
+  tier2Pct: Float!
+
+  """
+  Total DONATION points transferred, all-time (no window). Uses
+  t_transactions directly so the value is independent of MV retention.
+  """
+  totalDonationPointsAllTime: Float!
+
+  """Total status='JOINED' members at asOf."""
+  totalMembers: Int!
+}
+
+"""Input for the L1 all-community overview (`sysAdminDashboard`)."""
+input SysAdminDashboardInput {
+  """
+  The "as of" timestamp. All trailing-window calculations are anchored
+  here: the "latest month" is the JST calendar month containing asOf,
+  and "latest week" is the ISO-week containing asOf. Defaults to now
+  when omitted.
+  """
+  asOf: Datetime
+
+  """Stage-count thresholds (see SysAdminSegmentThresholdsInput)."""
+  segmentThresholds: SysAdminSegmentThresholdsInput
+}
+
+"""Root payload for sysAdminDashboard (L1)."""
+type SysAdminDashboardPayload {
+  """As-of timestamp echoed back (UTC instant)."""
+  asOf: Datetime!
+
+  """One row per community, in dashboard sort order."""
+  communities: [SysAdminCommunityOverview!]!
+
+  """Platform-wide aggregate row."""
+  platform: SysAdminPlatformSummary!
+}
+
+"""Paginated member list for the L2 detail."""
+type SysAdminMemberList {
+  """Whether more pages exist after this one."""
+  hasNextPage: Boolean!
+
+  """
+  Opaque cursor to pass back in `SysAdminCommunityDetailInput.cursor` to
+  fetch the next page. null when no further pages exist.
+  """
+  nextCursor: String
+
+  """
+  Member rows for the current page, matching filter & sort applied
+  server-side.
+  """
+  users: [SysAdminMemberRow!]!
+}
+
+"""
+One row of the L2 member list. Raw values only — stage classification
+(habitual / regular / occasional / latent) is the client's concern so
+server-side thresholds can be tuned without a schema change.
+"""
+type SysAdminMemberRow {
+  """Distinct months with at least one DONATION out."""
+  donationOutMonths: Int!
+
+  """Tenure in JST calendar months (floor, minimum 1)."""
+  monthsIn: Int!
+
+  """User display name (users.name). null when the user has no name set."""
+  name: String
+
+  """All-time DONATION points sent by this user in this community."""
+  totalPointsOut: Float!
+
+  """User id."""
+  userId: ID!
+
+  """
+  Individual monthly-send rate: `donationOutMonths / monthsIn`, 0.0–1.0,
+  rounded to 3 decimals. INDIVIDUAL LTV variable (not the same as
+  communityActivityRate elsewhere in this schema).
+  """
+  userSendRate: Float!
+}
+
+"""One month of community activity trend."""
+type SysAdminMonthlyActivityPoint {
+  """
+  Share of DONATION transactions that were part of a chain (chain_depth
+  > 0) in the month. 0.0–1.0.
+  """
+  chainPct: Float
+
+  """
+  senderCount / month-end totalMembers. Read alongside newMembers: a
+  month with many new joiners can dip the rate even if absolute activity
+  grew.
+  """
+  communityActivityRate: Float!
+
+  """Sum of DONATION points transferred in the month."""
+  donationPointsSum: Float!
+
+  """First day (JST) of the calendar month, e.g. 2025-10-01T00:00+09:00."""
+  month: Datetime!
+
+  """t_memberships.created_at (status='JOINED') rows falling in the month."""
+  newMembers: Int!
+
+  """Distinct DONATION senders in the month."""
+  senderCount: Int!
+}
+
+"""
+Platform-wide headline, computed by summing across every community in
+scope for the caller (which is every community since this query is
+SYS_ADMIN-gated).
+"""
+type SysAdminPlatformSummary {
+  """Number of communities included in the response."""
+  communitiesCount: Int!
+
+  """
+  Sum of DONATION points transferred during the JST calendar month
+  containing `asOf`, across every community.
+  """
+  latestMonthDonationPoints: Float!
+
+  """Sum of status='JOINED' members across every community."""
+  totalMembers: Int!
+}
+
+"""One ISO week of retention signals."""
+type SysAdminRetentionTrendPoint {
+  """Senders in the prior week who did NOT send this week."""
+  churnedSenders: Int!
+
+  """
+  Community activity rate for the week: distinct senders / totalMembers
+  as of week end. null when the community had zero members during the
+  week.
+  """
+  communityActivityRate: Float
+
+  """New t_memberships.created_at rows (status='JOINED') this week."""
+  newMembers: Int!
+
+  """
+  Senders in both the prior week and this week (same-user on
+  donation_out_count > 0).
+  """
+  retainedSenders: Int!
+
+  """
+  Senders this week who did NOT send last week but DID send some week
+  in the prior 12-week window.
+  """
+  returnedSenders: Int!
+
+  """Monday 00:00 JST of the ISO week."""
+  week: Datetime!
+}
+
+"""
+Stage-count snapshot for one community, computed by the server using the
+client-supplied `SysAdminSegmentThresholdsInput`. Cumulative semantics:
+`tier2Count` INCLUDES members counted in `tier1Count`.
+"""
+type SysAdminSegmentCounts {
+  """Members with userSendRate > 0 (excludes latent)."""
+  activeCount: Int!
+
+  """Members with donationOutMonths == 0 (latent / not-yet-participated)."""
+  passiveCount: Int!
+
+  """Members with userSendRate >= tier1."""
+  tier1Count: Int!
+
+  """Members with userSendRate >= tier2 (includes tier1)."""
+  tier2Count: Int!
+
+  """Total status='JOINED' members at asOf."""
+  total: Int!
+}
+
+"""
+Stage classification thresholds, supplied by the client.
+Thresholds define WHERE the boundary between stages sits, but naming
+(habitual / regular / occasional / latent) remains fixed on the server.
+"""
+input SysAdminSegmentThresholdsInput {
+  """
+  Habitual stage threshold. A user with `userSendRate >= tier1` is
+  counted as "habitual" (i.e. sends donations in at least tier1 share
+  of their tenure). Default 0.7.
+  """
+  tier1: Float = 0.7
+
+  """
+  Regular stage threshold. `userSendRate >= tier2` AND `< tier1`
+  classifies as "regular". Default 0.4.
+  """
+  tier2: Float = 0.4
+}
+
+"""Sort direction for the member list."""
+enum SysAdminSortOrder {
+  """
+  Ascending — smallest value first (e.g. SEND_RATE ASC puts latent
+  and occasional members before habitual).
+  """
+  ASC
+
+  """
+  Descending — largest value first (e.g. SEND_RATE DESC puts habitual
+  members at the top). This is the default.
+  """
+  DESC
+}
+
+"""
+Summary for one stage (habitual / regular / occasional / latent).
+Stage membership is classified server-side using the thresholds supplied
+in the request. `pointsContributionPct` is the share of total DONATION
+points-out attributed to members in this stage, in the asOf month.
+"""
+type SysAdminStageBucket {
+  """Average monthsIn across members in this stage."""
+  avgMonthsIn: Float!
+
+  """Average userSendRate across members in this stage (0.0–1.0)."""
+  avgSendRate: Float!
+
+  """Number of members in this stage."""
+  count: Int!
+
+  """count / totalMembers (0.0–1.0)."""
+  pct: Float!
+
+  """
+  Stage's share of this community's all-time DONATION points-out
+  (0.0–1.0). Numerator is the sum of `totalPointsOut` across the
+  stage's members; denominator is the same sum across all members.
+  0 for the latent stage by definition.
+  """
+  pointsContributionPct: Float!
+}
+
+"""
+Four-stage distribution of the community's membership.
+`pointsContributionPct` on `latent` is always 0 since latent members
+haven't donated by definition.
+"""
+type SysAdminStageDistribution {
+  """userSendRate >= tier1."""
+  habitual: SysAdminStageBucket!
+
+  """donationOutMonths == 0."""
+  latent: SysAdminStageBucket!
+
+  """0 < userSendRate < tier2."""
+  occasional: SysAdminStageBucket!
+
+  """tier2 <= userSendRate < tier1."""
+  regular: SysAdminStageBucket!
+}
+
+"""
+Member-list filters for the L2 detail (`sysAdminCommunityDetail`).
+All conditions AND together. Unspecified fields do not filter.
+"""
+input SysAdminUserListFilter {
+  """Inclusive upper bound on userSendRate."""
+  maxSendRate: Float
+
+  """Inclusive lower bound on donationOutMonths."""
+  minDonationOutMonths: Int
+
+  """Inclusive lower bound on monthsIn (JST-calendar months)."""
+  minMonthsIn: Int
+
+  """Inclusive lower bound on userSendRate. Default 0.7 (habitual only)."""
+  minSendRate: Float = 0.7
+}
+
+"""
+Sort configuration for the L2 member list. Both fields are optional;
+omitting either falls back to the default (SEND_RATE DESC) so the
+"top habitual members first" view renders out of the box.
+"""
+input SysAdminUserListSort {
+  """
+  Column to sort on. See SysAdminUserSortField for what each value
+  addresses. Default: SEND_RATE.
+  """
+  field: SysAdminUserSortField = SEND_RATE
+
+  """Sort direction. Default: DESC."""
+  order: SysAdminSortOrder = DESC
+}
+
+"""Sortable columns on the member list."""
+enum SysAdminUserSortField {
+  """donationOutMonths (distinct months with a DONATION out)."""
+  DONATION_OUT_MONTHS
+
+  """monthsIn (tenure in JST calendar months)."""
+  MONTHS_IN
+
+  """userSendRate (individual monthly-send rate, 0.0–1.0)."""
+  SEND_RATE
+
+  """totalPointsOut (lifetime DONATION points sent)."""
+  TOTAL_POINTS_OUT
 }
 
 enum SysRole {

--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -2151,6 +2151,36 @@ type SysAdminCommunityOverview {
   communityName: String!
 
   """
+  Number of members classified as a "hub" within the parametric
+  window (`windowDays`):
+  
+    hubMemberCount = COUNT(member)
+      WHERE windowUniqueDonationRecipients >= input.hubBreadthThreshold
+  
+  `windowUniqueDonationRecipients` is the count of DISTINCT users
+  this member sent a DONATION to during
+  `[asOf - windowDays JST日, asOf + 1 JST日)` — distinct from the
+  L2 `SysAdminMemberRow.uniqueDonationRecipients` field which is
+  tenure-wide. The window-scoped variant is computed on demand in
+  this aggregate but not exposed per-member at L1 (members
+  themselves are an L2 concern).
+  
+  Hub classification deliberately uses BREADTH only — a member
+  who reached `hubBreadthThreshold` distinct recipients during
+  the window necessarily transacted at least that many times,
+  making an explicit frequency floor redundant. This keeps the
+  threshold knobs to one (`hubBreadthThreshold`).
+  
+  Invariants (the client may assert these):
+    hubMemberCount <= windowActivity.senderCount <= totalMembers
+  
+  The first holds because any hub member donated >= 3 times in
+  the window and is therefore a window sender; the second because
+  any window sender is a JOINED member at asOf.
+  """
+  hubMemberCount: Int!
+
+  """
   Latest completed monthly cohort and its M+1 activity. See
   SysAdminLatestCohort.
   """
@@ -2248,6 +2278,30 @@ input SysAdminDashboardInput {
   """
   asOf: Datetime
 
+  """
+  Minimum number of distinct DONATION recipients within the
+  parametric window (`windowDays`) for a member to be classified
+  as a hub. Used to populate `SysAdminCommunityOverview.hubMemberCount`.
+  
+  Defaults to 3, meaning "sent DONATION to at least 3 different
+  people during the window". The threshold is on **unique
+  counterparties** (set cardinality), not transaction count, so a
+  member who donated 100 times to the same recipient does not
+  qualify on this axis alone.
+  
+  Effective range 1..1000; values outside are silently clamped on
+  the server.
+  
+  This is intentionally an absolute threshold rather than a
+  community-relative percentile: a percentile-based hub would
+  always classify ~N% of members as hubs by definition, defeating
+  cross-community comparison ("which communities have the highest
+  hub ratio?"). Community size differences are absorbed
+  client-side by displaying `hubMemberCount / totalMembers` rather
+  than the raw count.
+  """
+  hubBreadthThreshold: Int = 3
+
   """Stage classification thresholds (see SysAdminSegmentThresholdsInput)."""
   segmentThresholds: SysAdminSegmentThresholdsInput
 
@@ -2334,6 +2388,23 @@ type SysAdminMemberRow {
 
   """All-time DONATION points sent by this user in this community."""
   totalPointsOut: Float!
+
+  """
+  All-time count of distinct OTHER users this member has sent at
+  least one DONATION to in this community. The "network breadth"
+  half of the donor profile (paired with frequency-based
+  `userSendRate` and volume-based `totalPointsOut`):
+  
+    breadth × frequency × volume → the client's per-member
+    classification space (e.g. true hub vs single-target loyal vs
+    rare-but-far-reaching).
+  
+  Counts unique counterparty user_id, not transaction count, so a
+  member who sent 100 donations to the same recipient still scores
+  1. Excludes burn / system targets (recipient wallets without a
+  user_id).
+  """
+  uniqueDonationRecipients: Int!
 
   """User id."""
   userId: ID!

--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -2616,6 +2616,17 @@ type SysAdminWindowActivity {
   newMemberCountPrev: Int!
 
   """
+  Users who sent at least one DONATION in BOTH the current window
+  AND the previous window (set intersection on user_id). Same
+  shape as SysAdminWeeklyRetention.retainedSenders but at
+  windowDays scale, enabling client-side leaky-bucket derivation:
+  
+    newlyActivatedSenders = senderCount     - retainedSenders
+    churnedSenders        = senderCountPrev - retainedSenders
+  """
+  retainedSenders: Int!
+
+  """
   Unique users with at least one outgoing DONATION transaction
   during the current window (donation_out_count > 0 in
   mv_user_transaction_daily).

--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -2135,21 +2135,15 @@ type SysAdminCommunityDetailPayload {
 }
 
 """
-One row of the L1 all-community table. See the module docstring for the
-distinction between `communityActivityRate` (this type) and
-`userSendRate` (SysAdminMemberRow).
+One row of the L1 all-community table. Designed for at-a-glance
+intervention judgment: each row carries the raw counts the client
+needs to derive rates, growth, alerts, sort keys, and filter
+predicates without a second round-trip.
+
+Calendar-month metrics live on the L2 detail card
+(SysAdminCommunitySummaryCard) — L1 is rolling-window only.
 """
 type SysAdminCommunityOverview {
-  """Alert flags (see SysAdminCommunityAlerts)."""
-  alerts: SysAdminCommunityAlerts!
-
-  """
-  Community activity rate for the JST calendar month containing asOf:
-  unique DONATION senders in that month / month-end total_members.
-  0.0–1.0. NOT the individual-level userSendRate.
-  """
-  communityActivityRate: Float!
-
   """Community id."""
   communityId: ID!
 
@@ -2157,42 +2151,31 @@ type SysAdminCommunityOverview {
   communityName: String!
 
   """
-  Month-over-month % change in communityActivityRate.
-  Returned as a fraction (e.g. -0.2 == -20%). null when the prior month
-  has no data to compare against.
+  Latest completed monthly cohort and its M+1 activity. See
+  SysAdminLatestCohort.
   """
-  growthRateActivity: Float
+  latestCohort: SysAdminLatestCohort!
 
   """
-  Retention rate of the most recent completed cohort (members who joined
-  in asOf's previous JST month) measured in the month after joining.
-  null when that cohort is empty.
+  Per-stage member counts (tier1 / tier2 / passive, cumulative
+  per the type doc) classified against input.segmentThresholds.
   """
-  latestCohortRetentionM1: Float
-
-  """
-  Direct member count for the "latent" stage (never donated).
-  Convenience field (== segmentCounts.passiveCount).
-  """
-  passiveCount: Int!
-
-  """Stage counts under the supplied thresholds (cumulative, see type doc)."""
   segmentCounts: SysAdminSegmentCounts!
 
   """
-  Direct member count for the "habitual" stage (userSendRate >= tier1).
-  Convenience field (== segmentCounts.tier1Count).
+  Total status='JOINED' members as of asOf. Members whose
+  created_at is after asOf are excluded from the count.
   """
-  tier1Count: Int!
-
-  """
-  Direct member count for the "regular+habitual" stage
-  (userSendRate >= tier2). Convenience field (== segmentCounts.tier2Count).
-  """
-  tier2Count: Int!
-
-  """Total status='JOINED' members at asOf."""
   totalMembers: Int!
+
+  """
+  Latest completed-week retention signals for client-side churn
+  detection. See SysAdminWeeklyRetention.
+  """
+  weeklyRetention: SysAdminWeeklyRetention!
+
+  """Rolling-window DONATION activity. See SysAdminWindowActivity."""
+  windowActivity: SysAdminWindowActivity!
 }
 
 """
@@ -2256,15 +2239,24 @@ type SysAdminCommunitySummaryCard {
 """Input for the L1 all-community overview (`sysAdminDashboard`)."""
 input SysAdminDashboardInput {
   """
-  The "as of" timestamp. All trailing-window calculations are anchored
-  here: the "latest month" is the JST calendar month containing asOf,
-  and "latest week" is the ISO-week containing asOf. Defaults to now
-  when omitted.
+  As-of timestamp anchor. All trailing-window calculations are
+  anchored here:
+    - parametric activity window: [asOf - windowDays, asOf + 1 JST日)
+    - weekly retention: latest completed ISO week before asOf
+    - latest cohort: (asOf JST月 - 2) so its M+1 window is fully past
+  Defaults to now when omitted.
   """
   asOf: Datetime
 
-  """Stage-count thresholds (see SysAdminSegmentThresholdsInput)."""
+  """Stage classification thresholds (see SysAdminSegmentThresholdsInput)."""
   segmentThresholds: SysAdminSegmentThresholdsInput
+
+  """
+  Length of the rolling activity window in JST days. Effective
+  range 7-90; values outside are silently clamped on the server.
+  Defaults to 28 (= 4 weeks, absorbs day-of-week variance).
+  """
+  windowDays: Int = 28
 }
 
 """Root payload for sysAdminDashboard (L1)."""
@@ -2277,6 +2269,34 @@ type SysAdminDashboardPayload {
 
   """Platform-wide aggregate row."""
   platform: SysAdminPlatformSummary!
+}
+
+"""
+Most recently completed monthly cohort plus its M+1 activity.
+"M+1" follows standard cohort-analysis convention: the calendar
+month immediately after the joining month.
+
+The cohort is selected as (asOf's JST month - 2 months) so its
+M+1 window — the JST month immediately preceding asOf's month —
+is fully past. This avoids reporting an artificially low retention
+during the in-progress month.
+
+Raw counts are returned; the client divides for the retention rate
+and decides how to handle small-N cohorts via `size`.
+"""
+type SysAdminLatestCohort {
+  """
+  Of those cohort members, how many sent at least one DONATION
+  during the M+1 month.
+  """
+  activeAtM1: Int!
+
+  """
+  Cohort size: status='JOINED' members whose created_at falls
+  within the cohort month. 0 when no one joined that month
+  (callers should treat M+1 retention as null in that case).
+  """
+  size: Int!
 }
 
 """Paginated member list for the L2 detail."""
@@ -2555,6 +2575,55 @@ enum SysAdminUserSortField {
 
   """totalPointsOut (lifetime DONATION points sent)."""
   TOTAL_POINTS_OUT
+}
+
+"""
+DONATION sender retention against the most recently completed
+ISO week (Monday 00:00 JST). Raw signals only; the client composes
+churn alerts (e.g. churnedSenders > retainedSenders).
+"""
+type SysAdminWeeklyRetention {
+  """
+  Users who sent DONATION in the week-before-latest but NOT in
+  the latest completed week. "Lost this week, was engaged last week."
+  """
+  churnedSenders: Int!
+
+  """
+  Users who sent DONATION in the latest completed week AND in
+  the week before it. "Engaged this week, was engaged last week."
+  """
+  retainedSenders: Int!
+}
+
+"""
+DONATION activity within the parametric window driven by
+`SysAdminDashboardInput.windowDays`. Both the current window and
+the immediately preceding window of equal length are returned so
+the client can derive growth rates without a second query.
+
+  current  = [asOf - windowDays JST日, asOf + 1 JST日)
+  previous = [asOf - 2 * windowDays, asOf - windowDays)
+"""
+type SysAdminWindowActivity {
+  """
+  New JOINED memberships (t_memberships.created_at within the
+  current window, status='JOINED').
+  """
+  newMemberCount: Int!
+
+  """Same metric for the previous window."""
+  newMemberCountPrev: Int!
+
+  """
+  Unique users with at least one outgoing DONATION transaction
+  during the current window (donation_out_count > 0 in
+  mv_user_transaction_daily).
+  """
+  senderCount: Int!
+
+  """Same metric for the previous window of equal length."""
+  senderCountPrev: Int!
 }
 
 enum SysRole {

--- a/scripts/sysadmin_bench.ts
+++ b/scripts/sysadmin_bench.ts
@@ -1,0 +1,391 @@
+/**
+ * Perf benchmark: weekly retention trend — bulk vs loop.
+ *
+ * Seeds N members, DONATION transactions across M weeks, then runs
+ *   A) the new bulk `findWeeklyRetentionSeries`
+ *   B) a hand-rolled loop mirroring the old per-week
+ *      `findRetentionAggregate` + `findMonthActivity` pattern
+ * ten times each and reports the median.
+ *
+ * Run with:
+ *   DATABASE_URL=postgresql://civicship:civicship@127.0.0.1:5432/civicship_dev \
+ *     pnpm tsx scripts/sysadmin_bench.ts
+ */
+import "reflect-metadata";
+import { PrismaClient } from "@prisma/client";
+import { isoWeekStartJst, addDays } from "@/application/domain/report/util";
+
+const prisma = new PrismaClient();
+
+const COMMUNITY_ID = "bench_c1";
+const MEMBER_COUNT = Number(process.env.MEMBERS ?? 100);
+const WINDOW_WEEKS = Number(process.env.WEEKS ?? 43); // ~windowMonths=10
+const ASOF = new Date("2026-04-21T00:00:00Z");
+
+/** Deterministic pseudo-random (mulberry32) so runs are reproducible. */
+function mulberry32(seed: number): () => number {
+  let a = seed;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+async function seed() {
+  console.log("Resetting bench fixtures...");
+  // Clear only what we re-create; leave other communities alone.
+  await prisma.$executeRawUnsafe(
+    `DELETE FROM "t_transactions" WHERE EXISTS (
+       SELECT 1 FROM "t_wallets" fw
+       WHERE fw."id" = "t_transactions"."from" AND fw."community_id" = $1
+     )`,
+    COMMUNITY_ID,
+  );
+  await prisma.$executeRawUnsafe(
+    `DELETE FROM "t_wallets" WHERE "community_id" = $1`,
+    COMMUNITY_ID,
+  );
+  await prisma.$executeRawUnsafe(
+    `DELETE FROM "t_memberships" WHERE "community_id" = $1`,
+    COMMUNITY_ID,
+  );
+  await prisma.$executeRawUnsafe(
+    `DELETE FROM "t_communities" WHERE "id" = $1`,
+    COMMUNITY_ID,
+  );
+  await prisma.$executeRawUnsafe(
+    `DELETE FROM "t_users" WHERE "id" LIKE 'bench_u%'`,
+  );
+
+  console.log("Creating community, users, memberships, wallets...");
+  await prisma.community.create({
+    data: {
+      id: COMMUNITY_ID,
+      name: "Bench Community",
+      pointName: "BenchPoint",
+    },
+  });
+
+  const rand = mulberry32(12345);
+  const userIds: string[] = [];
+  const walletIds: string[] = [];
+
+  for (let i = 0; i < MEMBER_COUNT; i++) {
+    const uid = `bench_u${i}`;
+    userIds.push(uid);
+    // Joined at a random point in the trailing 12 months so member
+    // count at week end varies per week.
+    const joinOffset = Math.floor(rand() * 365);
+    const createdAt = addDays(ASOF, -joinOffset);
+    await prisma.user.create({
+      data: {
+        id: uid,
+        name: `Bench ${i}`,
+        slug: `bench-${i}`,
+        currentPrefecture: "KAGAWA",
+      },
+    });
+    await prisma.membership.create({
+      data: {
+        userId: uid,
+        communityId: COMMUNITY_ID,
+        status: "JOINED",
+        reason: "CREATED_COMMUNITY",
+        role: "MEMBER",
+        createdAt,
+      },
+    });
+    const wallet = await prisma.wallet.create({
+      data: {
+        communityId: COMMUNITY_ID,
+        userId: uid,
+      },
+    });
+    walletIds.push(wallet.id);
+  }
+
+  console.log("Creating DONATION transactions across 43 weeks x 100 members...");
+  const latestWeek = isoWeekStartJst(ASOF);
+  const txRows: Array<{
+    from: string;
+    to: string;
+    createdAt: Date;
+  }> = [];
+
+  for (let wk = 0; wk < WINDOW_WEEKS; wk++) {
+    const weekStart = addDays(latestWeek, -wk * 7);
+    for (let m = 0; m < MEMBER_COUNT; m++) {
+      // Each member has a base send-rate; multiply by a per-week
+      // perturbation so the retention join sees real churn/return.
+      const baseRate = (m % 10) / 10; // 0.0..0.9
+      const perturb = rand();
+      if (perturb < baseRate) {
+        // Pick a random recipient that isn't self.
+        let target = Math.floor(rand() * MEMBER_COUNT);
+        if (target === m) target = (target + 1) % MEMBER_COUNT;
+        const createdAt = addDays(weekStart, Math.floor(rand() * 7));
+        txRows.push({
+          from: walletIds[m],
+          to: walletIds[target],
+          createdAt,
+        });
+      }
+    }
+  }
+
+  // Batch insert for speed.
+  console.log(`  inserting ${txRows.length} transactions...`);
+  const chunkSize = 500;
+  for (let i = 0; i < txRows.length; i += chunkSize) {
+    const chunk = txRows.slice(i, i + chunkSize);
+    await prisma.transaction.createMany({
+      data: chunk.map((r) => ({
+        reason: "DONATION",
+        from: r.from,
+        fromPointChange: 100,
+        to: r.to,
+        toPointChange: 100,
+        createdAt: r.createdAt,
+      })),
+    });
+  }
+
+  console.log("Refreshing materialized views...");
+  await prisma.$executeRawUnsafe(
+    `REFRESH MATERIALIZED VIEW "mv_transaction_summary_daily"`,
+  );
+  await prisma.$executeRawUnsafe(
+    `REFRESH MATERIALIZED VIEW "mv_user_transaction_daily"`,
+  );
+  console.log(`Seed complete: ${MEMBER_COUNT} members, ${txRows.length} DONATIONs.`);
+}
+
+function buildWeekStarts(asOf: Date, weeks: number): Date[] {
+  const latest = isoWeekStartJst(asOf);
+  const first = addDays(latest, -(weeks - 1) * 7);
+  const out: Date[] = [];
+  for (let wk = first; wk <= latest; wk = addDays(wk, 7)) out.push(wk);
+  return out;
+}
+
+/** The bulk SQL, inlined so the bench doesn't depend on repo imports. */
+async function runBulk(weekStarts: Date[]) {
+  const t0 = performance.now();
+  await prisma.$queryRawUnsafe(
+    `
+    WITH target_weeks AS (
+      SELECT unnest($1::date[]) AS week_start
+    ),
+    lookback_bounds AS (
+      SELECT
+        (MIN(week_start) - INTERVAL '12 weeks')::date AS first_date,
+        (MAX(week_start) + INTERVAL '7 days')::date   AS last_date
+      FROM target_weeks
+    ),
+    user_week_flags AS (
+      SELECT
+        mv."user_id",
+        DATE_TRUNC('week', mv."date")::date AS week_start,
+        BOOL_OR(mv."donation_out_count" > 0) AS is_sender,
+        BOOL_OR(mv."received_donation_count" > 0) AS is_receiver
+      FROM "mv_user_transaction_daily" mv
+      CROSS JOIN lookback_bounds lb
+      WHERE mv."community_id" = $2
+        AND mv."date" >= lb.first_date
+        AND mv."date" <  lb.last_date
+      GROUP BY mv."user_id", DATE_TRUNC('week', mv."date")
+    ),
+    ever_before AS (
+      SELECT DISTINCT
+        tw.week_start AS target_week,
+        uwf."user_id"
+      FROM target_weeks tw
+      INNER JOIN user_week_flags uwf
+        ON uwf.week_start >= (tw.week_start - INTERVAL '12 weeks')::date
+        AND uwf.week_start <  (tw.week_start - INTERVAL '7 days')::date
+        AND uwf.is_sender = true
+    ),
+    per_target AS (
+      SELECT
+        tw.week_start AS target_week,
+        COALESCE(cw."user_id", pw."user_id") AS user_id,
+        cw.is_sender AS curr_is_sender,
+        cw.is_receiver AS curr_is_receiver,
+        pw.is_sender AS prev_is_sender
+      FROM target_weeks tw
+      LEFT JOIN user_week_flags cw ON cw.week_start = tw.week_start
+      FULL OUTER JOIN user_week_flags pw
+        ON pw.week_start = (tw.week_start - INTERVAL '7 days')::date
+        AND (cw."user_id" IS NULL OR pw."user_id" = cw."user_id")
+      WHERE cw."user_id" IS NOT NULL OR pw."user_id" IS NOT NULL
+    ),
+    retention_counts AS (
+      SELECT
+        pt.target_week AS week_start,
+        COUNT(*) FILTER (WHERE pt.curr_is_sender = true AND pt.prev_is_sender = true)::int AS retained_senders,
+        COUNT(*) FILTER (WHERE pt.prev_is_sender = true AND (pt.curr_is_sender IS NULL OR pt.curr_is_sender = false))::int AS churned_senders,
+        COUNT(*) FILTER (WHERE pt.curr_is_sender = true AND (pt.prev_is_sender IS NULL OR pt.prev_is_sender = false) AND eb."user_id" IS NOT NULL)::int AS returned_senders,
+        COUNT(*) FILTER (WHERE pt.curr_is_sender = true)::int AS current_senders_count,
+        COUNT(*) FILTER (WHERE pt.curr_is_sender = true OR pt.curr_is_receiver = true)::int AS current_active_count
+      FROM per_target pt
+      LEFT JOIN ever_before eb ON eb.target_week = pt.target_week AND eb."user_id" = pt.user_id
+      GROUP BY pt.target_week
+    ),
+    new_members_per_week AS (
+      SELECT tw.week_start, COUNT(m."user_id")::int AS new_members
+      FROM target_weeks tw
+      LEFT JOIN "t_memberships" m
+        ON m."community_id" = $2 AND m."status" = 'JOINED'
+        AND m."created_at" >= (tw.week_start::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+        AND m."created_at" <  ((tw.week_start + INTERVAL '7 days')::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+      GROUP BY tw.week_start
+    ),
+    total_members_per_week AS (
+      SELECT tw.week_start, COUNT(m."user_id")::int AS total_members
+      FROM target_weeks tw
+      LEFT JOIN "t_memberships" m
+        ON m."community_id" = $2 AND m."status" = 'JOINED'
+        AND m."created_at" <  ((tw.week_start + INTERVAL '7 days')::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+      GROUP BY tw.week_start
+    )
+    SELECT tw.week_start,
+           COALESCE(rc.retained_senders, 0)::int AS retained_senders,
+           COALESCE(rc.churned_senders, 0)::int AS churned_senders,
+           COALESCE(rc.returned_senders, 0)::int AS returned_senders,
+           COALESCE(rc.current_senders_count, 0)::int AS current_senders_count,
+           COALESCE(rc.current_active_count, 0)::int AS current_active_count,
+           COALESCE(nm.new_members, 0)::int AS new_members,
+           COALESCE(tm.total_members, 0)::int AS total_members
+    FROM target_weeks tw
+    LEFT JOIN retention_counts rc ON rc.week_start = tw.week_start
+    LEFT JOIN new_members_per_week nm ON nm.week_start = tw.week_start
+    LEFT JOIN total_members_per_week tm ON tm.week_start = tw.week_start
+    ORDER BY tw.week_start ASC
+    `,
+    weekStarts,
+    COMMUNITY_ID,
+  );
+  return performance.now() - t0;
+}
+
+/** Loop-style — one findRetentionAggregate + one findMonthActivity per
+ *  week, all fired in parallel with Promise.all (old behaviour). */
+async function runLoop(weekStarts: Date[]) {
+  const t0 = performance.now();
+  await Promise.all(
+    weekStarts.flatMap((weekStart) => {
+      const nextWeekStart = addDays(weekStart, 7);
+      const prevWeekStart = addDays(weekStart, -7);
+      const twelveWeeksAgo = addDays(weekStart, -84);
+      return [
+        prisma.$queryRawUnsafe(
+          `
+          WITH current_week AS (
+            SELECT "user_id",
+                   BOOL_OR("donation_out_count" > 0) AS is_sender,
+                   BOOL_OR("received_donation_count" > 0) AS is_receiver
+            FROM "mv_user_transaction_daily"
+            WHERE "community_id" = $1
+              AND "date" >= $2::date AND "date" < $3::date
+            GROUP BY "user_id"
+          ),
+          prev_week AS (
+            SELECT "user_id",
+                   BOOL_OR("donation_out_count" > 0) AS is_sender
+            FROM "mv_user_transaction_daily"
+            WHERE "community_id" = $1
+              AND "date" >= $4::date AND "date" < $2::date
+            GROUP BY "user_id"
+          ),
+          ever_before AS (
+            SELECT DISTINCT "user_id"
+            FROM "mv_user_transaction_daily"
+            WHERE "community_id" = $1
+              AND "date" >= $5::date AND "date" < $4::date
+              AND "donation_out_count" > 0
+          )
+          SELECT
+            COUNT(*) FILTER (WHERE cw.is_sender = true AND pw.is_sender = true)::int AS retained,
+            COUNT(*) FILTER (WHERE cw.is_sender = true
+                              AND (pw.is_sender IS NULL OR pw.is_sender = false)
+                              AND eb."user_id" IS NOT NULL)::int AS returned,
+            COUNT(*) FILTER (WHERE pw.is_sender = true
+                              AND (cw.is_sender IS NULL OR cw.is_sender = false))::int AS churned
+          FROM current_week cw
+          FULL OUTER JOIN prev_week pw ON cw."user_id" = pw."user_id"
+          LEFT JOIN ever_before eb ON COALESCE(cw."user_id", pw."user_id") = eb."user_id"
+          `,
+          COMMUNITY_ID,
+          weekStart,
+          nextWeekStart,
+          prevWeekStart,
+          twelveWeeksAgo,
+        ),
+        prisma.$queryRawUnsafe(
+          `
+          SELECT
+            (SELECT COUNT(DISTINCT "user_id")::int
+             FROM "mv_user_transaction_daily"
+             WHERE "community_id" = $1
+               AND "date" >= $2::date AND "date" < $3::date
+               AND "donation_out_count" > 0) AS sender_count,
+            (SELECT COUNT(*)::int FROM "t_memberships"
+             WHERE "community_id" = $1 AND "status" = 'JOINED'
+               AND "created_at" < ($3::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')) AS total_members
+          `,
+          COMMUNITY_ID,
+          weekStart,
+          nextWeekStart,
+        ),
+      ];
+    }),
+  );
+  return performance.now() - t0;
+}
+
+function median(xs: number[]): number {
+  const s = [...xs].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 === 0 ? (s[mid - 1] + s[mid]) / 2 : s[mid];
+}
+
+async function main() {
+  await seed();
+
+  const weekStarts = buildWeekStarts(ASOF, WINDOW_WEEKS);
+
+  console.log(`\nBenchmarking ${weekStarts.length} weeks...`);
+
+  // Warm-up (planner, caches).
+  await runBulk(weekStarts);
+  await runLoop(weekStarts);
+
+  const TRIALS = 10;
+  const bulkTimes: number[] = [];
+  const loopTimes: number[] = [];
+  for (let i = 0; i < TRIALS; i++) {
+    bulkTimes.push(await runBulk(weekStarts));
+    loopTimes.push(await runLoop(weekStarts));
+  }
+
+  const bulkMed = median(bulkTimes);
+  const loopMed = median(loopTimes);
+
+  console.log(`\nResults (median of ${TRIALS} trials):`);
+  console.log(`  bulk: ${bulkMed.toFixed(1)} ms`);
+  console.log(`  loop: ${loopMed.toFixed(1)} ms (${(loopTimes.length * 2)} queries in parallel)`);
+  console.log(`  speedup: ${(loopMed / bulkMed).toFixed(2)}x`);
+  console.log(`\n  bulk samples: ${bulkTimes.map((t) => t.toFixed(0)).join(", ")}`);
+  console.log(`  loop samples: ${loopTimes.map((t) => t.toFixed(0)).join(", ")}`);
+
+  await prisma.$disconnect();
+}
+
+main().catch(async (e) => {
+  console.error(e);
+  await prisma.$disconnect();
+  process.exit(1);
+});

--- a/src/__tests__/unit/sysadmin/presenter.test.ts
+++ b/src/__tests__/unit/sysadmin/presenter.test.ts
@@ -1,0 +1,307 @@
+import "reflect-metadata";
+import SysAdminPresenter from "@/application/domain/sysadmin/presenter";
+import type {
+  SysAdminAllTimeTotalsRow,
+  SysAdminMemberStatsRow,
+  SysAdminMonthlyActivityRow,
+  SysAdminPlatformTotalsRow,
+} from "@/application/domain/sysadmin/data/type";
+import type {
+  AlertFlags,
+  MemberListResult,
+  MonthlyCohortPoint,
+  StageBreakdown,
+  StageCounts,
+  WeeklyRetentionPoint,
+} from "@/application/domain/sysadmin/service";
+
+/**
+ * Presenter is a pure shape-mapper. These tests lock in the contract
+ * that the repository's bigint fields route through bigintToSafeNumber
+ * (blowing up on overflow) and that null propagation is preserved
+ * through to the GraphQL payload.
+ */
+describe("SysAdminPresenter", () => {
+  describe("platform / summaryCard / memberRow — bigint handling", () => {
+    it("converts latestMonthDonationPoints bigint to a plain number", () => {
+      const row: SysAdminPlatformTotalsRow = {
+        communitiesCount: 6,
+        totalMembers: 500,
+        latestMonthDonationPoints: BigInt(1_234_567),
+      };
+      const out = SysAdminPresenter.platform(row);
+      expect(out.latestMonthDonationPoints).toBe(1_234_567);
+      expect(typeof out.latestMonthDonationPoints).toBe("number");
+    });
+
+    it("throws RangeError when a DONATION total overflows Number.MAX_SAFE_INTEGER", () => {
+      // bigintToSafeNumber is the safety net for external-reporting
+      // totals. Silent precision loss would corrupt "累計流通ポイント"
+      // downstream, so failing loud is intentional.
+      const overflow: SysAdminPlatformTotalsRow = {
+        communitiesCount: 1,
+        totalMembers: 1,
+        latestMonthDonationPoints: BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1),
+      };
+      expect(() => SysAdminPresenter.platform(overflow)).toThrow(RangeError);
+    });
+
+    it("converts totalPointsOut on member rows", () => {
+      const row: SysAdminMemberStatsRow = {
+        userId: "u1",
+        name: "Alice",
+        monthsIn: 12,
+        donationOutMonths: 10,
+        userSendRate: 0.833,
+        totalPointsOut: BigInt(5_000),
+      };
+      const out = SysAdminPresenter.memberRow(row);
+      expect(out.totalPointsOut).toBe(5_000);
+      expect(typeof out.totalPointsOut).toBe("number");
+    });
+
+    it("passes null name through untouched", () => {
+      const row: SysAdminMemberStatsRow = {
+        userId: "u1",
+        name: null,
+        monthsIn: 1,
+        donationOutMonths: 0,
+        userSendRate: 0,
+        totalPointsOut: BigInt(0),
+      };
+      expect(SysAdminPresenter.memberRow(row).name).toBeNull();
+    });
+  });
+
+  describe("summaryCard — null propagation & tier2Pct", () => {
+    function allTimeTotals(
+      overrides: Partial<SysAdminAllTimeTotalsRow> = {},
+    ): SysAdminAllTimeTotalsRow {
+      return {
+        totalDonationPoints: overrides.totalDonationPoints ?? BigInt(0),
+        maxChainDepth: overrides.maxChainDepth ?? null,
+        dataFrom: overrides.dataFrom ?? null,
+        dataTo: overrides.dataTo ?? null,
+      };
+    }
+
+    it("keeps null values null (growthRateActivity, maxChainDepth, dataFrom/To, 3m avg)", () => {
+      const out = SysAdminPresenter.summaryCard({
+        communityId: "c1",
+        communityName: "C",
+        totalMembers: 10,
+        communityActivityRate: 0.3,
+        communityActivityRate3mAvg: null,
+        growthRateActivity: null,
+        tier2Count: 4,
+        allTimeTotals: allTimeTotals(),
+      });
+      expect(out.communityActivityRate3mAvg).toBeNull();
+      expect(out.growthRateActivity).toBeNull();
+      expect(out.maxChainDepthAllTime).toBeNull();
+      expect(out.dataFrom).toBeNull();
+      expect(out.dataTo).toBeNull();
+    });
+
+    it("computes tier2Pct = tier2Count / totalMembers", () => {
+      const out = SysAdminPresenter.summaryCard({
+        communityId: "c1",
+        communityName: "C",
+        totalMembers: 10,
+        communityActivityRate: 0.5,
+        communityActivityRate3mAvg: 0.4,
+        growthRateActivity: 0.1,
+        tier2Count: 3,
+        allTimeTotals: allTimeTotals({ totalDonationPoints: BigInt(0) }),
+      });
+      expect(out.tier2Pct).toBeCloseTo(0.3);
+    });
+
+    it("returns tier2Pct=0 when totalMembers is 0 (no divide-by-zero)", () => {
+      const out = SysAdminPresenter.summaryCard({
+        communityId: "c1",
+        communityName: "C",
+        totalMembers: 0,
+        communityActivityRate: 0,
+        communityActivityRate3mAvg: null,
+        growthRateActivity: null,
+        tier2Count: 0,
+        allTimeTotals: allTimeTotals(),
+      });
+      expect(out.tier2Pct).toBe(0);
+    });
+  });
+
+  describe("monthlyActivityPoint — chainPct & divide-by-zero guards", () => {
+    const baseRow: SysAdminMonthlyActivityRow = {
+      monthStart: new Date(Date.UTC(2026, 3, 1)),
+      senderCount: 0,
+      totalMembersEndOfMonth: 0,
+      newMembers: 0,
+      donationPointsSum: BigInt(0),
+      donationTxCount: BigInt(0),
+      donationChainTxCount: BigInt(0),
+    };
+
+    it("returns null chainPct when no DONATION tx occurred that month", () => {
+      const out = SysAdminPresenter.monthlyActivityPoint({
+        ...baseRow,
+        donationTxCount: BigInt(0),
+        donationChainTxCount: BigInt(0),
+      });
+      expect(out.chainPct).toBeNull();
+    });
+
+    it("returns rate 0 when total_members is 0 (no divide-by-zero)", () => {
+      const out = SysAdminPresenter.monthlyActivityPoint({
+        ...baseRow,
+        senderCount: 0,
+        totalMembersEndOfMonth: 0,
+      });
+      expect(out.communityActivityRate).toBe(0);
+    });
+
+    it("computes rate & chainPct as fractions", () => {
+      const out = SysAdminPresenter.monthlyActivityPoint({
+        ...baseRow,
+        senderCount: 4,
+        totalMembersEndOfMonth: 20,
+        donationTxCount: BigInt(10),
+        donationChainTxCount: BigInt(3),
+        donationPointsSum: BigInt(5_000),
+      });
+      expect(out.communityActivityRate).toBeCloseTo(0.2);
+      expect(out.chainPct).toBeCloseTo(0.3);
+      expect(out.donationPointsSum).toBe(5_000);
+    });
+
+    it("throws RangeError when donation tx count overflows safe integer", () => {
+      // ::bigint on the SUM keeps the SQL side safe; the presenter
+      // should fail loud (not silently truncate) if cumulative tx
+      // counts somehow exceed Number.MAX_SAFE_INTEGER.
+      expect(() =>
+        SysAdminPresenter.monthlyActivityPoint({
+          ...baseRow,
+          donationTxCount: BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1),
+          donationChainTxCount: BigInt(0),
+        }),
+      ).toThrow(RangeError);
+    });
+  });
+
+  describe("retentionTrendPoint / cohortPoint — null passthrough", () => {
+    it("retention trend keeps null activity rate when week had no members", () => {
+      const point: WeeklyRetentionPoint = {
+        weekStart: new Date(Date.UTC(2026, 3, 20)),
+        retainedSenders: 0,
+        churnedSenders: 0,
+        returnedSenders: 0,
+        newMembers: 0,
+        communityActivityRate: null,
+      };
+      expect(SysAdminPresenter.retentionTrendPoint(point).communityActivityRate).toBeNull();
+    });
+
+    it("cohortPoint keeps individual retentionMN null fields (too-recent cohort)", () => {
+      const point: MonthlyCohortPoint = {
+        cohortMonthStart: new Date(Date.UTC(2026, 3, 1)),
+        cohortSize: 10,
+        retentionM1: 0.3,
+        retentionM3: null,
+        retentionM6: null,
+      };
+      const out = SysAdminPresenter.cohortPoint(point);
+      expect(out.retentionM1).toBeCloseTo(0.3);
+      expect(out.retentionM3).toBeNull();
+      expect(out.retentionM6).toBeNull();
+    });
+  });
+
+  describe("memberList / stages — passthrough structure", () => {
+    it("passes hasNextPage + nextCursor untouched", () => {
+      const result: MemberListResult = {
+        users: [
+          {
+            userId: "u",
+            name: "Alice",
+            monthsIn: 1,
+            donationOutMonths: 1,
+            userSendRate: 1,
+            totalPointsOut: BigInt(0),
+          },
+        ],
+        hasNextPage: true,
+        nextCursor: "MQ==",
+      };
+      const out = SysAdminPresenter.memberList(result);
+      expect(out.hasNextPage).toBe(true);
+      expect(out.nextCursor).toBe("MQ==");
+      expect(out.users).toHaveLength(1);
+    });
+
+    it("nextCursor stays null when there is no next page", () => {
+      const out = SysAdminPresenter.memberList({
+        users: [],
+        hasNextPage: false,
+        nextCursor: null,
+      });
+      expect(out.nextCursor).toBeNull();
+    });
+
+    it("stages mirrors the service breakdown buckets 1:1", () => {
+      const zeroBucket = {
+        count: 0,
+        pct: 0,
+        pointsContributionPct: 0,
+        avgSendRate: 0,
+        avgMonthsIn: 0,
+      };
+      const bd: StageBreakdown = {
+        habitual: { ...zeroBucket, count: 2, pct: 0.2, avgSendRate: 0.8 },
+        regular: { ...zeroBucket, count: 3, pct: 0.3 },
+        occasional: { ...zeroBucket, count: 1, pct: 0.1 },
+        latent: { ...zeroBucket, count: 4, pct: 0.4 },
+      };
+      const out = SysAdminPresenter.stages(bd);
+      expect(out.habitual.count).toBe(2);
+      expect(out.regular.count).toBe(3);
+      expect(out.occasional.count).toBe(1);
+      expect(out.latent.count).toBe(4);
+      expect(out.latent.pointsContributionPct).toBe(0);
+    });
+  });
+
+  describe("overviewRow — cumulative count passthrough", () => {
+    it("copies tier1/tier2/passive counts to BOTH segmentCounts and top-level convenience fields", () => {
+      const counts: StageCounts = {
+        total: 10,
+        tier1Count: 2,
+        tier2Count: 5,
+        activeCount: 7,
+        passiveCount: 3,
+      };
+      const alerts: AlertFlags = {
+        churnSpike: false,
+        activeDrop: true,
+        noNewMembers: false,
+      };
+      const out = SysAdminPresenter.overviewRow({
+        communityId: "c1",
+        communityName: "C",
+        totalMembers: 10,
+        stageCounts: counts,
+        communityActivityRate: 0.3,
+        growthRateActivity: -0.25,
+        latestCohortRetentionM1: 0.5,
+        alerts,
+      });
+      expect(out.tier1Count).toBe(2);
+      expect(out.segmentCounts.tier1Count).toBe(2);
+      expect(out.tier2Count).toBe(5);
+      expect(out.segmentCounts.tier2Count).toBe(5);
+      expect(out.passiveCount).toBe(3);
+      expect(out.segmentCounts.passiveCount).toBe(3);
+      expect(out.alerts.activeDrop).toBe(true);
+    });
+  });
+});

--- a/src/__tests__/unit/sysadmin/presenter.test.ts
+++ b/src/__tests__/unit/sysadmin/presenter.test.ts
@@ -289,6 +289,7 @@ describe("SysAdminPresenter", () => {
           senderCountPrev: 6,
           newMemberCount: 1,
           newMemberCountPrev: 2,
+          retainedSenders: 3,
         },
         weeklyRetention: {
           retainedSenders: 3,
@@ -307,6 +308,7 @@ describe("SysAdminPresenter", () => {
         senderCountPrev: 6,
         newMemberCount: 1,
         newMemberCountPrev: 2,
+        retainedSenders: 3,
       });
       expect(out.weeklyRetention).toEqual({
         retainedSenders: 3,

--- a/src/__tests__/unit/sysadmin/presenter.test.ts
+++ b/src/__tests__/unit/sysadmin/presenter.test.ts
@@ -53,10 +53,12 @@ describe("SysAdminPresenter", () => {
         donationOutMonths: 10,
         userSendRate: 0.833,
         totalPointsOut: BigInt(5_000),
+        uniqueDonationRecipients: 4,
       };
       const out = SysAdminPresenter.memberRow(row);
       expect(out.totalPointsOut).toBe(5_000);
       expect(typeof out.totalPointsOut).toBe("number");
+      expect(out.uniqueDonationRecipients).toBe(4);
     });
 
     it("passes null name through untouched", () => {
@@ -67,6 +69,7 @@ describe("SysAdminPresenter", () => {
         donationOutMonths: 0,
         userSendRate: 0,
         totalPointsOut: BigInt(0),
+        uniqueDonationRecipients: 0,
       };
       expect(SysAdminPresenter.memberRow(row).name).toBeNull();
     });
@@ -227,6 +230,7 @@ describe("SysAdminPresenter", () => {
             donationOutMonths: 1,
             userSendRate: 1,
             totalPointsOut: BigInt(0),
+            uniqueDonationRecipients: 0,
           },
         ],
         hasNextPage: true,
@@ -299,6 +303,7 @@ describe("SysAdminPresenter", () => {
           size: 8,
           activeAtM1: 4,
         },
+        hubMemberCount: 2,
       });
       expect(out.segmentCounts.tier1Count).toBe(2);
       expect(out.segmentCounts.tier2Count).toBe(5);
@@ -315,6 +320,7 @@ describe("SysAdminPresenter", () => {
         churnedSenders: 5,
       });
       expect(out.latestCohort).toEqual({ size: 8, activeAtM1: 4 });
+      expect(out.hubMemberCount).toBe(2);
     });
   });
 });

--- a/src/__tests__/unit/sysadmin/presenter.test.ts
+++ b/src/__tests__/unit/sysadmin/presenter.test.ts
@@ -7,7 +7,6 @@ import type {
   SysAdminPlatformTotalsRow,
 } from "@/application/domain/sysadmin/data/type";
 import type {
-  AlertFlags,
   MemberListResult,
   MonthlyCohortPoint,
   StageBreakdown,
@@ -271,8 +270,8 @@ describe("SysAdminPresenter", () => {
     });
   });
 
-  describe("overviewRow — cumulative count passthrough", () => {
-    it("copies tier1/tier2/passive counts to BOTH segmentCounts and top-level convenience fields", () => {
+  describe("overviewRow — nested raw signal passthrough", () => {
+    it("forwards stage / window / weekly retention / latest cohort counts unchanged", () => {
       const counts: StageCounts = {
         total: 10,
         tier1Count: 2,
@@ -280,28 +279,40 @@ describe("SysAdminPresenter", () => {
         activeCount: 7,
         passiveCount: 3,
       };
-      const alerts: AlertFlags = {
-        churnSpike: false,
-        activeDrop: true,
-        noNewMembers: false,
-      };
       const out = SysAdminPresenter.overviewRow({
         communityId: "c1",
         communityName: "C",
         totalMembers: 10,
         stageCounts: counts,
-        communityActivityRate: 0.3,
-        growthRateActivity: -0.25,
-        latestCohortRetentionM1: 0.5,
-        alerts,
+        windowActivity: {
+          senderCount: 4,
+          senderCountPrev: 6,
+          newMemberCount: 1,
+          newMemberCountPrev: 2,
+        },
+        weeklyRetention: {
+          retainedSenders: 3,
+          churnedSenders: 5,
+        },
+        latestCohort: {
+          size: 8,
+          activeAtM1: 4,
+        },
       });
-      expect(out.tier1Count).toBe(2);
       expect(out.segmentCounts.tier1Count).toBe(2);
-      expect(out.tier2Count).toBe(5);
       expect(out.segmentCounts.tier2Count).toBe(5);
-      expect(out.passiveCount).toBe(3);
       expect(out.segmentCounts.passiveCount).toBe(3);
-      expect(out.alerts.activeDrop).toBe(true);
+      expect(out.windowActivity).toEqual({
+        senderCount: 4,
+        senderCountPrev: 6,
+        newMemberCount: 1,
+        newMemberCountPrev: 2,
+      });
+      expect(out.weeklyRetention).toEqual({
+        retainedSenders: 3,
+        churnedSenders: 5,
+      });
+      expect(out.latestCohort).toEqual({ size: 8, activeAtM1: 4 });
     });
   });
 });

--- a/src/__tests__/unit/sysadmin/service.test.ts
+++ b/src/__tests__/unit/sysadmin/service.test.ts
@@ -1,0 +1,504 @@
+import "reflect-metadata";
+import { container } from "tsyringe";
+import SysAdminService, {
+  DEFAULT_SEGMENT_THRESHOLDS,
+} from "@/application/domain/sysadmin/service";
+import type {
+  SysAdminMemberStatsRow,
+  SysAdminMonthlyActivityRow,
+} from "@/application/domain/sysadmin/data/type";
+
+/**
+ * Member factory keeps the tests readable — every test below really
+ * only cares about 2–3 fields, so the helper defaults the rest to
+ * non-interesting values.
+ */
+function member(overrides: Partial<SysAdminMemberStatsRow>): SysAdminMemberStatsRow {
+  return {
+    userId: overrides.userId ?? "u",
+    name: overrides.name ?? null,
+    monthsIn: overrides.monthsIn ?? 1,
+    donationOutMonths: overrides.donationOutMonths ?? 0,
+    totalPointsOut: overrides.totalPointsOut ?? BigInt(0),
+    userSendRate: overrides.userSendRate ?? 0,
+  };
+}
+
+/**
+ * Minimal mock repositories. `jest.fn()` everywhere so tests can
+ * assert call shape AND return canned rows. The orchestrator-level
+ * alert test below installs return values explicitly.
+ */
+class MockSysAdminRepository {
+  findAllCommunities = jest.fn();
+  findCommunityById = jest.fn();
+  findMemberStats = jest.fn();
+  findMonthlyActivity = jest.fn();
+  findActivitySnapshot = jest.fn();
+  findNewMemberCount = jest.fn();
+  findAllTimeTotals = jest.fn();
+  findPlatformTotals = jest.fn();
+}
+
+/**
+ * Stub the few ReportService wrappers SysAdminService leans on.
+ * Per CLAUDE.md the cross-domain boundary is the service, not the
+ * repository, so the test follows the same boundary.
+ */
+class MockReportService {
+  getRetentionAggregate = jest.fn();
+  getCohortRetention = jest.fn();
+}
+
+describe("SysAdminService", () => {
+  let service: SysAdminService;
+  let repo: MockSysAdminRepository;
+  let reportService: MockReportService;
+
+  beforeEach(() => {
+    container.reset();
+    repo = new MockSysAdminRepository();
+    reportService = new MockReportService();
+    container.register("SysAdminRepository", { useValue: repo });
+    container.register("ReportService", { useValue: reportService });
+    service = container.resolve(SysAdminService);
+  });
+
+  // ========================================================================
+  // computeStageCounts: cumulative (tier2 includes tier1)
+  // ========================================================================
+  describe("computeStageCounts", () => {
+    it("classifies members by the supplied thresholds with cumulative tiers", () => {
+      // userSendRate: 0 (latent), 0.3 (occasional), 0.5 (regular),
+      // 0.8 (habitual). Default thresholds tier1=0.7, tier2=0.4.
+      const members = [
+        member({ userId: "a", donationOutMonths: 0, userSendRate: 0 }),
+        member({ userId: "b", donationOutMonths: 1, userSendRate: 0.3 }),
+        member({ userId: "c", donationOutMonths: 2, userSendRate: 0.5 }),
+        member({ userId: "d", donationOutMonths: 5, userSendRate: 0.8 }),
+      ];
+      const counts = service.computeStageCounts(members, DEFAULT_SEGMENT_THRESHOLDS);
+      expect(counts).toEqual({
+        total: 4,
+        tier1Count: 1, // userSendRate >= 0.7 (habitual)
+        tier2Count: 2, // userSendRate >= 0.4 (regular + habitual — cumulative)
+        activeCount: 3, // donationOutMonths > 0
+        passiveCount: 1, // donationOutMonths == 0
+      });
+    });
+
+    it("treats members with donationOutMonths=0 as passive even if userSendRate is nonzero", () => {
+      // userSendRate is a derived value; the authoritative signal for
+      // "has this user ever donated?" is donationOutMonths > 0.
+      const members = [
+        member({ userId: "a", donationOutMonths: 0, userSendRate: 0.9 }),
+      ];
+      const counts = service.computeStageCounts(members, DEFAULT_SEGMENT_THRESHOLDS);
+      expect(counts.passiveCount).toBe(1);
+      expect(counts.tier1Count).toBe(0);
+      expect(counts.activeCount).toBe(0);
+    });
+
+    it("exactly-at-threshold rows are INCLUDED (>= comparison)", () => {
+      // userSendRate == tier1 exactly should count as habitual.
+      const members = [
+        member({ userId: "a", donationOutMonths: 7, userSendRate: 0.7 }),
+        member({ userId: "b", donationOutMonths: 4, userSendRate: 0.4 }),
+      ];
+      const counts = service.computeStageCounts(members, DEFAULT_SEGMENT_THRESHOLDS);
+      expect(counts.tier1Count).toBe(1);
+      expect(counts.tier2Count).toBe(2);
+    });
+
+    it("empty member list yields all-zero counts", () => {
+      expect(service.computeStageCounts([], DEFAULT_SEGMENT_THRESHOLDS)).toEqual({
+        total: 0,
+        tier1Count: 0,
+        tier2Count: 0,
+        activeCount: 0,
+        passiveCount: 0,
+      });
+    });
+
+    it("custom thresholds re-classify existing members without a new scan", () => {
+      const members = [
+        member({ userId: "a", donationOutMonths: 3, userSendRate: 0.5 }),
+        member({ userId: "b", donationOutMonths: 5, userSendRate: 0.9 }),
+      ];
+      // Loosen tier1 to 0.5: now BOTH users are habitual.
+      const counts = service.computeStageCounts(members, { tier1: 0.5, tier2: 0.3 });
+      expect(counts.tier1Count).toBe(2);
+      expect(counts.tier2Count).toBe(2);
+    });
+  });
+
+  // ========================================================================
+  // computeStageBreakdown: disjoint buckets sum to 100%
+  // ========================================================================
+  describe("computeStageBreakdown", () => {
+    it("splits members into 4 disjoint buckets whose counts sum to total", () => {
+      const members = [
+        member({ userId: "a", donationOutMonths: 0, userSendRate: 0 }), // latent
+        member({ userId: "b", donationOutMonths: 1, userSendRate: 0.3 }), // occasional
+        member({ userId: "c", donationOutMonths: 2, userSendRate: 0.5 }), // regular
+        member({ userId: "d", donationOutMonths: 7, userSendRate: 0.9 }), // habitual
+      ];
+      const bd = service.computeStageBreakdown(members, DEFAULT_SEGMENT_THRESHOLDS);
+      expect(bd.latent.count).toBe(1);
+      expect(bd.occasional.count).toBe(1);
+      expect(bd.regular.count).toBe(1);
+      expect(bd.habitual.count).toBe(1);
+      expect(bd.latent.count + bd.occasional.count + bd.regular.count + bd.habitual.count).toBe(
+        members.length,
+      );
+    });
+
+    it("pct of each bucket sums to 1.0", () => {
+      const members = [
+        member({ userId: "a", donationOutMonths: 0 }),
+        member({ userId: "b", donationOutMonths: 0 }),
+        member({ userId: "c", donationOutMonths: 3, userSendRate: 0.4 }),
+        member({ userId: "d", donationOutMonths: 7, userSendRate: 0.8 }),
+      ];
+      const bd = service.computeStageBreakdown(members, DEFAULT_SEGMENT_THRESHOLDS);
+      expect(
+        bd.latent.pct + bd.occasional.pct + bd.regular.pct + bd.habitual.pct,
+      ).toBeCloseTo(1.0);
+    });
+
+    it("pointsContributionPct is 0 for latent and sums to 1.0 over non-latent buckets", () => {
+      // Habitual: 700pt, regular: 200pt, occasional: 100pt. Total 1000.
+      const members = [
+        member({ userId: "a", donationOutMonths: 0, totalPointsOut: BigInt(0) }),
+        member({
+          userId: "b",
+          donationOutMonths: 1,
+          userSendRate: 0.3,
+          totalPointsOut: BigInt(100),
+        }),
+        member({
+          userId: "c",
+          donationOutMonths: 4,
+          userSendRate: 0.5,
+          totalPointsOut: BigInt(200),
+        }),
+        member({
+          userId: "d",
+          donationOutMonths: 7,
+          userSendRate: 0.9,
+          totalPointsOut: BigInt(700),
+        }),
+      ];
+      const bd = service.computeStageBreakdown(members, DEFAULT_SEGMENT_THRESHOLDS);
+      expect(bd.latent.pointsContributionPct).toBe(0);
+      expect(bd.occasional.pointsContributionPct).toBeCloseTo(0.1);
+      expect(bd.regular.pointsContributionPct).toBeCloseTo(0.2);
+      expect(bd.habitual.pointsContributionPct).toBeCloseTo(0.7);
+    });
+
+    it("empty buckets return all-zero stats (no divide-by-zero)", () => {
+      const members = [
+        member({ userId: "a", donationOutMonths: 0 }),
+        member({ userId: "b", donationOutMonths: 0 }),
+      ];
+      const bd = service.computeStageBreakdown(members, DEFAULT_SEGMENT_THRESHOLDS);
+      expect(bd.habitual).toEqual({
+        count: 0,
+        pct: 0,
+        pointsContributionPct: 0,
+        avgSendRate: 0,
+        avgMonthsIn: 0,
+      });
+      expect(bd.regular.count).toBe(0);
+      expect(bd.occasional.count).toBe(0);
+      expect(bd.latent.count).toBe(2);
+    });
+
+    it("empty member list returns four all-zero buckets", () => {
+      const bd = service.computeStageBreakdown([], DEFAULT_SEGMENT_THRESHOLDS);
+      for (const bucket of [bd.habitual, bd.regular, bd.occasional, bd.latent]) {
+        expect(bucket).toEqual({
+          count: 0,
+          pct: 0,
+          pointsContributionPct: 0,
+          avgSendRate: 0,
+          avgMonthsIn: 0,
+        });
+      }
+    });
+  });
+
+  // ========================================================================
+  // paginateMembers: in-memory filter + sort + slice
+  // ========================================================================
+  describe("paginateMembers", () => {
+    const baseMembers: SysAdminMemberStatsRow[] = [
+      member({ userId: "a", userSendRate: 0.9, monthsIn: 10, donationOutMonths: 9 }),
+      member({ userId: "b", userSendRate: 0.5, monthsIn: 8, donationOutMonths: 4 }),
+      member({ userId: "c", userSendRate: 0.2, monthsIn: 5, donationOutMonths: 1 }),
+      member({ userId: "d", userSendRate: 0, monthsIn: 3, donationOutMonths: 0 }),
+    ];
+
+    it("filters on minSendRate (inclusive)", () => {
+      const { users } = service.paginateMembers(baseMembers, {
+        minSendRate: 0.5,
+        sortField: "SEND_RATE",
+        sortOrder: "DESC",
+        limit: 50,
+      });
+      expect(users.map((u) => u.userId)).toEqual(["a", "b"]);
+    });
+
+    it("filters on minMonthsIn AND minDonationOutMonths simultaneously", () => {
+      const { users } = service.paginateMembers(baseMembers, {
+        minSendRate: 0,
+        minMonthsIn: 6,
+        minDonationOutMonths: 2,
+        sortField: "SEND_RATE",
+        sortOrder: "DESC",
+        limit: 50,
+      });
+      // `a` (monthsIn=10, donationOutMonths=9) and `b` (monthsIn=8,
+      // donationOutMonths=4) both pass. Default sort is SEND_RATE DESC,
+      // so `a` (0.9) ahead of `b` (0.5).
+      expect(users.map((u) => u.userId)).toEqual(["a", "b"]);
+    });
+
+    it("respects maxSendRate as an inclusive upper bound", () => {
+      const { users } = service.paginateMembers(baseMembers, {
+        minSendRate: 0,
+        maxSendRate: 0.5,
+        sortField: "SEND_RATE",
+        sortOrder: "DESC",
+        limit: 50,
+      });
+      // 0.9 is excluded; 0.5, 0.2, 0 included.
+      expect(users.map((u) => u.userId)).toEqual(["b", "c", "d"]);
+    });
+
+    it("sorts by SEND_RATE DESC by default and paginates via cursor", () => {
+      const page1 = service.paginateMembers(baseMembers, {
+        minSendRate: 0,
+        sortField: "SEND_RATE",
+        sortOrder: "DESC",
+        limit: 2,
+      });
+      expect(page1.users.map((u) => u.userId)).toEqual(["a", "b"]);
+      expect(page1.hasNextPage).toBe(true);
+      expect(page1.nextCursor).not.toBeNull();
+
+      const page2 = service.paginateMembers(baseMembers, {
+        minSendRate: 0,
+        sortField: "SEND_RATE",
+        sortOrder: "DESC",
+        limit: 2,
+        cursor: page1.nextCursor!,
+      });
+      expect(page2.users.map((u) => u.userId)).toEqual(["c", "d"]);
+      expect(page2.hasNextPage).toBe(false);
+      expect(page2.nextCursor).toBeNull();
+    });
+
+    it("sorts by MONTHS_IN ASC", () => {
+      const { users } = service.paginateMembers(baseMembers, {
+        minSendRate: 0,
+        sortField: "MONTHS_IN",
+        sortOrder: "ASC",
+        limit: 50,
+      });
+      expect(users.map((u) => u.userId)).toEqual(["d", "c", "b", "a"]);
+    });
+
+    it("ties break deterministically on userId (stable cursor)", () => {
+      const tied = [
+        member({ userId: "zzz", userSendRate: 0.5 }),
+        member({ userId: "aaa", userSendRate: 0.5 }),
+        member({ userId: "mmm", userSendRate: 0.5 }),
+      ];
+      const { users } = service.paginateMembers(tied, {
+        minSendRate: 0,
+        sortField: "SEND_RATE",
+        sortOrder: "DESC",
+        limit: 50,
+      });
+      // Same send-rate → fallback to userId ASC.
+      expect(users.map((u) => u.userId)).toEqual(["aaa", "mmm", "zzz"]);
+    });
+
+    it("clamps limit to MAX_LIMIT upper bound and 1 lower bound", () => {
+      const page = service.paginateMembers(baseMembers, {
+        minSendRate: 0,
+        sortField: "SEND_RATE",
+        sortOrder: "DESC",
+        limit: 100000,
+      });
+      expect(page.users.length).toBe(4); // all rows fit
+      expect(page.hasNextPage).toBe(false);
+    });
+  });
+
+  // ========================================================================
+  // computeActivityRate3mAvg: null when <3 months of data
+  // ========================================================================
+  describe("computeActivityRate3mAvg", () => {
+    function trendRow(
+      month: string,
+      senderCount: number,
+      totalMembers: number,
+    ): SysAdminMonthlyActivityRow {
+      return {
+        monthStart: new Date(month),
+        senderCount,
+        totalMembersEndOfMonth: totalMembers,
+        newMembers: 0,
+        donationPointsSum: BigInt(0),
+        donationTxCount: BigInt(0),
+        donationChainTxCount: BigInt(0),
+      };
+    }
+
+    it("returns null with fewer than 3 months of data", () => {
+      expect(service.computeActivityRate3mAvg([])).toBeNull();
+      expect(service.computeActivityRate3mAvg([trendRow("2026-04-01", 1, 10)])).toBeNull();
+      expect(
+        service.computeActivityRate3mAvg([
+          trendRow("2026-03-01", 1, 10),
+          trendRow("2026-04-01", 2, 10),
+        ]),
+      ).toBeNull();
+    });
+
+    it("averages the last 3 months' rates when >= 3 months of data", () => {
+      // Rates: 0.1, 0.2, 0.3 → avg 0.2
+      const avg = service.computeActivityRate3mAvg([
+        trendRow("2026-02-01", 1, 10),
+        trendRow("2026-03-01", 2, 10),
+        trendRow("2026-04-01", 3, 10),
+      ]);
+      expect(avg).toBeCloseTo(0.2);
+    });
+
+    it("uses only the TRAILING 3 months when more data exists", () => {
+      // Older months (0 senders) are ignored; trailing 3 are 0.4, 0.5, 0.6.
+      const avg = service.computeActivityRate3mAvg([
+        trendRow("2025-12-01", 0, 10),
+        trendRow("2026-01-01", 0, 10),
+        trendRow("2026-02-01", 4, 10),
+        trendRow("2026-03-01", 5, 10),
+        trendRow("2026-04-01", 6, 10),
+      ]);
+      expect(avg).toBeCloseTo(0.5);
+    });
+
+    it("treats months with zero total_members as rate 0 (no divide-by-zero)", () => {
+      // No members yet → rate 0 that month.
+      const avg = service.computeActivityRate3mAvg([
+        trendRow("2026-02-01", 0, 0),
+        trendRow("2026-03-01", 2, 10),
+        trendRow("2026-04-01", 3, 10),
+      ]);
+      expect(avg).toBeCloseTo((0 + 0.2 + 0.3) / 3);
+    });
+  });
+
+  // ========================================================================
+  // getAlerts: last-completed-period churnSpike + activeDrop, 14-day
+  // no-new-members. Alert frame was deliberately shifted back so the
+  // in-progress week/month doesn't trigger false positives.
+  // ========================================================================
+  describe("getAlerts", () => {
+    const ctx = {} as never;
+    const asOf = new Date("2026-04-21T00:00:00Z");
+
+    function setup(params: {
+      retention: { retainedSenders: number; churnedSenders: number };
+      newMemberCount: number;
+      prevMonth: { senderCount: number; totalMembers: number };
+      prevPrevMonth: { senderCount: number; totalMembers: number };
+    }) {
+      reportService.getRetentionAggregate.mockResolvedValue({
+        newMembers: 0,
+        retainedSenders: params.retention.retainedSenders,
+        returnedSenders: 0,
+        churnedSenders: params.retention.churnedSenders,
+        currentSendersCount: 0,
+        currentActiveCount: 0,
+      });
+      repo.findNewMemberCount.mockResolvedValue({ count: params.newMemberCount });
+      // First findActivitySnapshot call is prev month, second is prev-prev.
+      repo.findActivitySnapshot
+        .mockResolvedValueOnce(params.prevMonth)
+        .mockResolvedValueOnce(params.prevPrevMonth);
+    }
+
+    const neutralMonths = {
+      prevMonth: { senderCount: 1, totalMembers: 10 }, // 10% rate
+      prevPrevMonth: { senderCount: 1, totalMembers: 10 }, // 10% rate — no change
+    };
+
+    it("fires churnSpike when churned > retained, not when equal", async () => {
+      setup({
+        retention: { retainedSenders: 5, churnedSenders: 6 },
+        newMemberCount: 10,
+        ...neutralMonths,
+      });
+      expect((await service.getAlerts(ctx, "c1", asOf)).churnSpike).toBe(true);
+
+      setup({
+        retention: { retainedSenders: 5, churnedSenders: 5 },
+        newMemberCount: 10,
+        ...neutralMonths,
+      });
+      expect((await service.getAlerts(ctx, "c1", asOf)).churnSpike).toBe(false);
+    });
+
+    it("fires activeDrop when prev month's rate dropped <=-20% vs prev-prev month", async () => {
+      // prevPrevRate = 10/10 = 1.0, prevRate = 7/10 = ~0.7 → change ~-30%
+      // (the -20% exact boundary is avoided here because JS double
+      // representation of e.g. (0.8 - 1.0) / 1.0 lands at -0.199999… so
+      // equality on the threshold is flaky; -30% is safely past it).
+      setup({
+        retention: { retainedSenders: 1, churnedSenders: 0 },
+        newMemberCount: 10,
+        prevMonth: { senderCount: 7, totalMembers: 10 },
+        prevPrevMonth: { senderCount: 10, totalMembers: 10 },
+      });
+      expect((await service.getAlerts(ctx, "c1", asOf)).activeDrop).toBe(true);
+
+      // prevRate = 0.81, prevPrevRate = 1.0 → -19% → above threshold
+      setup({
+        retention: { retainedSenders: 1, churnedSenders: 0 },
+        newMemberCount: 10,
+        prevMonth: { senderCount: 81, totalMembers: 100 },
+        prevPrevMonth: { senderCount: 100, totalMembers: 100 },
+      });
+      expect((await service.getAlerts(ctx, "c1", asOf)).activeDrop).toBe(false);
+    });
+
+    it("does NOT fire activeDrop when prev-prev month has no data (nothing to compare)", async () => {
+      setup({
+        retention: { retainedSenders: 1, churnedSenders: 0 },
+        newMemberCount: 10,
+        prevMonth: { senderCount: 0, totalMembers: 10 },
+        prevPrevMonth: { senderCount: 0, totalMembers: 0 },
+      });
+      expect((await service.getAlerts(ctx, "c1", asOf)).activeDrop).toBe(false);
+    });
+
+    it("fires noNewMembers when the 14-day count is zero", async () => {
+      setup({
+        retention: { retainedSenders: 1, churnedSenders: 0 },
+        newMemberCount: 0,
+        ...neutralMonths,
+      });
+      expect((await service.getAlerts(ctx, "c1", asOf)).noNewMembers).toBe(true);
+
+      setup({
+        retention: { retainedSenders: 1, churnedSenders: 0 },
+        newMemberCount: 1,
+        ...neutralMonths,
+      });
+      expect((await service.getAlerts(ctx, "c1", asOf)).noNewMembers).toBe(false);
+    });
+  });
+});

--- a/src/__tests__/unit/sysadmin/service.test.ts
+++ b/src/__tests__/unit/sysadmin/service.test.ts
@@ -21,6 +21,7 @@ function member(overrides: Partial<SysAdminMemberStatsRow>): SysAdminMemberStats
     donationOutMonths: overrides.donationOutMonths ?? 0,
     totalPointsOut: overrides.totalPointsOut ?? BigInt(0),
     userSendRate: overrides.userSendRate ?? 0,
+    uniqueDonationRecipients: overrides.uniqueDonationRecipients ?? 0,
   };
 }
 
@@ -37,6 +38,7 @@ class MockSysAdminRepository {
   findActivitySnapshot = jest.fn();
   findNewMemberCount = jest.fn();
   findWindowActivityCounts = jest.fn();
+  findWindowHubMemberCount = jest.fn();
   findAllTimeTotals = jest.fn();
   findPlatformTotals = jest.fn();
 }

--- a/src/__tests__/unit/sysadmin/service.test.ts
+++ b/src/__tests__/unit/sysadmin/service.test.ts
@@ -36,6 +36,7 @@ class MockSysAdminRepository {
   findMonthlyActivity = jest.fn();
   findActivitySnapshot = jest.fn();
   findNewMemberCount = jest.fn();
+  findWindowActivityCounts = jest.fn();
   findAllTimeTotals = jest.fn();
   findPlatformTotals = jest.fn();
 }

--- a/src/__tests__/unit/sysadmin/util.test.ts
+++ b/src/__tests__/unit/sysadmin/util.test.ts
@@ -1,0 +1,120 @@
+import {
+  formatJstMonth,
+  jstMonthStart,
+  jstMonthStartOffset,
+  jstNextMonthStart,
+} from "@/application/domain/report/util";
+
+/**
+ * JST month helpers live on top of the day-level helpers in
+ * `report/util`. The key invariant they promise: the returned Date's
+ * UTC components encode the first day of the JST calendar month at
+ * UTC 00:00. That shape round-trips through the MV filters that
+ * compare against `@db.Date` columns bucketed at JST midnight.
+ */
+describe("jstMonthStart", () => {
+  it("returns the first day of the JST month for a mid-month JST time", () => {
+    // 2026-04-21 15:00 JST == 2026-04-21 06:00 UTC
+    const midMonth = new Date("2026-04-21T06:00:00Z");
+    expect(jstMonthStart(midMonth).toISOString().slice(0, 10)).toBe("2026-04-01");
+  });
+
+  it("returns the current JST month when the UTC day lags by 9h", () => {
+    // 2026-04-01T00:30+09:00 == 2026-03-31T15:30Z. Naive UTC truncation
+    // would snap this to March; the JST-aware helper must snap it to
+    // April (the same calendar month that DATE_TRUNC handling in SQL
+    // sees).
+    const earlyApril = new Date("2026-03-31T15:30:00Z");
+    expect(jstMonthStart(earlyApril).toISOString().slice(0, 10)).toBe("2026-04-01");
+  });
+
+  it("is idempotent — applying twice yields the same value", () => {
+    const d = new Date("2026-07-15T00:00:00Z");
+    const once = jstMonthStart(d);
+    expect(jstMonthStart(once).getTime()).toBe(once.getTime());
+  });
+
+  it("handles year boundaries (Dec → Jan) correctly", () => {
+    // 2025-12-31T23:59 JST == 2025-12-31T14:59Z. This is the last
+    // moment of 2025 in JST; the month start should be 2025-12-01.
+    const lastMomentOf2025Jst = new Date("2025-12-31T14:59:00Z");
+    expect(jstMonthStart(lastMomentOf2025Jst).toISOString().slice(0, 10)).toBe(
+      "2025-12-01",
+    );
+  });
+});
+
+describe("jstMonthStartOffset", () => {
+  it("returns the same month when offset is 0", () => {
+    const d = new Date("2026-04-15T00:00:00Z");
+    expect(jstMonthStartOffset(d, 0).toISOString().slice(0, 10)).toBe("2026-04-01");
+  });
+
+  it("rolls forward N months", () => {
+    const d = new Date("2026-04-15T00:00:00Z");
+    expect(jstMonthStartOffset(d, 3).toISOString().slice(0, 10)).toBe("2026-07-01");
+  });
+
+  it("rolls back N months", () => {
+    const d = new Date("2026-04-15T00:00:00Z");
+    expect(jstMonthStartOffset(d, -3).toISOString().slice(0, 10)).toBe("2026-01-01");
+  });
+
+  it("crosses a year boundary going backward", () => {
+    const d = new Date("2026-02-10T00:00:00Z");
+    expect(jstMonthStartOffset(d, -3).toISOString().slice(0, 10)).toBe("2025-11-01");
+  });
+
+  it("crosses a year boundary going forward", () => {
+    const d = new Date("2025-11-20T00:00:00Z");
+    expect(jstMonthStartOffset(d, 3).toISOString().slice(0, 10)).toBe("2026-02-01");
+  });
+
+  it("handles a 10-month windowMonths lookback (used by L2 default)", () => {
+    // Default windowMonths = 10: the earliest month in the trend is
+    // 9 months before asOf's month.
+    const asOf = new Date("2026-04-21T00:00:00Z");
+    expect(jstMonthStartOffset(asOf, -9).toISOString().slice(0, 10)).toBe(
+      "2025-07-01",
+    );
+  });
+});
+
+describe("jstNextMonthStart", () => {
+  it("returns the first day of the following month", () => {
+    const d = new Date("2026-04-21T06:00:00Z");
+    expect(jstNextMonthStart(d).toISOString().slice(0, 10)).toBe("2026-05-01");
+  });
+
+  it("wraps Dec → Jan of the next year", () => {
+    const d = new Date("2025-12-15T00:00:00Z");
+    expect(jstNextMonthStart(d).toISOString().slice(0, 10)).toBe("2026-01-01");
+  });
+
+  it("returns the next month even when called on the 1st", () => {
+    // Confirms the helper doesn't accidentally return the same month
+    // when already at a month boundary.
+    const firstOfMonth = new Date("2026-04-01T00:00:00Z");
+    expect(jstNextMonthStart(firstOfMonth).toISOString().slice(0, 10)).toBe(
+      "2026-05-01",
+    );
+  });
+});
+
+describe("formatJstMonth", () => {
+  it("formats the JST-encoded date as YYYY-MM", () => {
+    const d = new Date("2026-04-01T00:00:00Z");
+    expect(formatJstMonth(d)).toBe("2026-04");
+  });
+
+  it("zero-pads single-digit months", () => {
+    const d = new Date("2026-01-01T00:00:00Z");
+    expect(formatJstMonth(d)).toBe("2026-01");
+  });
+
+  it("reads from UTC components (JST month convention)", () => {
+    // Input is a UTC-encoded JST month start. UTC month + 1 == label.
+    const d = new Date(Date.UTC(2025, 10, 1)); // UTC Nov 1, 2025
+    expect(formatJstMonth(d)).toBe("2025-11");
+  });
+});

--- a/src/application/domain/report/README.md
+++ b/src/application/domain/report/README.md
@@ -1,0 +1,355 @@
+# report ドメイン — 計算ロジック解説
+
+このドキュメントは、`report` および `report` を再利用する `sysadmin` ドメインで使われる
+**集計・分析クエリの計算ロジック**を日本語でまとめたものです。
+新しい分析メソッドを追加する際は、本ドキュメントを参照して既存パターンと整合させてください。
+
+> 設計の意図やレイヤー責務は `CLAUDE.md` を参照。
+> 本ドキュメントはあくまで「実装上の計算式と境界条件」に焦点を当てています。
+
+---
+
+## 0. 設計前提
+
+### 退会がない構造
+プラットフォームの多くのコミュニティでは退会が発生しません。
+そのため、**`MembershipStatus.LEFT` は実運用では出現しない前提**で集計式を設計しています。
+分母となる `total_members` はすべて `status = 'JOINED'` でフィルタ。
+
+### LTV の唯一変数は月次送信率
+在籍期間がほぼ全員共通のため、LTV を決めるのは「何ヶ月に 1 回 DONATION を送るか」だけ。
+これが個人指標 `userSendRate` と、コミュニティ指標 `communityActivityRate` の意味の核です。
+
+### 「個人」と「コミュニティ」の指標分離
+混同しやすいので必ず区別する:
+
+| 指標 | 単位 | 計算式 |
+|---|---|---|
+| `userSendRate` | 個人 | `donation_out_months / months_in` |
+| `communityActivityRate` | コミュニティ | `直近月のsender数 / 月末時点のtotal_members` |
+
+GraphQL スキーマでは命名で区別 (`SysAdminMemberRow.userSendRate` vs
+`SysAdminCommunityOverview.communityActivityRate`)、description にも常に注記。
+
+---
+
+## 1. JST タイムゾーンの扱い
+
+### 1.1. 二段階変換パターン
+
+すべての日付集計で以下のパターンを使用:
+
+```sql
+(t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')::date
+```
+
+- `created_at` は naive UTC timestamp (`timestamp WITHOUT time zone`)
+- 1 段目 `AT TIME ZONE 'UTC'` で UTC 時刻として解釈 → timestamptz
+- 2 段目 `AT TIME ZONE 'Asia/Tokyo'` で JST 表記に変換 → naive timestamp
+
+> ⚠️ 単段の `AT TIME ZONE 'Asia/Tokyo'` は **値を JST と解釈してしまう**ため、
+> 00:00〜08:59 JST のレコードが前日に分類される。
+> 過去の MV バグは `migrations/20260416000001_fix_report_views_jst_bucketing/` で修正済み。
+
+### 1.2. 境界値を SQL に渡すパターン
+
+JST 月初 / 週初 などの境界値を SQL に渡すときは **「JST 日付を UTC midnight に encode した Date」** を使う。
+TS 側の helper:
+
+| 関数 | 返り値 |
+|---|---|
+| `truncateToJstDate(d)` | `d` の JST 暦日の 00:00 を UTC midnight として返す |
+| `isoWeekStartJst(d)` | `d` を含む ISO 週の月曜 00:00 JST（同上の encode） |
+| `jstMonthStart(d)` | `d` を含む JST 月の 1 日 00:00（同上の encode） |
+| `jstMonthStartOffset(d, n)` | n ヶ月オフセットした JST 月初 |
+| `jstNextMonthStart(d)` | 翌月の JST 月初 |
+
+repository 側ではこれを受け取って `::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC'` で
+naive UTC timestamp に変換して比較:
+
+```sql
+AND m."created_at" < (${jstUpper}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+```
+
+> ⚠️ raw な JS `Date` を直接渡すと、UTC 15:00–23:59 のとき `::date` の結果が JST 翌日になり、
+> 1 日ずれる。必ず `truncateToJstDate` 経由で渡すこと。
+
+### 1.3. 半開区間の徹底
+日付窓は常に `[from, to)` の半開区間で表現する:
+
+- 「直近 N 日間」 → `[asOfJstDay - (N-1)日, asOfJstDay + 1日)` で N 日ちょうど
+- 「ある月」 → `[monthStart, nextMonthStart)`
+- 「ある週」 → `[weekStart, weekStart + 7日)`
+
+`<= asOf::timestamp` のような閉区間と JST 日単位の `< (...)::date` を
+混在させると `findMemberStats` と `findActivitySnapshot` で精度がズレるので統一する。
+
+---
+
+## 2. 主要な指標の計算式
+
+### 2.1. `userSendRate`（個人の月次送信率）
+
+```
+userSendRate = donation_out_months / months_in
+```
+
+- `donation_out_months`：そのユーザーが DONATION-out を送った **distinct な JST 月数**
+- `months_in`：在籍した **distinct な JST 月数**（後述）
+
+返却値は小数点 3 桁に丸める（SQL 側で `ROUND(..., 3)`）。
+
+### 2.2. `months_in`（在籍月数）
+
+入会月から asOf 月までの **inclusive なスパン**:
+
+```
+months_in = (asOf 年 − created_at 年) × 12
+          + (asOf 月 − created_at 月)
+          + 1
+```
+
+- 2025-03-15 入会、asOf 2025-04-10 → `months_in = 2`（3 月と 4 月、2 ヶ月在籍）
+- 2026-04-21 入会、asOf 2026-04-21 → `months_in = 1`（当月のみ、最小値 1）
+- `GREATEST(1, ...)` で防御的に最小値 1 を保証
+
+> ⚠️ `+1` を忘れると `donation_out_months > months_in` となり `userSendRate > 1.0` になる。
+> 過去のバグでは「3 月と 4 月で donate した人が `userSendRate = 2.0`」が起きた。
+
+### 2.3. `communityActivityRate`（コミュニティ月次稼働率）
+
+```
+communityActivityRate = 直近月の DONATION sender 数 / 月末時点の total_members
+```
+
+- 分子：`mv_user_transaction_daily` で `donation_out_count > 0` の DISTINCT user_id
+- 分母：`t_memberships` で `created_at < (月末翌日 JST 00:00)` の `JOINED` メンバー数
+
+> ⚠️ 過去 / 現在進行中の月では分母を **asOf 当日まで**にクランプする必要がある。
+> `findMonthlyActivity` の `member_upper = LEAST(next_month_start, asOf+1日)` パターンを参照。
+
+### 2.4. `growthRateActivity`（前月比 — UI 用 informational signal）
+
+```
+growthRateActivity = (currRate − prevRate) / prevRate
+```
+
+- `prev.totalMembers === 0` または `prevRate === 0` のとき **null を返す**
+- そのまま割ると `Infinity` になり、GraphQL `Float` がエラーを返す
+
+> ⚠️ **これはダッシュボードに出す表示用の値**で、**`activeDrop` アラートの判定には使わない**。
+> アラートは「進行中月を対象にしない」ため、current vs prev ではなく
+> prev vs prev-prev で判定する（§4 参照）。
+> 同じ「前月比」でも表示用とアラート用で参照期間が違う点に注意。
+
+### 2.5. `community_activity_rate_3m_avg`（3 ヶ月移動平均）
+
+直近 3 ヶ月の `communityActivityRate` の単純平均。
+データが 3 ヶ月分未満のときは null を返す。
+
+---
+
+## 3. retention の計算
+
+### 3.1. `is_sender` / `is_receiver` の定義
+
+retention 系のすべての判定は **DONATION のみ**を対象とする:
+
+- `is_sender` ⇔ `donation_out_count > 0`
+- `is_receiver` ⇔ `received_donation_count > 0`
+
+> ⚠️ `tx_count_out > 0` だと ONBOARDING / GRANT による発行も含むので、
+> peer-to-peer engagement の指標として誤った値になる。
+> MV のカラム名にだまされないこと。
+
+### 3.2. 週次 retention の各カウンタ
+
+`findRetentionAggregate` は単一週に対して以下を返す:
+
+| カウンタ | 意味 |
+|---|---|
+| `retained_senders` | 今週も先週も sender だった人数 |
+| `churned_senders` | 先週は sender だが今週は止まった人数 |
+| `returned_senders` | 今週 sender、先週は止まっていたが、過去 12 週以内に sender だった人数 |
+| `current_senders_count` | 今週 sender だった人数 |
+| `current_active_count` | 今週 sender または receiver だった人数 |
+| `new_members` | 今週 `t_memberships.created_at` が落ちた人数 |
+
+### 3.3. `ever_before` の 12 週制限
+
+`returned_senders` 判定で「過去に sender だったか」を見るとき、
+**直近 12 週まで** で打ち切る:
+
+```sql
+ever_before AS (
+  SELECT DISTINCT "user_id"
+  FROM "mv_user_transaction_daily"
+  WHERE "date" >= ${twelveWeeksAgo}::date
+    AND "date" <  ${prevWeekStart}::date
+    AND "donation_out_count" > 0
+)
+```
+
+理由：歴の長いコミュニティで全期間 DISTINCT すると MV のフルスキャンになる。
+13 週以上前にしか活動がなかった人は returned に分類しない（既存ユーザーとみなす）トレードオフ。
+
+### 3.4. 月次コホート retention
+
+「入会月 m に joined した人のうち、月 m+1 / m+3 / m+6 に DONATION を送った人の割合」を計算。
+
+進行中の月は除外する:
+
+```ts
+if (activeEnd > latestMonthStart) return null;
+```
+
+理由：asOf を含む月は完了していないので、retention が不当に低く出る。
+完了済みの月のみ評価することで、外部報告で使える正確な数値になる。
+
+#### L1 の `latestCohortRetentionM1` も同じ規則
+
+L1 ダッシュボードに出る「直近コホート retention_m1」も、**asOf 月を
+active 期間として扱うと同じ問題**が起きるため、cohort を 1 ヶ月
+遡らせて「2 ヶ月前に joined した人の 1 ヶ月後 retention（= 先月中の
+DONATION 送信率）」として算出する。active 期間は asOf 月の直前で
+終わる完了月になるため、L2 の `activeEnd > latestMonthStart` ルールと
+整合する。
+
+---
+
+## 4. アラート判定
+
+集計指標を組み合わせた boolean フラグは **API 側で確定**してから返す
+（フロントは表示するだけ）。
+
+| フラグ | 条件 | 判定対象期間 |
+|---|---|---|
+| `churnSpike` | `churned_senders > retained_senders` | **直近の完了済み週** vs その前の週 |
+| `activeDrop` | 月次稼働率の変化 `<= -20%` | **直近の完了済み月** vs その前の月 |
+| `noNewMembers` | 直近 14 日間（JST）に `JOINED` が 0 件 | `asOf` を終点に含む 14 日間 |
+
+> ⚠️ **進行中の週 / 月はアラート判定の対象にしない**。
+> asOf を含む週 / 月を対象にすると、週の月曜や月初で
+> データ蓄積が途中のまま完了期間と比較してしまい、
+> 毎週 / 毎月の週頭・月初で必ず誤検知する。
+> 判定は常に「完了済み直近期間」を参照する。
+> UI に出す `growthRateActivity`（current vs prev）は別の informational signal として維持される。
+
+### 4.1. `noNewMembers` 窓の作り方
+
+正確に「14 日間」にするための半開区間:
+
+```ts
+const asOfJstDay = truncateToJstDate(asOf);
+const fourteenDaysAgo = addDays(asOfJstDay, -(14 - 1));   // 13 日前
+const upperExclusive = addDays(asOfJstDay, 1);            // 翌日 0:00 JST
+// 窓 = [fourteenDaysAgo, upperExclusive) = 14 日ちょうど
+```
+
+> ⚠️ 過去のバグ:
+> - `addDays(latestWeekStart, -14)` 起点 → 窓が 14〜21 日に可変
+> - `addDays(asOfJstDay, -14)` + `asOfJstDay + 1` → 15 日窓（off-by-one）
+
+### 4.2. `activeDrop` のゼロ除算ガード
+
+`activeDrop` は **prev-month rate vs prev-prev-month rate** で判定する
+（§4 の表参照）。次のいずれかで `null` を返し、アラートは発火させない:
+
+- `prevPrevMonth.totalMembers === 0`（prev-prev 月にメンバーがいない）
+- `prevPrevRate === 0`（prev-prev 月の稼働率が 0）
+
+`percentChange(prevRate, prevPrevRate)` が内部で `null` を返すケースと
+同じで、そのまま割ると `Infinity` になり GraphQL `Float` がエラーになる。
+
+---
+
+## 5. ステージ分類（sysadmin）
+
+`userSendRate` の閾値で 4 段階に分類:
+
+| ステージ | 条件 |
+|---|---|
+| `latent` | `donation_out_months === 0`（未参加） |
+| `occasional` | `0 < userSendRate < tier2`（散発参加） |
+| `regular` | `tier2 <= userSendRate < tier1`（定期参加） |
+| `habitual` | `userSendRate >= tier1`（習慣化） |
+
+デフォルト閾値：`tier1 = 0.7`、`tier2 = 0.4`。
+**閾値はフロントから input で受け取る** — サーバ側に固定値を埋め込まない。
+
+### 5.1. 累積 (cumulative) と分割 (disjoint) の使い分け
+
+| 用途 | 計算方法 |
+|---|---|
+| `SegmentCounts.tier1Count` / `tier2Count` | `userSendRate >= tier1`（または tier2）の人数（**累積**） |
+| `StageBreakdown.{habitual, regular, occasional, latent}` | 4 バケツに**排他的**に分類、`pct` の合計 = 1.0 |
+
+L1 dashboard の表示用には累積、L2 詳細の構成比表示には disjoint を使う。
+
+---
+
+## 6. レイヤー責務
+
+`CLAUDE.md` の規則を実装で守るためのチェック:
+
+### 6.1. UseCase
+- ✅ Service と Presenter のみ呼ぶ
+- ❌ Repository を直接呼ばない（Service に thin pass-through を追加すること）
+
+### 6.2. Service
+- ✅ 自ドメインの Repository を呼ぶ
+- ✅ 他ドメインの **Service** を呼ぶ（read 専用）
+- ❌ 他ドメインの **Repository** を直接呼ばない
+
+例：`SysAdminService` は `ReportService.getRetentionAggregate` を呼ぶ
+（`ReportRepository.findRetentionAggregate` を直接呼んではいけない）。
+
+### 6.3. Repository
+- ✅ Prisma クエリを実行
+- ✅ `ctx.issuer.public()` / `internal()` で RLS をバイパス
+- ❌ ビジネスロジックを書かない（フィルタ・ソート・ページングは Service へ）
+
+---
+
+## 7. パフォーマンス
+
+### 7.1. fan-out 戦略
+
+- 現状（コミュニティ数 〜6）：N ループを許容（`Promise.all`）
+- 〜20 を超えたら：`GROUP BY community_id` のバルク取得メソッドを検討
+- 週次 retention のループ（〜43 週）も同様。MV のインデックス
+  `(community_id, date)` が効くので並列小クエリで十分速い
+  （`scripts/sysadmin_bench.ts` の計測：bulk 化は 364x 遅化したので revert）
+
+### 7.2. `windowMonths` の上限
+
+`getCohortRetention` は 1 ヶ月あたり 4 SQL 発行するので、
+input に上限を設ける（`MAX_WINDOW_MONTHS = 36`）。
+
+---
+
+## 8. よくある落とし穴（過去のバグから）
+
+| 症状 | 原因 | 対処 |
+|---|---|---|
+| `userSendRate > 1.0` | `months_in` の `+1` 忘れ | `months_in` を inclusive スパンに |
+| 過去 asOf でメンバー数が膨らむ | repo の `members` CTE に `created_at <= asOf` が無い | 各クエリで asOf clamp を統一 |
+| `noNewMembers` が誤検出 | 14 日窓が 14〜21 日 / 15 日に可変 | `[asOfJstDay-13, asOfJstDay+1)` で 14 日ちょうど |
+| `growthRateActivity` が `Infinity` | `prevRate === 0` で割り算 | 明示的に null を返す |
+| 日付が 1 日ずれる | raw JS `Date` を repo に渡している | `truncateToJstDate` 経由で JST-encoded に |
+| L1 と L2 で `totalMembers` が違う | クエリ間で precision が `<= timestamp` と `< date` で混在 | JST 日単位で統一 |
+| Build が失敗 (TS1005) | SQL コメント内に `` ` `` を使った | バッククォートを除去（template literal を閉じる） |
+| cohort retention が不当に低い | 進行中月を含めて評価 | `activeEnd > latestMonthStart` で除外 |
+
+---
+
+## 9. 関連ファイル
+
+| パス | 内容 |
+|---|---|
+| `src/application/domain/report/util.ts` | JST 日付ヘルパー、`bigintToSafeNumber`、`percentChange` |
+| `src/application/domain/report/data/repository.ts` | retention / cohort / period aggregates の中核実装 |
+| `src/application/domain/sysadmin/data/repository.ts` | `findMemberStats` / `findMonthlyActivity` などの sysadmin 固有クエリ |
+| `src/application/domain/sysadmin/service.ts` | アラート判定・ステージ分類・トレンド orchestrator |
+| `scripts/sysadmin_bench.ts` | 週次 retention のローカル計測スクリプト |
+| `src/infrastructure/prisma/migrations/20260416000001_fix_report_views_jst_bucketing/` | JST バケツバグの修正履歴 |

--- a/src/application/domain/report/util.ts
+++ b/src/application/domain/report/util.ts
@@ -103,3 +103,50 @@ export function percentChange(current: number, previous: number): number | null 
   if (previous === 0) return null;
   return ((current - previous) / previous) * 100;
 }
+
+// ============================================================================
+// JST month-level helpers
+//
+// Same UTC-encoded-JST convention as `truncateToJstDate`: a "JST month
+// start" is a Date whose UTC components encode the first day of the JST
+// calendar month at UTC 00:00. Round-trips through Prisma `@db.Date`
+// filters and the `::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC'`
+// SQL pattern the report / sysadmin repositories use.
+//
+// Lived under sysadmin/util.ts originally; moved here so every analytics
+// domain imports from the same place as the day/week helpers above.
+// ============================================================================
+
+/**
+ * Return the first day of the JST calendar month that `d` falls in,
+ * encoded as a UTC-midnight Date.
+ */
+export function jstMonthStart(d: Date): Date {
+  const jst = new Date(d.getTime() + 9 * 60 * 60 * 1000);
+  return new Date(Date.UTC(jst.getUTCFullYear(), jst.getUTCMonth(), 1));
+}
+
+/**
+ * Return the first day of the JST month `offset` months away from the
+ * month containing `d` (negative = earlier, positive = later).
+ */
+export function jstMonthStartOffset(d: Date, offset: number): Date {
+  const start = jstMonthStart(d);
+  return new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth() + offset, 1));
+}
+
+/** Same as `jstMonthStartOffset(d, 1)` — start of the month after `d`. */
+export function jstNextMonthStart(d: Date): Date {
+  return jstMonthStartOffset(d, 1);
+}
+
+/**
+ * Format a JST-month-start Date (or any Date) as `YYYY-MM`. Uses the
+ * date's UTC components because, by convention, JST month starts are
+ * stored with their JST year/month encoded at UTC 00:00.
+ */
+export function formatJstMonth(d: Date): string {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  return `${y}-${m}`;
+}

--- a/src/application/domain/sysadmin/bounds.ts
+++ b/src/application/domain/sysadmin/bounds.ts
@@ -1,0 +1,46 @@
+import { addDays, truncateToJstDate } from "@/application/domain/report/util";
+
+/**
+ * Clamp helper for queries whose upper bound should never land in the
+ * future relative to an `asOf` timestamp.
+ *
+ * Four places across the sysadmin domain need the same calculation:
+ *   - usecase.getDashboard  (findPlatformTotals upper)
+ *   - service.getMonthActivityWithPrev (current-month snapshot)
+ *   - service.getRetentionTrend (per-week denominator)
+ *   - service.getAlerts (findNewMemberCount upper)
+ *
+ * Before this helper they all read roughly:
+ *   const asOfJstDayPlusOne = addDays(truncateToJstDate(asOf), 1);
+ *   const upper = boundary < asOfJstDayPlusOne ? boundary : asOfJstDayPlusOne;
+ *
+ * Centralising the expression here keeps the "asOf JST day + 1"
+ * definition in one spot; if the convention ever changes (e.g. the
+ * analytics boundary moves to "asOf exactly", or to start-of-next-week),
+ * every call site updates together.
+ */
+export type AsOfBounds = {
+  /**
+   * The JST midnight that starts the day AFTER asOf's JST day, encoded
+   * as a UTC-midnight Date (same convention as `truncateToJstDate`).
+   * This is the exclusive upper bound for "anything up to and
+   * including asOf's JST day".
+   */
+  readonly asOfJstDayPlusOne: Date;
+
+  /**
+   * Clamp a future-side boundary (e.g. `jstNextMonthStart(asOf)` or a
+   * week's `nextWeekStart`) so it never exceeds `asOfJstDayPlusOne`.
+   * For any boundary that's already ≤ asOfJstDayPlusOne (i.e. a past
+   * month/week), the input is returned unchanged.
+   */
+  clampFuture(futureBoundary: Date): Date;
+};
+
+export function asOfBounds(asOf: Date): AsOfBounds {
+  const asOfJstDayPlusOne = addDays(truncateToJstDate(asOf), 1);
+  return {
+    asOfJstDayPlusOne,
+    clampFuture: (b) => (b < asOfJstDayPlusOne ? b : asOfJstDayPlusOne),
+  };
+}

--- a/src/application/domain/sysadmin/controller/resolver.ts
+++ b/src/application/domain/sysadmin/controller/resolver.ts
@@ -1,0 +1,23 @@
+import { inject, injectable } from "tsyringe";
+import { IContext } from "@/types/server";
+import SysAdminUseCase from "@/application/domain/sysadmin/usecase";
+import {
+  GqlQuerySysAdminCommunityDetailArgs,
+  GqlQuerySysAdminDashboardArgs,
+} from "@/types/graphql";
+
+@injectable()
+export default class SysAdminResolver {
+  constructor(@inject("SysAdminUseCase") private readonly useCase: SysAdminUseCase) {}
+
+  Query = {
+    sysAdminDashboard: (_: unknown, args: GqlQuerySysAdminDashboardArgs, ctx: IContext) =>
+      this.useCase.getDashboard(args, ctx),
+
+    sysAdminCommunityDetail: (
+      _: unknown,
+      args: GqlQuerySysAdminCommunityDetailArgs,
+      ctx: IContext,
+    ) => this.useCase.getCommunityDetail(args, ctx),
+  };
+}

--- a/src/application/domain/sysadmin/data/interface.ts
+++ b/src/application/domain/sysadmin/data/interface.ts
@@ -7,6 +7,7 @@ import {
   SysAdminMonthlyActivityRow,
   SysAdminNewMemberCountRow,
   SysAdminPlatformTotalsRow,
+  SysAdminWindowActivityCountsRow,
 } from "@/application/domain/sysadmin/data/type";
 
 /**
@@ -75,6 +76,24 @@ export interface ISysAdminRepository {
     from: Date,
     to: Date,
   ): Promise<SysAdminNewMemberCountRow>;
+
+  /**
+   * All five raw counts the L1 `SysAdminWindowActivity` payload needs
+   * for the parametric window pair driven by `windowDays`. Issues a
+   * single SQL with two scans (one over `mv_user_transaction_daily`
+   * and one over `t_memberships`), each spanning `[prevLower, upper)`.
+   *
+   * Replaces three separate `findActivitySnapshot` / intersection
+   * calls and two `findNewMemberCount` calls; the previous design
+   * scanned the same MV three times for overlapping windows.
+   */
+  findWindowActivityCounts(
+    ctx: IContext,
+    communityId: string,
+    prevLower: Date,
+    currLower: Date,
+    upper: Date,
+  ): Promise<SysAdminWindowActivityCountsRow>;
 
   /** All-time DONATION totals + MV data window for the summary card,
    * clamped at `asOf` for historic-asOf consistency with the rest of

--- a/src/application/domain/sysadmin/data/interface.ts
+++ b/src/application/domain/sysadmin/data/interface.ts
@@ -1,0 +1,94 @@
+import { IContext } from "@/types/server";
+import {
+  SysAdminAllTimeTotalsRow,
+  SysAdminCommunityRow,
+  SysAdminMemberStatsRow,
+  SysAdminActivitySnapshotRow,
+  SysAdminMonthlyActivityRow,
+  SysAdminNewMemberCountRow,
+  SysAdminPlatformTotalsRow,
+} from "@/application/domain/sysadmin/data/type";
+
+/**
+ * Repository contract for the sysadmin analytics surface.
+ *
+ * All queries read through `ctx.issuer.public` (MVs bypass RLS anyway,
+ * and the t_memberships / t_transactions reads here are gated at the
+ * resolver with `@authz(rules: [IsAdmin])`). No method mutates state.
+ */
+export interface ISysAdminRepository {
+  /** Every community id + display name, ordered by name. */
+  findAllCommunities(ctx: IContext): Promise<SysAdminCommunityRow[]>;
+
+  /**
+   * Resolve one community by id, returning the same projection shape
+   * as `findAllCommunities`. Returns null when the id is unknown so
+   * the usecase can surface a NotFoundError without a fallback scan.
+   */
+  findCommunityById(
+    ctx: IContext,
+    communityId: string,
+  ): Promise<SysAdminCommunityRow | null>;
+
+  /**
+   * Per-member LTV-variable counters at `asOf` for one community.
+   * Scoped to `status='JOINED'`. A member with zero DONATION-outs is
+   * still present (donationOutMonths=0, userSendRate=0, latent stage).
+   */
+  findMemberStats(
+    ctx: IContext,
+    communityId: string,
+    asOf: Date,
+  ): Promise<SysAdminMemberStatsRow[]>;
+
+  /**
+   * Monthly activity series for `windowMonths` trailing JST months
+   * ending at `asOf`. One row per month with data; months with zero
+   * senders and zero new members are still emitted (with zero
+   * counters) so the UI can render a contiguous x-axis.
+   */
+  findMonthlyActivity(
+    ctx: IContext,
+    communityId: string,
+    asOf: Date,
+    windowMonths: number,
+  ): Promise<SysAdminMonthlyActivityRow[]>;
+
+  /**
+   * Latest-month unique sender count + total_members snapshot used to
+   * compute `communityActivityRate` and power growth-rate math.
+   */
+  findActivitySnapshot(
+    ctx: IContext,
+    communityId: string,
+    jstMonthStart: Date,
+    jstNextMonthStart: Date,
+  ): Promise<SysAdminActivitySnapshotRow>;
+
+  /**
+   * Count of `t_memberships.status='JOINED'` rows whose `created_at`
+   * falls within `[from, to)`. Used for the `no_new_members` alert.
+   */
+  findNewMemberCount(
+    ctx: IContext,
+    communityId: string,
+    from: Date,
+    to: Date,
+  ): Promise<SysAdminNewMemberCountRow>;
+
+  /** All-time DONATION totals + MV data window for the summary card,
+   * clamped at `asOf` for historic-asOf consistency with the rest of
+   * the dashboard. */
+  findAllTimeTotals(
+    ctx: IContext,
+    communityId: string,
+    asOf: Date,
+  ): Promise<SysAdminAllTimeTotalsRow>;
+
+  /** Platform-wide headline row for the L1 dashboard. */
+  findPlatformTotals(
+    ctx: IContext,
+    jstMonthStart: Date,
+    jstNextMonthStart: Date,
+  ): Promise<SysAdminPlatformTotalsRow>;
+}

--- a/src/application/domain/sysadmin/data/interface.ts
+++ b/src/application/domain/sysadmin/data/interface.ts
@@ -4,6 +4,7 @@ import {
   SysAdminCommunityRow,
   SysAdminMemberStatsRow,
   SysAdminActivitySnapshotRow,
+  SysAdminHubMemberCountRow,
   SysAdminMonthlyActivityRow,
   SysAdminNewMemberCountRow,
   SysAdminPlatformTotalsRow,
@@ -76,6 +77,28 @@ export interface ISysAdminRepository {
     from: Date,
     to: Date,
   ): Promise<SysAdminNewMemberCountRow>;
+
+  /**
+   * Per-community count of members whose distinct DONATION
+   * recipient count within `[currLower, upper)` reaches
+   * `hubBreadthThreshold`. Backs
+   * `SysAdminCommunityOverview.hubMemberCount`.
+   *
+   * The recipient count is computed against `t_transactions`
+   * directly (not `mv_user_transaction_daily`) because the MV's
+   * per-day `unique_counterparties` does not compose into a
+   * window-wide DISTINCT — the same recipient across multiple days
+   * would double-count under SUM. Same reasoning as the
+   * `donation_recipients` CTE in `findMemberStats`, restricted to
+   * the parametric window instead of the full tenure.
+   */
+  findWindowHubMemberCount(
+    ctx: IContext,
+    communityId: string,
+    currLower: Date,
+    upper: Date,
+    hubBreadthThreshold: number,
+  ): Promise<SysAdminHubMemberCountRow>;
 
   /**
    * All five raw counts the L1 `SysAdminWindowActivity` payload needs

--- a/src/application/domain/sysadmin/data/repository.ts
+++ b/src/application/domain/sysadmin/data/repository.ts
@@ -245,7 +245,7 @@ export default class SysAdminRepository implements ISysAdminRepository {
             DATE_TRUNC(
               'month',
               (${asOf}::timestamp AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')
-            ) - make_interval(months => ${windowMonths} - 1),
+            ) - make_interval(months => (${windowMonths})::int - 1),
             DATE_TRUNC(
               'month',
               (${asOf}::timestamp AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')

--- a/src/application/domain/sysadmin/data/repository.ts
+++ b/src/application/domain/sysadmin/data/repository.ts
@@ -1,0 +1,544 @@
+import { injectable } from "tsyringe";
+import { IContext } from "@/types/server";
+import {
+  SysAdminAllTimeTotalsRow,
+  SysAdminCommunityRow,
+  SysAdminMemberStatsRow,
+  SysAdminActivitySnapshotRow,
+  SysAdminMonthlyActivityRow,
+  SysAdminNewMemberCountRow,
+  SysAdminPlatformTotalsRow,
+} from "@/application/domain/sysadmin/data/type";
+import { ISysAdminRepository } from "@/application/domain/sysadmin/data/interface";
+
+/**
+ * SQL helpers for the sysadmin analytics surface.
+ *
+ * Conventions inherited from the report repository:
+ *   - Every read goes through `ctx.issuer.public`; MVs are RLS-less and
+ *     `t_memberships` / `t_transactions` are protected upstream by the
+ *     `@authz(rules: [IsAdmin])` directive.
+ *   - `t_transactions.created_at` and `t_memberships.created_at` are
+ *     timestamp WITHOUT time zone (Prisma DateTime default) holding naive
+ *     UTC. JST-calendar date boundaries are converted to naive UTC on the
+ *     constant side (`::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC'`)
+ *     so the B-tree indexes on `created_at` stay SARGable.
+ *   - `::int` and `::bigint` casts on aggregate outputs keep Prisma from
+ *     surfacing bigints for small counts.
+ */
+@injectable()
+export default class SysAdminRepository implements ISysAdminRepository {
+  async findAllCommunities(ctx: IContext): Promise<SysAdminCommunityRow[]> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      const rows = await tx.$queryRaw<{ id: string; name: string }[]>`
+        SELECT c."id", c."name"
+        FROM "t_communities" c
+        ORDER BY c."name" ASC
+      `;
+      return rows.map((r) => ({ communityId: r.id, communityName: r.name }));
+    });
+  }
+
+  async findCommunityById(
+    ctx: IContext,
+    communityId: string,
+  ): Promise<SysAdminCommunityRow | null> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      const rows = await tx.$queryRaw<{ id: string; name: string }[]>`
+        SELECT c."id", c."name"
+        FROM "t_communities" c
+        WHERE c."id" = ${communityId}
+        LIMIT 1
+      `;
+      if (rows.length === 0) return null;
+      const r = rows[0];
+      return { communityId: r.id, communityName: r.name };
+    });
+  }
+
+  /**
+   * One row per JOINED member with tenure + donation-out counters at
+   * `asOf`. `months_in` is the JST-calendar-month difference (floor,
+   * minimum 1) so a member who joined today and a member who joined
+   * earlier this month both get `months_in = 1` — the spec defines
+   * tenure in completed-month units, not days.
+   *
+   * `donation_out_months` counts DISTINCT JST calendar months with at
+   * least one DONATION-out originating from a wallet owned by this
+   * member in this community. `total_points_out` sums the Int
+   * `from_point_change` column; the `::bigint` upcast protects against
+   * overflow once SUM aggregates enough rows.
+   *
+   * `user_send_rate` is emitted already-rounded to 3dp so the presenter
+   * stays a pure shape-mapper.
+   *
+   * The `t.created_at <= asOf` comparison is a naive-UTC vs naive-UTC
+   * compare — both sides hold the same storage format, no timezone
+   * dance required.
+   */
+  async findMemberStats(
+    ctx: IContext,
+    communityId: string,
+    asOf: Date,
+  ): Promise<SysAdminMemberStatsRow[]> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      const rows = await tx.$queryRaw<
+        {
+          user_id: string;
+          name: string | null;
+          months_in: number;
+          donation_out_months: number;
+          total_points_out: bigint;
+          user_send_rate: number;
+        }[]
+      >`
+        WITH asof_jst AS (
+          -- The asOf instant expressed in JST, computed once so every
+          -- downstream CTE can reuse the same naive JST timestamp
+          -- (for year/month extraction and day-boundary derivation).
+          SELECT (${asOf}::timestamp AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo') AS ts
+        ),
+        asof_bound AS (
+          -- Derive the "asOf JST day + 1, at JST midnight, expressed
+          -- as a naive UTC timestamp" once and reuse everywhere the
+          -- query wants an exclusive upper bound on t_*.created_at.
+          -- The expression is the same JST-day clamp findActivitySnapshot
+          -- / findMonthlyActivity receive pre-computed from the
+          -- service layer; inlining it into a single CTE here keeps
+          -- findMemberStats' signature unchanged without duplicating
+          -- the double-AT TIME ZONE dance across three WHERE clauses.
+          SELECT
+            ((ts::date + 1) AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC') AS upper_ts
+          FROM asof_jst
+        ),
+        members AS (
+          -- Filter to members whose membership existed at asOf.
+          -- Without this, a historic asOf would include members who
+          -- joined after that point, inflating stageCounts.total,
+          -- polluting stage classification, and leaking future members
+          -- into the paginated list. findActivitySnapshot already scopes
+          -- total_members this way; mirroring it keeps the activity
+          -- rate denominator consistent with stageCounts.total.
+          SELECT
+            m."user_id",
+            m."created_at"
+          FROM "t_memberships" m, asof_bound ab
+          WHERE m."community_id" = ${communityId}
+            AND m."status" = 'JOINED'
+            AND m."created_at" < ab.upper_ts
+        ),
+        donation_months AS (
+          SELECT
+            fw."user_id" AS user_id,
+            DATE_TRUNC(
+              'month',
+              (t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')
+            ) AS jst_month,
+            SUM(t."from_point_change") AS month_points_out
+          FROM "t_transactions" t
+          INNER JOIN "t_wallets" fw
+            ON fw."id" = t."from"
+            AND fw."community_id" = ${communityId}
+          INNER JOIN members m ON m."user_id" = fw."user_id"
+          CROSS JOIN asof_bound ab
+          WHERE t."reason" = 'DONATION'
+            AND t."created_at" < ab.upper_ts
+            -- JST-day-unit upper bound so donation activity lines up
+            -- with the member-tenure bound in the members CTE above.
+            -- findActivitySnapshot / findPlatformTotals also use this
+            -- unit, so stageCounts.total and the activity-rate
+            -- denominator agree on what "as of asOf" includes.
+          GROUP BY fw."user_id", jst_month
+        ),
+        member_tenure AS (
+          -- Compute months_in ONCE per member so the final SELECT can
+          -- reuse it as both months_in and the denominator of
+          -- user_send_rate. The formula is "distinct JST calendar
+          -- months the member has been present in (join-month through
+          -- asOf-month inclusive)" — the +1 turns the month-number
+          -- diff into a span count, matching how
+          -- donation_out_months (COUNT DISTINCT jst_month) counts.
+          -- GREATEST(1, ...) defends against any future clock skew.
+          -- Pulling the asOf-side conversion from asof_jst.ts avoids
+          -- re-running the double AT TIME ZONE cast once per row.
+          SELECT
+            m."user_id",
+            GREATEST(
+              1,
+              (
+                (
+                  EXTRACT(YEAR FROM aj.ts)::int
+                  - EXTRACT(YEAR FROM (m."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo'))::int
+                ) * 12
+                + (
+                  EXTRACT(MONTH FROM aj.ts)::int
+                  - EXTRACT(MONTH FROM (m."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo'))::int
+                )
+                + 1
+              )
+            )::int AS months_in
+          FROM members m, asof_jst aj
+        )
+        SELECT
+          m."user_id",
+          u."name" AS "name",
+          mt.months_in,
+          COALESCE(COUNT(DISTINCT dm.jst_month), 0)::int AS donation_out_months,
+          COALESCE(SUM(dm.month_points_out), 0)::bigint AS total_points_out,
+          -- GREATEST(1, ...) inside member_tenure guarantees the
+          -- divisor is >= 1; no zero branch needed around ROUND.
+          ROUND(
+            COALESCE(COUNT(DISTINCT dm.jst_month), 0)::numeric
+              / mt.months_in::numeric,
+            3
+          )::double precision AS user_send_rate
+        FROM members m
+        INNER JOIN member_tenure mt ON mt."user_id" = m."user_id"
+        LEFT JOIN donation_months dm ON dm.user_id = m."user_id"
+        LEFT JOIN "t_users" u ON u."id" = m."user_id"
+        GROUP BY m."user_id", mt.months_in, u."name"
+        ORDER BY m."user_id"
+      `;
+      return rows.map((r) => ({
+        userId: r.user_id,
+        name: r.name,
+        monthsIn: r.months_in,
+        donationOutMonths: r.donation_out_months,
+        totalPointsOut: r.total_points_out,
+        userSendRate: r.user_send_rate,
+      }));
+    });
+  }
+
+  /**
+   * `windowMonths` trailing JST months (inclusive of the asOf month).
+   * Sources everything off MVs except the member counts, which come
+   * from `t_memberships` so "new_members" / "total_members" are not
+   * tied to MV refresh cadence.
+   *
+   * `total_members_end_of_month` counts JOINED memberships whose
+   * `created_at` is before the next-month boundary — the same frame
+   * used by `monthlyActivityRate`'s denominator so the rate stays
+   * self-consistent.
+   */
+  async findMonthlyActivity(
+    ctx: IContext,
+    communityId: string,
+    asOf: Date,
+    windowMonths: number,
+  ): Promise<SysAdminMonthlyActivityRow[]> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      const rows = await tx.$queryRaw<
+        {
+          month_start: Date;
+          sender_count: number;
+          total_members_end_of_month: number;
+          new_members: number;
+          donation_points_sum: bigint;
+          donation_tx_count: bigint;
+          donation_chain_tx_count: bigint;
+        }[]
+      >`
+        WITH month_starts AS (
+          SELECT gs::date AS month_start
+          FROM generate_series(
+            DATE_TRUNC(
+              'month',
+              (${asOf}::timestamp AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')
+            ) - make_interval(months => ${windowMonths} - 1),
+            DATE_TRUNC(
+              'month',
+              (${asOf}::timestamp AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')
+            ),
+            '1 month'
+          ) AS gs
+        ),
+        month_bounds AS (
+          SELECT
+            month_start,
+            (month_start + INTERVAL '1 month')::date AS next_month_start,
+            -- Membership-side upper bound: clamp at (asOf JST day + 1)
+            -- so the most recent month doesn't count members who
+            -- joined after asOf. For past months the LEAST collapses
+            -- to next_month_start, so behaviour is unchanged. Mirrors
+            -- the clamp findMemberStats / findActivitySnapshot already
+            -- apply, so totalMembersEndOfMonth on the trend lines up
+            -- with stageCounts.total and the summary-card rate.
+            LEAST(
+              (month_start + INTERVAL '1 month')::date,
+              ((${asOf}::timestamp AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')::date + 1)
+            ) AS member_upper
+          FROM month_starts
+        ),
+        senders AS (
+          SELECT
+            mb.month_start,
+            COUNT(DISTINCT mv."user_id")::int AS sender_count
+          FROM month_bounds mb
+          LEFT JOIN "mv_user_transaction_daily" mv
+            ON mv."community_id" = ${communityId}
+            AND mv."date" >= mb.month_start
+            -- Use member_upper (LEAST of next_month_start and
+            -- asOf+1 JST) as the upper bound so the asOf month's
+            -- sender count doesn't include MV rows past asOf when a
+            -- historic asOf is supplied. Keeps the numerator aligned
+            -- with total_members in member_counts below.
+            AND mv."date" <  mb.member_upper
+            AND mv."donation_out_count" > 0
+          GROUP BY mb.month_start
+        ),
+        tx_totals AS (
+          SELECT
+            mb.month_start,
+            COALESCE(SUM(
+              CASE WHEN ts."reason" = 'DONATION' THEN ts."points_sum" ELSE 0 END
+            ), 0)::bigint AS donation_points_sum,
+            COALESCE(SUM(
+              CASE WHEN ts."reason" = 'DONATION' THEN ts."tx_count" ELSE 0 END
+            ), 0)::bigint AS donation_tx_count,
+            -- chain_root_count is chain_depth=1 (root of a chain),
+            -- chain_descendant_count is chain_depth>=2. The sum is
+            -- "transactions that are part of a chain" for this reason.
+            -- COALESCE each column so a hypothetical NULL (MV reshape,
+            -- LEFT JOIN miss) doesn't null out the whole addition and
+            -- silently drop from SUM. ::bigint so the tx count cannot
+            -- overflow int32 (~2.1B) on long-running or busy
+            -- communities — the Presenter converts through
+            -- bigintToSafeNumber before it hits the GraphQL payload.
+            COALESCE(SUM(
+              CASE WHEN ts."reason" = 'DONATION'
+                THEN COALESCE(ts."chain_root_count", 0)
+                     + COALESCE(ts."chain_descendant_count", 0)
+                ELSE 0
+              END
+            ), 0)::bigint AS donation_chain_tx_count
+          FROM month_bounds mb
+          LEFT JOIN "mv_transaction_summary_daily" ts
+            ON ts."community_id" = ${communityId}
+            AND ts."date" >= mb.month_start
+            -- Match the member_counts / senders clamp. Historic asOf
+            -- queries must not pull tx activity from dates past
+            -- asOf; past months collapse member_upper back to
+            -- next_month_start so behaviour is unchanged there.
+            AND ts."date" <  mb.member_upper
+          GROUP BY mb.month_start
+        ),
+        member_counts AS (
+          -- Single-scan pass over t_memberships computes both
+          -- new_members and total_members_end_of_month. The JOIN
+          -- predicate bounds everything at member_upper (asOf+1 JST
+          -- day for the asOf month, next_month_start otherwise); the
+          -- new_members FILTER narrows further to rows that joined
+          -- in the month itself. Collapsing the two previous CTEs
+          -- halves the LEFT JOINs against t_memberships.
+          SELECT
+            mb.month_start,
+            COUNT(m."user_id") FILTER (
+              WHERE m."created_at" >= (mb.month_start AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+            )::int AS new_members,
+            COUNT(m."user_id")::int AS total_members_end_of_month
+          FROM month_bounds mb
+          LEFT JOIN "t_memberships" m
+            ON m."community_id" = ${communityId}
+            AND m."status" = 'JOINED'
+            AND m."created_at" <  (mb.member_upper AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+          GROUP BY mb.month_start
+        )
+        SELECT
+          mb.month_start,
+          COALESCE(s.sender_count, 0)::int AS sender_count,
+          COALESCE(mc.total_members_end_of_month, 0)::int AS total_members_end_of_month,
+          COALESCE(mc.new_members, 0)::int AS new_members,
+          COALESCE(tt.donation_points_sum, 0)::bigint AS donation_points_sum,
+          COALESCE(tt.donation_tx_count, 0)::bigint AS donation_tx_count,
+          COALESCE(tt.donation_chain_tx_count, 0)::bigint AS donation_chain_tx_count
+        FROM month_bounds mb
+        LEFT JOIN senders s USING (month_start)
+        LEFT JOIN tx_totals tt USING (month_start)
+        LEFT JOIN member_counts mc USING (month_start)
+        ORDER BY mb.month_start ASC
+      `;
+      return rows.map((r) => ({
+        monthStart: r.month_start,
+        senderCount: r.sender_count,
+        totalMembersEndOfMonth: r.total_members_end_of_month,
+        newMembers: r.new_members,
+        donationPointsSum: r.donation_points_sum,
+        donationTxCount: r.donation_tx_count,
+        donationChainTxCount: r.donation_chain_tx_count,
+      }));
+    });
+  }
+
+  async findActivitySnapshot(
+    ctx: IContext,
+    communityId: string,
+    jstMonthStart: Date,
+    jstNextMonthStart: Date,
+  ): Promise<SysAdminActivitySnapshotRow> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      const rows = await tx.$queryRaw<{ sender_count: number; total_members: number }[]>`
+        WITH senders AS (
+          SELECT COUNT(DISTINCT "user_id")::int AS n
+          FROM "mv_user_transaction_daily"
+          WHERE "community_id" = ${communityId}
+            AND "date" >= ${jstMonthStart}::date
+            AND "date" <  ${jstNextMonthStart}::date
+            AND "donation_out_count" > 0
+        ),
+        members AS (
+          SELECT COUNT(*)::int AS n
+          FROM "t_memberships"
+          WHERE "community_id" = ${communityId}
+            AND "status" = 'JOINED'
+            AND "created_at" <  (${jstNextMonthStart}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+        )
+        SELECT s.n AS sender_count, m.n AS total_members
+        FROM senders s, members m
+      `;
+      const r = rows[0];
+      return {
+        senderCount: r.sender_count,
+        totalMembers: r.total_members,
+      };
+    });
+  }
+
+  async findNewMemberCount(
+    ctx: IContext,
+    communityId: string,
+    from: Date,
+    to: Date,
+  ): Promise<SysAdminNewMemberCountRow> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      const rows = await tx.$queryRaw<{ n: number }[]>`
+        SELECT COUNT(*)::int AS n
+        FROM "t_memberships"
+        WHERE "community_id" = ${communityId}
+          AND "status" = 'JOINED'
+          AND "created_at" >= (${from}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+          AND "created_at" <  (${to}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+      `;
+      return { count: rows[0]?.n ?? 0 };
+    });
+  }
+
+  /**
+   * All-time DONATION totals + the data window actually covered by the
+   * MV for this community, clamped at `asOf` for historic-asOf
+   * consistency. `max_chain_depth` reads the live
+   * `t_transactions.chain_depth` column so the summary card surfaces
+   * the literal deepest chain rather than a month-bucketed max.
+   */
+  async findAllTimeTotals(
+    ctx: IContext,
+    communityId: string,
+    asOf: Date,
+  ): Promise<SysAdminAllTimeTotalsRow> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      const rows = await tx.$queryRaw<
+        {
+          total_donation_points: bigint;
+          max_chain_depth: number | null;
+          data_from: Date | null;
+          data_to: Date | null;
+        }[]
+      >`
+        WITH asof_bound AS (
+          -- Same (asOf JST day + 1) clamp the other sysadmin queries
+          -- use. Historic asOf must not count DONATION transactions
+          -- or chain depths from dates past asOf; otherwise the
+          -- summary card would mix the past-point view with whatever
+          -- landed after, contradicting stageCounts.total /
+          -- communityActivityRate which ARE clamped.
+          SELECT (
+            ((${asOf}::timestamp AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')::date + 1)
+            AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC'
+          ) AS upper_ts
+        ),
+        donation_totals AS (
+          SELECT
+            COALESCE(SUM(t."from_point_change"), 0)::bigint AS total_donation_points,
+            MAX(t."chain_depth")::int AS max_chain_depth
+          FROM "t_transactions" t
+          INNER JOIN "t_wallets" fw
+            ON fw."id" = t."from"
+            AND fw."community_id" = ${communityId}
+          CROSS JOIN asof_bound ab
+          WHERE t."reason" = 'DONATION'
+            AND t."created_at" < ab.upper_ts
+        ),
+        data_range AS (
+          -- MV "date" column is a JST-encoded date; compare against
+          -- the JST calendar date of asOf (ab.upper_ts is JST-midnight
+          -- in naive UTC, so dropping back to ::date gives the JST
+          -- day after asOf; exclusive less-than keeps the last
+          -- included day as asOf).
+          SELECT
+            MIN("date") AS data_from,
+            MAX("date") AS data_to
+          FROM "mv_transaction_summary_daily", asof_bound
+          WHERE "community_id" = ${communityId}
+            AND "date" < ((${asOf}::timestamp AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')::date + 1)
+        )
+        SELECT
+          dt.total_donation_points,
+          dt.max_chain_depth,
+          dr.data_from,
+          dr.data_to
+        FROM donation_totals dt, data_range dr
+      `;
+      const r = rows[0];
+      return {
+        totalDonationPoints: r.total_donation_points,
+        maxChainDepth: r.max_chain_depth,
+        dataFrom: r.data_from,
+        dataTo: r.data_to,
+      };
+    });
+  }
+
+  async findPlatformTotals(
+    ctx: IContext,
+    jstMonthStart: Date,
+    jstNextMonthStart: Date,
+  ): Promise<SysAdminPlatformTotalsRow> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      const rows = await tx.$queryRaw<
+        {
+          communities_count: number;
+          total_members: number;
+          latest_month_donation_points: bigint;
+        }[]
+      >`
+        WITH comm AS (
+          SELECT COUNT(*)::int AS n FROM "t_communities"
+        ),
+        members AS (
+          SELECT COUNT(*)::int AS n
+          FROM "t_memberships"
+          WHERE "status" = 'JOINED'
+            AND "created_at" <  (${jstNextMonthStart}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+        ),
+        donations AS (
+          SELECT COALESCE(SUM("points_sum"), 0)::bigint AS n
+          FROM "mv_transaction_summary_daily"
+          WHERE "date" >= ${jstMonthStart}::date
+            AND "date" <  ${jstNextMonthStart}::date
+            AND "reason" = 'DONATION'
+        )
+        SELECT
+          comm.n AS communities_count,
+          members.n AS total_members,
+          donations.n AS latest_month_donation_points
+        FROM comm, members, donations
+      `;
+      const r = rows[0];
+      return {
+        communitiesCount: r.communities_count,
+        totalMembers: r.total_members,
+        latestMonthDonationPoints: r.latest_month_donation_points,
+      };
+    });
+  }
+}

--- a/src/application/domain/sysadmin/data/repository.ts
+++ b/src/application/domain/sysadmin/data/repository.ts
@@ -8,6 +8,7 @@ import {
   SysAdminMonthlyActivityRow,
   SysAdminNewMemberCountRow,
   SysAdminPlatformTotalsRow,
+  SysAdminWindowActivityCountsRow,
 } from "@/application/domain/sysadmin/data/type";
 import { ISysAdminRepository } from "@/application/domain/sysadmin/data/interface";
 
@@ -420,6 +421,86 @@ export default class SysAdminRepository implements ISysAdminRepository {
           AND "created_at" <  (${to}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
       `;
       return { count: rows[0]?.n ?? 0 };
+    });
+  }
+
+  async findWindowActivityCounts(
+    ctx: IContext,
+    communityId: string,
+    prevLower: Date,
+    currLower: Date,
+    upper: Date,
+  ): Promise<SysAdminWindowActivityCountsRow> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      const rows = await tx.$queryRaw<
+        {
+          curr_sender_count: number;
+          prev_sender_count: number;
+          retained_count: number;
+          curr_new_member_count: number;
+          prev_new_member_count: number;
+        }[]
+      >`
+        WITH window_senders AS (
+          -- One MV scan over [prevLower, upper). Per-user aggregation
+          -- collapses each user's daily rows into two booleans
+          -- recording whether they sent a DONATION in the current /
+          -- previous window. The outer FILTER clauses then count
+          -- senders, prev-senders, and the intersection (retained)
+          -- without rescanning the MV.
+          SELECT
+            "user_id",
+            bool_or("date" >= ${currLower}::date AND "date" <  ${upper}::date) AS in_curr,
+            bool_or("date" >= ${prevLower}::date AND "date" <  ${currLower}::date) AS in_prev
+          FROM "mv_user_transaction_daily"
+          WHERE "community_id" = ${communityId}
+            AND "donation_out_count" > 0
+            AND "date" >= ${prevLower}::date
+            AND "date" <  ${upper}::date
+          GROUP BY "user_id"
+        ),
+        sender_aggregates AS (
+          SELECT
+            COUNT(*) FILTER (WHERE in_curr)::int                AS curr_sender_count,
+            COUNT(*) FILTER (WHERE in_prev)::int                AS prev_sender_count,
+            COUNT(*) FILTER (WHERE in_curr AND in_prev)::int    AS retained_count
+          FROM window_senders
+        ),
+        new_members AS (
+          -- One t_memberships scan over [prevLower, upper).
+          -- Same FILTER pattern: split current vs previous in one pass.
+          SELECT
+            COUNT(*) FILTER (
+              WHERE "created_at" >= (${currLower}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+                AND "created_at" <  (${upper}::date     AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+            )::int AS curr_new_member_count,
+            COUNT(*) FILTER (
+              WHERE "created_at" >= (${prevLower}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+                AND "created_at" <  (${currLower}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+            )::int AS prev_new_member_count
+          FROM "t_memberships"
+          WHERE "community_id" = ${communityId}
+            AND "status" = 'JOINED'
+            AND "created_at" >= (${prevLower}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+            AND "created_at" <  (${upper}::date     AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+        )
+        SELECT
+          COALESCE(s.curr_sender_count, 0)     AS curr_sender_count,
+          COALESCE(s.prev_sender_count, 0)     AS prev_sender_count,
+          COALESCE(s.retained_count, 0)        AS retained_count,
+          COALESCE(n.curr_new_member_count, 0) AS curr_new_member_count,
+          COALESCE(n.prev_new_member_count, 0) AS prev_new_member_count
+        FROM sender_aggregates s
+        CROSS JOIN new_members n
+      `;
+      const r = rows[0];
+      return {
+        senderCount: r?.curr_sender_count ?? 0,
+        senderCountPrev: r?.prev_sender_count ?? 0,
+        retainedSenders: r?.retained_count ?? 0,
+        newMemberCount: r?.curr_new_member_count ?? 0,
+        newMemberCountPrev: r?.prev_new_member_count ?? 0,
+      };
     });
   }
 

--- a/src/application/domain/sysadmin/data/repository.ts
+++ b/src/application/domain/sysadmin/data/repository.ts
@@ -6,6 +6,7 @@ import {
   SysAdminMemberStatsRow,
   SysAdminActivitySnapshotRow,
   SysAdminMonthlyActivityRow,
+  SysAdminHubMemberCountRow,
   SysAdminNewMemberCountRow,
   SysAdminPlatformTotalsRow,
   SysAdminWindowActivityCountsRow,
@@ -91,6 +92,7 @@ export default class SysAdminRepository implements ISysAdminRepository {
           donation_out_months: number;
           total_points_out: bigint;
           user_send_rate: number;
+          unique_donation_recipients: number;
         }[]
       >`
         WITH asof_jst AS (
@@ -151,6 +153,45 @@ export default class SysAdminRepository implements ISysAdminRepository {
             -- denominator agree on what "as of asOf" includes.
           GROUP BY fw."user_id", jst_month
         ),
+        donation_recipients AS (
+          -- Per-sender count of DISTINCT recipient user_ids over the
+          -- whole tenure (clamped at asOf). This is the "network
+          -- breadth" half of the donor profile and cannot be derived
+          -- from mv_user_transaction_daily — that MV's
+          -- unique_counterparties column is per-day and does not
+          -- compose into an all-time DISTINCT (the same recipient
+          -- across multiple days would double-count under SUM).
+          --
+          -- Scoped to (a) DONATION transactions only, (b) sender wallet
+          -- in this community, and (c) recipient wallet either
+          -- in-community or unattached — same "no cross-community
+          -- leakage" guard that mv_user_transaction_daily and
+          -- v_transaction_comments apply at the view layer. Wallets
+          -- without a user_id (burn / system targets) are excluded so
+          -- a member who only donated into a burn target scores 0.
+          -- Self-donations (fw.user_id = tw.user_id) are excluded so
+          -- the count matches the "distinct OTHER users" wording in
+          -- SysAdminMemberRow.uniqueDonationRecipients — the wallet
+          -- validator does not block same-user transfers, so the
+          -- guard has to live here.
+          SELECT
+            fw."user_id" AS user_id,
+            COUNT(DISTINCT tw."user_id")::int AS unique_recipients
+          FROM "t_transactions" t
+          INNER JOIN "t_wallets" fw
+            ON fw."id" = t."from"
+            AND fw."community_id" = ${communityId}
+          INNER JOIN "t_wallets" tw
+            ON tw."id" = t."to"
+            AND tw."user_id" IS NOT NULL
+            AND tw."user_id" <> fw."user_id"
+          INNER JOIN members m ON m."user_id" = fw."user_id"
+          CROSS JOIN asof_bound ab
+          WHERE t."reason" = 'DONATION'
+            AND t."created_at" < ab.upper_ts
+            AND (tw."community_id" IS NULL OR tw."community_id" = fw."community_id")
+          GROUP BY fw."user_id"
+        ),
         member_tenure AS (
           -- Compute months_in ONCE per member so the final SELECT can
           -- reuse it as both months_in and the denominator of
@@ -192,10 +233,18 @@ export default class SysAdminRepository implements ISysAdminRepository {
             COALESCE(COUNT(DISTINCT dm.jst_month), 0)::numeric
               / mt.months_in::numeric,
             3
-          )::double precision AS user_send_rate
+          )::double precision AS user_send_rate,
+          -- donation_recipients is pre-grouped by user_id, so each
+          -- sender appears at most once on the right side of the
+          -- LEFT JOIN. MAX() (rather than adding the column to GROUP
+          -- BY) propagates that single value through the per-user
+          -- grouping cleanly and matches the COALESCE/MAX pattern
+          -- used elsewhere when joining a pre-aggregated CTE.
+          COALESCE(MAX(dr.unique_recipients), 0)::int AS unique_donation_recipients
         FROM members m
         INNER JOIN member_tenure mt ON mt."user_id" = m."user_id"
         LEFT JOIN donation_months dm ON dm.user_id = m."user_id"
+        LEFT JOIN donation_recipients dr ON dr.user_id = m."user_id"
         LEFT JOIN "t_users" u ON u."id" = m."user_id"
         GROUP BY m."user_id", mt.months_in, u."name"
         ORDER BY m."user_id"
@@ -207,6 +256,7 @@ export default class SysAdminRepository implements ISysAdminRepository {
         donationOutMonths: r.donation_out_months,
         totalPointsOut: r.total_points_out,
         userSendRate: r.user_send_rate,
+        uniqueDonationRecipients: r.unique_donation_recipients,
       }));
     });
   }
@@ -501,6 +551,60 @@ export default class SysAdminRepository implements ISysAdminRepository {
         newMemberCount: r?.curr_new_member_count ?? 0,
         newMemberCountPrev: r?.prev_new_member_count ?? 0,
       };
+    });
+  }
+
+  async findWindowHubMemberCount(
+    ctx: IContext,
+    communityId: string,
+    currLower: Date,
+    upper: Date,
+    hubBreadthThreshold: number,
+  ): Promise<SysAdminHubMemberCountRow> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      const rows = await tx.$queryRaw<{ n: number }[]>`
+        WITH window_recipients AS (
+          -- Per-sender DISTINCT recipient count over the parametric
+          -- window. Same shape as the donation_recipients CTE in
+          -- findMemberStats but window-clamped on both sides instead
+          -- of tenure-clamped (upper only). Cannot reuse
+          -- mv_user_transaction_daily because its per-day
+          -- unique_counterparties does not compose into a window-wide
+          -- DISTINCT (same recipient across multiple days would
+          -- double-count under SUM).
+          --
+          -- Cross-community + burn-target guards mirror the defenses
+          -- on mv_user_transaction_daily / v_transaction_comments so
+          -- a system-target wallet (no user_id) does not silently
+          -- inflate the recipient count. Self-donations are excluded
+          -- (matches the "different people" wording in
+          -- SysAdminCommunityOverview.hubMemberCount and the
+          -- "distinct OTHER users" definition in
+          -- SysAdminMemberRow.uniqueDonationRecipients) — the wallet
+          -- validator does not block same-user transfers, so the
+          -- guard has to live in this query.
+          SELECT
+            fw."user_id" AS user_id,
+            COUNT(DISTINCT tw."user_id")::int AS unique_recipients
+          FROM "t_transactions" t
+          INNER JOIN "t_wallets" fw
+            ON fw."id" = t."from"
+            AND fw."community_id" = ${communityId}
+          INNER JOIN "t_wallets" tw
+            ON tw."id" = t."to"
+            AND tw."user_id" IS NOT NULL
+            AND tw."user_id" <> fw."user_id"
+          WHERE t."reason" = 'DONATION'
+            AND t."created_at" >= (${currLower}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+            AND t."created_at" <  (${upper}::date     AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+            AND (tw."community_id" IS NULL OR tw."community_id" = fw."community_id")
+          GROUP BY fw."user_id"
+        )
+        SELECT COUNT(*)::int AS n
+        FROM window_recipients
+        WHERE unique_recipients >= ${hubBreadthThreshold}
+      `;
+      return { count: rows[0]?.n ?? 0 };
     });
   }
 

--- a/src/application/domain/sysadmin/data/type.ts
+++ b/src/application/domain/sysadmin/data/type.ts
@@ -68,6 +68,26 @@ export type SysAdminNewMemberCountRow = {
 };
 
 /**
+ * All five raw counts the L1 `SysAdminWindowActivity` payload needs,
+ * derived from a single MV scan + a single membership scan over
+ * `[prevLower, upper)`. Consolidates what used to be 3 overlapping
+ * mv_user_transaction_daily reads (curr senders, prev senders,
+ * intersection) and 2 overlapping t_memberships reads (curr/prev
+ * new members) into one method so the dashboard load cost grows
+ * linearly with community count instead of with a 5x multiplier.
+ *
+ * Field shape mirrors `WindowActivityCounts` so the service can
+ * pass the row through without re-mapping.
+ */
+export type SysAdminWindowActivityCountsRow = {
+  senderCount: number;
+  senderCountPrev: number;
+  retainedSenders: number;
+  newMemberCount: number;
+  newMemberCountPrev: number;
+};
+
+/**
  * Platform-wide totals for the L1 dashboard header. Derived in one CTE
  * query rather than summing per-community payloads in memory so the
  * answer stays atomic with a single asOf timestamp.

--- a/src/application/domain/sysadmin/data/type.ts
+++ b/src/application/domain/sysadmin/data/type.ts
@@ -1,0 +1,79 @@
+/**
+ * Row shapes returned by SysAdminRepository to the service layer.
+ *
+ * All numeric counts are already `number` (the repository `::int`-casts
+ * them on the SQL side so Prisma doesn't surface bigints for count
+ * outputs). Monetary / volume fields stay as `bigint` and the presenter
+ * layer is responsible for running them through `bigintToSafeNumber`.
+ */
+
+export type SysAdminCommunityRow = {
+  communityId: string;
+  communityName: string;
+};
+
+/**
+ * One member of a community with derived LTV-variable counters at the
+ * given `asOf` timestamp. `userSendRate` is `donationOutMonths /
+ * monthsIn` rounded to 3 decimals by the SQL.
+ *
+ * `name` is nullable to handle race conditions (member row without a
+ * user row shouldn't normally happen but keeps the type honest).
+ */
+export type SysAdminMemberStatsRow = {
+  userId: string;
+  name: string | null;
+  monthsIn: number;
+  donationOutMonths: number;
+  totalPointsOut: bigint;
+  userSendRate: number;
+};
+
+/** Monthly activity counters, sourced from `mv_*` + `t_memberships`.
+ *
+ * `donationTxCount` / `donationChainTxCount` are bigint because the
+ * underlying SUM can exceed int32 on long-running communities (the
+ * per-day `tx_count` column is int32 but cumulative window sums
+ * could legitimately hit 2B+). The presenter layer converts through
+ * `bigintToSafeNumber` before the value leaves the domain.
+ */
+export type SysAdminMonthlyActivityRow = {
+  /** JST month start (UTC-encoded, first day of the month at 00:00). */
+  monthStart: Date;
+  senderCount: number;
+  totalMembersEndOfMonth: number;
+  newMembers: number;
+  donationPointsSum: bigint;
+  donationTxCount: bigint;
+  donationChainTxCount: bigint;
+};
+
+/** All-time totals for the summary card, keyed by community. */
+export type SysAdminAllTimeTotalsRow = {
+  totalDonationPoints: bigint;
+  maxChainDepth: number | null;
+  dataFrom: Date | null;
+  dataTo: Date | null;
+};
+
+/** Latest-month activity snapshot used by the L1 dashboard + summary card. */
+export type SysAdminActivitySnapshotRow = {
+  senderCount: number;
+  totalMembers: number;
+};
+
+/** New-member count within an arbitrary window (used for `no_new_members`). */
+export type SysAdminNewMemberCountRow = {
+  count: number;
+};
+
+/**
+ * Platform-wide totals for the L1 dashboard header. Derived in one CTE
+ * query rather than summing per-community payloads in memory so the
+ * answer stays atomic with a single asOf timestamp.
+ */
+export type SysAdminPlatformTotalsRow = {
+  communitiesCount: number;
+  totalMembers: number;
+  latestMonthDonationPoints: bigint;
+};

--- a/src/application/domain/sysadmin/data/type.ts
+++ b/src/application/domain/sysadmin/data/type.ts
@@ -27,6 +27,7 @@ export type SysAdminMemberStatsRow = {
   donationOutMonths: number;
   totalPointsOut: bigint;
   userSendRate: number;
+  uniqueDonationRecipients: number;
 };
 
 /** Monthly activity counters, sourced from `mv_*` + `t_memberships`.
@@ -64,6 +65,16 @@ export type SysAdminActivitySnapshotRow = {
 
 /** New-member count within an arbitrary window (used for `no_new_members`). */
 export type SysAdminNewMemberCountRow = {
+  count: number;
+};
+
+/**
+ * Window-scoped count of members classified as hubs. A member is a
+ * hub if they sent DONATION to at least `hubBreadthThreshold` DISTINCT
+ * counterparties during `[currLower, upper)` JST. Powers
+ * `SysAdminCommunityOverview.hubMemberCount`.
+ */
+export type SysAdminHubMemberCountRow = {
   count: number;
 };
 

--- a/src/application/domain/sysadmin/presenter.ts
+++ b/src/application/domain/sysadmin/presenter.ts
@@ -77,6 +77,7 @@ export default class SysAdminPresenter {
       senderCountPrev: counts.senderCountPrev,
       newMemberCount: counts.newMemberCount,
       newMemberCountPrev: counts.newMemberCountPrev,
+      retainedSenders: counts.retainedSenders,
     };
   }
 

--- a/src/application/domain/sysadmin/presenter.ts
+++ b/src/application/domain/sysadmin/presenter.ts
@@ -6,6 +6,7 @@ import {
   GqlSysAdminCommunityOverview,
   GqlSysAdminCommunitySummaryCard,
   GqlSysAdminDashboardPayload,
+  GqlSysAdminLatestCohort,
   GqlSysAdminMemberList,
   GqlSysAdminMemberRow,
   GqlSysAdminMonthlyActivityPoint,
@@ -14,6 +15,8 @@ import {
   GqlSysAdminSegmentCounts,
   GqlSysAdminStageBucket,
   GqlSysAdminStageDistribution,
+  GqlSysAdminWeeklyRetention,
+  GqlSysAdminWindowActivity,
 } from "@/types/graphql";
 import {
   SysAdminAllTimeTotalsRow,
@@ -23,12 +26,15 @@ import {
 } from "@/application/domain/sysadmin/data/type";
 import {
   AlertFlags,
+  LatestCohortCounts,
   MemberListResult,
   MonthlyCohortPoint,
   StageBreakdown,
   StageBucketStats,
   StageCounts,
+  WeeklyRetentionCounts,
   WeeklyRetentionPoint,
+  WindowActivityCounts,
 } from "@/application/domain/sysadmin/service";
 
 /**
@@ -65,28 +71,46 @@ export default class SysAdminPresenter {
     };
   }
 
+  static windowActivity(counts: WindowActivityCounts): GqlSysAdminWindowActivity {
+    return {
+      senderCount: counts.senderCount,
+      senderCountPrev: counts.senderCountPrev,
+      newMemberCount: counts.newMemberCount,
+      newMemberCountPrev: counts.newMemberCountPrev,
+    };
+  }
+
+  static weeklyRetention(counts: WeeklyRetentionCounts): GqlSysAdminWeeklyRetention {
+    return {
+      retainedSenders: counts.retainedSenders,
+      churnedSenders: counts.churnedSenders,
+    };
+  }
+
+  static latestCohort(counts: LatestCohortCounts): GqlSysAdminLatestCohort {
+    return {
+      size: counts.size,
+      activeAtM1: counts.activeAtM1,
+    };
+  }
+
   static overviewRow(params: {
     communityId: string;
     communityName: string;
     totalMembers: number;
     stageCounts: StageCounts;
-    communityActivityRate: number;
-    growthRateActivity: number | null;
-    latestCohortRetentionM1: number | null;
-    alerts: AlertFlags;
+    windowActivity: WindowActivityCounts;
+    weeklyRetention: WeeklyRetentionCounts;
+    latestCohort: LatestCohortCounts;
   }): GqlSysAdminCommunityOverview {
     return {
       communityId: params.communityId,
       communityName: params.communityName,
       totalMembers: params.totalMembers,
       segmentCounts: SysAdminPresenter.segmentCounts(params.stageCounts),
-      tier1Count: params.stageCounts.tier1Count,
-      tier2Count: params.stageCounts.tier2Count,
-      passiveCount: params.stageCounts.passiveCount,
-      communityActivityRate: params.communityActivityRate,
-      growthRateActivity: params.growthRateActivity,
-      latestCohortRetentionM1: params.latestCohortRetentionM1,
-      alerts: SysAdminPresenter.alerts(params.alerts),
+      windowActivity: SysAdminPresenter.windowActivity(params.windowActivity),
+      weeklyRetention: SysAdminPresenter.weeklyRetention(params.weeklyRetention),
+      latestCohort: SysAdminPresenter.latestCohort(params.latestCohort),
     };
   }
 

--- a/src/application/domain/sysadmin/presenter.ts
+++ b/src/application/domain/sysadmin/presenter.ts
@@ -103,6 +103,7 @@ export default class SysAdminPresenter {
     windowActivity: WindowActivityCounts;
     weeklyRetention: WeeklyRetentionCounts;
     latestCohort: LatestCohortCounts;
+    hubMemberCount: number;
   }): GqlSysAdminCommunityOverview {
     return {
       communityId: params.communityId,
@@ -112,6 +113,7 @@ export default class SysAdminPresenter {
       windowActivity: SysAdminPresenter.windowActivity(params.windowActivity),
       weeklyRetention: SysAdminPresenter.weeklyRetention(params.weeklyRetention),
       latestCohort: SysAdminPresenter.latestCohort(params.latestCohort),
+      hubMemberCount: params.hubMemberCount,
     };
   }
 
@@ -228,6 +230,7 @@ export default class SysAdminPresenter {
       monthsIn: row.monthsIn,
       donationOutMonths: row.donationOutMonths,
       totalPointsOut: bigintToSafeNumber(row.totalPointsOut),
+      uniqueDonationRecipients: row.uniqueDonationRecipients,
     };
   }
 

--- a/src/application/domain/sysadmin/presenter.ts
+++ b/src/application/domain/sysadmin/presenter.ts
@@ -1,0 +1,244 @@
+import { bigintToSafeNumber } from "@/application/domain/report/util";
+import {
+  GqlSysAdminCohortRetentionPoint,
+  GqlSysAdminCommunityAlerts,
+  GqlSysAdminCommunityDetailPayload,
+  GqlSysAdminCommunityOverview,
+  GqlSysAdminCommunitySummaryCard,
+  GqlSysAdminDashboardPayload,
+  GqlSysAdminMemberList,
+  GqlSysAdminMemberRow,
+  GqlSysAdminMonthlyActivityPoint,
+  GqlSysAdminPlatformSummary,
+  GqlSysAdminRetentionTrendPoint,
+  GqlSysAdminSegmentCounts,
+  GqlSysAdminStageBucket,
+  GqlSysAdminStageDistribution,
+} from "@/types/graphql";
+import {
+  SysAdminAllTimeTotalsRow,
+  SysAdminMemberStatsRow,
+  SysAdminMonthlyActivityRow,
+  SysAdminPlatformTotalsRow,
+} from "@/application/domain/sysadmin/data/type";
+import {
+  AlertFlags,
+  MemberListResult,
+  MonthlyCohortPoint,
+  StageBreakdown,
+  StageBucketStats,
+  StageCounts,
+  WeeklyRetentionPoint,
+} from "@/application/domain/sysadmin/service";
+
+/**
+ * Prisma / service rows → GraphQL payload shapes. Pure functions.
+ *
+ * BigInt → number conversions go through `bigintToSafeNumber` so values
+ * beyond `Number.MAX_SAFE_INTEGER` throw loudly rather than silently
+ * losing precision in the externally-reported totals.
+ */
+export default class SysAdminPresenter {
+  static platform(row: SysAdminPlatformTotalsRow): GqlSysAdminPlatformSummary {
+    return {
+      communitiesCount: row.communitiesCount,
+      totalMembers: row.totalMembers,
+      latestMonthDonationPoints: bigintToSafeNumber(row.latestMonthDonationPoints),
+    };
+  }
+
+  static segmentCounts(counts: StageCounts): GqlSysAdminSegmentCounts {
+    return {
+      total: counts.total,
+      tier1Count: counts.tier1Count,
+      tier2Count: counts.tier2Count,
+      activeCount: counts.activeCount,
+      passiveCount: counts.passiveCount,
+    };
+  }
+
+  static alerts(flags: AlertFlags): GqlSysAdminCommunityAlerts {
+    return {
+      churnSpike: flags.churnSpike,
+      activeDrop: flags.activeDrop,
+      noNewMembers: flags.noNewMembers,
+    };
+  }
+
+  static overviewRow(params: {
+    communityId: string;
+    communityName: string;
+    totalMembers: number;
+    stageCounts: StageCounts;
+    communityActivityRate: number;
+    growthRateActivity: number | null;
+    latestCohortRetentionM1: number | null;
+    alerts: AlertFlags;
+  }): GqlSysAdminCommunityOverview {
+    return {
+      communityId: params.communityId,
+      communityName: params.communityName,
+      totalMembers: params.totalMembers,
+      segmentCounts: SysAdminPresenter.segmentCounts(params.stageCounts),
+      tier1Count: params.stageCounts.tier1Count,
+      tier2Count: params.stageCounts.tier2Count,
+      passiveCount: params.stageCounts.passiveCount,
+      communityActivityRate: params.communityActivityRate,
+      growthRateActivity: params.growthRateActivity,
+      latestCohortRetentionM1: params.latestCohortRetentionM1,
+      alerts: SysAdminPresenter.alerts(params.alerts),
+    };
+  }
+
+  static dashboard(params: {
+    asOf: Date;
+    platform: SysAdminPlatformTotalsRow;
+    communities: GqlSysAdminCommunityOverview[];
+  }): GqlSysAdminDashboardPayload {
+    return {
+      asOf: params.asOf,
+      platform: SysAdminPresenter.platform(params.platform),
+      communities: params.communities,
+    };
+  }
+
+  // --- L2 ----------------------------------------------------------------
+
+  static summaryCard(params: {
+    communityId: string;
+    communityName: string;
+    totalMembers: number;
+    communityActivityRate: number;
+    communityActivityRate3mAvg: number | null;
+    growthRateActivity: number | null;
+    tier2Count: number;
+    allTimeTotals: SysAdminAllTimeTotalsRow;
+  }): GqlSysAdminCommunitySummaryCard {
+    const tier2Pct = params.totalMembers === 0 ? 0 : params.tier2Count / params.totalMembers;
+    return {
+      communityId: params.communityId,
+      communityName: params.communityName,
+      totalMembers: params.totalMembers,
+      communityActivityRate: params.communityActivityRate,
+      communityActivityRate3mAvg: params.communityActivityRate3mAvg,
+      growthRateActivity: params.growthRateActivity,
+      tier2Count: params.tier2Count,
+      tier2Pct,
+      totalDonationPointsAllTime: bigintToSafeNumber(params.allTimeTotals.totalDonationPoints),
+      maxChainDepthAllTime: params.allTimeTotals.maxChainDepth,
+      dataFrom: params.allTimeTotals.dataFrom,
+      dataTo: params.allTimeTotals.dataTo,
+    };
+  }
+
+  private static stageBucket(b: StageBucketStats): GqlSysAdminStageBucket {
+    return {
+      count: b.count,
+      pct: b.pct,
+      pointsContributionPct: b.pointsContributionPct,
+      avgSendRate: b.avgSendRate,
+      avgMonthsIn: b.avgMonthsIn,
+    };
+  }
+
+  static stages(breakdown: StageBreakdown): GqlSysAdminStageDistribution {
+    return {
+      habitual: SysAdminPresenter.stageBucket(breakdown.habitual),
+      regular: SysAdminPresenter.stageBucket(breakdown.regular),
+      occasional: SysAdminPresenter.stageBucket(breakdown.occasional),
+      // The latent bucket's pointsContributionPct is always 0 by
+      // definition (latent ≡ never-donated). summarize() already
+      // computes 0 because `sumPointsOut` is 0 for latent rows.
+      latent: SysAdminPresenter.stageBucket(breakdown.latent),
+    };
+  }
+
+  static monthlyActivityPoint(row: SysAdminMonthlyActivityRow): GqlSysAdminMonthlyActivityPoint {
+    const rate =
+      row.totalMembersEndOfMonth === 0 ? 0 : row.senderCount / row.totalMembersEndOfMonth;
+    // Route both sides of chainPct through bigintToSafeNumber so an
+    // extreme community's tx-count sums surface as a RangeError
+    // instead of silently truncating to Number. The ratio itself is
+    // a small [0, 1] fraction regardless of cumulative counts.
+    const donationTxCount = bigintToSafeNumber(row.donationTxCount);
+    const donationChainTxCount = bigintToSafeNumber(row.donationChainTxCount);
+    const chainPct =
+      donationTxCount === 0 ? null : donationChainTxCount / donationTxCount;
+    return {
+      month: row.monthStart,
+      senderCount: row.senderCount,
+      communityActivityRate: rate,
+      newMembers: row.newMembers,
+      donationPointsSum: bigintToSafeNumber(row.donationPointsSum),
+      chainPct,
+    };
+  }
+
+  static retentionTrendPoint(point: WeeklyRetentionPoint): GqlSysAdminRetentionTrendPoint {
+    return {
+      week: point.weekStart,
+      retainedSenders: point.retainedSenders,
+      churnedSenders: point.churnedSenders,
+      returnedSenders: point.returnedSenders,
+      newMembers: point.newMembers,
+      communityActivityRate: point.communityActivityRate,
+    };
+  }
+
+  static cohortPoint(point: MonthlyCohortPoint): GqlSysAdminCohortRetentionPoint {
+    return {
+      cohortMonth: point.cohortMonthStart,
+      cohortSize: point.cohortSize,
+      retentionM1: point.retentionM1,
+      retentionM3: point.retentionM3,
+      retentionM6: point.retentionM6,
+    };
+  }
+
+  static memberRow(row: SysAdminMemberStatsRow): GqlSysAdminMemberRow {
+    return {
+      userId: row.userId,
+      name: row.name,
+      userSendRate: row.userSendRate,
+      monthsIn: row.monthsIn,
+      donationOutMonths: row.donationOutMonths,
+      totalPointsOut: bigintToSafeNumber(row.totalPointsOut),
+    };
+  }
+
+  static memberList(result: MemberListResult): GqlSysAdminMemberList {
+    return {
+      users: result.users.map(SysAdminPresenter.memberRow),
+      hasNextPage: result.hasNextPage,
+      nextCursor: result.nextCursor,
+    };
+  }
+
+  static communityDetail(params: {
+    communityId: string;
+    communityName: string;
+    asOf: Date;
+    windowMonths: number;
+    summary: GqlSysAdminCommunitySummaryCard;
+    stages: GqlSysAdminStageDistribution;
+    monthlyActivityTrend: GqlSysAdminMonthlyActivityPoint[];
+    retentionTrend: GqlSysAdminRetentionTrendPoint[];
+    cohortRetention: GqlSysAdminCohortRetentionPoint[];
+    memberList: GqlSysAdminMemberList;
+    alerts: GqlSysAdminCommunityAlerts;
+  }): GqlSysAdminCommunityDetailPayload {
+    return {
+      communityId: params.communityId,
+      communityName: params.communityName,
+      asOf: params.asOf,
+      windowMonths: params.windowMonths,
+      summary: params.summary,
+      stages: params.stages,
+      monthlyActivityTrend: params.monthlyActivityTrend,
+      retentionTrend: params.retentionTrend,
+      cohortRetention: params.cohortRetention,
+      memberList: params.memberList,
+      alerts: params.alerts,
+    };
+  }
+}

--- a/src/application/domain/sysadmin/schema/query.graphql
+++ b/src/application/domain/sysadmin/schema/query.graphql
@@ -1,0 +1,27 @@
+# ------------------------------
+# SysAdmin Query Definitions
+#
+# SYS_ADMIN-only aggregates for platform operators. Both queries bypass
+# per-community RLS under the hood (ctx.issuer.public) because admins
+# legitimately need to see across every community at once.
+# ------------------------------
+extend type Query {
+  """
+  L1 overview: platform totals plus one row per community. Intended for
+  the "is any community stalling?" scan. Community fan-out is served
+  with N in-process calls (acceptable at today's community count —
+  switch to a GROUP BY implementation once the platform exceeds ~20
+  communities).
+  """
+  sysAdminDashboard(input: SysAdminDashboardInput): SysAdminDashboardPayload!
+    @authz(rules: [IsAdmin])
+
+  """
+  L2 detail for a single community: summary card, stage distribution,
+  trailing-window trends, cohort retention, and a paginated member list.
+  Intended for answering "what are kibotcha's numbers?" in an external
+  report conversation.
+  """
+  sysAdminCommunityDetail(input: SysAdminCommunityDetailInput!): SysAdminCommunityDetailPayload!
+    @authz(rules: [IsAdmin])
+}

--- a/src/application/domain/sysadmin/schema/type.graphql
+++ b/src/application/domain/sysadmin/schema/type.graphql
@@ -298,6 +298,17 @@ type SysAdminWindowActivity {
   Same metric for the previous window.
   """
   newMemberCountPrev: Int!
+
+  """
+  Users who sent at least one DONATION in BOTH the current window
+  AND the previous window (set intersection on user_id). Same
+  shape as SysAdminWeeklyRetention.retainedSenders but at
+  windowDays scale, enabling client-side leaky-bucket derivation:
+
+    newlyActivatedSenders = senderCount     - retainedSenders
+    churnedSenders        = senderCountPrev - retainedSenders
+  """
+  retainedSenders: Int!
 }
 
 """

--- a/src/application/domain/sysadmin/schema/type.graphql
+++ b/src/application/domain/sysadmin/schema/type.graphql
@@ -65,6 +65,30 @@ input SysAdminDashboardInput {
   Stage classification thresholds (see SysAdminSegmentThresholdsInput).
   """
   segmentThresholds: SysAdminSegmentThresholdsInput
+
+  """
+  Minimum number of distinct DONATION recipients within the
+  parametric window (`windowDays`) for a member to be classified
+  as a hub. Used to populate `SysAdminCommunityOverview.hubMemberCount`.
+
+  Defaults to 3, meaning "sent DONATION to at least 3 different
+  people during the window". The threshold is on **unique
+  counterparties** (set cardinality), not transaction count, so a
+  member who donated 100 times to the same recipient does not
+  qualify on this axis alone.
+
+  Effective range 1..1000; values outside are silently clamped on
+  the server.
+
+  This is intentionally an absolute threshold rather than a
+  community-relative percentile: a percentile-based hub would
+  always classify ~N% of members as hubs by definition, defeating
+  cross-community comparison ("which communities have the highest
+  hub ratio?"). Community size differences are absorbed
+  client-side by displaying `hubMemberCount / totalMembers` rather
+  than the raw count.
+  """
+  hubBreadthThreshold: Int = 3
 }
 
 """
@@ -406,6 +430,36 @@ type SysAdminCommunityOverview {
   SysAdminLatestCohort.
   """
   latestCohort: SysAdminLatestCohort!
+
+  """
+  Number of members classified as a "hub" within the parametric
+  window (`windowDays`):
+
+    hubMemberCount = COUNT(member)
+      WHERE windowUniqueDonationRecipients >= input.hubBreadthThreshold
+
+  `windowUniqueDonationRecipients` is the count of DISTINCT users
+  this member sent a DONATION to during
+  `[asOf - windowDays JST日, asOf + 1 JST日)` — distinct from the
+  L2 `SysAdminMemberRow.uniqueDonationRecipients` field which is
+  tenure-wide. The window-scoped variant is computed on demand in
+  this aggregate but not exposed per-member at L1 (members
+  themselves are an L2 concern).
+
+  Hub classification deliberately uses BREADTH only — a member
+  who reached `hubBreadthThreshold` distinct recipients during
+  the window necessarily transacted at least that many times,
+  making an explicit frequency floor redundant. This keeps the
+  threshold knobs to one (`hubBreadthThreshold`).
+
+  Invariants (the client may assert these):
+    hubMemberCount <= windowActivity.senderCount <= totalMembers
+
+  The first holds because any hub member donated >= 3 times in
+  the window and is therefore a window sender; the second because
+  any window sender is a JOINED member at asOf.
+  """
+  hubMemberCount: Int!
 }
 
 """
@@ -678,6 +732,22 @@ type SysAdminMemberRow {
   All-time DONATION points sent by this user in this community.
   """
   totalPointsOut: Float!
+  """
+  All-time count of distinct OTHER users this member has sent at
+  least one DONATION to in this community. The "network breadth"
+  half of the donor profile (paired with frequency-based
+  `userSendRate` and volume-based `totalPointsOut`):
+
+    breadth × frequency × volume → the client's per-member
+    classification space (e.g. true hub vs single-target loyal vs
+    rare-but-far-reaching).
+
+  Counts unique counterparty user_id, not transaction count, so a
+  member who sent 100 donations to the same recipient still scores
+  1. Excludes burn / system targets (recipient wallets without a
+  user_id).
+  """
+  uniqueDonationRecipients: Int!
 }
 
 """

--- a/src/application/domain/sysadmin/schema/type.graphql
+++ b/src/application/domain/sysadmin/schema/type.graphql
@@ -45,15 +45,24 @@ Input for the L1 all-community overview (`sysAdminDashboard`).
 """
 input SysAdminDashboardInput {
   """
-  The "as of" timestamp. All trailing-window calculations are anchored
-  here: the "latest month" is the JST calendar month containing asOf,
-  and "latest week" is the ISO-week containing asOf. Defaults to now
-  when omitted.
+  As-of timestamp anchor. All trailing-window calculations are
+  anchored here:
+    - parametric activity window: [asOf - windowDays, asOf + 1 JST日)
+    - weekly retention: latest completed ISO week before asOf
+    - latest cohort: (asOf JST月 - 2) so its M+1 window is fully past
+  Defaults to now when omitted.
   """
   asOf: Datetime
 
   """
-  Stage-count thresholds (see SysAdminSegmentThresholdsInput).
+  Length of the rolling activity window in JST days. Effective
+  range 7-90; values outside are silently clamped on the server.
+  Defaults to 28 (= 4 weeks, absorbs day-of-week variance).
+  """
+  windowDays: Int = 28
+
+  """
+  Stage classification thresholds (see SysAdminSegmentThresholdsInput).
   """
   segmentThresholds: SysAdminSegmentThresholdsInput
 }
@@ -258,71 +267,134 @@ type SysAdminPlatformSummary {
 }
 
 """
-One row of the L1 all-community table. See the module docstring for the
-distinction between `communityActivityRate` (this type) and
-`userSendRate` (SysAdminMemberRow).
+DONATION activity within the parametric window driven by
+`SysAdminDashboardInput.windowDays`. Both the current window and
+the immediately preceding window of equal length are returned so
+the client can derive growth rates without a second query.
+
+  current  = [asOf - windowDays JST日, asOf + 1 JST日)
+  previous = [asOf - 2 * windowDays, asOf - windowDays)
+"""
+type SysAdminWindowActivity {
+  """
+  Unique users with at least one outgoing DONATION transaction
+  during the current window (donation_out_count > 0 in
+  mv_user_transaction_daily).
+  """
+  senderCount: Int!
+
+  """
+  Same metric for the previous window of equal length.
+  """
+  senderCountPrev: Int!
+
+  """
+  New JOINED memberships (t_memberships.created_at within the
+  current window, status='JOINED').
+  """
+  newMemberCount: Int!
+
+  """
+  Same metric for the previous window.
+  """
+  newMemberCountPrev: Int!
+}
+
+"""
+DONATION sender retention against the most recently completed
+ISO week (Monday 00:00 JST). Raw signals only; the client composes
+churn alerts (e.g. churnedSenders > retainedSenders).
+"""
+type SysAdminWeeklyRetention {
+  """
+  Users who sent DONATION in the latest completed week AND in
+  the week before it. "Engaged this week, was engaged last week."
+  """
+  retainedSenders: Int!
+
+  """
+  Users who sent DONATION in the week-before-latest but NOT in
+  the latest completed week. "Lost this week, was engaged last week."
+  """
+  churnedSenders: Int!
+}
+
+"""
+Most recently completed monthly cohort plus its M+1 activity.
+"M+1" follows standard cohort-analysis convention: the calendar
+month immediately after the joining month.
+
+The cohort is selected as (asOf's JST month - 2 months) so its
+M+1 window — the JST month immediately preceding asOf's month —
+is fully past. This avoids reporting an artificially low retention
+during the in-progress month.
+
+Raw counts are returned; the client divides for the retention rate
+and decides how to handle small-N cohorts via `size`.
+"""
+type SysAdminLatestCohort {
+  """
+  Cohort size: status='JOINED' members whose created_at falls
+  within the cohort month. 0 when no one joined that month
+  (callers should treat M+1 retention as null in that case).
+  """
+  size: Int!
+
+  """
+  Of those cohort members, how many sent at least one DONATION
+  during the M+1 month.
+  """
+  activeAtM1: Int!
+}
+
+"""
+One row of the L1 all-community table. Designed for at-a-glance
+intervention judgment: each row carries the raw counts the client
+needs to derive rates, growth, alerts, sort keys, and filter
+predicates without a second round-trip.
+
+Calendar-month metrics live on the L2 detail card
+(SysAdminCommunitySummaryCard) — L1 is rolling-window only.
 """
 type SysAdminCommunityOverview {
   """
   Community id.
   """
   communityId: ID!
+
   """
   Community display name (t_communities.name).
   """
   communityName: String!
 
   """
-  Total status='JOINED' members at asOf.
+  Total status='JOINED' members as of asOf. Members whose
+  created_at is after asOf are excluded from the count.
   """
   totalMembers: Int!
 
   """
-  Stage counts under the supplied thresholds (cumulative, see type doc).
+  Per-stage member counts (tier1 / tier2 / passive, cumulative
+  per the type doc) classified against input.segmentThresholds.
   """
   segmentCounts: SysAdminSegmentCounts!
 
   """
-  Direct member count for the "habitual" stage (userSendRate >= tier1).
-  Convenience field (== segmentCounts.tier1Count).
+  Rolling-window DONATION activity. See SysAdminWindowActivity.
   """
-  tier1Count: Int!
-  """
-  Direct member count for the "regular+habitual" stage
-  (userSendRate >= tier2). Convenience field (== segmentCounts.tier2Count).
-  """
-  tier2Count: Int!
-  """
-  Direct member count for the "latent" stage (never donated).
-  Convenience field (== segmentCounts.passiveCount).
-  """
-  passiveCount: Int!
+  windowActivity: SysAdminWindowActivity!
 
   """
-  Community activity rate for the JST calendar month containing asOf:
-  unique DONATION senders in that month / month-end total_members.
-  0.0–1.0. NOT the individual-level userSendRate.
+  Latest completed-week retention signals for client-side churn
+  detection. See SysAdminWeeklyRetention.
   """
-  communityActivityRate: Float!
+  weeklyRetention: SysAdminWeeklyRetention!
 
   """
-  Month-over-month % change in communityActivityRate.
-  Returned as a fraction (e.g. -0.2 == -20%). null when the prior month
-  has no data to compare against.
+  Latest completed monthly cohort and its M+1 activity. See
+  SysAdminLatestCohort.
   """
-  growthRateActivity: Float
-
-  """
-  Retention rate of the most recent completed cohort (members who joined
-  in asOf's previous JST month) measured in the month after joining.
-  null when that cohort is empty.
-  """
-  latestCohortRetentionM1: Float
-
-  """
-  Alert flags (see SysAdminCommunityAlerts).
-  """
-  alerts: SysAdminCommunityAlerts!
+  latestCohort: SysAdminLatestCohort!
 }
 
 """

--- a/src/application/domain/sysadmin/schema/type.graphql
+++ b/src/application/domain/sysadmin/schema/type.graphql
@@ -1,0 +1,675 @@
+# ==========================================================================
+# SysAdmin dashboard types
+#
+# Provides a platform-operator view over every community's health. All
+# fields are gated by `@authz(rules: [IsAdmin])` on the enclosing queries.
+#
+# Two key indicators appear throughout and MUST NOT be confused:
+#
+#   - `userSendRate`     : INDIVIDUAL LTV variable. A single member's
+#                          donation_out_months / months_in (0.0–1.0).
+#   - `communityActivityRate` : COMMUNITY monthly activity. The unique
+#                          DONATION senders in a given month divided by
+#                          the month-end total_members (0.0–1.0).
+#
+# Descriptions on every field restate the distinction so the value is
+# unambiguous when the schema is read in GraphQL Playground.
+# ==========================================================================
+
+# --------------------------------------------------------------------------
+# Inputs
+# --------------------------------------------------------------------------
+
+"""
+Stage classification thresholds, supplied by the client.
+Thresholds define WHERE the boundary between stages sits, but naming
+(habitual / regular / occasional / latent) remains fixed on the server.
+"""
+input SysAdminSegmentThresholdsInput {
+  """
+  Habitual stage threshold. A user with `userSendRate >= tier1` is
+  counted as "habitual" (i.e. sends donations in at least tier1 share
+  of their tenure). Default 0.7.
+  """
+  tier1: Float = 0.7
+
+  """
+  Regular stage threshold. `userSendRate >= tier2` AND `< tier1`
+  classifies as "regular". Default 0.4.
+  """
+  tier2: Float = 0.4
+}
+
+"""
+Input for the L1 all-community overview (`sysAdminDashboard`).
+"""
+input SysAdminDashboardInput {
+  """
+  The "as of" timestamp. All trailing-window calculations are anchored
+  here: the "latest month" is the JST calendar month containing asOf,
+  and "latest week" is the ISO-week containing asOf. Defaults to now
+  when omitted.
+  """
+  asOf: Datetime
+
+  """
+  Stage-count thresholds (see SysAdminSegmentThresholdsInput).
+  """
+  segmentThresholds: SysAdminSegmentThresholdsInput
+}
+
+"""
+Member-list filters for the L2 detail (`sysAdminCommunityDetail`).
+All conditions AND together. Unspecified fields do not filter.
+"""
+input SysAdminUserListFilter {
+  """
+  Inclusive lower bound on userSendRate. Default 0.7 (habitual only).
+  """
+  minSendRate: Float = 0.7
+  """
+  Inclusive upper bound on userSendRate.
+  """
+  maxSendRate: Float
+  """
+  Inclusive lower bound on monthsIn (JST-calendar months).
+  """
+  minMonthsIn: Int
+  """
+  Inclusive lower bound on donationOutMonths.
+  """
+  minDonationOutMonths: Int
+}
+
+"""
+Sort direction for the member list.
+"""
+enum SysAdminSortOrder {
+  """
+  Ascending — smallest value first (e.g. SEND_RATE ASC puts latent
+  and occasional members before habitual).
+  """
+  ASC
+  """
+  Descending — largest value first (e.g. SEND_RATE DESC puts habitual
+  members at the top). This is the default.
+  """
+  DESC
+}
+
+"""
+Sortable columns on the member list.
+"""
+enum SysAdminUserSortField {
+  """
+  userSendRate (individual monthly-send rate, 0.0–1.0).
+  """
+  SEND_RATE
+  """
+  monthsIn (tenure in JST calendar months).
+  """
+  MONTHS_IN
+  """
+  donationOutMonths (distinct months with a DONATION out).
+  """
+  DONATION_OUT_MONTHS
+  """
+  totalPointsOut (lifetime DONATION points sent).
+  """
+  TOTAL_POINTS_OUT
+}
+
+"""
+Sort configuration for the L2 member list. Both fields are optional;
+omitting either falls back to the default (SEND_RATE DESC) so the
+"top habitual members first" view renders out of the box.
+"""
+input SysAdminUserListSort {
+  """
+  Column to sort on. See SysAdminUserSortField for what each value
+  addresses. Default: SEND_RATE.
+  """
+  field: SysAdminUserSortField = SEND_RATE
+  """
+  Sort direction. Default: DESC.
+  """
+  order: SysAdminSortOrder = DESC
+}
+
+input SysAdminCommunityDetailInput {
+  """
+  Target community id.
+  """
+  communityId: ID!
+
+  """
+  As-of timestamp (see SysAdminDashboardInput.asOf).
+  """
+  asOf: Datetime
+
+  """
+  How many trailing JST months to include in the trend / cohort arrays.
+  Default 10.
+  """
+  windowMonths: Int = 10
+
+  """
+  Stage-count thresholds for the stage distribution and tier counts.
+  """
+  segmentThresholds: SysAdminSegmentThresholdsInput
+
+  """
+  Member list filter. Defaults to `minSendRate = 0.7` (habitual only).
+  """
+  userFilter: SysAdminUserListFilter
+
+  """
+  Member list sort. Defaults to SEND_RATE DESC.
+  """
+  userSort: SysAdminUserListSort
+
+  """
+  Member list page size (default 50, max 200).
+  """
+  limit: Int = 50
+
+  """
+  Opaque cursor for pagination. Internally a base64-encoded offset of
+  the prior page's position. Treat as opaque — pass back the cursor
+  returned by the previous response unchanged.
+  """
+  cursor: String
+}
+
+# --------------------------------------------------------------------------
+# Shared output types
+# --------------------------------------------------------------------------
+
+"""
+Stage-count snapshot for one community, computed by the server using the
+client-supplied `SysAdminSegmentThresholdsInput`. Cumulative semantics:
+`tier2Count` INCLUDES members counted in `tier1Count`.
+"""
+type SysAdminSegmentCounts {
+  """
+  Total status='JOINED' members at asOf.
+  """
+  total: Int!
+  """
+  Members with userSendRate >= tier1.
+  """
+  tier1Count: Int!
+  """
+  Members with userSendRate >= tier2 (includes tier1).
+  """
+  tier2Count: Int!
+  """
+  Members with userSendRate > 0 (excludes latent).
+  """
+  activeCount: Int!
+  """
+  Members with donationOutMonths == 0 (latent / not-yet-participated).
+  """
+  passiveCount: Int!
+}
+
+"""
+API-side alert flags. Boolean only: the server owns the cross-field
+judgement, the client just renders the badge.
+"""
+type SysAdminCommunityAlerts {
+  """
+  Latest-week churned_senders > retained_senders.
+  """
+  churnSpike: Boolean!
+  """
+  Month-over-month communityActivityRate change <= -20%.
+  """
+  activeDrop: Boolean!
+  """
+  No t_memberships.created_at rows (status='JOINED') in the last 14 days.
+  """
+  noNewMembers: Boolean!
+}
+
+# --------------------------------------------------------------------------
+# L1: dashboard overview
+# --------------------------------------------------------------------------
+
+"""
+Platform-wide headline, computed by summing across every community in
+scope for the caller (which is every community since this query is
+SYS_ADMIN-gated).
+"""
+type SysAdminPlatformSummary {
+  """
+  Number of communities included in the response.
+  """
+  communitiesCount: Int!
+  """
+  Sum of status='JOINED' members across every community.
+  """
+  totalMembers: Int!
+  """
+  Sum of DONATION points transferred during the JST calendar month
+  containing `asOf`, across every community.
+  """
+  latestMonthDonationPoints: Float!
+}
+
+"""
+One row of the L1 all-community table. See the module docstring for the
+distinction between `communityActivityRate` (this type) and
+`userSendRate` (SysAdminMemberRow).
+"""
+type SysAdminCommunityOverview {
+  """
+  Community id.
+  """
+  communityId: ID!
+  """
+  Community display name (t_communities.name).
+  """
+  communityName: String!
+
+  """
+  Total status='JOINED' members at asOf.
+  """
+  totalMembers: Int!
+
+  """
+  Stage counts under the supplied thresholds (cumulative, see type doc).
+  """
+  segmentCounts: SysAdminSegmentCounts!
+
+  """
+  Direct member count for the "habitual" stage (userSendRate >= tier1).
+  Convenience field (== segmentCounts.tier1Count).
+  """
+  tier1Count: Int!
+  """
+  Direct member count for the "regular+habitual" stage
+  (userSendRate >= tier2). Convenience field (== segmentCounts.tier2Count).
+  """
+  tier2Count: Int!
+  """
+  Direct member count for the "latent" stage (never donated).
+  Convenience field (== segmentCounts.passiveCount).
+  """
+  passiveCount: Int!
+
+  """
+  Community activity rate for the JST calendar month containing asOf:
+  unique DONATION senders in that month / month-end total_members.
+  0.0–1.0. NOT the individual-level userSendRate.
+  """
+  communityActivityRate: Float!
+
+  """
+  Month-over-month % change in communityActivityRate.
+  Returned as a fraction (e.g. -0.2 == -20%). null when the prior month
+  has no data to compare against.
+  """
+  growthRateActivity: Float
+
+  """
+  Retention rate of the most recent completed cohort (members who joined
+  in asOf's previous JST month) measured in the month after joining.
+  null when that cohort is empty.
+  """
+  latestCohortRetentionM1: Float
+
+  """
+  Alert flags (see SysAdminCommunityAlerts).
+  """
+  alerts: SysAdminCommunityAlerts!
+}
+
+"""
+Root payload for sysAdminDashboard (L1).
+"""
+type SysAdminDashboardPayload {
+  """
+  As-of timestamp echoed back (UTC instant).
+  """
+  asOf: Datetime!
+  """
+  Platform-wide aggregate row.
+  """
+  platform: SysAdminPlatformSummary!
+  """
+  One row per community, in dashboard sort order.
+  """
+  communities: [SysAdminCommunityOverview!]!
+}
+
+# --------------------------------------------------------------------------
+# L2: community detail
+# --------------------------------------------------------------------------
+
+"""
+Summary card for a single community. Fronts the L2 detail screen and
+answers "is this community improving?" in one row of numbers.
+"""
+type SysAdminCommunitySummaryCard {
+  """
+  Community id.
+  """
+  communityId: ID!
+  """
+  Community display name.
+  """
+  communityName: String!
+  """
+  Total status='JOINED' members at asOf.
+  """
+  totalMembers: Int!
+
+  """
+  Latest-month communityActivityRate (PRIMARY indicator — see module
+  docstring for the distinction vs userSendRate).
+  """
+  communityActivityRate: Float!
+  """
+  3-month trailing average of communityActivityRate, ending at the JST
+  calendar month containing asOf (inclusive). null when fewer than 3
+  months of data exist.
+  """
+  communityActivityRate3mAvg: Float
+  """
+  Month-over-month % change in communityActivityRate (fraction, e.g.
+  -0.2 == -20%). null when the prior month has no data.
+  """
+  growthRateActivity: Float
+
+  """
+  Cumulative members in tier2 or above under the supplied thresholds.
+  """
+  tier2Count: Int!
+  """
+  tier2Count / totalMembers (0.0–1.0).
+  """
+  tier2Pct: Float!
+
+  """
+  Total DONATION points transferred, all-time (no window). Uses
+  t_transactions directly so the value is independent of MV retention.
+  """
+  totalDonationPointsAllTime: Float!
+  """
+  Maximum chain depth observed in any DONATION, all-time. null when
+  no chained transactions exist.
+  """
+  maxChainDepthAllTime: Int
+
+  """
+  Oldest date with MV data for this community (JST calendar).
+  """
+  dataFrom: Datetime
+  """
+  Newest date with MV data for this community (JST calendar).
+  """
+  dataTo: Datetime
+}
+
+"""
+Summary for one stage (habitual / regular / occasional / latent).
+Stage membership is classified server-side using the thresholds supplied
+in the request. `pointsContributionPct` is the share of total DONATION
+points-out attributed to members in this stage, in the asOf month.
+"""
+type SysAdminStageBucket {
+  """
+  Number of members in this stage.
+  """
+  count: Int!
+  """
+  count / totalMembers (0.0–1.0).
+  """
+  pct: Float!
+  """
+  Stage's share of this community's all-time DONATION points-out
+  (0.0–1.0). Numerator is the sum of `totalPointsOut` across the
+  stage's members; denominator is the same sum across all members.
+  0 for the latent stage by definition.
+  """
+  pointsContributionPct: Float!
+  """
+  Average userSendRate across members in this stage (0.0–1.0).
+  """
+  avgSendRate: Float!
+  """
+  Average monthsIn across members in this stage.
+  """
+  avgMonthsIn: Float!
+}
+
+"""
+Four-stage distribution of the community's membership.
+`pointsContributionPct` on `latent` is always 0 since latent members
+haven't donated by definition.
+"""
+type SysAdminStageDistribution {
+  """
+  userSendRate >= tier1.
+  """
+  habitual: SysAdminStageBucket!
+  """
+  tier2 <= userSendRate < tier1.
+  """
+  regular: SysAdminStageBucket!
+  """
+  0 < userSendRate < tier2.
+  """
+  occasional: SysAdminStageBucket!
+  """
+  donationOutMonths == 0.
+  """
+  latent: SysAdminStageBucket!
+}
+
+"""
+One month of community activity trend.
+"""
+type SysAdminMonthlyActivityPoint {
+  """
+  First day (JST) of the calendar month, e.g. 2025-10-01T00:00+09:00.
+  """
+  month: Datetime!
+  """
+  Distinct DONATION senders in the month.
+  """
+  senderCount: Int!
+  """
+  senderCount / month-end totalMembers. Read alongside newMembers: a
+  month with many new joiners can dip the rate even if absolute activity
+  grew.
+  """
+  communityActivityRate: Float!
+  """
+  t_memberships.created_at (status='JOINED') rows falling in the month.
+  """
+  newMembers: Int!
+  """
+  Sum of DONATION points transferred in the month.
+  """
+  donationPointsSum: Float!
+  """
+  Share of DONATION transactions that were part of a chain (chain_depth
+  > 0) in the month. 0.0–1.0.
+  """
+  chainPct: Float
+}
+
+"""
+One ISO week of retention signals.
+"""
+type SysAdminRetentionTrendPoint {
+  """
+  Monday 00:00 JST of the ISO week.
+  """
+  week: Datetime!
+  """
+  Senders in both the prior week and this week (same-user on
+  donation_out_count > 0).
+  """
+  retainedSenders: Int!
+  """
+  Senders in the prior week who did NOT send this week.
+  """
+  churnedSenders: Int!
+  """
+  Senders this week who did NOT send last week but DID send some week
+  in the prior 12-week window.
+  """
+  returnedSenders: Int!
+  """
+  New t_memberships.created_at rows (status='JOINED') this week.
+  """
+  newMembers: Int!
+  """
+  Community activity rate for the week: distinct senders / totalMembers
+  as of week end. null when the community had zero members during the
+  week.
+  """
+  communityActivityRate: Float
+}
+
+"""
+One entry-month cohort's retention curve.
+"""
+type SysAdminCohortRetentionPoint {
+  """
+  Entry month, first day JST (e.g. 2025-10-01T00:00+09:00).
+  """
+  cohortMonth: Datetime!
+  """
+  Cohort size at entry (status='JOINED' joiners in the month).
+  """
+  cohortSize: Int!
+  """
+  Fraction of the cohort with a DONATION out in the SECOND month after
+  entry (m+1). null for an empty cohort or a cohort too recent to have
+  a completed m+1 window.
+  """
+  retentionM1: Float
+  """
+  Fraction active in m+3.
+  """
+  retentionM3: Float
+  """
+  Fraction active in m+6.
+  """
+  retentionM6: Float
+}
+
+"""
+One row of the L2 member list. Raw values only — stage classification
+(habitual / regular / occasional / latent) is the client's concern so
+server-side thresholds can be tuned without a schema change.
+"""
+type SysAdminMemberRow {
+  """
+  User id.
+  """
+  userId: ID!
+  """
+  User display name (users.name). null when the user has no name set.
+  """
+  name: String
+  """
+  Individual monthly-send rate: `donationOutMonths / monthsIn`, 0.0–1.0,
+  rounded to 3 decimals. INDIVIDUAL LTV variable (not the same as
+  communityActivityRate elsewhere in this schema).
+  """
+  userSendRate: Float!
+  """
+  Tenure in JST calendar months (floor, minimum 1).
+  """
+  monthsIn: Int!
+  """
+  Distinct months with at least one DONATION out.
+  """
+  donationOutMonths: Int!
+  """
+  All-time DONATION points sent by this user in this community.
+  """
+  totalPointsOut: Float!
+}
+
+"""
+Paginated member list for the L2 detail.
+"""
+type SysAdminMemberList {
+  """
+  Member rows for the current page, matching filter & sort applied
+  server-side.
+  """
+  users: [SysAdminMemberRow!]!
+  """
+  Whether more pages exist after this one.
+  """
+  hasNextPage: Boolean!
+  """
+  Opaque cursor to pass back in `SysAdminCommunityDetailInput.cursor` to
+  fetch the next page. null when no further pages exist.
+  """
+  nextCursor: String
+}
+
+"""
+Root payload for sysAdminCommunityDetail (L2).
+"""
+type SysAdminCommunityDetailPayload {
+  """
+  Community id.
+  """
+  communityId: ID!
+  """
+  Community display name.
+  """
+  communityName: String!
+  """
+  As-of timestamp echoed back.
+  """
+  asOf: Datetime!
+  """
+  Trailing window length in JST months (echoed back).
+  """
+  windowMonths: Int!
+
+  """
+  Summary card — see type doc.
+  """
+  summary: SysAdminCommunitySummaryCard!
+  """
+  Stage distribution, classified server-side with the request's
+  thresholds. Computed over ALL members (independent of member-list
+  filter).
+  """
+  stages: SysAdminStageDistribution!
+  """
+  One entry per month (length <= windowMonths), newest last. Older
+  months with no MV data are omitted rather than zero-padded.
+  """
+  monthlyActivityTrend: [SysAdminMonthlyActivityPoint!]!
+  """
+  One entry per ISO week, newest last. Length approximates
+  `windowMonths * ~4.3` weeks; sparse weeks with no activity still emit
+  a row with zero counters.
+  """
+  retentionTrend: [SysAdminRetentionTrendPoint!]!
+  """
+  One entry per entry month (length <= windowMonths), newest last.
+  `retentionM*` fields are null when the cohort is empty or too recent.
+  """
+  cohortRetention: [SysAdminCohortRetentionPoint!]!
+  """
+  Paginated member list — see type doc.
+  """
+  memberList: SysAdminMemberList!
+  """
+  Alert flags (same structure as L1, evaluated for this community).
+  """
+  alerts: SysAdminCommunityAlerts!
+}

--- a/src/application/domain/sysadmin/service.ts
+++ b/src/application/domain/sysadmin/service.ts
@@ -1,0 +1,762 @@
+import { inject, injectable } from "tsyringe";
+import { IContext } from "@/types/server";
+import { ISysAdminRepository } from "@/application/domain/sysadmin/data/interface";
+import ReportService from "@/application/domain/report/service";
+import {
+  SysAdminMemberStatsRow,
+  SysAdminMonthlyActivityRow,
+} from "@/application/domain/sysadmin/data/type";
+import {
+  addDays,
+  bigintToSafeNumber,
+  isoWeekStartJst,
+  jstMonthStart,
+  jstMonthStartOffset,
+  jstNextMonthStart,
+  percentChange,
+} from "@/application/domain/report/util";
+import { asOfBounds } from "@/application/domain/sysadmin/bounds";
+
+/**
+ * Stage-count thresholds come from the client. tier1 >= tier2 >= 0 is
+ * enforced at the service boundary so the cumulative-count invariant
+ * (`tier2Count >= tier1Count`) is guaranteed downstream.
+ */
+export type SegmentThresholds = {
+  tier1: number;
+  tier2: number;
+};
+
+export const DEFAULT_SEGMENT_THRESHOLDS: SegmentThresholds = {
+  tier1: 0.7,
+  tier2: 0.4,
+};
+
+/**
+ * Result of classifying a community's members against the supplied
+ * thresholds. `tier2Count` and `tier1Count` are cumulative (tier2
+ * INCLUDES tier1 members); the per-bucket breakdown lives in
+ * `stageBreakdown` below so both shapes are available without a second
+ * scan.
+ */
+export type StageCounts = {
+  total: number;
+  tier1Count: number;
+  tier2Count: number;
+  activeCount: number;
+  passiveCount: number;
+};
+
+export type StageBucketStats = {
+  count: number;
+  pct: number;
+  pointsContributionPct: number;
+  avgSendRate: number;
+  avgMonthsIn: number;
+};
+
+export type StageBreakdown = {
+  habitual: StageBucketStats;
+  regular: StageBucketStats;
+  occasional: StageBucketStats;
+  latent: StageBucketStats;
+};
+
+export type WeeklyRetentionPoint = {
+  weekStart: Date;
+  retainedSenders: number;
+  churnedSenders: number;
+  returnedSenders: number;
+  newMembers: number;
+  communityActivityRate: number | null;
+};
+
+export type MonthlyCohortPoint = {
+  cohortMonthStart: Date;
+  cohortSize: number;
+  retentionM1: number | null;
+  retentionM3: number | null;
+  retentionM6: number | null;
+};
+
+export type SortField = "SEND_RATE" | "MONTHS_IN" | "DONATION_OUT_MONTHS" | "TOTAL_POINTS_OUT";
+export type SortOrder = "ASC" | "DESC";
+
+export type MemberListParams = {
+  minSendRate?: number | null;
+  maxSendRate?: number | null;
+  minMonthsIn?: number | null;
+  minDonationOutMonths?: number | null;
+  sortField: SortField;
+  sortOrder: SortOrder;
+  limit: number;
+  cursor?: string | null;
+};
+
+export type MemberListResult = {
+  users: SysAdminMemberStatsRow[];
+  hasNextPage: boolean;
+  nextCursor: string | null;
+};
+
+export type AlertFlags = {
+  churnSpike: boolean;
+  activeDrop: boolean;
+  noNewMembers: boolean;
+};
+
+/**
+ * Return shape of `getMonthActivityWithPrev`. Flat, not nested, because
+ * every caller only reads the current-month fields plus the derived
+ * `growthRateActivity`; keeping a `previous` sub-tree around was dead
+ * payload that tempted readers to assume the previous-month snapshot
+ * was part of the API contract.
+ */
+export type MonthActivityWithPrev = {
+  currentRate: number;
+  currentSenderCount: number;
+  currentTotalMembers: number;
+  growthRateActivity: number | null;
+};
+
+export const DEFAULT_WINDOW_MONTHS = 10;
+/**
+ * Upper bound on `windowMonths`. Defensive guard against a caller
+ * (or a tampered persisted query) requesting an unreasonably long
+ * trend — `getCohortRetention` fires 4 SQL calls per month in the
+ * window, so unbounded input would let a single request fan out
+ * arbitrarily. 36 months (3 years) comfortably covers every
+ * analytics need the spec references today.
+ */
+export const MAX_WINDOW_MONTHS = 36;
+export const MAX_LIMIT = 200;
+export const ACTIVE_DROP_THRESHOLD = -0.2; // month-over-month fraction
+export const NO_NEW_MEMBERS_WINDOW_DAYS = 14;
+
+/**
+ * Cap on how many DB round-trips the retention-trend and cohort-
+ * retention orchestrators will keep in flight at once. At the MAX
+ * windowMonths (36) those loops otherwise fan out to ~310 concurrent
+ * `$queryRaw` calls (each under its own `ctx.issuer.public` tx),
+ * which can exhaust the Prisma connection pool and stall the whole
+ * request. Keep the degree of concurrency small — bench measurements
+ * showed Postgres handles per-week scans in ~1ms each, so serialising
+ * chunks adds only a few ms of wall-clock latency.
+ */
+export const FANOUT_CONCURRENCY = 8;
+
+/**
+ * Run `fn(item)` across `items` with a bounded number of in-flight
+ * promises. Returns results in the same order as `items`. No library
+ * dependency — the loop is short enough to inline rather than reach
+ * for `p-limit`.
+ */
+async function runBatched<T, R>(
+  items: readonly T[],
+  batchSize: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = [];
+  for (let i = 0; i < items.length; i += batchSize) {
+    const chunk = items.slice(i, i + batchSize);
+    const chunkResults = await Promise.all(chunk.map(fn));
+    results.push(...chunkResults);
+  }
+  return results;
+}
+
+/**
+ * Fraction of the community that sent DONATION in a window:
+ * `senderCount / totalMembers`, or 0 when the community had no members
+ * during the window. Appears verbatim in several orchestrators
+ * (getMonthActivityWithPrev, getAlerts, computeActivityRate3mAvg); one
+ * helper keeps the "divide-by-zero ⇒ 0" convention in a single place.
+ */
+function rateOf(senderCount: number, totalMembers: number): number {
+  return totalMembers === 0 ? 0 : senderCount / totalMembers;
+}
+
+@injectable()
+export default class SysAdminService {
+  constructor(
+    @inject("SysAdminRepository") private readonly repository: ISysAdminRepository,
+    // Cross-domain reads route through ReportService (the report
+    // domain's service-layer entry point), not the report repository.
+    // CLAUDE.md restricts services to "Call other domain services
+    // (read operations only)" — going straight to the repository
+    // would couple sysadmin to the report domain's data layer.
+    @inject("ReportService") private readonly reportService: ReportService,
+  ) {}
+
+  // ==========================================================================
+  // Pure classification / aggregation helpers
+  //
+  // Split out from the orchestrator methods below so they're easy to
+  // unit-test without any database or context plumbing. Every one is a
+  // pure function of `members`, `thresholds`, and (for alerts) the
+  // pre-fetched rows.
+  // ==========================================================================
+
+  computeStageCounts(
+    members: SysAdminMemberStatsRow[],
+    thresholds: SegmentThresholds,
+  ): StageCounts {
+    const total = members.length;
+    let tier1Count = 0;
+    let tier2Count = 0;
+    let activeCount = 0;
+    let passiveCount = 0;
+    for (const m of members) {
+      if (m.donationOutMonths === 0) {
+        passiveCount++;
+        continue;
+      }
+      activeCount++;
+      if (m.userSendRate >= thresholds.tier1) tier1Count++;
+      if (m.userSendRate >= thresholds.tier2) tier2Count++;
+    }
+    return { total, tier1Count, tier2Count, activeCount, passiveCount };
+  }
+
+  /**
+   * Four-bucket stage breakdown. Unlike `computeStageCounts` these
+   * buckets are disjoint (`habitual`, `regular`, `occasional`, `latent`)
+   * so `pct` sums to 1.0. `pointsContributionPct` is the share of the
+   * community's total DONATION points-out attributed to each bucket.
+   */
+  computeStageBreakdown(
+    members: SysAdminMemberStatsRow[],
+    thresholds: SegmentThresholds,
+  ): StageBreakdown {
+    const totalMembers = members.length;
+    const totalPointsOut = members.reduce<bigint>((acc, m) => acc + m.totalPointsOut, BigInt(0));
+
+    const buckets = {
+      habitual: [] as SysAdminMemberStatsRow[],
+      regular: [] as SysAdminMemberStatsRow[],
+      occasional: [] as SysAdminMemberStatsRow[],
+      latent: [] as SysAdminMemberStatsRow[],
+    };
+    for (const m of members) {
+      if (m.donationOutMonths === 0) {
+        buckets.latent.push(m);
+      } else if (m.userSendRate >= thresholds.tier1) {
+        buckets.habitual.push(m);
+      } else if (m.userSendRate >= thresholds.tier2) {
+        buckets.regular.push(m);
+      } else {
+        buckets.occasional.push(m);
+      }
+    }
+
+    const summarize = (rows: SysAdminMemberStatsRow[]): StageBucketStats => {
+      const count = rows.length;
+      if (count === 0) {
+        return {
+          count: 0,
+          pct: 0,
+          pointsContributionPct: 0,
+          avgSendRate: 0,
+          avgMonthsIn: 0,
+        };
+      }
+      // Single-pass reduce over rows so we visit the bucket once
+      // instead of three times. At realistic bucket sizes the
+      // difference is negligible, but it keeps the intent ("summarise
+      // this bucket") in one place.
+      const { sumSendRate, sumMonthsIn, sumPointsOut } = rows.reduce(
+        (acc, r) => ({
+          sumSendRate: acc.sumSendRate + r.userSendRate,
+          sumMonthsIn: acc.sumMonthsIn + r.monthsIn,
+          sumPointsOut: acc.sumPointsOut + r.totalPointsOut,
+        }),
+        { sumSendRate: 0, sumMonthsIn: 0, sumPointsOut: BigInt(0) },
+      );
+      // Route both sides of pointsContributionPct through
+      // bigintToSafeNumber so an extreme community's cumulative
+      // points total surfaces as a RangeError instead of silently
+      // truncating through `Number(bigint)`. The ratio itself is a
+      // [0, 1] fraction regardless of magnitude.
+      const pointsContributionPct =
+        totalPointsOut === BigInt(0)
+          ? 0
+          : bigintToSafeNumber(sumPointsOut) / bigintToSafeNumber(totalPointsOut);
+      return {
+        count,
+        pct: totalMembers === 0 ? 0 : count / totalMembers,
+        pointsContributionPct,
+        avgSendRate: sumSendRate / count,
+        avgMonthsIn: sumMonthsIn / count,
+      };
+    };
+
+    return {
+      habitual: summarize(buckets.habitual),
+      regular: summarize(buckets.regular),
+      occasional: summarize(buckets.occasional),
+      // The latent bucket's pointsContributionPct is always 0 by
+      // definition (latent === never-donated), so summarize() returns 0
+      // naturally without a special case.
+      latent: summarize(buckets.latent),
+    };
+  }
+
+  /**
+   * Filter + sort + page a pre-fetched member list. Pagination uses an
+   * offset-encoded cursor (`"n"`) so the caller can resume from row N
+   * without re-running the underlying aggregation. At <6 communities
+   * with a few hundred members each, in-memory paging is cheaper than
+   * a new SQL round-trip per page.
+   */
+  paginateMembers(members: SysAdminMemberStatsRow[], params: MemberListParams): MemberListResult {
+    const filtered = members.filter((m) => {
+      if (params.minSendRate != null && m.userSendRate < params.minSendRate) return false;
+      if (params.maxSendRate != null && m.userSendRate > params.maxSendRate) return false;
+      if (params.minMonthsIn != null && m.monthsIn < params.minMonthsIn) return false;
+      if (params.minDonationOutMonths != null && m.donationOutMonths < params.minDonationOutMonths)
+        return false;
+      return true;
+    });
+
+    const sign = params.sortOrder === "ASC" ? 1 : -1;
+    const numericKey = (m: SysAdminMemberStatsRow): number => {
+      switch (params.sortField) {
+        case "SEND_RATE":
+          return m.userSendRate;
+        case "MONTHS_IN":
+          return m.monthsIn;
+        case "DONATION_OUT_MONTHS":
+          return m.donationOutMonths;
+        case "TOTAL_POINTS_OUT":
+          // Handled in the bigint branch below; placeholder here so
+          // the switch is exhaustive.
+          return 0;
+      }
+    };
+    const sorted = [...filtered].sort((a, b) => {
+      let cmp: number;
+      if (params.sortField === "TOTAL_POINTS_OUT") {
+        // Compare bigints directly — Number(bigint) would silently
+        // lose precision past Number.MAX_SAFE_INTEGER and quietly
+        // mis-order the leaderboard for extreme donors.
+        if (a.totalPointsOut < b.totalPointsOut) cmp = -1;
+        else if (a.totalPointsOut > b.totalPointsOut) cmp = 1;
+        else cmp = 0;
+      } else {
+        cmp = numericKey(a) - numericKey(b);
+      }
+      if (cmp !== 0) return sign * cmp;
+      // Stable secondary sort on userId to make the cursor deterministic.
+      return a.userId.localeCompare(b.userId);
+    });
+
+    const start = params.cursor ? parseCursor(params.cursor) : 0;
+    const limit = Math.min(Math.max(params.limit, 1), MAX_LIMIT);
+    const page = sorted.slice(start, start + limit);
+    const hasNextPage = start + limit < sorted.length;
+    return {
+      users: page,
+      hasNextPage,
+      nextCursor: hasNextPage ? encodeCursor(start + limit) : null,
+    };
+  }
+
+  // ==========================================================================
+  // Orchestrators — the methods the usecase actually calls
+  // ==========================================================================
+
+  // --------------------------------------------------------------------------
+  // Thin pass-throughs to the repository.
+  //
+  // Per CLAUDE.md, the UseCase layer must not talk to repositories
+  // directly — cross-layer calls go UseCase → Service → Repository.
+  // These `get*` methods mirror the matching `find*` methods on the
+  // repo 1:1 so the usecase can stay service-only without forcing the
+  // repo to rename or split its surface.
+  // --------------------------------------------------------------------------
+
+  async getAllCommunities(ctx: IContext) {
+    return this.repository.findAllCommunities(ctx);
+  }
+
+  async getCommunityById(ctx: IContext, communityId: string) {
+    return this.repository.findCommunityById(ctx, communityId);
+  }
+
+  async getMemberStats(ctx: IContext, communityId: string, asOf: Date) {
+    return this.repository.findMemberStats(ctx, communityId, asOf);
+  }
+
+  async getMonthlyActivity(
+    ctx: IContext,
+    communityId: string,
+    asOf: Date,
+    windowMonths: number,
+  ) {
+    return this.repository.findMonthlyActivity(ctx, communityId, asOf, windowMonths);
+  }
+
+  async getAllTimeTotals(ctx: IContext, communityId: string, asOf: Date) {
+    return this.repository.findAllTimeTotals(ctx, communityId, asOf);
+  }
+
+  async getPlatformTotals(
+    ctx: IContext,
+    jstMonthStart: Date,
+    jstNextMonthStart: Date,
+  ) {
+    return this.repository.findPlatformTotals(ctx, jstMonthStart, jstNextMonthStart);
+  }
+
+  /**
+   * Week-by-week retention series across `windowMonths`.
+   *
+   * Fans out one `findRetentionAggregate` + one `findActivitySnapshot`
+   * per target week, fired in parallel via `Promise.all`. At the
+   * default `windowMonths=10` that's ~43 weeks × 2 = ~86 small SQL
+   * statements.
+   *
+   * This was briefly rewritten as a single bulk CTE query but the
+   * benchmark (`scripts/sysadmin_bench.ts`) showed the bulk form was
+   * 5× slower at 100 members, 40× slower at 500, and 364× slower at
+   * 2000. The `ever_before` lookup combined with the
+   * `per_target` FULL OUTER JOIN scaled super-linearly in member
+   * count, while the per-week loop's narrow single-week scans stay
+   * cheap thanks to the `mv_user_transaction_daily`
+   * `(community_id, date)` index. Postgres handles the parallel
+   * queries efficiently over a single connection-pool checkout.
+   */
+  async getRetentionTrend(
+    ctx: IContext,
+    communityId: string,
+    asOf: Date,
+    windowMonths: number,
+  ): Promise<WeeklyRetentionPoint[]> {
+    const latestWeekStart = isoWeekStartJst(asOf);
+    const firstMonthStart = jstMonthStartOffset(asOf, -(windowMonths - 1));
+    const firstWeekStart = isoWeekStartJst(firstMonthStart);
+    // Clamp each week's `nextWeekStart` at asOf+1 JST day so
+    // mid-week reads don't leak memberships that joined after asOf
+    // into the activity-rate denominator.
+    const bounds = asOfBounds(asOf);
+
+    const weekStarts: Date[] = [];
+    for (let wk = firstWeekStart; wk <= latestWeekStart; wk = addDays(wk, 7)) {
+      weekStarts.push(wk);
+    }
+
+    // Each week fires 2 queries (retention + activity snapshot).
+    // At MAX windowMonths that's ~310 concurrent queries if we did a
+    // naive Promise.all; FANOUT_CONCURRENCY caps it at a
+    // pool-friendly 8 weeks (= 16 queries) at a time.
+    const points = await runBatched(weekStarts, FANOUT_CONCURRENCY, async (weekStart) => {
+      const nextWeekStart = addDays(weekStart, 7);
+      const prevWeekStart = addDays(weekStart, -7);
+      const twelveWeeksAgo = addDays(weekStart, -7 * 12);
+      const denominatorUpperBound = bounds.clampFuture(nextWeekStart);
+      const [retention, snapshot] = await Promise.all([
+        this.reportService.getRetentionAggregate(ctx, communityId, {
+          currentWeekStart: weekStart,
+          // Clamp the upper bound of the "current week" too: for a
+          // historic asOf the MV holds data past asOf, and a raw
+          // `nextWeekStart` would let future sender rows into the
+          // in-progress week's numerator. Past weeks' nextWeekStart
+          // stays unchanged because `clampFuture` no-ops when the
+          // boundary is already before asOf+1.
+          nextWeekStart: denominatorUpperBound,
+          prevWeekStart,
+          twelveWeeksAgo,
+        }),
+        // Denominator for the rate: all JOINED members as of week
+        // end (or asOf, whichever is earlier). Without the clamp,
+        // the current-week row would include members who joined
+        // between asOf and the next Monday in its denominator.
+        this.repository.findActivitySnapshot(
+          ctx,
+          communityId,
+          weekStart,
+          denominatorUpperBound,
+        ),
+      ]);
+      const communityActivityRate =
+        snapshot.totalMembers === 0
+          ? null
+          : retention.currentSendersCount / snapshot.totalMembers;
+      return {
+        weekStart,
+        retainedSenders: retention.retainedSenders,
+        churnedSenders: retention.churnedSenders,
+        returnedSenders: retention.returnedSenders,
+        newMembers: retention.newMembers,
+        communityActivityRate,
+      };
+    });
+
+    return points;
+  }
+
+  /**
+   * Monthly cohort retention for the last `windowMonths` entry months.
+   * For each entry month, measures the cohort's DONATION-out activity
+   * in the m+1 / m+3 / m+6 windows. Returns `null` when the lookahead
+   * window ends after `asOf` (cohort too recent) or the cohort itself
+   * is empty.
+   */
+  async getCohortRetention(
+    ctx: IContext,
+    communityId: string,
+    asOf: Date,
+    windowMonths: number,
+  ): Promise<MonthlyCohortPoint[]> {
+    const latestMonthStart = jstMonthStart(asOf);
+
+    const cohortMonths: Date[] = [];
+    for (let i = windowMonths - 1; i >= 0; i--) {
+      cohortMonths.push(jstMonthStartOffset(latestMonthStart, -i));
+    }
+
+    // Each cohort issues up to 4 getCohortRetention calls (m1/m3/m6
+    // + cohort_size probe). At MAX windowMonths=36 that's 144 queries
+    // if we Promise.all'd naively; FANOUT_CONCURRENCY keeps concurrent
+    // work to 8 cohorts × 4 = 32 queries, well under Prisma pool size.
+    const points = await runBatched(cohortMonths, FANOUT_CONCURRENCY, async (cohortStart) => {
+      const cohortEnd = jstMonthStartOffset(cohortStart, 1);
+      const activeM1Start = jstMonthStartOffset(cohortStart, 1);
+      const activeM1End = jstMonthStartOffset(cohortStart, 2);
+      const activeM3Start = jstMonthStartOffset(cohortStart, 3);
+      const activeM3End = jstMonthStartOffset(cohortStart, 4);
+      const activeM6Start = jstMonthStartOffset(cohortStart, 6);
+      const activeM6End = jstMonthStartOffset(cohortStart, 7);
+
+      const fetchRetention = async (
+        activeStart: Date,
+        activeEnd: Date,
+      ): Promise<number | null> => {
+        // Skip any window whose end hasn't passed the START of the
+        // asOf month. The asOf month itself is still in progress —
+        // showing a cohort's retention against a partially-observed
+        // month makes the number look artificially low (members
+        // still have the rest of the month to donate). Only release
+        // the value once `activeEnd` sits entirely in completed
+        // history (i.e. at or before the current month's start).
+        if (activeEnd > latestMonthStart) return null;
+        const row = await this.reportService.getCohortRetention(
+          ctx,
+          communityId,
+          { cohortStart, cohortEnd },
+          { activeStart, activeEnd },
+        );
+        if (row.cohortSize === 0) return null;
+        return row.activeNextWeek / row.cohortSize;
+      };
+
+      const [retentionM1, retentionM3, retentionM6, cohortSizeRow] = await Promise.all([
+        fetchRetention(activeM1Start, activeM1End),
+        fetchRetention(activeM3Start, activeM3End),
+        fetchRetention(activeM6Start, activeM6End),
+        // Re-use findCohortRetention with an active-window that
+        // overlaps the cohort month itself just to read the
+        // cohort_size counter; the numerator is ignored.
+        this.reportService.getCohortRetention(
+          ctx,
+          communityId,
+          { cohortStart, cohortEnd },
+          { activeStart: cohortStart, activeEnd: cohortEnd },
+        ),
+      ]);
+
+      return {
+        cohortMonthStart: cohortStart,
+        cohortSize: cohortSizeRow.cohortSize,
+        retentionM1,
+        retentionM3,
+        retentionM6,
+      };
+    });
+
+    return points;
+  }
+
+  /**
+   * Community activity rate for the JST calendar month containing
+   * `asOf`, plus the previous-month baseline needed to compute
+   * `growthRateActivity` and fire the `active_drop` alert. Returned
+   * shape is flat so both the L1 overview row and the L2 summary card
+   * can destructure it.
+   */
+  async getMonthActivityWithPrev(
+    ctx: IContext,
+    communityId: string,
+    asOf: Date,
+  ): Promise<MonthActivityWithPrev> {
+    const monthStart = jstMonthStart(asOf);
+    const prevMonthStart = jstMonthStartOffset(monthStart, -1);
+    // Cap the current-month upper bound at asOf+1 JST day so
+    // mid-month / historic-asOf snapshots don't count memberships
+    // created after asOf in the denominator. `findActivitySnapshot`
+    // filters total_members with `created_at < upper`. The prev
+    // month call doesn't need clamping because its upper bound
+    // (monthStart) is strictly in the past.
+    const currNextBound = asOfBounds(asOf).clampFuture(jstNextMonthStart(asOf));
+
+    const [curr, prev] = await Promise.all([
+      this.repository.findActivitySnapshot(ctx, communityId, monthStart, currNextBound),
+      this.repository.findActivitySnapshot(ctx, communityId, prevMonthStart, monthStart),
+    ]);
+
+    const currRate = rateOf(curr.senderCount, curr.totalMembers);
+    const prevRate = rateOf(prev.senderCount, prev.totalMembers);
+    // Explicit `prevRate === 0` guard: `percentChange` already returns
+    // null when the denominator is 0, but making both conditions
+    // visible at the call site keeps the Infinity risk obvious to the
+    // next reader and doesn't rely on implementation details of the
+    // shared util.
+    const growth =
+      prev.totalMembers === 0 || prevRate === 0
+        ? null
+        : percentChange(currRate, prevRate);
+
+    return {
+      currentRate: currRate,
+      currentSenderCount: curr.senderCount,
+      currentTotalMembers: curr.totalMembers,
+      // percentChange returns a percentage (×100). Convert back to a
+      // fraction so downstream comparisons (`<= -20%` → `<= -0.2`) line
+      // up with the requirement-doc spelling and the schema docstring.
+      growthRateActivity: growth == null ? null : growth / 100,
+    };
+  }
+
+  /** 3-month trailing average of communityActivityRate, ending at
+   * asOf's month (inclusive). null when <3 months of trend data exist. */
+  computeActivityRate3mAvg(trend: SysAdminMonthlyActivityRow[]): number | null {
+    if (trend.length < 3) return null;
+    const last3 = trend.slice(-3);
+    const sumRates = last3.reduce(
+      (acc, r) => acc + rateOf(r.senderCount, r.totalMembersEndOfMonth),
+      0,
+    );
+    return sumRates / 3;
+  }
+
+  /**
+   * Most recent COMPLETED m1 retention: the fraction of members who
+   * joined two JST months before asOf and sent a DONATION during the
+   * month-after-that (= the month just before asOf's month).
+   *
+   * Shifted back from "prev-month cohort, asOf-month active" so the
+   * active window is always a fully completed month — matches the L2
+   * cohort-retention convention (README §3.4: "進行中の月は除外") and
+   * avoids reporting artificially low numbers on the 1st of every
+   * month. Returns null when the cohort is empty.
+   */
+  async getLatestCohortRetentionM1(
+    ctx: IContext,
+    communityId: string,
+    asOf: Date,
+  ): Promise<number | null> {
+    const monthStart = jstMonthStart(asOf);
+    const cohortStart = jstMonthStartOffset(monthStart, -2); // 2 months before asOf
+    const cohortEnd = jstMonthStartOffset(monthStart, -1); // 1 month before asOf
+    const activeStart = cohortEnd;
+    const activeEnd = monthStart; // last completed month's end
+    const row = await this.reportService.getCohortRetention(
+      ctx,
+      communityId,
+      { cohortStart, cohortEnd },
+      { activeStart, activeEnd },
+    );
+    if (row.cohortSize === 0) return null;
+    return row.activeNextWeek / row.cohortSize;
+  }
+
+  /**
+   * Evaluate all three alert flags in one pass.
+   *
+   * churnSpike / activeDrop use the LAST COMPLETED period (prev-week
+   * vs week-before, prev-month vs month-before) rather than the
+   * in-progress asOf week/month. Comparing a partially-observed week
+   * against a full prior week would reliably fire the alert on
+   * Monday-Tuesday of every week (the in-progress side has almost no
+   * data yet). The UI's own `growthRateActivity` (current vs prev)
+   * remains visible as an informational, non-alerting signal.
+   *
+   * noNewMembers stays anchored to asOf itself: "have any members
+   * joined in the last NO_NEW_MEMBERS_WINDOW_DAYS JST days, ending
+   * today." The schema description "直近14日間" uses the half-open
+   * interval [asOfJstDay - (N-1), asOfJstDay + 1) so the full JST
+   * calendar day containing asOf is included.
+   */
+  async getAlerts(ctx: IContext, communityId: string, asOf: Date): Promise<AlertFlags> {
+    const latestWeekStart = isoWeekStartJst(asOf);
+    // Alert frame: the completed week just before asOf's week.
+    const prevWeekStart = addDays(latestWeekStart, -7);
+    const prevPrevWeekStart = addDays(prevWeekStart, -7);
+    const twelveWeeksAgo = addDays(prevWeekStart, -7 * 12);
+
+    // Month frame: compare the last TWO completed months so an asOf
+    // early in the month doesn't trigger activeDrop purely because
+    // the in-progress month is empty.
+    const monthStart = jstMonthStart(asOf);
+    const prevMonthStart = jstMonthStartOffset(monthStart, -1);
+    const prevPrevMonthStart = jstMonthStartOffset(monthStart, -2);
+
+    const bounds = asOfBounds(asOf);
+    const fourteenDaysAgo = addDays(
+      bounds.asOfJstDayPlusOne,
+      -NO_NEW_MEMBERS_WINDOW_DAYS,
+    );
+    const upperExclusive = bounds.asOfJstDayPlusOne;
+
+    const [retention, newMembers, prevMonth, prevPrevMonth] = await Promise.all([
+      this.reportService.getRetentionAggregate(ctx, communityId, {
+        // Evaluate retention on the last completed week.
+        currentWeekStart: prevWeekStart,
+        nextWeekStart: latestWeekStart,
+        prevWeekStart: prevPrevWeekStart,
+        twelveWeeksAgo,
+      }),
+      this.repository.findNewMemberCount(ctx, communityId, fourteenDaysAgo, upperExclusive),
+      this.repository.findActivitySnapshot(ctx, communityId, prevMonthStart, monthStart),
+      this.repository.findActivitySnapshot(
+        ctx,
+        communityId,
+        prevPrevMonthStart,
+        prevMonthStart,
+      ),
+    ]);
+
+    // activeDrop derives its own growth fraction from the
+    // completed-month snapshot pair (prev vs prev-prev), independent
+    // of the UI's growthRateActivity which tracks current-vs-prev.
+    // percentChange returns a percentage (× 100) and null when the
+    // denominator is 0, so converting to a fraction needs one extra
+    // divide — matches the same pattern getMonthActivityWithPrev uses.
+    const prevRate = rateOf(prevMonth.senderCount, prevMonth.totalMembers);
+    const prevPrevRate = rateOf(prevPrevMonth.senderCount, prevPrevMonth.totalMembers);
+    const alertGrowthPct = percentChange(prevRate, prevPrevRate);
+    const alertGrowth = alertGrowthPct == null ? null : alertGrowthPct / 100;
+
+    return {
+      churnSpike: retention.churnedSenders > retention.retainedSenders,
+      activeDrop: alertGrowth != null && alertGrowth <= ACTIVE_DROP_THRESHOLD,
+      noNewMembers: newMembers.count === 0,
+    };
+  }
+}
+
+function encodeCursor(offset: number): string {
+  // Simple numeric offset. Base64 to discourage clients from poking
+  // into the value and to match the "opaque cursor" contract.
+  return Buffer.from(String(offset), "utf8").toString("base64");
+}
+
+function parseCursor(cursor: string): number {
+  try {
+    const decoded = Buffer.from(cursor, "base64").toString("utf8");
+    const n = Number.parseInt(decoded, 10);
+    return Number.isFinite(n) && n >= 0 ? n : 0;
+  } catch {
+    return 0;
+  }
+}

--- a/src/application/domain/sysadmin/service.ts
+++ b/src/application/domain/sysadmin/service.ts
@@ -119,6 +119,42 @@ export type MonthActivityWithPrev = {
   growthRateActivity: number | null;
 };
 
+/**
+ * Raw activity counts for the parametric window driven by
+ * `windowDays`. The L1 overview returns these as-is so the client
+ * derives rates / growth rates / threshold alerts on its own (see
+ * SysAdminWindowActivity in schema/type.graphql).
+ */
+export type WindowActivityCounts = {
+  senderCount: number;
+  senderCountPrev: number;
+  newMemberCount: number;
+  newMemberCountPrev: number;
+};
+
+/**
+ * Raw weekly retention counts against the most recent COMPLETED ISO
+ * week. Exposing both halves lets the client compose churn alerts
+ * (e.g. churnedSenders > retainedSenders) without a server-side
+ * threshold judgement.
+ */
+export type WeeklyRetentionCounts = {
+  retainedSenders: number;
+  churnedSenders: number;
+};
+
+/**
+ * Raw counts for the most recently completed monthly cohort and its
+ * M+1 activity. Cohort = (asOf JST月 - 2). Returning the count pair
+ * (size, activeAtM1) instead of the pre-divided ratio lets the client
+ * decide how to handle small-N cohorts (e.g. greying out values when
+ * `size` is below a confidence threshold).
+ */
+export type LatestCohortCounts = {
+  size: number;
+  activeAtM1: number;
+};
+
 export const DEFAULT_WINDOW_MONTHS = 10;
 /**
  * Upper bound on `windowMonths`. Defensive guard against a caller
@@ -132,6 +168,16 @@ export const MAX_WINDOW_MONTHS = 36;
 export const MAX_LIMIT = 200;
 export const ACTIVE_DROP_THRESHOLD = -0.2; // month-over-month fraction
 export const NO_NEW_MEMBERS_WINDOW_DAYS = 14;
+
+/**
+ * Bounds for the L1 overview's parametric activity window. The lower
+ * bound (7) keeps the previous-window comparison meaningful; the upper
+ * bound (90) caps the per-community DB scan even on a malformed input
+ * value. Both are silent clamps applied at the usecase boundary.
+ */
+export const DEFAULT_WINDOW_DAYS = 28;
+export const MIN_WINDOW_DAYS = 7;
+export const MAX_WINDOW_DAYS = 90;
 
 /**
  * Cap on how many DB round-trips the retention-trend and cohort-
@@ -640,34 +686,104 @@ export default class SysAdminService {
   }
 
   /**
-   * Most recent COMPLETED m1 retention: the fraction of members who
-   * joined two JST months before asOf and sent a DONATION during the
-   * month-after-that (= the month just before asOf's month).
+   * Rolling-window DONATION activity for the L1 overview. Returns the
+   * raw sender / new-member counts for both the current window and the
+   * immediately preceding window of equal length. The client divides
+   * by `totalMembers` for rates and computes growth as
+   * `(currRate - prevRate) / prevRate` with a null guard.
    *
-   * Shifted back from "prev-month cohort, asOf-month active" so the
-   * active window is always a fully completed month — matches the L2
-   * cohort-retention convention (README §3.4: "進行中の月は除外") and
-   * avoids reporting artificially low numbers on the 1st of every
-   * month. Returns null when the cohort is empty.
+   *   current  = [asOf - windowDays JST日, asOf + 1 JST日)
+   *   previous = [asOf - 2 * windowDays, asOf - windowDays)
+   *
+   * Both windows reuse `findActivitySnapshot` / `findNewMemberCount`,
+   * so no new SQL is introduced — only the date arguments change.
    */
-  async getLatestCohortRetentionM1(
+  async getWindowActivity(
     ctx: IContext,
     communityId: string,
     asOf: Date,
-  ): Promise<number | null> {
+    windowDays: number,
+  ): Promise<WindowActivityCounts> {
+    const upper = asOfBounds(asOf).asOfJstDayPlusOne;
+    const currLower = addDays(upper, -windowDays);
+    const prevLower = addDays(upper, -windowDays * 2);
+
+    const [curr, prev, currNew, prevNew] = await Promise.all([
+      this.repository.findActivitySnapshot(ctx, communityId, currLower, upper),
+      this.repository.findActivitySnapshot(ctx, communityId, prevLower, currLower),
+      this.repository.findNewMemberCount(ctx, communityId, currLower, upper),
+      this.repository.findNewMemberCount(ctx, communityId, prevLower, currLower),
+    ]);
+
+    return {
+      senderCount: curr.senderCount,
+      senderCountPrev: prev.senderCount,
+      newMemberCount: currNew.count,
+      newMemberCountPrev: prevNew.count,
+    };
+  }
+
+  /**
+   * DONATION sender retention against the most recently completed ISO
+   * week. The asOf-containing week is in progress, so the "latest
+   * completed" week is the one starting `latestWeekStart - 7d`. The
+   * existing `getRetentionAggregate` already returns these counts —
+   * we just pass through the raw integers instead of reducing them to
+   * a boolean alert flag, leaving the threshold judgement to the client.
+   */
+  async getWeeklyRetention(
+    ctx: IContext,
+    communityId: string,
+    asOf: Date,
+  ): Promise<WeeklyRetentionCounts> {
+    const latestWeekStart = isoWeekStartJst(asOf);
+    const prevWeekStart = addDays(latestWeekStart, -7);
+    const prevPrevWeekStart = addDays(prevWeekStart, -7);
+    const twelveWeeksAgo = addDays(prevWeekStart, -7 * 12);
+
+    const retention = await this.reportService.getRetentionAggregate(ctx, communityId, {
+      currentWeekStart: prevWeekStart,
+      nextWeekStart: latestWeekStart,
+      prevWeekStart: prevPrevWeekStart,
+      twelveWeeksAgo,
+    });
+
+    return {
+      retainedSenders: retention.retainedSenders,
+      churnedSenders: retention.churnedSenders,
+    };
+  }
+
+  /**
+   * Most recently completed monthly cohort + its M+1 activity, as raw
+   * counts. The cohort is selected as (asOf JST月 - 2) so the M+1
+   * window — which is (asOf JST月 - 1) — is fully past; this matches
+   * the L2 cohort-retention convention (README §3.4 "進行中の月は除外").
+   *
+   * Returning {size, activeAtM1} instead of a pre-divided Float lets
+   * the client treat empty cohorts (size === 0) as null retention and
+   * grey out small-N cohorts via its own confidence threshold.
+   */
+  async getLatestCohort(
+    ctx: IContext,
+    communityId: string,
+    asOf: Date,
+  ): Promise<LatestCohortCounts> {
     const monthStart = jstMonthStart(asOf);
-    const cohortStart = jstMonthStartOffset(monthStart, -2); // 2 months before asOf
-    const cohortEnd = jstMonthStartOffset(monthStart, -1); // 1 month before asOf
+    const cohortStart = jstMonthStartOffset(monthStart, -2);
+    const cohortEnd = jstMonthStartOffset(monthStart, -1);
     const activeStart = cohortEnd;
-    const activeEnd = monthStart; // last completed month's end
+    const activeEnd = monthStart;
     const row = await this.reportService.getCohortRetention(
       ctx,
       communityId,
       { cohortStart, cohortEnd },
       { activeStart, activeEnd },
     );
-    if (row.cohortSize === 0) return null;
-    return row.activeNextWeek / row.cohortSize;
+    return {
+      size: row.cohortSize,
+      activeAtM1: row.activeNextWeek,
+    };
   }
 
   /**

--- a/src/application/domain/sysadmin/service.ts
+++ b/src/application/domain/sysadmin/service.ts
@@ -130,6 +130,7 @@ export type WindowActivityCounts = {
   senderCountPrev: number;
   newMemberCount: number;
   newMemberCountPrev: number;
+  retainedSenders: number;
 };
 
 /**
@@ -695,8 +696,13 @@ export default class SysAdminService {
    *   current  = [asOf - windowDays JST日, asOf + 1 JST日)
    *   previous = [asOf - 2 * windowDays, asOf - windowDays)
    *
-   * Both windows reuse `findActivitySnapshot` / `findNewMemberCount`,
-   * so no new SQL is introduced — only the date arguments change.
+   * All five counts come from a single repository call
+   * (`findWindowActivityCounts`) which scans `mv_user_transaction_daily`
+   * once over `[prevLower, upper)` and `t_memberships` once over the
+   * same span — collapsing what used to be five overlapping scans
+   * (curr senders + prev senders + intersection + curr new members +
+   * prev new members) into two. The service's only job here is the
+   * date-window arithmetic.
    */
   async getWindowActivity(
     ctx: IContext,
@@ -708,19 +714,13 @@ export default class SysAdminService {
     const currLower = addDays(upper, -windowDays);
     const prevLower = addDays(upper, -windowDays * 2);
 
-    const [curr, prev, currNew, prevNew] = await Promise.all([
-      this.repository.findActivitySnapshot(ctx, communityId, currLower, upper),
-      this.repository.findActivitySnapshot(ctx, communityId, prevLower, currLower),
-      this.repository.findNewMemberCount(ctx, communityId, currLower, upper),
-      this.repository.findNewMemberCount(ctx, communityId, prevLower, currLower),
-    ]);
-
-    return {
-      senderCount: curr.senderCount,
-      senderCountPrev: prev.senderCount,
-      newMemberCount: currNew.count,
-      newMemberCountPrev: prevNew.count,
-    };
+    return this.repository.findWindowActivityCounts(
+      ctx,
+      communityId,
+      prevLower,
+      currLower,
+      upper,
+    );
   }
 
   /**

--- a/src/application/domain/sysadmin/service.ts
+++ b/src/application/domain/sysadmin/service.ts
@@ -181,6 +181,20 @@ export const MIN_WINDOW_DAYS = 7;
 export const MAX_WINDOW_DAYS = 90;
 
 /**
+ * Hub breadth threshold defaults & defensive bounds. The threshold
+ * decides how many DISTINCT DONATION recipients within the window
+ * a member needs to qualify as a hub. Default is intentionally low
+ * (3) because civicship's per-member donation cadence is sparse;
+ * portal can tune via SysAdminDashboardInput.hubBreadthThreshold
+ * once real-data hub distribution is observed. Effective range
+ * 1..1000 — values outside are clamped at the usecase boundary the
+ * same way `windowDays` is.
+ */
+export const DEFAULT_HUB_BREADTH_THRESHOLD = 3;
+export const MIN_HUB_BREADTH_THRESHOLD = 1;
+export const MAX_HUB_BREADTH_THRESHOLD = 1000;
+
+/**
  * Cap on how many DB round-trips the retention-trend and cohort-
  * retention orchestrators will keep in flight at once. At the MAX
  * windowMonths (36) those loops otherwise fan out to ~310 concurrent
@@ -721,6 +735,40 @@ export default class SysAdminService {
       currLower,
       upper,
     );
+  }
+
+  /**
+   * Count of members classified as hubs within the parametric
+   * window: those who sent DONATION to at least
+   * `hubBreadthThreshold` DISTINCT counterparties during
+   * `[asOf - windowDays, asOf + 1 JST日)`.
+   *
+   * Single-axis classification (breadth only) — reaching the
+   * threshold inherently requires that many transactions, so a
+   * separate frequency floor would be redundant. The service's
+   * only job is the date arithmetic; the count itself comes from a
+   * dedicated repository SQL because it needs DISTINCT recipient
+   * aggregation against `t_transactions` (which the per-day MV
+   * cannot compose into a window-wide DISTINCT).
+   */
+  async getWindowHubMemberCount(
+    ctx: IContext,
+    communityId: string,
+    asOf: Date,
+    windowDays: number,
+    hubBreadthThreshold: number,
+  ): Promise<number> {
+    const upper = asOfBounds(asOf).asOfJstDayPlusOne;
+    const currLower = addDays(upper, -windowDays);
+
+    const row = await this.repository.findWindowHubMemberCount(
+      ctx,
+      communityId,
+      currLower,
+      upper,
+      hubBreadthThreshold,
+    );
+    return row.count;
   }
 
   /**

--- a/src/application/domain/sysadmin/usecase.ts
+++ b/src/application/domain/sysadmin/usecase.ts
@@ -10,9 +10,12 @@ import {
 } from "@/types/graphql";
 import SysAdminService, {
   DEFAULT_SEGMENT_THRESHOLDS,
+  DEFAULT_WINDOW_DAYS,
   DEFAULT_WINDOW_MONTHS,
   MAX_LIMIT,
+  MAX_WINDOW_DAYS,
   MAX_WINDOW_MONTHS,
+  MIN_WINDOW_DAYS,
   SegmentThresholds,
 } from "@/application/domain/sysadmin/service";
 import SysAdminPresenter from "@/application/domain/sysadmin/presenter";
@@ -39,6 +42,7 @@ export default class SysAdminUseCase {
   ): Promise<GqlSysAdminDashboardPayload> {
     const asOf = input?.asOf ?? new Date();
     const thresholds = resolveThresholds(input?.segmentThresholds);
+    const windowDays = clampWindowDays(input?.windowDays);
 
     const monthStart = jstMonthStart(asOf);
     // Clamp the platform-totals upper bound at asOf+1 JST day so a
@@ -55,31 +59,31 @@ export default class SysAdminUseCase {
 
     const rows = await Promise.all(
       communities.map(async (c): Promise<GqlSysAdminCommunityOverview> => {
-        const [members, currentMonthActivity, latestCohortRetentionM1] = await Promise.all([
+        const [members, windowActivity, weeklyRetention, latestCohort] = await Promise.all([
           this.service.getMemberStats(ctx, c.communityId, asOf),
-          this.service.getMonthActivityWithPrev(ctx, c.communityId, asOf),
-          this.service.getLatestCohortRetentionM1(ctx, c.communityId, asOf),
+          this.service.getWindowActivity(ctx, c.communityId, asOf, windowDays),
+          this.service.getWeeklyRetention(ctx, c.communityId, asOf),
+          this.service.getLatestCohort(ctx, c.communityId, asOf),
         ]);
         const stageCounts = this.service.computeStageCounts(members, thresholds);
-        const alerts = await this.service.getAlerts(ctx, c.communityId, asOf);
         return SysAdminPresenter.overviewRow({
           communityId: c.communityId,
           communityName: c.communityName,
           totalMembers: stageCounts.total,
           stageCounts,
-          communityActivityRate: currentMonthActivity.currentRate,
-          growthRateActivity: currentMonthActivity.growthRateActivity,
-          latestCohortRetentionM1,
-          alerts,
+          windowActivity,
+          weeklyRetention,
+          latestCohort,
         });
       }),
     );
 
-    // Sort by latest-month communityActivityRate descending — matches
-    // the "ソート: 直近月の community_activity_rate 降順（デフォルト）"
-    // behaviour in the requirement doc. Clients can still re-sort in
-    // the browser since the payload is small.
-    rows.sort((a, b) => b.communityActivityRate - a.communityActivityRate);
+    // Sorting moved to the client. The L1 payload no longer carries
+    // a single canonical "rate" the server can sort on, and the
+    // browser's filter()/sort() over <100 rows is sub-millisecond.
+    // Rows are returned in `findAllCommunities` order (community
+    // name ASC, see SysAdminRepository) so the response is
+    // deterministic before the client applies its own sort.
 
     return SysAdminPresenter.dashboard({
       asOf,
@@ -199,4 +203,16 @@ function resolveThresholds(
 function clampLimit(limit: number | null | undefined): number {
   const n = limit ?? 50;
   return Math.min(Math.max(n, 1), MAX_LIMIT);
+}
+
+/**
+ * L1 dashboard activity-window length, in JST days. Defaults to 28
+ * (= 4 weeks) when omitted, and is silently clamped to
+ * [MIN_WINDOW_DAYS, MAX_WINDOW_DAYS] so a malformed/hostile input can't
+ * fan the per-community DB scan out to year-long ranges. Documented in
+ * the SysAdminDashboardInput.windowDays SDL description.
+ */
+function clampWindowDays(input: number | null | undefined): number {
+  const n = input ?? DEFAULT_WINDOW_DAYS;
+  return Math.min(Math.max(n, MIN_WINDOW_DAYS), MAX_WINDOW_DAYS);
 }

--- a/src/application/domain/sysadmin/usecase.ts
+++ b/src/application/domain/sysadmin/usecase.ts
@@ -9,12 +9,15 @@ import {
   GqlSysAdminDashboardPayload,
 } from "@/types/graphql";
 import SysAdminService, {
+  DEFAULT_HUB_BREADTH_THRESHOLD,
   DEFAULT_SEGMENT_THRESHOLDS,
   DEFAULT_WINDOW_DAYS,
   DEFAULT_WINDOW_MONTHS,
+  MAX_HUB_BREADTH_THRESHOLD,
   MAX_LIMIT,
   MAX_WINDOW_DAYS,
   MAX_WINDOW_MONTHS,
+  MIN_HUB_BREADTH_THRESHOLD,
   MIN_WINDOW_DAYS,
   SegmentThresholds,
 } from "@/application/domain/sysadmin/service";
@@ -43,6 +46,7 @@ export default class SysAdminUseCase {
     const asOf = input?.asOf ?? new Date();
     const thresholds = resolveThresholds(input?.segmentThresholds);
     const windowDays = clampWindowDays(input?.windowDays);
+    const hubBreadthThreshold = clampHubBreadthThreshold(input?.hubBreadthThreshold);
 
     const monthStart = jstMonthStart(asOf);
     // Clamp the platform-totals upper bound at asOf+1 JST day so a
@@ -59,12 +63,20 @@ export default class SysAdminUseCase {
 
     const rows = await Promise.all(
       communities.map(async (c): Promise<GqlSysAdminCommunityOverview> => {
-        const [members, windowActivity, weeklyRetention, latestCohort] = await Promise.all([
-          this.service.getMemberStats(ctx, c.communityId, asOf),
-          this.service.getWindowActivity(ctx, c.communityId, asOf, windowDays),
-          this.service.getWeeklyRetention(ctx, c.communityId, asOf),
-          this.service.getLatestCohort(ctx, c.communityId, asOf),
-        ]);
+        const [members, windowActivity, weeklyRetention, latestCohort, hubMemberCount] =
+          await Promise.all([
+            this.service.getMemberStats(ctx, c.communityId, asOf),
+            this.service.getWindowActivity(ctx, c.communityId, asOf, windowDays),
+            this.service.getWeeklyRetention(ctx, c.communityId, asOf),
+            this.service.getLatestCohort(ctx, c.communityId, asOf),
+            this.service.getWindowHubMemberCount(
+              ctx,
+              c.communityId,
+              asOf,
+              windowDays,
+              hubBreadthThreshold,
+            ),
+          ]);
         const stageCounts = this.service.computeStageCounts(members, thresholds);
         return SysAdminPresenter.overviewRow({
           communityId: c.communityId,
@@ -74,6 +86,7 @@ export default class SysAdminUseCase {
           windowActivity,
           weeklyRetention,
           latestCohort,
+          hubMemberCount,
         });
       }),
     );
@@ -215,4 +228,19 @@ function clampLimit(limit: number | null | undefined): number {
 function clampWindowDays(input: number | null | undefined): number {
   const n = input ?? DEFAULT_WINDOW_DAYS;
   return Math.min(Math.max(n, MIN_WINDOW_DAYS), MAX_WINDOW_DAYS);
+}
+
+/**
+ * Hub-classification breadth threshold, in distinct DONATION
+ * recipients within the parametric window. Defaults to 3 when
+ * omitted, and clamped to
+ * [MIN_HUB_BREADTH_THRESHOLD, MAX_HUB_BREADTH_THRESHOLD] so a
+ * malformed/hostile input can't disable hub classification entirely
+ * (negative threshold) or scan-stall the comparison (gigantic
+ * threshold). Documented in the SysAdminDashboardInput
+ * .hubBreadthThreshold SDL description.
+ */
+function clampHubBreadthThreshold(input: number | null | undefined): number {
+  const n = input ?? DEFAULT_HUB_BREADTH_THRESHOLD;
+  return Math.min(Math.max(n, MIN_HUB_BREADTH_THRESHOLD), MAX_HUB_BREADTH_THRESHOLD);
 }

--- a/src/application/domain/sysadmin/usecase.ts
+++ b/src/application/domain/sysadmin/usecase.ts
@@ -1,0 +1,202 @@
+import { inject, injectable } from "tsyringe";
+import { IContext } from "@/types/server";
+import { NotFoundError } from "@/errors/graphql";
+import {
+  GqlQuerySysAdminCommunityDetailArgs,
+  GqlQuerySysAdminDashboardArgs,
+  GqlSysAdminCommunityDetailPayload,
+  GqlSysAdminCommunityOverview,
+  GqlSysAdminDashboardPayload,
+} from "@/types/graphql";
+import SysAdminService, {
+  DEFAULT_SEGMENT_THRESHOLDS,
+  DEFAULT_WINDOW_MONTHS,
+  MAX_LIMIT,
+  MAX_WINDOW_MONTHS,
+  SegmentThresholds,
+} from "@/application/domain/sysadmin/service";
+import SysAdminPresenter from "@/application/domain/sysadmin/presenter";
+import { jstMonthStart, jstNextMonthStart } from "@/application/domain/report/util";
+import { asOfBounds } from "@/application/domain/sysadmin/bounds";
+
+@injectable()
+export default class SysAdminUseCase {
+  // Only the service is injected. Per CLAUDE.md the UseCase layer
+  // must not talk to the repository directly — repository reads are
+  // routed through SysAdminService's `get*` pass-throughs.
+  constructor(@inject("SysAdminService") private readonly service: SysAdminService) {}
+
+  /**
+   * L1 dashboard: platform totals + one row per community.
+   *
+   * Fan-out is N in-process calls. At today's community count (~6)
+   * this is cheaper than a new bulk repository method; revisit once
+   * the platform exceeds ~20 communities (documented in the spec).
+   */
+  async getDashboard(
+    { input }: GqlQuerySysAdminDashboardArgs,
+    ctx: IContext,
+  ): Promise<GqlSysAdminDashboardPayload> {
+    const asOf = input?.asOf ?? new Date();
+    const thresholds = resolveThresholds(input?.segmentThresholds);
+
+    const monthStart = jstMonthStart(asOf);
+    // Clamp the platform-totals upper bound at asOf+1 JST day so a
+    // mid-month or historic asOf doesn't count memberships that
+    // hadn't been created yet. findPlatformTotals applies
+    // `created_at < upper` on t_memberships; asOfBounds.clampFuture
+    // collapses back to next_month_start for past months.
+    const platformUpperBound = asOfBounds(asOf).clampFuture(jstNextMonthStart(asOf));
+
+    const [platform, communities] = await Promise.all([
+      this.service.getPlatformTotals(ctx, monthStart, platformUpperBound),
+      this.service.getAllCommunities(ctx),
+    ]);
+
+    const rows = await Promise.all(
+      communities.map(async (c): Promise<GqlSysAdminCommunityOverview> => {
+        const [members, currentMonthActivity, latestCohortRetentionM1] = await Promise.all([
+          this.service.getMemberStats(ctx, c.communityId, asOf),
+          this.service.getMonthActivityWithPrev(ctx, c.communityId, asOf),
+          this.service.getLatestCohortRetentionM1(ctx, c.communityId, asOf),
+        ]);
+        const stageCounts = this.service.computeStageCounts(members, thresholds);
+        const alerts = await this.service.getAlerts(ctx, c.communityId, asOf);
+        return SysAdminPresenter.overviewRow({
+          communityId: c.communityId,
+          communityName: c.communityName,
+          totalMembers: stageCounts.total,
+          stageCounts,
+          communityActivityRate: currentMonthActivity.currentRate,
+          growthRateActivity: currentMonthActivity.growthRateActivity,
+          latestCohortRetentionM1,
+          alerts,
+        });
+      }),
+    );
+
+    // Sort by latest-month communityActivityRate descending — matches
+    // the "ソート: 直近月の community_activity_rate 降順（デフォルト）"
+    // behaviour in the requirement doc. Clients can still re-sort in
+    // the browser since the payload is small.
+    rows.sort((a, b) => b.communityActivityRate - a.communityActivityRate);
+
+    return SysAdminPresenter.dashboard({
+      asOf,
+      platform,
+      communities: rows,
+    });
+  }
+
+  /**
+   * L2 detail: summary card + stage breakdown + trailing-window trends
+   * + cohort retention + paginated member list + alerts for one
+   * community.
+   */
+  async getCommunityDetail(
+    { input }: GqlQuerySysAdminCommunityDetailArgs,
+    ctx: IContext,
+  ): Promise<GqlSysAdminCommunityDetailPayload> {
+    const asOf = input.asOf ?? new Date();
+    const thresholds = resolveThresholds(input.segmentThresholds);
+    // Clamp to [1, MAX_WINDOW_MONTHS]. getCohortRetention and the
+    // retention-trend fan-out both scale linearly with this value, so
+    // a cap prevents a single request from exhausting the connection
+    // pool on unbounded input.
+    const windowMonths = Math.min(
+      Math.max(input.windowMonths ?? DEFAULT_WINDOW_MONTHS, 1),
+      MAX_WINDOW_MONTHS,
+    );
+
+    // Resolve the community row first so we can 404 early if the id is
+    // bogus and also thread communityName through the payload. The
+    // id-indexed lookup keeps cost flat as the platform grows.
+    const community = await this.service.getCommunityById(ctx, input.communityId);
+    if (!community) {
+      throw new NotFoundError("Community", { id: input.communityId });
+    }
+
+    const [
+      members,
+      monthlyActivity,
+      allTimeTotals,
+      currentMonthActivity,
+      retentionTrend,
+      cohortRetention,
+    ] = await Promise.all([
+      this.service.getMemberStats(ctx, community.communityId, asOf),
+      this.service.getMonthlyActivity(ctx, community.communityId, asOf, windowMonths),
+      this.service.getAllTimeTotals(ctx, community.communityId, asOf),
+      this.service.getMonthActivityWithPrev(ctx, community.communityId, asOf),
+      this.service.getRetentionTrend(ctx, community.communityId, asOf, windowMonths),
+      this.service.getCohortRetention(ctx, community.communityId, asOf, windowMonths),
+    ]);
+
+    const stageCounts = this.service.computeStageCounts(members, thresholds);
+    const stageBreakdown = this.service.computeStageBreakdown(members, thresholds);
+
+    const alerts = await this.service.getAlerts(ctx, community.communityId, asOf);
+
+    const memberList = this.service.paginateMembers(members, {
+      minSendRate: input.userFilter?.minSendRate ?? 0.7,
+      maxSendRate: input.userFilter?.maxSendRate ?? null,
+      minMonthsIn: input.userFilter?.minMonthsIn ?? null,
+      minDonationOutMonths: input.userFilter?.minDonationOutMonths ?? null,
+      sortField: input.userSort?.field ?? "SEND_RATE",
+      sortOrder: input.userSort?.order ?? "DESC",
+      limit: clampLimit(input.limit),
+      cursor: input.cursor ?? null,
+    });
+
+    const summary = SysAdminPresenter.summaryCard({
+      communityId: community.communityId,
+      communityName: community.communityName,
+      totalMembers: stageCounts.total,
+      communityActivityRate: currentMonthActivity.currentRate,
+      communityActivityRate3mAvg: this.service.computeActivityRate3mAvg(monthlyActivity),
+      growthRateActivity: currentMonthActivity.growthRateActivity,
+      tier2Count: stageCounts.tier2Count,
+      allTimeTotals,
+    });
+
+    return SysAdminPresenter.communityDetail({
+      communityId: community.communityId,
+      communityName: community.communityName,
+      asOf,
+      windowMonths,
+      summary,
+      stages: SysAdminPresenter.stages(stageBreakdown),
+      monthlyActivityTrend: monthlyActivity.map(SysAdminPresenter.monthlyActivityPoint),
+      retentionTrend: retentionTrend.map(SysAdminPresenter.retentionTrendPoint),
+      cohortRetention: cohortRetention.map(SysAdminPresenter.cohortPoint),
+      memberList: SysAdminPresenter.memberList(memberList),
+      alerts: SysAdminPresenter.alerts(alerts),
+    });
+  }
+}
+
+function resolveThresholds(
+  input:
+    | {
+        tier1?: number | null;
+        tier2?: number | null;
+      }
+    | null
+    | undefined,
+): SegmentThresholds {
+  // Clamp negative inputs to 0 so the downstream invariant
+  // `tier1 >= tier2 >= 0` holds. Without this, a negative tier2 would
+  // make `userSendRate >= tier2` trivially true for every member and
+  // produce misleading stage counts.
+  const tier1 = Math.max(input?.tier1 ?? DEFAULT_SEGMENT_THRESHOLDS.tier1, 0);
+  const tier2 = Math.max(input?.tier2 ?? DEFAULT_SEGMENT_THRESHOLDS.tier2, 0);
+  // If a caller flips them (tier2 > tier1), swap silently rather than
+  // erroring — the "higher boundary" invariant is what the rest of the
+  // service relies on, and a swap is a less confusing DX than a 400.
+  return tier1 >= tier2 ? { tier1, tier2 } : { tier1: tier2, tier2: tier1 };
+}
+
+function clampLimit(limit: number | null | undefined): number {
+  const n = limit ?? 50;
+  return Math.min(Math.max(n, 1), MAX_LIMIT);
+}

--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -128,6 +128,9 @@ import VoteUseCase from "@/application/domain/vote/usecase";
 import VoteService from "@/application/domain/vote/service";
 import VoteConverter from "@/application/domain/vote/data/converter";
 import VoteRepository from "@/application/domain/vote/data/repository";
+import SysAdminRepository from "@/application/domain/sysadmin/data/repository";
+import SysAdminService from "@/application/domain/sysadmin/service";
+import SysAdminUseCase from "@/application/domain/sysadmin/usecase";
 
 export function registerProductionDependencies() {
   // ------------------------------
@@ -371,6 +374,14 @@ export function registerProductionDependencies() {
   container.register("VoteService", { useClass: VoteService });
   container.register("VoteConverter", { useClass: VoteConverter });
   container.register("VoteRepository", { useClass: VoteRepository });
+
+  // ------------------------------
+  // 🛰️ SysAdmin (platform operator analytics)
+  // ------------------------------
+
+  container.register("SysAdminRepository", { useClass: SysAdminRepository });
+  container.register("SysAdminService", { useClass: SysAdminService });
+  container.register("SysAdminUseCase", { useClass: SysAdminUseCase });
 
   // ------------------------------
   // 👓 View

--- a/src/presentation/graphql/resolver.ts
+++ b/src/presentation/graphql/resolver.ts
@@ -29,6 +29,7 @@ import NftTokenResolver from "@/application/domain/account/nft-token/controller/
 import VoteResolver from "@/application/domain/vote/controller/resolver";
 import ReportResolver from "@/application/domain/report/controller/resolver";
 import ReportFeedbackResolver from "@/application/domain/report/feedback/controller/resolver";
+import SysAdminResolver from "@/application/domain/sysadmin/controller/resolver";
 import scalarResolvers from "@/presentation/graphql/scalar";
 
 const identity = container.resolve(IdentityResolver);
@@ -65,6 +66,7 @@ const incentiveGrant = container.resolve(IncentiveGrantResolver);
 const vote = container.resolve(VoteResolver);
 const report = container.resolve(ReportResolver);
 const reportFeedback = container.resolve(ReportFeedbackResolver);
+const sysAdmin = container.resolve(SysAdminResolver);
 
 const resolvers = {
   Query: {
@@ -96,6 +98,7 @@ const resolvers = {
     ...vote.Query,
     ...report.Query,
     ...reportFeedback.Query,
+    ...sysAdmin.Query,
   },
   Mutation: {
     ...identity.Mutation,

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -3520,6 +3520,16 @@ export type GqlSysAdminWindowActivity = {
   /** Same metric for the previous window. */
   newMemberCountPrev: Scalars['Int']['output'];
   /**
+   * Users who sent at least one DONATION in BOTH the current window
+   * AND the previous window (set intersection on user_id). Same
+   * shape as SysAdminWeeklyRetention.retainedSenders but at
+   * windowDays scale, enabling client-side leaky-bucket derivation:
+   *
+   *   newlyActivatedSenders = senderCount     - retainedSenders
+   *   churnedSenders        = senderCountPrev - retainedSenders
+   */
+  retainedSenders: Scalars['Int']['output'];
+  /**
    * Unique users with at least one outgoing DONATION transaction
    * during the current window (donation_out_count > 0 in
    * mv_user_transaction_daily).
@@ -6906,6 +6916,7 @@ export type GqlSysAdminWeeklyRetentionResolvers<ContextType = any, ParentType ex
 export type GqlSysAdminWindowActivityResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminWindowActivity'] = GqlResolversParentTypes['SysAdminWindowActivity']> = ResolversObject<{
   newMemberCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   newMemberCountPrev?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  retainedSenders?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   senderCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   senderCountPrev?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -2184,6 +2184,21 @@ export type GqlQuery = {
   reservations: GqlReservationsConnection;
   signupBonusConfig?: Maybe<GqlCommunitySignupBonusConfig>;
   states: GqlStatesConnection;
+  /**
+   * L2 detail for a single community: summary card, stage distribution,
+   * trailing-window trends, cohort retention, and a paginated member list.
+   * Intended for answering "what are kibotcha's numbers?" in an external
+   * report conversation.
+   */
+  sysAdminCommunityDetail: GqlSysAdminCommunityDetailPayload;
+  /**
+   * L1 overview: platform totals plus one row per community. Intended for
+   * the "is any community stalling?" scan. Community fan-out is served
+   * with N in-process calls (acceptable at today's community count —
+   * switch to a GROUP BY implementation once the platform exceeds ~20
+   * communities).
+   */
+  sysAdminDashboard: GqlSysAdminDashboardPayload;
   ticket?: Maybe<GqlTicket>;
   ticketClaimLink?: Maybe<GqlTicketClaimLink>;
   ticketClaimLinks: GqlTicketClaimLinksConnection;
@@ -2479,6 +2494,16 @@ export type GqlQueryStatesArgs = {
   cursor?: InputMaybe<Scalars['String']['input']>;
   filter?: InputMaybe<GqlStatesInput>;
   first?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type GqlQuerySysAdminCommunityDetailArgs = {
+  input: GqlSysAdminCommunityDetailInput;
+};
+
+
+export type GqlQuerySysAdminDashboardArgs = {
+  input?: InputMaybe<GqlSysAdminDashboardInput>;
 };
 
 
@@ -2961,6 +2986,479 @@ export type GqlSubmitReportFeedbackSuccess = {
   feedback: GqlReportFeedback;
 };
 
+/** One entry-month cohort's retention curve. */
+export type GqlSysAdminCohortRetentionPoint = {
+  __typename?: 'SysAdminCohortRetentionPoint';
+  /** Entry month, first day JST (e.g. 2025-10-01T00:00+09:00). */
+  cohortMonth: Scalars['Datetime']['output'];
+  /** Cohort size at entry (status='JOINED' joiners in the month). */
+  cohortSize: Scalars['Int']['output'];
+  /**
+   * Fraction of the cohort with a DONATION out in the SECOND month after
+   * entry (m+1). null for an empty cohort or a cohort too recent to have
+   * a completed m+1 window.
+   */
+  retentionM1?: Maybe<Scalars['Float']['output']>;
+  /** Fraction active in m+3. */
+  retentionM3?: Maybe<Scalars['Float']['output']>;
+  /** Fraction active in m+6. */
+  retentionM6?: Maybe<Scalars['Float']['output']>;
+};
+
+/**
+ * API-side alert flags. Boolean only: the server owns the cross-field
+ * judgement, the client just renders the badge.
+ */
+export type GqlSysAdminCommunityAlerts = {
+  __typename?: 'SysAdminCommunityAlerts';
+  /** Month-over-month communityActivityRate change <= -20%. */
+  activeDrop: Scalars['Boolean']['output'];
+  /** Latest-week churned_senders > retained_senders. */
+  churnSpike: Scalars['Boolean']['output'];
+  /** No t_memberships.created_at rows (status='JOINED') in the last 14 days. */
+  noNewMembers: Scalars['Boolean']['output'];
+};
+
+export type GqlSysAdminCommunityDetailInput = {
+  /** As-of timestamp (see SysAdminDashboardInput.asOf). */
+  asOf?: InputMaybe<Scalars['Datetime']['input']>;
+  /** Target community id. */
+  communityId: Scalars['ID']['input'];
+  /**
+   * Opaque cursor for pagination. Internally a base64-encoded offset of
+   * the prior page's position. Treat as opaque — pass back the cursor
+   * returned by the previous response unchanged.
+   */
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  /** Member list page size (default 50, max 200). */
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  /** Stage-count thresholds for the stage distribution and tier counts. */
+  segmentThresholds?: InputMaybe<GqlSysAdminSegmentThresholdsInput>;
+  /** Member list filter. Defaults to `minSendRate = 0.7` (habitual only). */
+  userFilter?: InputMaybe<GqlSysAdminUserListFilter>;
+  /** Member list sort. Defaults to SEND_RATE DESC. */
+  userSort?: InputMaybe<GqlSysAdminUserListSort>;
+  /**
+   * How many trailing JST months to include in the trend / cohort arrays.
+   * Default 10.
+   */
+  windowMonths?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** Root payload for sysAdminCommunityDetail (L2). */
+export type GqlSysAdminCommunityDetailPayload = {
+  __typename?: 'SysAdminCommunityDetailPayload';
+  /** Alert flags (same structure as L1, evaluated for this community). */
+  alerts: GqlSysAdminCommunityAlerts;
+  /** As-of timestamp echoed back. */
+  asOf: Scalars['Datetime']['output'];
+  /**
+   * One entry per entry month (length <= windowMonths), newest last.
+   * `retentionM*` fields are null when the cohort is empty or too recent.
+   */
+  cohortRetention: Array<GqlSysAdminCohortRetentionPoint>;
+  /** Community id. */
+  communityId: Scalars['ID']['output'];
+  /** Community display name. */
+  communityName: Scalars['String']['output'];
+  /** Paginated member list — see type doc. */
+  memberList: GqlSysAdminMemberList;
+  /**
+   * One entry per month (length <= windowMonths), newest last. Older
+   * months with no MV data are omitted rather than zero-padded.
+   */
+  monthlyActivityTrend: Array<GqlSysAdminMonthlyActivityPoint>;
+  /**
+   * One entry per ISO week, newest last. Length approximates
+   * `windowMonths * ~4.3` weeks; sparse weeks with no activity still emit
+   * a row with zero counters.
+   */
+  retentionTrend: Array<GqlSysAdminRetentionTrendPoint>;
+  /**
+   * Stage distribution, classified server-side with the request's
+   * thresholds. Computed over ALL members (independent of member-list
+   * filter).
+   */
+  stages: GqlSysAdminStageDistribution;
+  /** Summary card — see type doc. */
+  summary: GqlSysAdminCommunitySummaryCard;
+  /** Trailing window length in JST months (echoed back). */
+  windowMonths: Scalars['Int']['output'];
+};
+
+/**
+ * One row of the L1 all-community table. See the module docstring for the
+ * distinction between `communityActivityRate` (this type) and
+ * `userSendRate` (SysAdminMemberRow).
+ */
+export type GqlSysAdminCommunityOverview = {
+  __typename?: 'SysAdminCommunityOverview';
+  /** Alert flags (see SysAdminCommunityAlerts). */
+  alerts: GqlSysAdminCommunityAlerts;
+  /**
+   * Community activity rate for the JST calendar month containing asOf:
+   * unique DONATION senders in that month / month-end total_members.
+   * 0.0–1.0. NOT the individual-level userSendRate.
+   */
+  communityActivityRate: Scalars['Float']['output'];
+  /** Community id. */
+  communityId: Scalars['ID']['output'];
+  /** Community display name (t_communities.name). */
+  communityName: Scalars['String']['output'];
+  /**
+   * Month-over-month % change in communityActivityRate.
+   * Returned as a fraction (e.g. -0.2 == -20%). null when the prior month
+   * has no data to compare against.
+   */
+  growthRateActivity?: Maybe<Scalars['Float']['output']>;
+  /**
+   * Retention rate of the most recent completed cohort (members who joined
+   * in asOf's previous JST month) measured in the month after joining.
+   * null when that cohort is empty.
+   */
+  latestCohortRetentionM1?: Maybe<Scalars['Float']['output']>;
+  /**
+   * Direct member count for the "latent" stage (never donated).
+   * Convenience field (== segmentCounts.passiveCount).
+   */
+  passiveCount: Scalars['Int']['output'];
+  /** Stage counts under the supplied thresholds (cumulative, see type doc). */
+  segmentCounts: GqlSysAdminSegmentCounts;
+  /**
+   * Direct member count for the "habitual" stage (userSendRate >= tier1).
+   * Convenience field (== segmentCounts.tier1Count).
+   */
+  tier1Count: Scalars['Int']['output'];
+  /**
+   * Direct member count for the "regular+habitual" stage
+   * (userSendRate >= tier2). Convenience field (== segmentCounts.tier2Count).
+   */
+  tier2Count: Scalars['Int']['output'];
+  /** Total status='JOINED' members at asOf. */
+  totalMembers: Scalars['Int']['output'];
+};
+
+/**
+ * Summary card for a single community. Fronts the L2 detail screen and
+ * answers "is this community improving?" in one row of numbers.
+ */
+export type GqlSysAdminCommunitySummaryCard = {
+  __typename?: 'SysAdminCommunitySummaryCard';
+  /**
+   * Latest-month communityActivityRate (PRIMARY indicator — see module
+   * docstring for the distinction vs userSendRate).
+   */
+  communityActivityRate: Scalars['Float']['output'];
+  /**
+   * 3-month trailing average of communityActivityRate, ending at the JST
+   * calendar month containing asOf (inclusive). null when fewer than 3
+   * months of data exist.
+   */
+  communityActivityRate3mAvg?: Maybe<Scalars['Float']['output']>;
+  /** Community id. */
+  communityId: Scalars['ID']['output'];
+  /** Community display name. */
+  communityName: Scalars['String']['output'];
+  /** Oldest date with MV data for this community (JST calendar). */
+  dataFrom?: Maybe<Scalars['Datetime']['output']>;
+  /** Newest date with MV data for this community (JST calendar). */
+  dataTo?: Maybe<Scalars['Datetime']['output']>;
+  /**
+   * Month-over-month % change in communityActivityRate (fraction, e.g.
+   * -0.2 == -20%). null when the prior month has no data.
+   */
+  growthRateActivity?: Maybe<Scalars['Float']['output']>;
+  /**
+   * Maximum chain depth observed in any DONATION, all-time. null when
+   * no chained transactions exist.
+   */
+  maxChainDepthAllTime?: Maybe<Scalars['Int']['output']>;
+  /** Cumulative members in tier2 or above under the supplied thresholds. */
+  tier2Count: Scalars['Int']['output'];
+  /** tier2Count / totalMembers (0.0–1.0). */
+  tier2Pct: Scalars['Float']['output'];
+  /**
+   * Total DONATION points transferred, all-time (no window). Uses
+   * t_transactions directly so the value is independent of MV retention.
+   */
+  totalDonationPointsAllTime: Scalars['Float']['output'];
+  /** Total status='JOINED' members at asOf. */
+  totalMembers: Scalars['Int']['output'];
+};
+
+/** Input for the L1 all-community overview (`sysAdminDashboard`). */
+export type GqlSysAdminDashboardInput = {
+  /**
+   * The "as of" timestamp. All trailing-window calculations are anchored
+   * here: the "latest month" is the JST calendar month containing asOf,
+   * and "latest week" is the ISO-week containing asOf. Defaults to now
+   * when omitted.
+   */
+  asOf?: InputMaybe<Scalars['Datetime']['input']>;
+  /** Stage-count thresholds (see SysAdminSegmentThresholdsInput). */
+  segmentThresholds?: InputMaybe<GqlSysAdminSegmentThresholdsInput>;
+};
+
+/** Root payload for sysAdminDashboard (L1). */
+export type GqlSysAdminDashboardPayload = {
+  __typename?: 'SysAdminDashboardPayload';
+  /** As-of timestamp echoed back (UTC instant). */
+  asOf: Scalars['Datetime']['output'];
+  /** One row per community, in dashboard sort order. */
+  communities: Array<GqlSysAdminCommunityOverview>;
+  /** Platform-wide aggregate row. */
+  platform: GqlSysAdminPlatformSummary;
+};
+
+/** Paginated member list for the L2 detail. */
+export type GqlSysAdminMemberList = {
+  __typename?: 'SysAdminMemberList';
+  /** Whether more pages exist after this one. */
+  hasNextPage: Scalars['Boolean']['output'];
+  /**
+   * Opaque cursor to pass back in `SysAdminCommunityDetailInput.cursor` to
+   * fetch the next page. null when no further pages exist.
+   */
+  nextCursor?: Maybe<Scalars['String']['output']>;
+  /**
+   * Member rows for the current page, matching filter & sort applied
+   * server-side.
+   */
+  users: Array<GqlSysAdminMemberRow>;
+};
+
+/**
+ * One row of the L2 member list. Raw values only — stage classification
+ * (habitual / regular / occasional / latent) is the client's concern so
+ * server-side thresholds can be tuned without a schema change.
+ */
+export type GqlSysAdminMemberRow = {
+  __typename?: 'SysAdminMemberRow';
+  /** Distinct months with at least one DONATION out. */
+  donationOutMonths: Scalars['Int']['output'];
+  /** Tenure in JST calendar months (floor, minimum 1). */
+  monthsIn: Scalars['Int']['output'];
+  /** User display name (users.name). null when the user has no name set. */
+  name?: Maybe<Scalars['String']['output']>;
+  /** All-time DONATION points sent by this user in this community. */
+  totalPointsOut: Scalars['Float']['output'];
+  /** User id. */
+  userId: Scalars['ID']['output'];
+  /**
+   * Individual monthly-send rate: `donationOutMonths / monthsIn`, 0.0–1.0,
+   * rounded to 3 decimals. INDIVIDUAL LTV variable (not the same as
+   * communityActivityRate elsewhere in this schema).
+   */
+  userSendRate: Scalars['Float']['output'];
+};
+
+/** One month of community activity trend. */
+export type GqlSysAdminMonthlyActivityPoint = {
+  __typename?: 'SysAdminMonthlyActivityPoint';
+  /**
+   * Share of DONATION transactions that were part of a chain (chain_depth
+   * > 0) in the month. 0.0–1.0.
+   */
+  chainPct?: Maybe<Scalars['Float']['output']>;
+  /**
+   * senderCount / month-end totalMembers. Read alongside newMembers: a
+   * month with many new joiners can dip the rate even if absolute activity
+   * grew.
+   */
+  communityActivityRate: Scalars['Float']['output'];
+  /** Sum of DONATION points transferred in the month. */
+  donationPointsSum: Scalars['Float']['output'];
+  /** First day (JST) of the calendar month, e.g. 2025-10-01T00:00+09:00. */
+  month: Scalars['Datetime']['output'];
+  /** t_memberships.created_at (status='JOINED') rows falling in the month. */
+  newMembers: Scalars['Int']['output'];
+  /** Distinct DONATION senders in the month. */
+  senderCount: Scalars['Int']['output'];
+};
+
+/**
+ * Platform-wide headline, computed by summing across every community in
+ * scope for the caller (which is every community since this query is
+ * SYS_ADMIN-gated).
+ */
+export type GqlSysAdminPlatformSummary = {
+  __typename?: 'SysAdminPlatformSummary';
+  /** Number of communities included in the response. */
+  communitiesCount: Scalars['Int']['output'];
+  /**
+   * Sum of DONATION points transferred during the JST calendar month
+   * containing `asOf`, across every community.
+   */
+  latestMonthDonationPoints: Scalars['Float']['output'];
+  /** Sum of status='JOINED' members across every community. */
+  totalMembers: Scalars['Int']['output'];
+};
+
+/** One ISO week of retention signals. */
+export type GqlSysAdminRetentionTrendPoint = {
+  __typename?: 'SysAdminRetentionTrendPoint';
+  /** Senders in the prior week who did NOT send this week. */
+  churnedSenders: Scalars['Int']['output'];
+  /**
+   * Community activity rate for the week: distinct senders / totalMembers
+   * as of week end. null when the community had zero members during the
+   * week.
+   */
+  communityActivityRate?: Maybe<Scalars['Float']['output']>;
+  /** New t_memberships.created_at rows (status='JOINED') this week. */
+  newMembers: Scalars['Int']['output'];
+  /**
+   * Senders in both the prior week and this week (same-user on
+   * donation_out_count > 0).
+   */
+  retainedSenders: Scalars['Int']['output'];
+  /**
+   * Senders this week who did NOT send last week but DID send some week
+   * in the prior 12-week window.
+   */
+  returnedSenders: Scalars['Int']['output'];
+  /** Monday 00:00 JST of the ISO week. */
+  week: Scalars['Datetime']['output'];
+};
+
+/**
+ * Stage-count snapshot for one community, computed by the server using the
+ * client-supplied `SysAdminSegmentThresholdsInput`. Cumulative semantics:
+ * `tier2Count` INCLUDES members counted in `tier1Count`.
+ */
+export type GqlSysAdminSegmentCounts = {
+  __typename?: 'SysAdminSegmentCounts';
+  /** Members with userSendRate > 0 (excludes latent). */
+  activeCount: Scalars['Int']['output'];
+  /** Members with donationOutMonths == 0 (latent / not-yet-participated). */
+  passiveCount: Scalars['Int']['output'];
+  /** Members with userSendRate >= tier1. */
+  tier1Count: Scalars['Int']['output'];
+  /** Members with userSendRate >= tier2 (includes tier1). */
+  tier2Count: Scalars['Int']['output'];
+  /** Total status='JOINED' members at asOf. */
+  total: Scalars['Int']['output'];
+};
+
+/**
+ * Stage classification thresholds, supplied by the client.
+ * Thresholds define WHERE the boundary between stages sits, but naming
+ * (habitual / regular / occasional / latent) remains fixed on the server.
+ */
+export type GqlSysAdminSegmentThresholdsInput = {
+  /**
+   * Habitual stage threshold. A user with `userSendRate >= tier1` is
+   * counted as "habitual" (i.e. sends donations in at least tier1 share
+   * of their tenure). Default 0.7.
+   */
+  tier1?: InputMaybe<Scalars['Float']['input']>;
+  /**
+   * Regular stage threshold. `userSendRate >= tier2` AND `< tier1`
+   * classifies as "regular". Default 0.4.
+   */
+  tier2?: InputMaybe<Scalars['Float']['input']>;
+};
+
+/** Sort direction for the member list. */
+export const GqlSysAdminSortOrder = {
+  /**
+   * Ascending — smallest value first (e.g. SEND_RATE ASC puts latent
+   * and occasional members before habitual).
+   */
+  Asc: 'ASC',
+  /**
+   * Descending — largest value first (e.g. SEND_RATE DESC puts habitual
+   * members at the top). This is the default.
+   */
+  Desc: 'DESC'
+} as const;
+
+export type GqlSysAdminSortOrder = typeof GqlSysAdminSortOrder[keyof typeof GqlSysAdminSortOrder];
+/**
+ * Summary for one stage (habitual / regular / occasional / latent).
+ * Stage membership is classified server-side using the thresholds supplied
+ * in the request. `pointsContributionPct` is the share of total DONATION
+ * points-out attributed to members in this stage, in the asOf month.
+ */
+export type GqlSysAdminStageBucket = {
+  __typename?: 'SysAdminStageBucket';
+  /** Average monthsIn across members in this stage. */
+  avgMonthsIn: Scalars['Float']['output'];
+  /** Average userSendRate across members in this stage (0.0–1.0). */
+  avgSendRate: Scalars['Float']['output'];
+  /** Number of members in this stage. */
+  count: Scalars['Int']['output'];
+  /** count / totalMembers (0.0–1.0). */
+  pct: Scalars['Float']['output'];
+  /**
+   * Stage's share of this community's all-time DONATION points-out
+   * (0.0–1.0). Numerator is the sum of `totalPointsOut` across the
+   * stage's members; denominator is the same sum across all members.
+   * 0 for the latent stage by definition.
+   */
+  pointsContributionPct: Scalars['Float']['output'];
+};
+
+/**
+ * Four-stage distribution of the community's membership.
+ * `pointsContributionPct` on `latent` is always 0 since latent members
+ * haven't donated by definition.
+ */
+export type GqlSysAdminStageDistribution = {
+  __typename?: 'SysAdminStageDistribution';
+  /** userSendRate >= tier1. */
+  habitual: GqlSysAdminStageBucket;
+  /** donationOutMonths == 0. */
+  latent: GqlSysAdminStageBucket;
+  /** 0 < userSendRate < tier2. */
+  occasional: GqlSysAdminStageBucket;
+  /** tier2 <= userSendRate < tier1. */
+  regular: GqlSysAdminStageBucket;
+};
+
+/**
+ * Member-list filters for the L2 detail (`sysAdminCommunityDetail`).
+ * All conditions AND together. Unspecified fields do not filter.
+ */
+export type GqlSysAdminUserListFilter = {
+  /** Inclusive upper bound on userSendRate. */
+  maxSendRate?: InputMaybe<Scalars['Float']['input']>;
+  /** Inclusive lower bound on donationOutMonths. */
+  minDonationOutMonths?: InputMaybe<Scalars['Int']['input']>;
+  /** Inclusive lower bound on monthsIn (JST-calendar months). */
+  minMonthsIn?: InputMaybe<Scalars['Int']['input']>;
+  /** Inclusive lower bound on userSendRate. Default 0.7 (habitual only). */
+  minSendRate?: InputMaybe<Scalars['Float']['input']>;
+};
+
+/**
+ * Sort configuration for the L2 member list. Both fields are optional;
+ * omitting either falls back to the default (SEND_RATE DESC) so the
+ * "top habitual members first" view renders out of the box.
+ */
+export type GqlSysAdminUserListSort = {
+  /**
+   * Column to sort on. See SysAdminUserSortField for what each value
+   * addresses. Default: SEND_RATE.
+   */
+  field?: InputMaybe<GqlSysAdminUserSortField>;
+  /** Sort direction. Default: DESC. */
+  order?: InputMaybe<GqlSysAdminSortOrder>;
+};
+
+/** Sortable columns on the member list. */
+export const GqlSysAdminUserSortField = {
+  /** donationOutMonths (distinct months with a DONATION out). */
+  DonationOutMonths: 'DONATION_OUT_MONTHS',
+  /** monthsIn (tenure in JST calendar months). */
+  MonthsIn: 'MONTHS_IN',
+  /** userSendRate (individual monthly-send rate, 0.0–1.0). */
+  SendRate: 'SEND_RATE',
+  /** totalPointsOut (lifetime DONATION points sent). */
+  TotalPointsOut: 'TOTAL_POINTS_OUT'
+} as const;
+
+export type GqlSysAdminUserSortField = typeof GqlSysAdminUserSortField[keyof typeof GqlSysAdminUserSortField];
 export const GqlSysRole = {
   SysAdmin: 'SYS_ADMIN',
   User: 'USER'
@@ -4380,6 +4878,27 @@ export type GqlResolversTypes = ResolversObject<{
   SubmitReportFeedbackInput: GqlSubmitReportFeedbackInput;
   SubmitReportFeedbackPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['SubmitReportFeedbackPayload']>;
   SubmitReportFeedbackSuccess: ResolverTypeWrapper<Omit<GqlSubmitReportFeedbackSuccess, 'feedback'> & { feedback: GqlResolversTypes['ReportFeedback'] }>;
+  SysAdminCohortRetentionPoint: ResolverTypeWrapper<GqlSysAdminCohortRetentionPoint>;
+  SysAdminCommunityAlerts: ResolverTypeWrapper<GqlSysAdminCommunityAlerts>;
+  SysAdminCommunityDetailInput: GqlSysAdminCommunityDetailInput;
+  SysAdminCommunityDetailPayload: ResolverTypeWrapper<GqlSysAdminCommunityDetailPayload>;
+  SysAdminCommunityOverview: ResolverTypeWrapper<GqlSysAdminCommunityOverview>;
+  SysAdminCommunitySummaryCard: ResolverTypeWrapper<GqlSysAdminCommunitySummaryCard>;
+  SysAdminDashboardInput: GqlSysAdminDashboardInput;
+  SysAdminDashboardPayload: ResolverTypeWrapper<GqlSysAdminDashboardPayload>;
+  SysAdminMemberList: ResolverTypeWrapper<GqlSysAdminMemberList>;
+  SysAdminMemberRow: ResolverTypeWrapper<GqlSysAdminMemberRow>;
+  SysAdminMonthlyActivityPoint: ResolverTypeWrapper<GqlSysAdminMonthlyActivityPoint>;
+  SysAdminPlatformSummary: ResolverTypeWrapper<GqlSysAdminPlatformSummary>;
+  SysAdminRetentionTrendPoint: ResolverTypeWrapper<GqlSysAdminRetentionTrendPoint>;
+  SysAdminSegmentCounts: ResolverTypeWrapper<GqlSysAdminSegmentCounts>;
+  SysAdminSegmentThresholdsInput: GqlSysAdminSegmentThresholdsInput;
+  SysAdminSortOrder: GqlSysAdminSortOrder;
+  SysAdminStageBucket: ResolverTypeWrapper<GqlSysAdminStageBucket>;
+  SysAdminStageDistribution: ResolverTypeWrapper<GqlSysAdminStageDistribution>;
+  SysAdminUserListFilter: GqlSysAdminUserListFilter;
+  SysAdminUserListSort: GqlSysAdminUserListSort;
+  SysAdminUserSortField: GqlSysAdminUserSortField;
   SysRole: GqlSysRole;
   Ticket: ResolverTypeWrapper<Ticket>;
   TicketClaimInput: GqlTicketClaimInput;
@@ -4761,6 +5280,25 @@ export type GqlResolversParentTypes = ResolversObject<{
   SubmitReportFeedbackInput: GqlSubmitReportFeedbackInput;
   SubmitReportFeedbackPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['SubmitReportFeedbackPayload'];
   SubmitReportFeedbackSuccess: Omit<GqlSubmitReportFeedbackSuccess, 'feedback'> & { feedback: GqlResolversParentTypes['ReportFeedback'] };
+  SysAdminCohortRetentionPoint: GqlSysAdminCohortRetentionPoint;
+  SysAdminCommunityAlerts: GqlSysAdminCommunityAlerts;
+  SysAdminCommunityDetailInput: GqlSysAdminCommunityDetailInput;
+  SysAdminCommunityDetailPayload: GqlSysAdminCommunityDetailPayload;
+  SysAdminCommunityOverview: GqlSysAdminCommunityOverview;
+  SysAdminCommunitySummaryCard: GqlSysAdminCommunitySummaryCard;
+  SysAdminDashboardInput: GqlSysAdminDashboardInput;
+  SysAdminDashboardPayload: GqlSysAdminDashboardPayload;
+  SysAdminMemberList: GqlSysAdminMemberList;
+  SysAdminMemberRow: GqlSysAdminMemberRow;
+  SysAdminMonthlyActivityPoint: GqlSysAdminMonthlyActivityPoint;
+  SysAdminPlatformSummary: GqlSysAdminPlatformSummary;
+  SysAdminRetentionTrendPoint: GqlSysAdminRetentionTrendPoint;
+  SysAdminSegmentCounts: GqlSysAdminSegmentCounts;
+  SysAdminSegmentThresholdsInput: GqlSysAdminSegmentThresholdsInput;
+  SysAdminStageBucket: GqlSysAdminStageBucket;
+  SysAdminStageDistribution: GqlSysAdminStageDistribution;
+  SysAdminUserListFilter: GqlSysAdminUserListFilter;
+  SysAdminUserListSort: GqlSysAdminUserListSort;
   Ticket: Ticket;
   TicketClaimInput: GqlTicketClaimInput;
   TicketClaimLink: TicketClaimLink;
@@ -5905,6 +6443,8 @@ export type GqlQueryResolvers<ContextType = any, ParentType extends GqlResolvers
   reservations?: Resolver<GqlResolversTypes['ReservationsConnection'], ParentType, ContextType, Partial<GqlQueryReservationsArgs>>;
   signupBonusConfig?: Resolver<Maybe<GqlResolversTypes['CommunitySignupBonusConfig']>, ParentType, ContextType, RequireFields<GqlQuerySignupBonusConfigArgs, 'communityId'>>;
   states?: Resolver<GqlResolversTypes['StatesConnection'], ParentType, ContextType, Partial<GqlQueryStatesArgs>>;
+  sysAdminCommunityDetail?: Resolver<GqlResolversTypes['SysAdminCommunityDetailPayload'], ParentType, ContextType, RequireFields<GqlQuerySysAdminCommunityDetailArgs, 'input'>>;
+  sysAdminDashboard?: Resolver<GqlResolversTypes['SysAdminDashboardPayload'], ParentType, ContextType, Partial<GqlQuerySysAdminDashboardArgs>>;
   ticket?: Resolver<Maybe<GqlResolversTypes['Ticket']>, ParentType, ContextType, RequireFields<GqlQueryTicketArgs, 'id'>>;
   ticketClaimLink?: Resolver<Maybe<GqlResolversTypes['TicketClaimLink']>, ParentType, ContextType, RequireFields<GqlQueryTicketClaimLinkArgs, 'id'>>;
   ticketClaimLinks?: Resolver<GqlResolversTypes['TicketClaimLinksConnection'], ParentType, ContextType, Partial<GqlQueryTicketClaimLinksArgs>>;
@@ -6137,6 +6677,145 @@ export type GqlSubmitReportFeedbackPayloadResolvers<ContextType = any, ParentTyp
 
 export type GqlSubmitReportFeedbackSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SubmitReportFeedbackSuccess'] = GqlResolversParentTypes['SubmitReportFeedbackSuccess']> = ResolversObject<{
   feedback?: Resolver<GqlResolversTypes['ReportFeedback'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlSysAdminCohortRetentionPointResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminCohortRetentionPoint'] = GqlResolversParentTypes['SysAdminCohortRetentionPoint']> = ResolversObject<{
+  cohortMonth?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  cohortSize?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  retentionM1?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  retentionM3?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  retentionM6?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlSysAdminCommunityAlertsResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminCommunityAlerts'] = GqlResolversParentTypes['SysAdminCommunityAlerts']> = ResolversObject<{
+  activeDrop?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  churnSpike?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  noNewMembers?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlSysAdminCommunityDetailPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminCommunityDetailPayload'] = GqlResolversParentTypes['SysAdminCommunityDetailPayload']> = ResolversObject<{
+  alerts?: Resolver<GqlResolversTypes['SysAdminCommunityAlerts'], ParentType, ContextType>;
+  asOf?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  cohortRetention?: Resolver<Array<GqlResolversTypes['SysAdminCohortRetentionPoint']>, ParentType, ContextType>;
+  communityId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  communityName?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  memberList?: Resolver<GqlResolversTypes['SysAdminMemberList'], ParentType, ContextType>;
+  monthlyActivityTrend?: Resolver<Array<GqlResolversTypes['SysAdminMonthlyActivityPoint']>, ParentType, ContextType>;
+  retentionTrend?: Resolver<Array<GqlResolversTypes['SysAdminRetentionTrendPoint']>, ParentType, ContextType>;
+  stages?: Resolver<GqlResolversTypes['SysAdminStageDistribution'], ParentType, ContextType>;
+  summary?: Resolver<GqlResolversTypes['SysAdminCommunitySummaryCard'], ParentType, ContextType>;
+  windowMonths?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlSysAdminCommunityOverviewResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminCommunityOverview'] = GqlResolversParentTypes['SysAdminCommunityOverview']> = ResolversObject<{
+  alerts?: Resolver<GqlResolversTypes['SysAdminCommunityAlerts'], ParentType, ContextType>;
+  communityActivityRate?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  communityId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  communityName?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  growthRateActivity?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  latestCohortRetentionM1?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  passiveCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  segmentCounts?: Resolver<GqlResolversTypes['SysAdminSegmentCounts'], ParentType, ContextType>;
+  tier1Count?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  tier2Count?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  totalMembers?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlSysAdminCommunitySummaryCardResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminCommunitySummaryCard'] = GqlResolversParentTypes['SysAdminCommunitySummaryCard']> = ResolversObject<{
+  communityActivityRate?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  communityActivityRate3mAvg?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  communityId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  communityName?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  dataFrom?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  dataTo?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  growthRateActivity?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  maxChainDepthAllTime?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  tier2Count?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  tier2Pct?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  totalDonationPointsAllTime?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  totalMembers?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlSysAdminDashboardPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminDashboardPayload'] = GqlResolversParentTypes['SysAdminDashboardPayload']> = ResolversObject<{
+  asOf?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  communities?: Resolver<Array<GqlResolversTypes['SysAdminCommunityOverview']>, ParentType, ContextType>;
+  platform?: Resolver<GqlResolversTypes['SysAdminPlatformSummary'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlSysAdminMemberListResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminMemberList'] = GqlResolversParentTypes['SysAdminMemberList']> = ResolversObject<{
+  hasNextPage?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  nextCursor?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  users?: Resolver<Array<GqlResolversTypes['SysAdminMemberRow']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlSysAdminMemberRowResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminMemberRow'] = GqlResolversParentTypes['SysAdminMemberRow']> = ResolversObject<{
+  donationOutMonths?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  monthsIn?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  name?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  totalPointsOut?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  userId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  userSendRate?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlSysAdminMonthlyActivityPointResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminMonthlyActivityPoint'] = GqlResolversParentTypes['SysAdminMonthlyActivityPoint']> = ResolversObject<{
+  chainPct?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  communityActivityRate?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  donationPointsSum?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  month?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  newMembers?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  senderCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlSysAdminPlatformSummaryResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminPlatformSummary'] = GqlResolversParentTypes['SysAdminPlatformSummary']> = ResolversObject<{
+  communitiesCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  latestMonthDonationPoints?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  totalMembers?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlSysAdminRetentionTrendPointResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminRetentionTrendPoint'] = GqlResolversParentTypes['SysAdminRetentionTrendPoint']> = ResolversObject<{
+  churnedSenders?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  communityActivityRate?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  newMembers?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  retainedSenders?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  returnedSenders?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  week?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlSysAdminSegmentCountsResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminSegmentCounts'] = GqlResolversParentTypes['SysAdminSegmentCounts']> = ResolversObject<{
+  activeCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  passiveCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  tier1Count?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  tier2Count?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  total?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlSysAdminStageBucketResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminStageBucket'] = GqlResolversParentTypes['SysAdminStageBucket']> = ResolversObject<{
+  avgMonthsIn?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  avgSendRate?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  count?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  pct?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  pointsContributionPct?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlSysAdminStageDistributionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminStageDistribution'] = GqlResolversParentTypes['SysAdminStageDistribution']> = ResolversObject<{
+  habitual?: Resolver<GqlResolversTypes['SysAdminStageBucket'], ParentType, ContextType>;
+  latent?: Resolver<GqlResolversTypes['SysAdminStageBucket'], ParentType, ContextType>;
+  occasional?: Resolver<GqlResolversTypes['SysAdminStageBucket'], ParentType, ContextType>;
+  regular?: Resolver<GqlResolversTypes['SysAdminStageBucket'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -6860,6 +7539,20 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   StorePhoneAuthTokenPayload?: GqlStorePhoneAuthTokenPayloadResolvers<ContextType>;
   SubmitReportFeedbackPayload?: GqlSubmitReportFeedbackPayloadResolvers<ContextType>;
   SubmitReportFeedbackSuccess?: GqlSubmitReportFeedbackSuccessResolvers<ContextType>;
+  SysAdminCohortRetentionPoint?: GqlSysAdminCohortRetentionPointResolvers<ContextType>;
+  SysAdminCommunityAlerts?: GqlSysAdminCommunityAlertsResolvers<ContextType>;
+  SysAdminCommunityDetailPayload?: GqlSysAdminCommunityDetailPayloadResolvers<ContextType>;
+  SysAdminCommunityOverview?: GqlSysAdminCommunityOverviewResolvers<ContextType>;
+  SysAdminCommunitySummaryCard?: GqlSysAdminCommunitySummaryCardResolvers<ContextType>;
+  SysAdminDashboardPayload?: GqlSysAdminDashboardPayloadResolvers<ContextType>;
+  SysAdminMemberList?: GqlSysAdminMemberListResolvers<ContextType>;
+  SysAdminMemberRow?: GqlSysAdminMemberRowResolvers<ContextType>;
+  SysAdminMonthlyActivityPoint?: GqlSysAdminMonthlyActivityPointResolvers<ContextType>;
+  SysAdminPlatformSummary?: GqlSysAdminPlatformSummaryResolvers<ContextType>;
+  SysAdminRetentionTrendPoint?: GqlSysAdminRetentionTrendPointResolvers<ContextType>;
+  SysAdminSegmentCounts?: GqlSysAdminSegmentCountsResolvers<ContextType>;
+  SysAdminStageBucket?: GqlSysAdminStageBucketResolvers<ContextType>;
+  SysAdminStageDistribution?: GqlSysAdminStageDistributionResolvers<ContextType>;
   Ticket?: GqlTicketResolvers<ContextType>;
   TicketClaimLink?: GqlTicketClaimLinkResolvers<ContextType>;
   TicketClaimLinkEdge?: GqlTicketClaimLinkEdgeResolvers<ContextType>;

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -3102,6 +3102,35 @@ export type GqlSysAdminCommunityOverview = {
   /** Community display name (t_communities.name). */
   communityName: Scalars['String']['output'];
   /**
+   * Number of members classified as a "hub" within the parametric
+   * window (`windowDays`):
+   *
+   *   hubMemberCount = COUNT(member)
+   *     WHERE windowUniqueDonationRecipients >= input.hubBreadthThreshold
+   *
+   * `windowUniqueDonationRecipients` is the count of DISTINCT users
+   * this member sent a DONATION to during
+   * `[asOf - windowDays JST日, asOf + 1 JST日)` — distinct from the
+   * L2 `SysAdminMemberRow.uniqueDonationRecipients` field which is
+   * tenure-wide. The window-scoped variant is computed on demand in
+   * this aggregate but not exposed per-member at L1 (members
+   * themselves are an L2 concern).
+   *
+   * Hub classification deliberately uses BREADTH only — a member
+   * who reached `hubBreadthThreshold` distinct recipients during
+   * the window necessarily transacted at least that many times,
+   * making an explicit frequency floor redundant. This keeps the
+   * threshold knobs to one (`hubBreadthThreshold`).
+   *
+   * Invariants (the client may assert these):
+   *   hubMemberCount <= windowActivity.senderCount <= totalMembers
+   *
+   * The first holds because any hub member donated >= 3 times in
+   * the window and is therefore a window sender; the second because
+   * any window sender is a JOINED member at asOf.
+   */
+  hubMemberCount: Scalars['Int']['output'];
+  /**
    * Latest completed monthly cohort and its M+1 activity. See
    * SysAdminLatestCohort.
    */
@@ -3184,6 +3213,29 @@ export type GqlSysAdminDashboardInput = {
    * Defaults to now when omitted.
    */
   asOf?: InputMaybe<Scalars['Datetime']['input']>;
+  /**
+   * Minimum number of distinct DONATION recipients within the
+   * parametric window (`windowDays`) for a member to be classified
+   * as a hub. Used to populate `SysAdminCommunityOverview.hubMemberCount`.
+   *
+   * Defaults to 3, meaning "sent DONATION to at least 3 different
+   * people during the window". The threshold is on **unique
+   * counterparties** (set cardinality), not transaction count, so a
+   * member who donated 100 times to the same recipient does not
+   * qualify on this axis alone.
+   *
+   * Effective range 1..1000; values outside are silently clamped on
+   * the server.
+   *
+   * This is intentionally an absolute threshold rather than a
+   * community-relative percentile: a percentile-based hub would
+   * always classify ~N% of members as hubs by definition, defeating
+   * cross-community comparison ("which communities have the highest
+   * hub ratio?"). Community size differences are absorbed
+   * client-side by displaying `hubMemberCount / totalMembers` rather
+   * than the raw count.
+   */
+  hubBreadthThreshold?: InputMaybe<Scalars['Int']['input']>;
   /** Stage classification thresholds (see SysAdminSegmentThresholdsInput). */
   segmentThresholds?: InputMaybe<GqlSysAdminSegmentThresholdsInput>;
   /**
@@ -3265,6 +3317,22 @@ export type GqlSysAdminMemberRow = {
   name?: Maybe<Scalars['String']['output']>;
   /** All-time DONATION points sent by this user in this community. */
   totalPointsOut: Scalars['Float']['output'];
+  /**
+   * All-time count of distinct OTHER users this member has sent at
+   * least one DONATION to in this community. The "network breadth"
+   * half of the donor profile (paired with frequency-based
+   * `userSendRate` and volume-based `totalPointsOut`):
+   *
+   *   breadth × frequency × volume → the client's per-member
+   *   classification space (e.g. true hub vs single-target loyal vs
+   *   rare-but-far-reaching).
+   *
+   * Counts unique counterparty user_id, not transaction count, so a
+   * member who sent 100 donations to the same recipient still scores
+   * 1. Excludes burn / system targets (recipient wallets without a
+   * user_id).
+   */
+  uniqueDonationRecipients: Scalars['Int']['output'];
   /** User id. */
   userId: Scalars['ID']['output'];
   /**
@@ -6800,6 +6868,7 @@ export type GqlSysAdminCommunityDetailPayloadResolvers<ContextType = any, Parent
 export type GqlSysAdminCommunityOverviewResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminCommunityOverview'] = GqlResolversParentTypes['SysAdminCommunityOverview']> = ResolversObject<{
   communityId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
   communityName?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  hubMemberCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   latestCohort?: Resolver<GqlResolversTypes['SysAdminLatestCohort'], ParentType, ContextType>;
   segmentCounts?: Resolver<GqlResolversTypes['SysAdminSegmentCounts'], ParentType, ContextType>;
   totalMembers?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
@@ -6849,6 +6918,7 @@ export type GqlSysAdminMemberRowResolvers<ContextType = any, ParentType extends 
   monthsIn?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   name?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   totalPointsOut?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  uniqueDonationRecipients?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   userId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
   userSendRate?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -3087,55 +3087,42 @@ export type GqlSysAdminCommunityDetailPayload = {
 };
 
 /**
- * One row of the L1 all-community table. See the module docstring for the
- * distinction between `communityActivityRate` (this type) and
- * `userSendRate` (SysAdminMemberRow).
+ * One row of the L1 all-community table. Designed for at-a-glance
+ * intervention judgment: each row carries the raw counts the client
+ * needs to derive rates, growth, alerts, sort keys, and filter
+ * predicates without a second round-trip.
+ *
+ * Calendar-month metrics live on the L2 detail card
+ * (SysAdminCommunitySummaryCard) — L1 is rolling-window only.
  */
 export type GqlSysAdminCommunityOverview = {
   __typename?: 'SysAdminCommunityOverview';
-  /** Alert flags (see SysAdminCommunityAlerts). */
-  alerts: GqlSysAdminCommunityAlerts;
-  /**
-   * Community activity rate for the JST calendar month containing asOf:
-   * unique DONATION senders in that month / month-end total_members.
-   * 0.0–1.0. NOT the individual-level userSendRate.
-   */
-  communityActivityRate: Scalars['Float']['output'];
   /** Community id. */
   communityId: Scalars['ID']['output'];
   /** Community display name (t_communities.name). */
   communityName: Scalars['String']['output'];
   /**
-   * Month-over-month % change in communityActivityRate.
-   * Returned as a fraction (e.g. -0.2 == -20%). null when the prior month
-   * has no data to compare against.
+   * Latest completed monthly cohort and its M+1 activity. See
+   * SysAdminLatestCohort.
    */
-  growthRateActivity?: Maybe<Scalars['Float']['output']>;
+  latestCohort: GqlSysAdminLatestCohort;
   /**
-   * Retention rate of the most recent completed cohort (members who joined
-   * in asOf's previous JST month) measured in the month after joining.
-   * null when that cohort is empty.
+   * Per-stage member counts (tier1 / tier2 / passive, cumulative
+   * per the type doc) classified against input.segmentThresholds.
    */
-  latestCohortRetentionM1?: Maybe<Scalars['Float']['output']>;
-  /**
-   * Direct member count for the "latent" stage (never donated).
-   * Convenience field (== segmentCounts.passiveCount).
-   */
-  passiveCount: Scalars['Int']['output'];
-  /** Stage counts under the supplied thresholds (cumulative, see type doc). */
   segmentCounts: GqlSysAdminSegmentCounts;
   /**
-   * Direct member count for the "habitual" stage (userSendRate >= tier1).
-   * Convenience field (== segmentCounts.tier1Count).
+   * Total status='JOINED' members as of asOf. Members whose
+   * created_at is after asOf are excluded from the count.
    */
-  tier1Count: Scalars['Int']['output'];
-  /**
-   * Direct member count for the "regular+habitual" stage
-   * (userSendRate >= tier2). Convenience field (== segmentCounts.tier2Count).
-   */
-  tier2Count: Scalars['Int']['output'];
-  /** Total status='JOINED' members at asOf. */
   totalMembers: Scalars['Int']['output'];
+  /**
+   * Latest completed-week retention signals for client-side churn
+   * detection. See SysAdminWeeklyRetention.
+   */
+  weeklyRetention: GqlSysAdminWeeklyRetention;
+  /** Rolling-window DONATION activity. See SysAdminWindowActivity. */
+  windowActivity: GqlSysAdminWindowActivity;
 };
 
 /**
@@ -3189,14 +3176,22 @@ export type GqlSysAdminCommunitySummaryCard = {
 /** Input for the L1 all-community overview (`sysAdminDashboard`). */
 export type GqlSysAdminDashboardInput = {
   /**
-   * The "as of" timestamp. All trailing-window calculations are anchored
-   * here: the "latest month" is the JST calendar month containing asOf,
-   * and "latest week" is the ISO-week containing asOf. Defaults to now
-   * when omitted.
+   * As-of timestamp anchor. All trailing-window calculations are
+   * anchored here:
+   *   - parametric activity window: [asOf - windowDays, asOf + 1 JST日)
+   *   - weekly retention: latest completed ISO week before asOf
+   *   - latest cohort: (asOf JST月 - 2) so its M+1 window is fully past
+   * Defaults to now when omitted.
    */
   asOf?: InputMaybe<Scalars['Datetime']['input']>;
-  /** Stage-count thresholds (see SysAdminSegmentThresholdsInput). */
+  /** Stage classification thresholds (see SysAdminSegmentThresholdsInput). */
   segmentThresholds?: InputMaybe<GqlSysAdminSegmentThresholdsInput>;
+  /**
+   * Length of the rolling activity window in JST days. Effective
+   * range 7-90; values outside are silently clamped on the server.
+   * Defaults to 28 (= 4 weeks, absorbs day-of-week variance).
+   */
+  windowDays?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** Root payload for sysAdminDashboard (L1). */
@@ -3208,6 +3203,34 @@ export type GqlSysAdminDashboardPayload = {
   communities: Array<GqlSysAdminCommunityOverview>;
   /** Platform-wide aggregate row. */
   platform: GqlSysAdminPlatformSummary;
+};
+
+/**
+ * Most recently completed monthly cohort plus its M+1 activity.
+ * "M+1" follows standard cohort-analysis convention: the calendar
+ * month immediately after the joining month.
+ *
+ * The cohort is selected as (asOf's JST month - 2 months) so its
+ * M+1 window — the JST month immediately preceding asOf's month —
+ * is fully past. This avoids reporting an artificially low retention
+ * during the in-progress month.
+ *
+ * Raw counts are returned; the client divides for the retention rate
+ * and decides how to handle small-N cohorts via `size`.
+ */
+export type GqlSysAdminLatestCohort = {
+  __typename?: 'SysAdminLatestCohort';
+  /**
+   * Of those cohort members, how many sent at least one DONATION
+   * during the M+1 month.
+   */
+  activeAtM1: Scalars['Int']['output'];
+  /**
+   * Cohort size: status='JOINED' members whose created_at falls
+   * within the cohort month. 0 when no one joined that month
+   * (callers should treat M+1 retention as null in that case).
+   */
+  size: Scalars['Int']['output'];
 };
 
 /** Paginated member list for the L2 detail. */
@@ -3459,6 +3482,53 @@ export const GqlSysAdminUserSortField = {
 } as const;
 
 export type GqlSysAdminUserSortField = typeof GqlSysAdminUserSortField[keyof typeof GqlSysAdminUserSortField];
+/**
+ * DONATION sender retention against the most recently completed
+ * ISO week (Monday 00:00 JST). Raw signals only; the client composes
+ * churn alerts (e.g. churnedSenders > retainedSenders).
+ */
+export type GqlSysAdminWeeklyRetention = {
+  __typename?: 'SysAdminWeeklyRetention';
+  /**
+   * Users who sent DONATION in the week-before-latest but NOT in
+   * the latest completed week. "Lost this week, was engaged last week."
+   */
+  churnedSenders: Scalars['Int']['output'];
+  /**
+   * Users who sent DONATION in the latest completed week AND in
+   * the week before it. "Engaged this week, was engaged last week."
+   */
+  retainedSenders: Scalars['Int']['output'];
+};
+
+/**
+ * DONATION activity within the parametric window driven by
+ * `SysAdminDashboardInput.windowDays`. Both the current window and
+ * the immediately preceding window of equal length are returned so
+ * the client can derive growth rates without a second query.
+ *
+ *   current  = [asOf - windowDays JST日, asOf + 1 JST日)
+ *   previous = [asOf - 2 * windowDays, asOf - windowDays)
+ */
+export type GqlSysAdminWindowActivity = {
+  __typename?: 'SysAdminWindowActivity';
+  /**
+   * New JOINED memberships (t_memberships.created_at within the
+   * current window, status='JOINED').
+   */
+  newMemberCount: Scalars['Int']['output'];
+  /** Same metric for the previous window. */
+  newMemberCountPrev: Scalars['Int']['output'];
+  /**
+   * Unique users with at least one outgoing DONATION transaction
+   * during the current window (donation_out_count > 0 in
+   * mv_user_transaction_daily).
+   */
+  senderCount: Scalars['Int']['output'];
+  /** Same metric for the previous window of equal length. */
+  senderCountPrev: Scalars['Int']['output'];
+};
+
 export const GqlSysRole = {
   SysAdmin: 'SYS_ADMIN',
   User: 'USER'
@@ -4886,6 +4956,7 @@ export type GqlResolversTypes = ResolversObject<{
   SysAdminCommunitySummaryCard: ResolverTypeWrapper<GqlSysAdminCommunitySummaryCard>;
   SysAdminDashboardInput: GqlSysAdminDashboardInput;
   SysAdminDashboardPayload: ResolverTypeWrapper<GqlSysAdminDashboardPayload>;
+  SysAdminLatestCohort: ResolverTypeWrapper<GqlSysAdminLatestCohort>;
   SysAdminMemberList: ResolverTypeWrapper<GqlSysAdminMemberList>;
   SysAdminMemberRow: ResolverTypeWrapper<GqlSysAdminMemberRow>;
   SysAdminMonthlyActivityPoint: ResolverTypeWrapper<GqlSysAdminMonthlyActivityPoint>;
@@ -4899,6 +4970,8 @@ export type GqlResolversTypes = ResolversObject<{
   SysAdminUserListFilter: GqlSysAdminUserListFilter;
   SysAdminUserListSort: GqlSysAdminUserListSort;
   SysAdminUserSortField: GqlSysAdminUserSortField;
+  SysAdminWeeklyRetention: ResolverTypeWrapper<GqlSysAdminWeeklyRetention>;
+  SysAdminWindowActivity: ResolverTypeWrapper<GqlSysAdminWindowActivity>;
   SysRole: GqlSysRole;
   Ticket: ResolverTypeWrapper<Ticket>;
   TicketClaimInput: GqlTicketClaimInput;
@@ -5288,6 +5361,7 @@ export type GqlResolversParentTypes = ResolversObject<{
   SysAdminCommunitySummaryCard: GqlSysAdminCommunitySummaryCard;
   SysAdminDashboardInput: GqlSysAdminDashboardInput;
   SysAdminDashboardPayload: GqlSysAdminDashboardPayload;
+  SysAdminLatestCohort: GqlSysAdminLatestCohort;
   SysAdminMemberList: GqlSysAdminMemberList;
   SysAdminMemberRow: GqlSysAdminMemberRow;
   SysAdminMonthlyActivityPoint: GqlSysAdminMonthlyActivityPoint;
@@ -5299,6 +5373,8 @@ export type GqlResolversParentTypes = ResolversObject<{
   SysAdminStageDistribution: GqlSysAdminStageDistribution;
   SysAdminUserListFilter: GqlSysAdminUserListFilter;
   SysAdminUserListSort: GqlSysAdminUserListSort;
+  SysAdminWeeklyRetention: GqlSysAdminWeeklyRetention;
+  SysAdminWindowActivity: GqlSysAdminWindowActivity;
   Ticket: Ticket;
   TicketClaimInput: GqlTicketClaimInput;
   TicketClaimLink: TicketClaimLink;
@@ -6712,17 +6788,13 @@ export type GqlSysAdminCommunityDetailPayloadResolvers<ContextType = any, Parent
 }>;
 
 export type GqlSysAdminCommunityOverviewResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminCommunityOverview'] = GqlResolversParentTypes['SysAdminCommunityOverview']> = ResolversObject<{
-  alerts?: Resolver<GqlResolversTypes['SysAdminCommunityAlerts'], ParentType, ContextType>;
-  communityActivityRate?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
   communityId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
   communityName?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
-  growthRateActivity?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
-  latestCohortRetentionM1?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
-  passiveCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  latestCohort?: Resolver<GqlResolversTypes['SysAdminLatestCohort'], ParentType, ContextType>;
   segmentCounts?: Resolver<GqlResolversTypes['SysAdminSegmentCounts'], ParentType, ContextType>;
-  tier1Count?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
-  tier2Count?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   totalMembers?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  weeklyRetention?: Resolver<GqlResolversTypes['SysAdminWeeklyRetention'], ParentType, ContextType>;
+  windowActivity?: Resolver<GqlResolversTypes['SysAdminWindowActivity'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -6746,6 +6818,12 @@ export type GqlSysAdminDashboardPayloadResolvers<ContextType = any, ParentType e
   asOf?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
   communities?: Resolver<Array<GqlResolversTypes['SysAdminCommunityOverview']>, ParentType, ContextType>;
   platform?: Resolver<GqlResolversTypes['SysAdminPlatformSummary'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlSysAdminLatestCohortResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminLatestCohort'] = GqlResolversParentTypes['SysAdminLatestCohort']> = ResolversObject<{
+  activeAtM1?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  size?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -6816,6 +6894,20 @@ export type GqlSysAdminStageDistributionResolvers<ContextType = any, ParentType 
   latent?: Resolver<GqlResolversTypes['SysAdminStageBucket'], ParentType, ContextType>;
   occasional?: Resolver<GqlResolversTypes['SysAdminStageBucket'], ParentType, ContextType>;
   regular?: Resolver<GqlResolversTypes['SysAdminStageBucket'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlSysAdminWeeklyRetentionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminWeeklyRetention'] = GqlResolversParentTypes['SysAdminWeeklyRetention']> = ResolversObject<{
+  churnedSenders?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  retainedSenders?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlSysAdminWindowActivityResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminWindowActivity'] = GqlResolversParentTypes['SysAdminWindowActivity']> = ResolversObject<{
+  newMemberCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  newMemberCountPrev?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  senderCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  senderCountPrev?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -7545,6 +7637,7 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   SysAdminCommunityOverview?: GqlSysAdminCommunityOverviewResolvers<ContextType>;
   SysAdminCommunitySummaryCard?: GqlSysAdminCommunitySummaryCardResolvers<ContextType>;
   SysAdminDashboardPayload?: GqlSysAdminDashboardPayloadResolvers<ContextType>;
+  SysAdminLatestCohort?: GqlSysAdminLatestCohortResolvers<ContextType>;
   SysAdminMemberList?: GqlSysAdminMemberListResolvers<ContextType>;
   SysAdminMemberRow?: GqlSysAdminMemberRowResolvers<ContextType>;
   SysAdminMonthlyActivityPoint?: GqlSysAdminMonthlyActivityPointResolvers<ContextType>;
@@ -7553,6 +7646,8 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   SysAdminSegmentCounts?: GqlSysAdminSegmentCountsResolvers<ContextType>;
   SysAdminStageBucket?: GqlSysAdminStageBucketResolvers<ContextType>;
   SysAdminStageDistribution?: GqlSysAdminStageDistributionResolvers<ContextType>;
+  SysAdminWeeklyRetention?: GqlSysAdminWeeklyRetentionResolvers<ContextType>;
+  SysAdminWindowActivity?: GqlSysAdminWindowActivityResolvers<ContextType>;
   Ticket?: GqlTicketResolvers<ContextType>;
   TicketClaimLink?: GqlTicketClaimLinkResolvers<ContextType>;
   TicketClaimLinkEdge?: GqlTicketClaimLinkEdgeResolvers<ContextType>;


### PR DESCRIPTION
* feat(sysadmin): add platform-operator dashboard and community detail

Adds a SYS_ADMIN-gated analytics surface so platform operators can survey every community's activity at once and drill into one community when answering external-report questions.

- sysAdminDashboard: per-community overview (stage counts under client-supplied thresholds, latest-month communityActivityRate, month-over-month growth, m+1 cohort retention, 3 alert flags)
- sysAdminCommunityDetail: summary card + stage distribution + monthly activity trend + weekly retention trend + cohort retention + filtered and paginated member list + alerts
- Two indicators are carefully distinguished throughout: individual userSendRate (LTV variable) vs community-wide communityActivityRate. Schema descriptions restate the distinction so GraphQL Playground readers can't confuse them.
- Reuses report repository helpers (findRetentionAggregate, findCohortRetention) for retention/cohort math rather than duplicating the SQL.
- Fan-out at the N=6-community scale is in-process; documented in the spec to switch to GROUP BY when the platform exceeds ~20.

https://claude.ai/code/session_016N4QQNKrk3gK9caaTDJyLx

* perf(sysadmin): bulk weekly retention series + service/presenter/util unit tests

Replaces the per-week findRetentionAggregate loop (~86 queries/page at windowMonths=10) with a single findWeeklyRetentionSeries call that pre-aggregates user-week flags across the whole window and derives retained/churned/returned counters in one round-trip.

Adds 57 unit tests across:
- util.ts: JST month boundaries (UTC-encoded JST, Dec→Jan, offsets)
- service.ts: stage classification (>=, cumulative tiers), stage breakdown (disjoint pct sum), paginateMembers (filter/sort/cursor), computeActivityRate3mAvg, alert thresholds (churnSpike equality, activeDrop <= -0.2, noNewMembers=0)
- presenter.ts: bigint overflow RangeError, null propagation, div-by-0 guards on rate/pct fields

* perf(sysadmin): revert to per-week retention loop (bulk measured 364x slower at 2k members)

Keeps the weekly retention trend on the original per-week findRetentionAggregate + findMonthActivity loop (~86 parallel queries at windowMonths=10). The previous commit attempted a single bulk CTE; benchmarking on a local Postgres showed it scaled catastrophically:

  Members   bulk      loop    ratio
  100       59 ms     12 ms    5x slower
  500       692 ms    17 ms   40x slower
  2000      10946 ms  30 ms  364x slower

The loop's narrow single-week scans use the (community_id, date) index on mv_user_transaction_daily; the bulk form's FULL OUTER JOIN over pre-aggregated user-week flags plus the ever_before lookup grew super-linearly with member count.

- src/application/domain/sysadmin/service.ts: restore Promise.all per-week loop with a comment linking to this measurement.
- src/application/domain/sysadmin/data/{interface,repository,type}.ts: remove findWeeklyRetentionSeries / SysAdminWeeklyRetentionRow.
- scripts/sysadmin_bench.ts: keep the benchmark so anyone reconsidering the optimisation has a repro script.

* fix(sysadmin): address review feedback on alerts, member filter, and windowMonths cap

- service.ts getAlerts: anchor `noNewMembers` window to `asOf` (not the ISO week start) so the lookback is exactly 14 days. Previous `latestWeekStart` anchor made the window 14–21 days wide depending on asOf's day-of-week, which contradicted the schema description "in the last 14 days" and the activeDrop window's `[asOf-14d, asOf)` convention. (gemini + devin, high)
- repository.ts findMemberStats: scope `members` CTE with `created_at <= asOf::timestamp` so historic asOf queries don't include members who joined after that point. Without this, stageCounts.total inflated and future members leaked into the paginated list; `findMonthActivity` already scoped its total_members this way, so this restores the invariant that the activity-rate denominator matches stageCounts.total. (devin, critical)
- repository.ts findMemberStats: drop the CASE/GREATEST(1,...)=0 dead-code guard around the ROUND() for user_send_rate — GREATEST guarantees the denominator is >= 1, so the zero branch was unreachable. (gemini, medium)
- service.ts + usecase.ts: clamp `windowMonths` to [1, MAX_WINDOW_MONTHS=36]. `getCohortRetention` fires 4 SQL calls per month in the window, so an unbounded input would let a single request fan out arbitrarily over the connection pool. (gemini, medium)

* fix(sysadmin): remove backticks from SQL comment that closed the $queryRaw template literal

The review-fix commit inserted a comment block inside findMemberStats' raw SQL that used backticks around identifiers (e.g. `asOf`, `total_members`). Inside a tx.\$queryRaw\`...\` tagged template, those backticks terminated the template early, producing a cascade of TS1005 / TS1443 parse errors and breaking the build job on #911.

Swap to plain prose so the comment survives the template literal.

* fix(sysadmin): correct months_in span + JST-encode noNewMembers window bounds

Two correctness fixes surfaced by Devin review:

1. months_in was computing month-number DIFFERENCE instead of the COUNT of distinct JST months the member has been present in, letting userSendRate exceed 1.0. A member joined March 15 with asOf=April 10 got months_in=1 but could have donation_out_months=2 (active in both March and April), yielding userSendRate=2.0 and violating the schema's 0.0-1.0 contract.

   Fix: add +1 to the month-diff formula so months_in counts the span (join-month through asOf-month inclusive). Denominator inside user_send_rate's ROUND mirrored so the rate stays bounded.

2. findNewMemberCount was receiving raw UTC timestamps from getAlerts but its SQL applies the `::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC'` pattern that expects JST-encoded dates. When asOf falls in the 15:00-23:59 UTC / 00:00-08:59 JST next-day window, `::date` truncates to the UTC date (one day behind the JST date), shifting the 14-day lookback by a day and producing false positives/negatives on the noNewMembers alert.

   Fix: run asOf through truncateToJstDate before computing the 14-day boundary and passing to the repo, matching the contract the other sysadmin repo methods already follow.

* refactor(sysadmin): cross-domain reads via ReportService instead of IReportRepository

CLAUDE.md restricts the service layer to "Call other domain services (read operations only)" for cross-domain access. SysAdminService was violating that boundary by injecting IReportRepository directly and calling findRetentionAggregate / findCohortRetention, coupling the sysadmin domain to the report domain's data layer.

Swap to ReportService, whose getRetentionAggregate / getCohortRetention wrappers (report/service.ts:117/130) have the same signatures, so call sites need no other change. Test mock follows the same boundary: replace MockReportRepository (an exhaustive stub of every IReportRepository method) with a focused MockReportService that only stubs the two methods sysadmin actually calls.

Caught by Devin review (BUG_0001).

* docs(sysadmin): add missing descriptions on SysAdminUserListSort + enum values

Requirement Section 7 promises descriptions on every field / type / enum. Audit of the schema caught three gaps: SysAdminUserListSort (the input type and both of its fields) and the two values of SysAdminSortOrder (ASC / DESC) had none. Filling those in keeps the "GraphQL Playground reads unambiguously" contract the PR was built around.

* fix(sysadmin): include asOf day in alert window, clamp activity-rate denominators, skip in-progress cohorts

Addresses four correctness issues surfaced by Devin + Gemini review:

1. getAlerts (service.ts): noNewMembers window excluded the asOf calendar day. `findNewMemberCount` uses `created_at < upper`, and passing `asOfJstDay` (= JST midnight of asOf day) meant any membership created during the asOf day itself dropped out. Extend the upper bound to `asOfJstDay + 1 day` so "直近14日間" actually covers through today. (Devin high + Gemini medium)

2. getMonthActivityWithPrev (service.ts): the current-month `findMonthActivity` call passed `jstNextMonthStart(asOf)` as the upper bound, which `findMonthActivity` uses to filter `total_members` with `created_at < upper`. Mid-month reads (and historic-asOf queries) ended up counting memberships created after `asOf` in the denominator — inconsistent with findMemberStats' newly-added asOf filter. Clamp the upper bound at `asOf + 1 day` so the activity-rate denominator matches the stageCounts.total the L1/L2 payloads expose. Also add an explicit `prevRate === 0` guard before calling `percentChange`, so the Infinity risk is visible at the call site rather than relying on the shared util's internal behaviour. (Gemini high + medium)

3. getRetentionTrend (service.ts): same denominator issue as #2 on the weekly trend — each week's `findMonthActivity` call used `nextWeekStart` as the upper bound. Clamp at `asOf + 1 day` so the most recent week's rate doesn't include memberships from the remainder of the week. Past weeks are unaffected because their `nextWeekStart` falls at or before asOf. (Gemini medium)

4. getCohortRetention (service.ts): the skip condition was `activeEnd > asOfMonthEnd`, which still permitted evaluating a cohort against the asOf MONTH — a month that is by definition still in progress and therefore has incomplete MV data, making the displayed retention artificially low. Tighten to `activeEnd > latestMonthStart` so only windows that end at or before the start of the current month are evaluated. (Gemini medium)

5. getDashboard (usecase.ts): clamp the `findPlatformTotals` upper bound at `asOf + 1 day` for the same reason as #2 (platform-wide total_members uses `created_at < upper`). Keeps the header members count consistent with per-community stageCounts.total. (Gemini medium)

All 57 sysadmin unit tests still pass; the mocked repositories make service-logic changes transparent to the test assertions.

* fix(sysadmin): unify asOf precision across repo methods, add findCommunityById, correct noNewMembers window to 14 days

Three review-driven corrections:

1. findMemberStats precision: both the `members` and `donation_months` CTEs used `<= asOf::timestamp` (second-level), while findMonthActivity / findPlatformTotals apply `< upper::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC'` (JST-day level). At mid-day asOf that let `totalMembers` from findMemberStats diverge from the activity-rate denominator. Swap findMemberStats to the same JST-day-unit expression so stageCounts.total and communityActivityRate agree on which members fall under "as of asOf". (Gemini medium)

2. findCommunityById: replace `findAllCommunities().find()` in getCommunityDetail with an indexed id lookup. Adds a focused repo method that returns the same projection shape as findAllCommunities. Keeps per-request cost flat as the platform grows past the current six communities. (Gemini medium)

3. noNewMembers 14-day window: the previous fix for the asOf-day exclusion pushed the upper bound to `asOfJstDay + 1` while leaving the lower bound at `-NO_NEW_MEMBERS_WINDOW_DAYS`, producing a 15-day span. Drop the lower bound to `-(WINDOW_DAYS - 1)` so the half-open interval covers exactly 14 JST calendar days ending today (inclusive), matching "直近14日間" in the schema. (Devin medium)

Also pruned a stale findWeeklyRetentionSeries jest.fn() from the service test mock left over from the reverted bulk method.

* refactor(sysadmin): route UseCase repository reads through SysAdminService (CLAUDE.md layer rule)

CLAUDE.md mandates the data flow UseCase → Service → Repository; the UseCase layer should only call services and presenters. SysAdminUseCase was violating that by injecting ISysAdminRepository and calling findPlatformTotals / findAllCommunities / findCommunityById / findMemberStats / findMonthlyActivity / findAllTimeTotals directly.

Add thin `get*` pass-throughs on SysAdminService that 1:1-delegate to each `find*` used by the usecase, then drop the repository injection from SysAdminUseCase. The service already held the repository reference, so this is a reshuffle — no new SQL or behaviour change — matching how report/experience/opportunity usecases in this repo stay service-only.

All 57 sysadmin unit tests continue to pass; the mock surface didn't need new entries because the tests assert at the pure-function / orchestrator boundary rather than the thin wrappers.

Caught by Devin (BUG_0001, critical).

* fix(sysadmin): clamp findMonthlyActivity member counts at asOf for the current month

The L2 monthly activity trend computed total_members_end_of_month and new_members up to the full calendar-month boundary, while findMemberStats and findMonthActivity already clamped at asOfJstDay+1. For a historic asOf the trend's most recent month inflated its denominator (members who joined after asOf were included), producing a communityActivityRate visibly lower than the summary card's rate for the same month and pulling computeActivityRate3mAvg with it.

Add a `member_upper` column on the month_bounds CTE that LEAST()s next_month_start with `(asOf JST day + 1)`. Past months collapse back to next_month_start (no behavioural change); the asOf month stops at the asOf clamp instead. Both the new_members and total_members CTEs now reference member_upper, so the membership-side counts on the trend match the rest of the sysadmin surface.

Caught by Devin (BUG_0001).

* docs(report): add Japanese README covering analytics calculation logic

Centralises the calculation conventions used by both the report domain and its consumers (sysadmin today, future analytics surfaces next) in one place so new methods don't need to re-discover the conventions from PR review feedback.

Sections:
- 0. 設計前提（退会なし / LTV 唯一変数 / 個人 vs コミュニティ指標の区別）
- 1. JST タイムゾーンの扱い（二段階変換、JST-encoded Date、半開区間）
- 2. 主要な指標の計算式（userSendRate / months_in inclusive span / communityActivityRate / growthRateActivity / 3m avg）
- 3. retention の計算（is_sender 定義、ever_before 12 週、進行中月除外）
- 4. アラート判定（noNewMembers の 14 日窓の作り方、Infinity ガード）
- 5. ステージ分類（cumulative tier vs disjoint stage breakdown）
- 6. レイヤー責務（UseCase → Service → Repository、cross-domain は service 経由）
- 7. パフォーマンス（fan-out 戦略、windowMonths 上限）
- 8. よくある落とし穴（PR #911 のレビューで出たバグの一覧表）

Distilled from the recurring review comments on PR #911 (gemini + devin) so the same gotchas don't bite the next analytics feature.

* refactor(sysadmin): consolidate CTEs and reduce, guard chain counts against NULL

Four code-quality improvements from Gemini review:

1. findMemberStats: extract the repeated months_in expression into a member_tenure CTE. The formula was duplicated between the months_in column and the user_send_rate denominator; now it lives in one place so future edits stay in sync.

2. findMonthlyActivity: guard the chain count sum against NULL. ts.chain_root_count + ts.chain_descendant_count would collapse to NULL if either column were null, silently dropping that row from SUM. Wrap each column in COALESCE(..., 0) before adding so a hypothetical NULL (MV reshape, LEFT JOIN miss) doesn't leak into the aggregate.

3. findMonthlyActivity: merge new_members and total_members CTEs into a single member_counts CTE that scans t_memberships once and emits both counters via COUNT(...) FILTER. Halves the LEFT JOINs the planner has to run against t_memberships per call.

4. service.computeStageBreakdown.summarize: fold three rows.reduce calls into one that returns { sumSendRate, sumMonthsIn, sumPointsOut }. Visits each bucket once instead of three times.

All 57 sysadmin unit tests still pass and the sysadmin scope remains clean under `pnpm build` / `pnpm lint`.

* fix(sysadmin): align findMonthlyActivity numerator bounds with member_upper clamp

The senders CTE (for sender_count) and tx_totals CTE (for donation_points_sum / donation_tx_count / donation_chain_tx_count) still used mb.next_month_start as the upper bound, while member_counts used mb.member_upper (= LEAST(next_month_start, asOfJstDayPlusOne)). For a historic asOf, that let the activity-rate numerator pull in MV data from dates past asOf while the denominator was already clamped, making the rate look inflated and inconsistent with other surfaces (stageCounts.total / summary-card rate).

Switch both LEFT JOIN predicates to `<= mb.member_upper` exclusive so every counter in findMonthlyActivity shares the same as-of-clamp. Past months are unaffected (member_upper collapses to next_month_start when the LEAST bound is the calendar boundary).

Caught by Gemini (two high-priority comments).

* refactor(sysadmin): dedupe JST-day boundary + widen donation tx counts to bigint

Five Gemini review comments folded into one change:

1. findMemberStats SQL: the "asOf JST day + 1 at JST midnight, expressed as naive UTC" expression lived inline in two WHERE clauses (members CTE, donation_months CTE). Extract it once into an `asof_bound` CTE and reference `ab.upper_ts` at both sites. Same formula as the service-layer `asOfJstDayPlusOne` clamp — keeping it inline was an obvious duplication and a footgun if one of the call sites ever diverged.

2. findMonthlyActivity SQL: cast the donation_tx_count and donation_chain_tx_count SUMs to ::bigint instead of ::int. The underlying mv_transaction_summary_daily.tx_count column is int32 but cumulative window sums over long-running / busy communities could legitimately cross the ~2.1B int32 ceiling. bigint lets the overflow fail loud via bigintToSafeNumber at the presenter boundary rather than silently wrapping.

3. SysAdminMonthlyActivityRow: widen `donationTxCount` / `donationChainTxCount` from number to bigint to match the new SQL shape. Doc comment on the type spells out why bigint is chosen over number.

4. SysAdminPresenter.monthlyActivityPoint: route both sides of the chainPct ratio through bigintToSafeNumber so extreme hypothetical totals surface as a RangeError, with the division itself happening in Number-space where the small [0, 1] fraction is safe.

5. Tests: update presenter / service test fixtures to the new bigint shape, and add a RangeError-on-overflow assertion to presenter.test.ts so the widening is enforced end-to-end (58 tests, was 57).

Caught by Gemini (5 medium comments).

* refactor(sysadmin): bigint-safe sort, dedupe asOf JST cast, rename findMonthActivity, disambiguate variable

Four Gemini review comments:

1. service.paginateMembers (high): sorting by TOTAL_POINTS_OUT ran Number(bigint) on totalPointsOut, which would silently lose precision past Number.MAX_SAFE_INTEGER and mis-order the top of the leaderboard for an extreme donor. Branch the comparator on sortField === "TOTAL_POINTS_OUT" and compare the bigints directly.

2. findMemberStats SQL: the `(asOf AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')` cast was re-evaluated twice inside the member_tenure CTE (once for EXTRACT(YEAR), once for EXTRACT(MONTH)). Extract an asof_jst CTE that computes the JST timestamp once, and reference aj.ts from every extraction. asof_bound now reads from asof_jst too, so the double-AT-TIME-ZONE dance lives in exactly one place.

3. usecase.getCommunityDetail: the destructured bundle was named `monthActivity`, one character off from `monthlyActivity` in the same destructure. Rename to `currentMonthActivity` (the usage reads current-month fields anyway) and apply the same rename consistently in getDashboard.

4. findMonthActivity rename: the method is used for BOTH the month-bundle path (getMonthActivityWithPrev) and the weekly denominator path (getRetentionTrend), so "findMonthActivity" was actively misleading. Rename to findActivitySnapshot (repo + interface + type + all call sites + service test mock); the docs README reference is updated too.

58 unit tests continue to pass; sysadmin build + lint remain clean.

* refactor(sysadmin): centralise asOf-clamp boundary in AsOfBounds helper

The `asOf JST day + 1` calculation (`addDays(truncateToJstDate(asOf), 1)`) plus the ternary clamping any future boundary at that value appeared in four places: getDashboard, getMonthActivityWithPrev, getRetentionTrend, getAlerts. Each had the same comment explaining the same invariant, and the next analytics surface adding an asOf-scoped query would have needed the same copy-paste.

Extract both into `src/application/domain/sysadmin/bounds.ts`:
- `AsOfBounds.asOfJstDayPlusOne` — the raw Date, used for boundary arithmetic
- `AsOfBounds.clampFuture(b)` — shorthand for `min(b, asOfJstDayPlusOne)`

Call sites collapse from 3–4 lines each to 1–2, and the JST-day convention now lives in exactly one file.

No behavioural change; 58 unit tests continue to pass.

* refactor(sysadmin): flatten getMonthActivityWithPrev return shape

The previous shape was `{ current: { rate, senderCount, totalMembers }, previous: ... | null, growthRateActivity }`. Every caller only read `current.rate` plus `growthRateActivity`, and the `previous` sub-tree never left the service (it only existed so `growthRateActivity` could be derived internally). Keeping the nested tree on the public return type falsely advertised a 'previous-month snapshot' as part of the API contract.

Replace with a flat `MonthActivityWithPrev` type exporting exactly the four values callers actually consume:
  currentRate, currentSenderCount, currentTotalMembers, growthRateActivity

The rate / growthRate derivation stays identical; only the shape of the return value (and the two UseCase destructurings) changed.

* refactor(sysadmin): consolidate JST month helpers into report/util

The JST month boundary helpers (jstMonthStart / jstMonthStartOffset / jstNextMonthStart / formatJstMonth) lived in
sysadmin/util.ts while the related day/week/arithmetic helpers (truncateToJstDate / addDays / isoWeekStartJst / percentChange) lived in report/util.ts. Callers needed two imports and two mental models for "the JST utility".

Move the month-level helpers into report/util.ts next to the day-level helpers they layer on top of. The report README already documented them there; now the code matches the docs. Delete the now-empty sysadmin/util.ts (bounds.ts from phase 1 remains for the asOfBounds helper). Tests keep their existing file path but import from the new location.

No behavioural change — 58 unit tests continue to pass; sysadmin build remains clean.

* fix(sysadmin): address Gemini + Copilot review comments

Gemini (medium):
- findAllTimeTotals: clamp t_transactions scan AND the mv_transaction_summary_daily data-window at (asOf JST day + 1). Without the clamp, a historic asOf would return all-time totals and a data_to value that extend past the caller's asOf — a different flavour of the same bug other sysadmin methods already fixed. Adds `asOf: Date` to the method / interface / service pass-through / usecase call site.

Copilot (7 findings):
1. cursor description: the schema (and generated types) claimed the opaque cursor was "the member id of the last row on prior page", but SysAdminService.paginateMembers uses a base64-encoded offset. Update the schema docstring to describe the actual contract.
2. resolveThresholds: `Math.max(..., 0)` on tier1 / tier2 so the downstream invariant `tier1 >= tier2 >= 0` holds even if a caller passes a negative threshold. Without the clamp a negative tier2 would make every member qualify and produce misleading stage counts.
3. pointsContributionPct precision: route both sides of the ratio through bigintToSafeNumber so extreme cumulative totals fail loud (RangeError) instead of silently truncating via Number(bigint).
4. pointsContributionPct spec alignment: the schema doc said "in the asOf month" but the implementation uses `totalPointsOut` (all-time). Update the docstring to describe the actual frame; switching the implementation to monthly would require a new SQL round trip per bucket with no external caller asking for it.
5. getRetentionTrend fan-out: up to ~310 concurrent `$queryRaw` calls at MAX windowMonths could exhaust the Prisma connection pool. Add `runBatched` (in-file helper, no dep) and a `FANOUT_CONCURRENCY = 8` cap. Past benchmarks showed per-week queries are ~1ms, so serialising chunks adds only milliseconds.
6. getCohortRetention fan-out: same concurrency cap — up to 4 queries per cohort × 36 cohorts = 144 concurrent calls in the worst case, now bounded to 32 in flight.
7. (same as 1, duplicate on generated graphql.ts — regenerated via `pnpm gql:generate`)

Rejected Gemini findings (documented here for the record):
- DISTINCT ON (user_id) / COUNT(DISTINCT user_id) on t_memberships were suggested but are unnecessary: `t_memberships.@@id(user_id, community_id)` (composite PK) already guarantees one row per user per community. CLAUDE.md's "退会がない構造" confirms re-join isn't a practical concern in data either.

58 unit tests continue to pass; sysadmin scope build + lint clean.

* fix(sysadmin): shift alerts + L1 cohort retention to last-completed-period frame

Five Gemini review comments, resolved together because they all touch the same "in-progress period leaking into correctness checks" problem:

1. getAlerts (high): churnSpike / activeDrop were comparing the IN-PROGRESS week / month against the full prior period. On Monday or month-day-2, the in-progress side has almost no data and the alert reliably fires purely from the comparison geometry, not from any real churn/drop. Rework getAlerts to operate on the last-completed week (prev-week vs week-before-last) and the last-completed month pair (prev-month vs prev-prev-month). getAlerts also now derives its own alert-side growth fraction internally, so the `growthRateActivity` parameter is dropped from the signature — the UI's current-vs-prev growth stays as an informational signal, unrelated to the alert gate. Also covers: - Gemini #1 (clamp nextWeekStart in getAlerts' retention call) — moot now that currentWeek is prev-week. - Gemini #3 (the false-positive framing itself).

2. getRetentionTrend (high): the per-week `getRetentionAggregate` call did not clamp `nextWeekStart`, so a historic asOf let MV rows from dates past asOf leak into the in-progress week's numerator. Apply `bounds.clampFuture` the same way the denominator already does.

3. getLatestCohortRetentionM1 (high + medium): the L1 "latest cohort retention" was evaluating `activeEnd = nextMonthStart` against the IN-PROGRESS asOf month, producing artificially low values and contradicting the L2 rule from README §3.4 ("進行中の月は除外する"). Shift the cohort two months back so the active window is the last completed month ([cohort=asOf-2mo, cohortEnd=asOf-1mo, activeStart=asOf-1mo, activeEnd=latestMonthStart]). This: - closes Gemini #2 (activeEnd now never exceeds latestMonthStart so the L2 completion rule holds), - closes Gemini #5 (L1 and L2 now share the same "completed-only" semantics), - gives the L1 number a meaningful value on every day of every month rather than whipsawing from "month's 1st looks terrible" to "month's 30th looks great".

Docs:
  - README §4 now lists the alert's evaluation period explicitly and flags the "進行中期間は対象にしない" invariant.
  - README §3.4 documents that L1 latestCohortRetentionM1 follows the same completed-month rule as L2 cohortRetention.

Tests:
  - getAlerts test rewritten. New fixtures supply prevMonth / prevPrevMonth activity snapshots for the activeDrop branch, and the -20% threshold check moved to a -30% reading to sidestep JS double imprecision on `(0.8 - 1.0) / 1.0` (represents as -0.1999...). ACTIVE_DROP_THRESHOLD import removed from the test (no longer referenced).

58 unit tests continue to pass; sysadmin build + lint clean.

* refactor(sysadmin): rateOf helper + percentChange reuse, README alert docs fix

Small polish that fell out of the last commit's alert rework.

Refactor:
- Extract rateOf(senderCount, totalMembers) as a private helper in service.ts. The `totalMembers === 0 ? 0 : senderCount / totalMembers` expression appeared verbatim in five spots (getMonthActivityWithPrev curr+prev, computeActivityRate3mAvg, getAlerts prev+prev-prev). Keeping the "div-by-zero ⇒ 0" convention in one function avoids the next edit drifting one site without the others.
- getAlerts' alertGrowth now routes through the shared `percentChange` from report/util (same pattern getMonthActivityWithPrev already uses) instead of the inlined subtract-and-divide. The null-on-zero-denominator guard inside percentChange replaces the hand-rolled guard here.

Docs:
- README §2.4 now explicitly labels growthRateActivity as a "UI informational signal" and calls out that activeDrop does NOT use it. Same "前月比" label was previously ambiguous.
- README §4.2 updated for the alert's completed-period frame: the null guard is now on prev-prev month (totalMembers 0 or prevPrevRate 0), not the UI's prev-month signal. The old prose was left over from the pre-shift implementation.

All 58 unit tests continue to pass.

---------
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
