### PR TITLE
Fix windowMonths parameter type casting in date range query

### DIFF
--- a/src/application/domain/sysadmin/data/repository.ts
+++ b/src/application/domain/sysadmin/data/repository.ts
@@ -245,7 +245,7 @@ export default class SysAdminRepository implements ISysAdminRepository {
             DATE_TRUNC(
               'month',
               (${asOf}::timestamp AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')
-            ) - make_interval(months => ${windowMonths} - 1),
+            ) - make_interval(months => (${windowMonths})::int - 1),
             DATE_TRUNC(
               'month',
               (${asOf}::timestamp AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')


### PR DESCRIPTION
## Summary
Fixed a type casting issue in the SysAdminRepository date range calculation query to ensure the `windowMonths` parameter is explicitly cast to integer before arithmetic operations.

## Key Changes
- Added explicit `::int` type cast to `${windowMonths}` parameter in the `make_interval()` function call
- Changed from `make_interval(months => ${windowMonths} - 1)` to `make_interval(months => (${windowMonths})::int - 1)`

## Implementation Details
This change ensures that the `windowMonths` parameter is properly cast to an integer type before being used in the arithmetic subtraction operation. This prevents potential type coercion issues and makes the query more robust when the parameter is passed as a string or other numeric type from the application layer.

https://claude.ai/code/session_01VBAKjP7WXWaWQbX6Cn7ksv
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/914" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
