### PR TITLE
Refactor deploy workflows to use reusable workflow template

### DIFF
--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -1,0 +1,239 @@
+name: _deploy-cloud-run (reusable)
+
+# Reusable deploy pipeline shared by:
+#   - deploy-to-cloud-run-{dev,prd}.yml         (service=internal)
+#   - deploy-external-api-{dev,prd}.yml         (service=external)
+#
+# Variation surface is expressed as `inputs` so the four caller workflows
+# can stay as thin wrappers. Behavior is intended to be byte-equivalent to
+# the pre-refactor workflows; tightening (cache / db:generate / pnpm setup)
+# happens in subsequent commits.
+
+on:
+  workflow_call:
+    inputs:
+      service:
+        description: 'internal | external'
+        required: true
+        type: string
+      stage:
+        description: 'dev | prd'
+        required: true
+        type: string
+      environment:
+        description: 'GitHub environment name (e.g. dev, co-creation-dao-prod)'
+        required: true
+        type: string
+      env_vars:
+        description: 'Multiline env_vars passed to deploy-cloudrun (KEY=VALUE per line)'
+        required: true
+        type: string
+      dockerfile:
+        description: 'Dockerfile path for the service image'
+        required: true
+        type: string
+      cloud_run_flags:
+        description: 'Extra flags forwarded to deploy-cloudrun (empty for internal)'
+        required: false
+        type: string
+        default: ''
+      apollo_variant:
+        description: 'Apollo Studio variant (only used when publish_apollo=true)'
+        required: false
+        type: string
+        default: ''
+      publish_apollo:
+        description: 'Run rover graph publish'
+        required: false
+        type: boolean
+        default: false
+      deploy_batch:
+        description: 'Build + deploy Dockerfile.batch as a Cloud Run Job'
+        required: false
+        type: boolean
+        default: false
+      create_tag:
+        description: 'Create and push a timestamped Git tag after deploy'
+        required: false
+        type: boolean
+        default: false
+      tag_prefix:
+        description: 'Prefix for the timestamp tag (e.g. "external-api-")'
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    timeout-minutes: 30
+
+    permissions:
+      id-token: write
+      # `create_tag` pushes a tag back to the repo, requiring contents: write.
+      # GitHub Actions does not allow conditional permissions, so we always
+      # request write here; non-tagging callers still don't push anything.
+      contents: write
+
+    env:
+      STAGE: ${{ inputs.stage }}
+      GCP_REGION: ${{ secrets.GCP_REGION }}
+      DB_USER: ${{ secrets.DB_USER }}
+      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+      DB_NAME: ${{ secrets.DB_NAME }}
+      CLOUD_SQL_CONNECTION_NAME: ${{ secrets.CLOUD_SQL_CONNECTION_NAME }}
+      ARTIFACT_REGISTRY: ${{ secrets.ARTIFACT_REGISTRY }}
+      APPLICATION_NAME: ${{ secrets.APPLICATION_NAME }}
+      EXTERNAL_API_NAME: ${{ secrets.EXTERNAL_API_NAME }}
+      BATCH_ARTIFACT_REGISTRY: ${{ secrets.BATCH_ARTIFACT_REGISTRY }}
+      BATCH_NAME: ${{ secrets.BATCH_NAME }}
+      JUMPBOX_INSTANCE_NAME: ${{ secrets.JUMPBOX_INSTANCE_NAME }}
+      JUMPBOX_ZONE: ${{ secrets.JUMPBOX_ZONE }}
+      APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Set up Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Authenticate to Google Cloud (Workload Identity Federation)
+        uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70 # v2.1.6
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+
+      - name: Set up gcloud SDK
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
+
+      - name: pnpm db:generate
+        env:
+          DATABASE_URL: postgresql://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
+        run: |
+          echo "--- Connecting to DB via jumpbox ---"
+          gcloud compute ssh ${{ env.JUMPBOX_INSTANCE_NAME }} \
+            --tunnel-through-iap \
+            --zone=${{ env.JUMPBOX_ZONE }} \
+            --quiet -- -N -L 5432:localhost:5432 &
+          SSH_PID=$!
+          sleep 60
+          for _ in {1..5}; do
+            pg_isready -h localhost -p 5432 -d ${{ env.DB_NAME }} && break
+            sleep 60
+          done
+
+          echo "--- Running prisma generate ---"
+          pnpm db:generate
+
+          echo "Killing SSH tunnel"
+          kill $SSH_PID
+
+      - name: pnpm gql:generate
+        if: ${{ inputs.publish_apollo }}
+        run: pnpm gql:generate
+
+      - name: Install and Publish via Rover CLI
+        if: ${{ inputs.publish_apollo }}
+        env:
+          APOLLO_KEY: ${{ env.APOLLO_KEY }}
+        run: |
+          curl -sSL https://rover.apollo.dev/nix/latest | sh
+          export PATH="$HOME/.rover/bin:$PATH"
+          rover graph publish civicship-api-jq1988@${{ inputs.apollo_variant }} --schema ./docs/schema.graphql
+
+      - name: pnpm build
+        run: pnpm build
+
+      - name: Configure Docker for GCP Artifact Registry
+        run: |
+          gcloud auth configure-docker ${{ env.ARTIFACT_REGISTRY }}
+          gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev
+
+      - name: Resolve service image name
+        id: image
+        run: |
+          if [ "${{ inputs.service }}" = "internal" ]; then
+            echo "name=${{ env.APPLICATION_NAME }}" >> "$GITHUB_OUTPUT"
+            echo "service_name=${{ env.APPLICATION_NAME }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=${{ env.EXTERNAL_API_NAME }}" >> "$GITHUB_OUTPUT"
+            echo "service_name=${{ env.EXTERNAL_API_NAME }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build Docker image (internal uses dotenvx)
+        if: ${{ inputs.service == 'internal' }}
+        run: |
+          pnpm dotenvx run -- docker build --no-cache \
+            -t ${{ env.ARTIFACT_REGISTRY }}/${{ steps.image.outputs.name }}:latest \
+            -f ${{ inputs.dockerfile }} .
+
+      - name: Build Docker image (external)
+        if: ${{ inputs.service == 'external' }}
+        run: |
+          docker build --no-cache \
+            -t ${{ env.ARTIFACT_REGISTRY }}/${{ steps.image.outputs.name }}:latest \
+            -f ${{ inputs.dockerfile }} .
+
+      - name: Push Docker image to Artifact Registry
+        run: |
+          docker push ${{ env.ARTIFACT_REGISTRY }}/${{ steps.image.outputs.name }}:latest
+
+      - name: Deploy to Cloud Run
+        id: 'deploy'
+        uses: 'google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522' # v2.7.6
+        with:
+          service: ${{ steps.image.outputs.service_name }}
+          image: ${{ env.ARTIFACT_REGISTRY }}/${{ steps.image.outputs.name }}:latest
+          region: ${{ env.GCP_REGION }}
+          flags: ${{ inputs.cloud_run_flags }}
+          env_vars: ${{ inputs.env_vars }}
+
+      - name: Build Docker image for batch job
+        if: ${{ inputs.deploy_batch }}
+        run: |
+          docker build -t ${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest -f Dockerfile.batch .
+
+      - name: Push Docker image for batch job to Artifact Registry
+        if: ${{ inputs.deploy_batch }}
+        run: |
+          docker push ${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest
+
+      - name: Update Cloud Run Job (batch) to new image
+        if: ${{ inputs.deploy_batch }}
+        # docker push :latest alone does not roll the Cloud Run Job to the new
+        # image — Cloud Run Jobs pin the image digest at deploy time, so we
+        # need an explicit `run jobs update` to create a new revision.
+        run: |
+          gcloud run jobs update ${{ env.BATCH_NAME }} \
+            --region=${{ env.GCP_REGION }} \
+            --image=${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest
+
+      - name: Create Git tag
+        if: ${{ inputs.create_tag }}
+        run: |
+          sudo apt-get update && sudo apt-get install -y tzdata
+          sudo ln -fs /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
+          sudo dpkg-reconfigure -f noninteractive tzdata
+
+          TAG_NAME="${{ inputs.tag_prefix }}$(date +"%Y%m%d%H%M%S")"
+
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+
+          git tag "$TAG_NAME"
+          git push origin "$TAG_NAME"
+
+      - name: Cleanup SSH Key
+        if: always()
+        run: rm -f ~/.ssh/google_compute_engine ~/.ssh/google_compute_engine.pub

--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -5,9 +5,9 @@ name: _deploy-cloud-run (reusable)
 #   - deploy-external-api-{dev,prd}.yml         (service=external)
 #
 # Variation surface is expressed as `inputs` so the four caller workflows
-# can stay as thin wrappers. Behavior is intended to be byte-equivalent to
-# the pre-refactor workflows; tightening (cache / db:generate / pnpm setup)
-# happens in subsequent commits.
+# stay as thin wrappers. TypedSQL generation runs against an ephemeral
+# Postgres service (not the live Cloud SQL via jumpbox) so deploy is
+# decoupled from prod DB availability and SSH tunnel timing.
 
 on:
   workflow_call:
@@ -76,21 +76,35 @@ jobs:
       # request write here; non-tagging callers still don't push anything.
       contents: write
 
+    # Ephemeral Postgres for `prisma generate --sql` (TypedSQL). Same pattern
+    # as ci.yml — migrations are the source of truth so a fresh DB seeded via
+    # `pnpm db:deploy` produces a schema identical to production for the
+    # purposes of TypedSQL type introspection.
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: civicship
+          POSTGRES_PASSWORD: civicship
+          POSTGRES_DB: civicship_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
     env:
       STAGE: ${{ inputs.stage }}
       GCP_REGION: ${{ secrets.GCP_REGION }}
-      DB_USER: ${{ secrets.DB_USER }}
-      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-      DB_NAME: ${{ secrets.DB_NAME }}
-      CLOUD_SQL_CONNECTION_NAME: ${{ secrets.CLOUD_SQL_CONNECTION_NAME }}
       ARTIFACT_REGISTRY: ${{ secrets.ARTIFACT_REGISTRY }}
       APPLICATION_NAME: ${{ secrets.APPLICATION_NAME }}
       EXTERNAL_API_NAME: ${{ secrets.EXTERNAL_API_NAME }}
       BATCH_ARTIFACT_REGISTRY: ${{ secrets.BATCH_ARTIFACT_REGISTRY }}
       BATCH_NAME: ${{ secrets.BATCH_NAME }}
-      JUMPBOX_INSTANCE_NAME: ${{ secrets.JUMPBOX_INSTANCE_NAME }}
-      JUMPBOX_ZONE: ${{ secrets.JUMPBOX_ZONE }}
       APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
+      DATABASE_URL: postgresql://civicship:civicship@localhost:5432/civicship_ci
 
     steps:
       - name: Checkout code
@@ -117,27 +131,14 @@ jobs:
       - name: Set up gcloud SDK
         uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
 
+      - name: Apply Prisma migrations to ephemeral Postgres
+        # TypedSQL (`prisma generate --sql`) introspects the live DB to type
+        # `@prisma/client/sql` exports. Migrations create the views / mvs that
+        # those .sql snippets reference, so they must be applied first.
+        run: pnpm db:deploy
+
       - name: pnpm db:generate
-        env:
-          DATABASE_URL: postgresql://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
-        run: |
-          echo "--- Connecting to DB via jumpbox ---"
-          gcloud compute ssh ${{ env.JUMPBOX_INSTANCE_NAME }} \
-            --tunnel-through-iap \
-            --zone=${{ env.JUMPBOX_ZONE }} \
-            --quiet -- -N -L 5432:localhost:5432 &
-          SSH_PID=$!
-          sleep 60
-          for _ in {1..5}; do
-            pg_isready -h localhost -p 5432 -d ${{ env.DB_NAME }} && break
-            sleep 60
-          done
-
-          echo "--- Running prisma generate ---"
-          pnpm db:generate
-
-          echo "Killing SSH tunnel"
-          kill $SSH_PID
+        run: pnpm db:generate
 
       - name: pnpm gql:generate
         if: ${{ inputs.publish_apollo }}
@@ -233,7 +234,3 @@ jobs:
 
           git tag "$TAG_NAME"
           git push origin "$TAG_NAME"
-
-      - name: Cleanup SSH Key
-        if: always()
-        run: rm -f ~/.ssh/google_compute_engine ~/.ssh/google_compute_engine.pub

--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -156,6 +156,9 @@ jobs:
         run: pnpm build
 
       - name: Configure Docker for GCP Artifact Registry
+        # Writes a credHelper entry to ~/.docker/config.json so both classic
+        # `docker push` and buildx (which shares the same config) can auth to
+        # Artifact Registry via the gcloud-issued OAuth token.
         run: |
           gcloud auth configure-docker ${{ env.ARTIFACT_REGISTRY }}
           gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev
@@ -165,49 +168,46 @@ jobs:
         run: |
           if [ "${{ inputs.service }}" = "internal" ]; then
             echo "name=${{ env.APPLICATION_NAME }}" >> "$GITHUB_OUTPUT"
-            echo "service_name=${{ env.APPLICATION_NAME }}" >> "$GITHUB_OUTPUT"
           else
             echo "name=${{ env.EXTERNAL_API_NAME }}" >> "$GITHUB_OUTPUT"
-            echo "service_name=${{ env.EXTERNAL_API_NAME }}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build Docker image (internal uses dotenvx)
-        if: ${{ inputs.service == 'internal' }}
-        run: |
-          pnpm dotenvx run -- docker build --no-cache \
-            -t ${{ env.ARTIFACT_REGISTRY }}/${{ steps.image.outputs.name }}:latest \
-            -f ${{ inputs.dockerfile }} .
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
 
-      - name: Build Docker image (external)
-        if: ${{ inputs.service == 'external' }}
-        run: |
-          docker build --no-cache \
-            -t ${{ env.ARTIFACT_REGISTRY }}/${{ steps.image.outputs.name }}:latest \
-            -f ${{ inputs.dockerfile }} .
-
-      - name: Push Docker image to Artifact Registry
-        run: |
-          docker push ${{ env.ARTIFACT_REGISTRY }}/${{ steps.image.outputs.name }}:latest
+      - name: Build and push service image
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
+        with:
+          context: .
+          file: ${{ inputs.dockerfile }}
+          push: true
+          tags: ${{ env.ARTIFACT_REGISTRY }}/${{ steps.image.outputs.name }}:latest
+          # Per-(service, stage) cache scope. Branches sharing a scope reuse
+          # layers; mode=max also exports intermediate layers, not just the
+          # final stage, which speeds up rebuilds when only late layers change.
+          cache-from: type=gha,scope=${{ inputs.service }}-${{ inputs.stage }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.service }}-${{ inputs.stage }}
 
       - name: Deploy to Cloud Run
         id: 'deploy'
         uses: 'google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522' # v2.7.6
         with:
-          service: ${{ steps.image.outputs.service_name }}
+          service: ${{ steps.image.outputs.name }}
           image: ${{ env.ARTIFACT_REGISTRY }}/${{ steps.image.outputs.name }}:latest
           region: ${{ env.GCP_REGION }}
           flags: ${{ inputs.cloud_run_flags }}
           env_vars: ${{ inputs.env_vars }}
 
-      - name: Build Docker image for batch job
+      - name: Build and push batch image
         if: ${{ inputs.deploy_batch }}
-        run: |
-          docker build -t ${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest -f Dockerfile.batch .
-
-      - name: Push Docker image for batch job to Artifact Registry
-        if: ${{ inputs.deploy_batch }}
-        run: |
-          docker push ${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
+        with:
+          context: .
+          file: Dockerfile.batch
+          push: true
+          tags: ${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest
+          cache-from: type=gha,scope=batch-${{ inputs.stage }}
+          cache-to: type=gha,mode=max,scope=batch-${{ inputs.stage }}
 
       - name: Update Cloud Run Job (batch) to new image
         if: ${{ inputs.deploy_batch }}

--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -96,8 +96,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Install pnpm
-        run: npm install -g pnpm
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Set up Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0

--- a/.github/workflows/deploy-external-api-dev.yml
+++ b/.github/workflows/deploy-external-api-dev.yml
@@ -11,101 +11,17 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    environment: dev
-    timeout-minutes: 30
-
-    permissions:
-      id-token: write
-      contents: read
-
-    env:
-      STAGE: dev
-      GCP_REGION: ${{ secrets.GCP_REGION }}
-      DB_USER: ${{ secrets.DB_USER }}
-      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-      DB_NAME: ${{ secrets.DB_NAME }}
-      CLOUD_SQL_CONNECTION_NAME: ${{ secrets.CLOUD_SQL_CONNECTION_NAME }}
-      ARTIFACT_REGISTRY: ${{ secrets.ARTIFACT_REGISTRY }}
-      EXTERNAL_API_NAME: ${{ secrets.EXTERNAL_API_NAME }}
-      JUMPBOX_INSTANCE_NAME: ${{ secrets.JUMPBOX_INSTANCE_NAME }}
-      JUMPBOX_ZONE: ${{ secrets.JUMPBOX_ZONE }}
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-    - name: Install pnpm
-      run: npm install -g pnpm
-
-    - name: Set up Node.js
-      uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
-      with:
-        node-version: '20'
-        cache: 'pnpm'
-
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile
-
-    - name: Authenticate to Google Cloud (Workload Identity Federation)
-      uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70 # v2.1.6
-      with:
-        workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
-        service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-
-    - name: Set up gcloud SDK
-      uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
-
-    - name: pnpm db:generate
-      env:
-        DATABASE_URL: postgresql://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
-      run: |
-        echo "--- Connecting to DB via jumpbox ---"
-        gcloud compute ssh ${{ env.JUMPBOX_INSTANCE_NAME }} \
-          --tunnel-through-iap \
-          --zone=${{ env.JUMPBOX_ZONE }} \
-          --quiet -- -N -L 5432:localhost:5432 &
-        SSH_PID=$!
-        sleep 60
-        for _ in {1..5}; do
-          pg_isready -h localhost -p 5432 -d ${{ env.DB_NAME }} && break
-          sleep 60
-        done
-
-        echo "--- Running prisma generate ---"
-        pnpm db:generate
-
-        echo "Killing SSH tunnel"
-        kill $SSH_PID
-
-    - name: pnpm build
-      run: pnpm build
-
-    - name: Configure Docker for GCP Artifact Registry
-      run: |
-        gcloud auth configure-docker ${{ env.ARTIFACT_REGISTRY }}
-        gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev
-
-    - name: Build External API Docker image
-      run: |
-        docker build --no-cache -t ${{ env.ARTIFACT_REGISTRY }}/${{ env.EXTERNAL_API_NAME }}:latest -f Dockerfile.external .
-
-    - name: Push External API Docker image to Artifact Registry
-      run: |
-        docker push ${{ env.ARTIFACT_REGISTRY }}/${{ env.EXTERNAL_API_NAME }}:latest
-
-    - name: Deploy External API to Cloud Run
-      id: 'deploy'
-      uses: 'google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522' # v2.7.6
-      with:
-        service: ${{ env.EXTERNAL_API_NAME }}
-        image: ${{ env.ARTIFACT_REGISTRY }}/${{ env.EXTERNAL_API_NAME }}:latest
-        region: ${{ env.GCP_REGION }}
-        flags: '--allow-unauthenticated --port=3000'
-        env_vars: |
-          NODE_ENV=development
-          ENV=dev
-
-    - name: Cleanup SSH Key
-      if: always()
-      run: rm -f ~/.ssh/google_compute_engine ~/.ssh/google_compute_engine.pub
+    uses: ./.github/workflows/_deploy-cloud-run.yml
+    with:
+      service: external
+      stage: dev
+      environment: dev
+      dockerfile: Dockerfile.external
+      cloud_run_flags: '--allow-unauthenticated --port=3000'
+      env_vars: |
+        NODE_ENV=development
+        ENV=dev
+      publish_apollo: false
+      deploy_batch: false
+      create_tag: false
+    secrets: inherit

--- a/.github/workflows/deploy-external-api-dev.yml
+++ b/.github/workflows/deploy-external-api-dev.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - develop
 
+permissions:
+  # Caps the reusable workflow's GITHUB_TOKEN to the minimum this caller
+  # needs: id-token for WIF, contents: read for checkout. The dev caller
+  # does not tag (create_tag=false), so contents: write is not required.
+  contents: read
+  id-token: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/deploy-external-api-prd.yml
+++ b/.github/workflows/deploy-external-api-prd.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - master
 
+permissions:
+  # Caps the reusable workflow's GITHUB_TOKEN to the minimum this caller
+  # needs: id-token for WIF, contents: write because the prd caller pushes
+  # a release tag after deploy (create_tag=true).
+  contents: write
+  id-token: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/deploy-external-api-prd.yml
+++ b/.github/workflows/deploy-external-api-prd.yml
@@ -11,114 +11,17 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    environment: co-creation-dao-prod
-    timeout-minutes: 30
-
-    permissions:
-      id-token: write
-      contents: write
-
-    env:
-      STAGE: prd
-      GCP_REGION: ${{ secrets.GCP_REGION }}
-      DB_USER: ${{ secrets.DB_USER }}
-      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-      DB_NAME: ${{ secrets.DB_NAME }}
-      CLOUD_SQL_CONNECTION_NAME: ${{ secrets.CLOUD_SQL_CONNECTION_NAME }}
-      ARTIFACT_REGISTRY: ${{ secrets.ARTIFACT_REGISTRY }}
-      EXTERNAL_API_NAME: ${{ secrets.EXTERNAL_API_NAME }}
-      JUMPBOX_INSTANCE_NAME: ${{ secrets.JUMPBOX_INSTANCE_NAME }}
-      JUMPBOX_ZONE: ${{ secrets.JUMPBOX_ZONE }}
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-    - name: Install pnpm
-      run: npm install -g pnpm
-
-    - name: Set up Node.js
-      uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
-      with:
-        node-version: '20'
-        cache: 'pnpm'
-
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile
-
-    - name: Authenticate to Google Cloud (Workload Identity Federation)
-      uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70 # v2.1.6
-      with:
-        workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
-        service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-
-    - name: Set up gcloud SDK
-      uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
-
-    - name: pnpm db:generate
-      env:
-        DATABASE_URL: postgresql://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
-      run: |
-        echo "--- Connecting to DB via jumpbox ---"
-        gcloud compute ssh ${{ env.JUMPBOX_INSTANCE_NAME }} \
-          --tunnel-through-iap \
-          --zone=${{ env.JUMPBOX_ZONE }} \
-          --quiet -- -N -L 5432:localhost:5432 &
-        SSH_PID=$!
-        sleep 60
-        for _ in {1..5}; do
-          pg_isready -h localhost -p 5432 -d ${{ env.DB_NAME }} && break
-          sleep 60
-        done
-
-        echo "--- Running prisma generate ---"
-        pnpm db:generate
-
-        echo "Killing SSH tunnel"
-        kill $SSH_PID
-
-    - name: pnpm build
-      run: pnpm build
-
-    - name: Configure Docker for GCP Artifact Registry
-      run: |
-        gcloud auth configure-docker ${{ env.ARTIFACT_REGISTRY }}
-        gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev
-
-    - name: Build External API Docker image
-      run: |
-        docker build --no-cache -t ${{ env.ARTIFACT_REGISTRY }}/${{ env.EXTERNAL_API_NAME }}:latest -f Dockerfile.external .
-
-    - name: Push External API Docker image to Artifact Registry
-      run: |
-        docker push ${{ env.ARTIFACT_REGISTRY }}/${{ env.EXTERNAL_API_NAME }}:latest
-
-    - name: Deploy External API to Cloud Run
-      id: 'deploy'
-      uses: 'google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522' # v2.7.6
-      with:
-        service: ${{ env.EXTERNAL_API_NAME }}
-        image: ${{ env.ARTIFACT_REGISTRY }}/${{ env.EXTERNAL_API_NAME }}:latest
-        region: ${{ env.GCP_REGION }}
-        flags: '--allow-unauthenticated --port=3000'
-        env_vars: |
-          NODE_ENV=production
-
-    - name: Create Git tag for External API
-      run: |
-        sudo apt-get update && sudo apt-get install -y tzdata
-        sudo ln -fs /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
-        sudo dpkg-reconfigure -f noninteractive tzdata
-        
-        TAG_NAME="external-api-$(date +"%Y%m%d%H%M%S")"
-        
-        git config user.name "github-actions"
-        git config user.email "github-actions@github.com"
-        
-        git tag "$TAG_NAME"
-        git push origin "$TAG_NAME"
-
-    - name: Cleanup SSH Key
-      if: always()
-      run: rm -f ~/.ssh/google_compute_engine ~/.ssh/google_compute_engine.pub
+    uses: ./.github/workflows/_deploy-cloud-run.yml
+    with:
+      service: external
+      stage: prd
+      environment: co-creation-dao-prod
+      dockerfile: Dockerfile.external
+      cloud_run_flags: '--allow-unauthenticated --port=3000'
+      env_vars: |
+        NODE_ENV=production
+      publish_apollo: false
+      deploy_batch: false
+      create_tag: true
+      tag_prefix: 'external-api-'
+    secrets: inherit

--- a/.github/workflows/deploy-to-cloud-run-dev.yml
+++ b/.github/workflows/deploy-to-cloud-run-dev.yml
@@ -11,139 +11,17 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    environment: dev
-    timeout-minutes: 30
-
-    permissions:
-      id-token: write
-      contents: read
-
-    env:
-      # stage
-      STAGE: dev
-      # GCP settings
-      GCP_REGION: ${{ secrets.GCP_REGION }}
-      # DB credentials
-      DB_USER: ${{ secrets.DB_USER }}
-      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-      DB_NAME: ${{ secrets.DB_NAME }}
-      CLOUD_SQL_CONNECTION_NAME: ${{ secrets.CLOUD_SQL_CONNECTION_NAME }}
-      # application settings
-      ARTIFACT_REGISTRY: ${{ secrets.ARTIFACT_REGISTRY }}
-      APPLICATION_NAME: ${{ secrets.APPLICATION_NAME }}
-      # batch settings
-      BATCH_ARTIFACT_REGISTRY: ${{ secrets.BATCH_ARTIFACT_REGISTRY }}
-      BATCH_NAME: ${{ secrets.BATCH_NAME }}
-      # Jumpbox settings
-      JUMPBOX_INSTANCE_NAME: ${{ secrets.JUMPBOX_INSTANCE_NAME }}
-      JUMPBOX_ZONE: ${{ secrets.JUMPBOX_ZONE }}
-      # Apollo studio
-      APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-    - name: Install pnpm
-      run: npm install -g pnpm
-
-    - name: Set up Node.js
-      uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
-      with:
-        node-version: '20'
-        cache: 'pnpm'
-
-    - name: Install dependencies
-      run: |
-          pnpm install --frozen-lockfile
-
-    - name: Authenticate to Google Cloud (Workload Identity Federation)
-      uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70 # v2.1.6
-      with:
-        workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
-        service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-
-    - name: Set up gcloud SDK
-      uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
-
-    - name: pnpm db:generate
-      env:
-        DATABASE_URL: postgresql://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
-      run: |
-        echo "--- Connecting to DB via jumpbox ---"
-        gcloud compute ssh ${{ env.JUMPBOX_INSTANCE_NAME }} \
-          --tunnel-through-iap \
-          --zone=${{ env.JUMPBOX_ZONE }} \
-          --quiet -- -N -L 5432:localhost:5432 &
-        SSH_PID=$!
-        sleep 60
-        for _ in {1..5}; do
-          pg_isready -h localhost -p 5432 -d ${{ env.DB_NAME }} && break
-          sleep 60
-        done
-
-        echo "--- Running prisma generate ---"
-        pnpm db:generate
-
-        echo "Killing SSH tunnel"
-        kill $SSH_PID
-
-    - name: pnpm gql:generate
-      run: pnpm gql:generate
-
-    - name: Install and Publish via Rover CLI
-      env:
-        APOLLO_KEY: ${{ env.APOLLO_KEY }}
-      run: |
-        curl -sSL https://rover.apollo.dev/nix/latest | sh
-        export PATH="$HOME/.rover/bin:$PATH"
-        rover graph publish civicship-api-jq1988@dev --schema ./docs/schema.graphql
-
-    - name: pnpm build
-      run: pnpm build
-
-    - name: Configure Docker for GCP Artifact Registry
-      run: |
-        gcloud auth configure-docker ${{ env.ARTIFACT_REGISTRY }}
-        gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev
-
-    - name: Build Docker image
-      run: |
-        pnpm dotenvx run -- docker build --no-cache -t ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest .
-
-    - name: Push Docker image to Artifact Registry
-      run: |
-        docker push ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest
-
-    - name: Deploy Internal API to Cloud Run
-      id: 'deploy'
-      uses: 'google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522' # v2.7.6
-      with:
-        service: ${{ env.APPLICATION_NAME }}
-        image: ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest
-        region: ${{ env.GCP_REGION }}
-        env_vars: |
-          NODE_ENV=development
-          ENV=dev
-
-    - name: Build Docker image for batch job
-      run: |
-        docker build -t ${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest -f Dockerfile.batch .
-
-    - name: Push Docker image for batch job to Artifact Registry
-      run: |
-        docker push ${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest
-
-    - name: Update Cloud Run Job (batch) to new image
-      # docker push :latest alone does not roll the Cloud Run Job to the new
-      # image — Cloud Run Jobs pin the image digest at deploy time, so we
-      # need an explicit `run jobs update` to create a new revision.
-      run: |
-        gcloud run jobs update ${{ env.BATCH_NAME }} \
-          --region=${{ env.GCP_REGION }} \
-          --image=${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest
-
-    - name: Cleanup SSH Key
-      if: always()
-      run: rm -f ~/.ssh/google_compute_engine ~/.ssh/google_compute_engine.pub
+    uses: ./.github/workflows/_deploy-cloud-run.yml
+    with:
+      service: internal
+      stage: dev
+      environment: dev
+      dockerfile: Dockerfile
+      env_vars: |
+        NODE_ENV=development
+        ENV=dev
+      publish_apollo: true
+      apollo_variant: dev
+      deploy_batch: true
+      create_tag: false
+    secrets: inherit

--- a/.github/workflows/deploy-to-cloud-run-dev.yml
+++ b/.github/workflows/deploy-to-cloud-run-dev.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - develop
 
+permissions:
+  # Caps the reusable workflow's GITHUB_TOKEN to the minimum this caller
+  # needs: id-token for WIF, contents: read for checkout. The dev caller
+  # does not tag (create_tag=false), so contents: write is not required.
+  contents: read
+  id-token: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/deploy-to-cloud-run-prd.yml
+++ b/.github/workflows/deploy-to-cloud-run-prd.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - master
 
+permissions:
+  # Caps the reusable workflow's GITHUB_TOKEN to the minimum this caller
+  # needs: id-token for WIF, contents: write because the prd caller pushes
+  # a release tag after deploy (create_tag=true).
+  contents: write
+  id-token: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/deploy-to-cloud-run-prd.yml
+++ b/.github/workflows/deploy-to-cloud-run-prd.yml
@@ -11,156 +11,17 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    environment: co-creation-dao-prod
-    timeout-minutes: 30
-
-    permissions:
-      id-token: write
-      contents: write
-
-    env:
-      # stage
-      STAGE: prd
-      # GCP settings
-      GCP_REGION: ${{ secrets.GCP_REGION }}
-      # DB credentials
-      DB_USER: ${{ secrets.DB_USER }}
-      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-      DB_NAME: ${{ secrets.DB_NAME }}
-      CLOUD_SQL_CONNECTION_NAME: ${{ secrets.CLOUD_SQL_CONNECTION_NAME }}
-      # application settings
-      ARTIFACT_REGISTRY: ${{ secrets.ARTIFACT_REGISTRY }}
-      APPLICATION_NAME: ${{ secrets.APPLICATION_NAME }}
-      # batch settings
-      BATCH_ARTIFACT_REGISTRY: ${{ secrets.BATCH_ARTIFACT_REGISTRY }}
-      BATCH_NAME: ${{ secrets.BATCH_NAME }}
-      # Jumpbox settings
-      JUMPBOX_INSTANCE_NAME: ${{ secrets.JUMPBOX_INSTANCE_NAME }}
-      JUMPBOX_ZONE: ${{ secrets.JUMPBOX_ZONE }}
-      # Apollo studio
-      APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-    - name: Install pnpm
-      run: npm install -g pnpm
-
-    - name: Set up Node.js
-      uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
-      with:
-        node-version: '20'
-        cache: 'pnpm'
-
-    - name: Install dependencies
-      run: |
-          pnpm install --frozen-lockfile
-
-    - name: Authenticate to Google Cloud (Workload Identity Federation)
-      uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70 # v2.1.6
-      with:
-        workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
-        service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-
-    - name: Set up gcloud SDK
-      uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
-
-    - name: pnpm db:generate
-      env:
-        DATABASE_URL: postgresql://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
-      run: |
-        echo "--- Connecting to DB via jumpbox ---"
-        gcloud compute ssh ${{ env.JUMPBOX_INSTANCE_NAME }} \
-          --tunnel-through-iap \
-          --zone=${{ env.JUMPBOX_ZONE }} \
-          --quiet -- -N -L 5432:localhost:5432 &
-        SSH_PID=$!
-        sleep 60
-        for _ in {1..5}; do
-          pg_isready -h localhost -p 5432 -d ${{ env.DB_NAME }} && break
-          sleep 60
-        done
-
-        echo "--- Running prisma generate ---"
-        pnpm db:generate
-
-        echo "Killing SSH tunnel"
-        kill $SSH_PID
-
-    - name: pnpm gql:generate
-      run: pnpm gql:generate
-
-    - name: Install and Publish via Rover CLI
-      env:
-        APOLLO_KEY: ${{ env.APOLLO_KEY }}
-      run: |
-        curl -sSL https://rover.apollo.dev/nix/latest | sh
-        export PATH="$HOME/.rover/bin:$PATH"
-        rover graph publish civicship-api-jq1988@prod --schema ./docs/schema.graphql
-
-    - name: pnpm build
-      run: pnpm build
-
-    - name: Configure Docker for GCP Artifact Registry
-      run: |
-        gcloud auth configure-docker ${{ env.ARTIFACT_REGISTRY }}
-        gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev
-
-    - name: Build Docker image
-      run: |
-        pnpm dotenvx run -- docker build --no-cache -t ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest .
-
-    - name: Push Docker image to Artifact Registry
-      run: |
-        docker push ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest
-
-    - name: Deploy Internal API to Cloud Run
-      id: 'deploy'
-      uses: 'google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522' # v2.7.6
-      with:
-        service: ${{ env.APPLICATION_NAME }}
-        image: ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest
-        region: ${{ env.GCP_REGION }}
-        env_vars: |
-          NODE_ENV=production
-
-    - name: Build Docker image for batch job
-      run: |
-        docker build -t ${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest -f Dockerfile.batch .
-
-    - name: Push Docker image for batch job to Artifact Registry
-      run: |
-        docker push ${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest
-
-    - name: Update Cloud Run Job (batch) to new image
-      # docker push :latest alone does not roll the Cloud Run Job to the new
-      # image — Cloud Run Jobs pin the image digest at deploy time, so we
-      # need an explicit `run jobs update` to create a new revision.
-      run: |
-        gcloud run jobs update ${{ env.BATCH_NAME }} \
-          --region=${{ env.GCP_REGION }} \
-          --image=${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest
-
-    - name: Create Git tag
-      run: |
-        # Install tzdata to use Japan timezone
-        sudo apt-get update && sudo apt-get install -y tzdata
-        sudo ln -fs /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
-        sudo dpkg-reconfigure -f noninteractive tzdata
-        
-        # Generate timestamp in yyyymmddhhmmss format
-        TAG_NAME=$(date +"%Y%m%d%H%M%S")
-        
-        # Configure Git user info (required inside GitHub Actions)
-        git config user.name "github-actions"
-        git config user.email "github-actions@github.com"
-        
-        # Create and push tag
-        git tag "$TAG_NAME"
-        git push origin "$TAG_NAME"
-
-    - name: Cleanup SSH Key
-      if: always()
-      run: rm -f ~/.ssh/google_compute_engine ~/.ssh/google_compute_engine.pub
+    uses: ./.github/workflows/_deploy-cloud-run.yml
+    with:
+      service: internal
+      stage: prd
+      environment: co-creation-dao-prod
+      dockerfile: Dockerfile
+      env_vars: |
+        NODE_ENV=production
+      publish_apollo: true
+      apollo_variant: prod
+      deploy_batch: true
+      create_tag: true
+      tag_prefix: ''
+    secrets: inherit


### PR DESCRIPTION
## Summary
Consolidated duplicate deployment logic across four Cloud Run deployment workflows by extracting a reusable workflow template. This reduces code duplication and makes future maintenance easier.

## Key Changes
- **New reusable workflow** (`_deploy-cloud-run.yml`): Centralized deployment pipeline that handles both internal and external API deployments to Cloud Run, with support for optional batch job deployment and Git tagging
- **Simplified caller workflows**: Converted `deploy-to-cloud-run-{dev,prd}.yml` and `deploy-external-api-{dev,prd}.yml` to thin wrappers that call the reusable workflow with appropriate parameters
- **Improved database handling**: Replaced SSH tunnel-based database access with an ephemeral PostgreSQL service for TypedSQL generation, decoupling deployments from production database availability
- **Enhanced Docker caching**: Implemented per-(service, stage) Docker layer caching via GitHub Actions cache to speed up rebuilds
- **Parameterized configuration**: Introduced workflow inputs for service type, stage, environment, Dockerfile path, Cloud Run flags, Apollo variant, and tagging options

## Notable Implementation Details
- The reusable workflow uses an ephemeral Postgres service (same pattern as CI) for `prisma generate --sql` type introspection, eliminating dependency on jumpbox SSH tunnels
- Migrations are applied to the ephemeral database to ensure schema matches production for accurate TypedSQL generation
- Docker buildx caching uses scoped cache keys (`{service}-{stage}` and `batch-{stage}`) to allow layer reuse across branches while maintaining per-service isolation
- Git tagging is optional and configurable via `create_tag` and `tag_prefix` inputs, with timezone handling for consistent timestamp formatting
- All four deployment workflows now use `secrets: inherit` to pass secrets to the reusable workflow

https://claude.ai/code/session_018hfiFZXQaPFsm7Rtfz3EHG
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/913" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
