### PR TITLE
Refactor L1 dashboard to use raw signal counts instead of derived metrics

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -2135,21 +2135,15 @@ type SysAdminCommunityDetailPayload {
 }
 
 """
-One row of the L1 all-community table. See the module docstring for the
-distinction between `communityActivityRate` (this type) and
-`userSendRate` (SysAdminMemberRow).
+One row of the L1 all-community table. Designed for at-a-glance
+intervention judgment: each row carries the raw counts the client
+needs to derive rates, growth, alerts, sort keys, and filter
+predicates without a second round-trip.
+
+Calendar-month metrics live on the L2 detail card
+(SysAdminCommunitySummaryCard) — L1 is rolling-window only.
 """
 type SysAdminCommunityOverview {
-  """Alert flags (see SysAdminCommunityAlerts)."""
-  alerts: SysAdminCommunityAlerts!
-
-  """
-  Community activity rate for the JST calendar month containing asOf:
-  unique DONATION senders in that month / month-end total_members.
-  0.0–1.0. NOT the individual-level userSendRate.
-  """
-  communityActivityRate: Float!
-
   """Community id."""
   communityId: ID!
 
@@ -2157,42 +2151,31 @@ type SysAdminCommunityOverview {
   communityName: String!
 
   """
-  Month-over-month % change in communityActivityRate.
-  Returned as a fraction (e.g. -0.2 == -20%). null when the prior month
-  has no data to compare against.
+  Latest completed monthly cohort and its M+1 activity. See
+  SysAdminLatestCohort.
   """
-  growthRateActivity: Float
+  latestCohort: SysAdminLatestCohort!
 
   """
-  Retention rate of the most recent completed cohort (members who joined
-  in asOf's previous JST month) measured in the month after joining.
-  null when that cohort is empty.
+  Per-stage member counts (tier1 / tier2 / passive, cumulative
+  per the type doc) classified against input.segmentThresholds.
   """
-  latestCohortRetentionM1: Float
-
-  """
-  Direct member count for the "latent" stage (never donated).
-  Convenience field (== segmentCounts.passiveCount).
-  """
-  passiveCount: Int!
-
-  """Stage counts under the supplied thresholds (cumulative, see type doc)."""
   segmentCounts: SysAdminSegmentCounts!
 
   """
-  Direct member count for the "habitual" stage (userSendRate >= tier1).
-  Convenience field (== segmentCounts.tier1Count).
+  Total status='JOINED' members as of asOf. Members whose
+  created_at is after asOf are excluded from the count.
   """
-  tier1Count: Int!
-
-  """
-  Direct member count for the "regular+habitual" stage
-  (userSendRate >= tier2). Convenience field (== segmentCounts.tier2Count).
-  """
-  tier2Count: Int!
-
-  """Total status='JOINED' members at asOf."""
   totalMembers: Int!
+
+  """
+  Latest completed-week retention signals for client-side churn
+  detection. See SysAdminWeeklyRetention.
+  """
+  weeklyRetention: SysAdminWeeklyRetention!
+
+  """Rolling-window DONATION activity. See SysAdminWindowActivity."""
+  windowActivity: SysAdminWindowActivity!
 }
 
 """
@@ -2256,15 +2239,24 @@ type SysAdminCommunitySummaryCard {
 """Input for the L1 all-community overview (`sysAdminDashboard`)."""
 input SysAdminDashboardInput {
   """
-  The "as of" timestamp. All trailing-window calculations are anchored
-  here: the "latest month" is the JST calendar month containing asOf,
-  and "latest week" is the ISO-week containing asOf. Defaults to now
-  when omitted.
+  As-of timestamp anchor. All trailing-window calculations are
+  anchored here:
+    - parametric activity window: [asOf - windowDays, asOf + 1 JST日)
+    - weekly retention: latest completed ISO week before asOf
+    - latest cohort: (asOf JST月 - 2) so its M+1 window is fully past
+  Defaults to now when omitted.
   """
   asOf: Datetime
 
-  """Stage-count thresholds (see SysAdminSegmentThresholdsInput)."""
+  """Stage classification thresholds (see SysAdminSegmentThresholdsInput)."""
   segmentThresholds: SysAdminSegmentThresholdsInput
+
+  """
+  Length of the rolling activity window in JST days. Effective
+  range 7-90; values outside are silently clamped on the server.
+  Defaults to 28 (= 4 weeks, absorbs day-of-week variance).
+  """
+  windowDays: Int = 28
 }
 
 """Root payload for sysAdminDashboard (L1)."""
@@ -2277,6 +2269,34 @@ type SysAdminDashboardPayload {
 
   """Platform-wide aggregate row."""
   platform: SysAdminPlatformSummary!
+}
+
+"""
+Most recently completed monthly cohort plus its M+1 activity.
+"M+1" follows standard cohort-analysis convention: the calendar
+month immediately after the joining month.
+
+The cohort is selected as (asOf's JST month - 2 months) so its
+M+1 window — the JST month immediately preceding asOf's month —
+is fully past. This avoids reporting an artificially low retention
+during the in-progress month.
+
+Raw counts are returned; the client divides for the retention rate
+and decides how to handle small-N cohorts via `size`.
+"""
+type SysAdminLatestCohort {
+  """
+  Of those cohort members, how many sent at least one DONATION
+  during the M+1 month.
+  """
+  activeAtM1: Int!
+
+  """
+  Cohort size: status='JOINED' members whose created_at falls
+  within the cohort month. 0 when no one joined that month
+  (callers should treat M+1 retention as null in that case).
+  """
+  size: Int!
 }
 
 """Paginated member list for the L2 detail."""
@@ -2555,6 +2575,55 @@ enum SysAdminUserSortField {
 
   """totalPointsOut (lifetime DONATION points sent)."""
   TOTAL_POINTS_OUT
+}
+
+"""
+DONATION sender retention against the most recently completed
+ISO week (Monday 00:00 JST). Raw signals only; the client composes
+churn alerts (e.g. churnedSenders > retainedSenders).
+"""
+type SysAdminWeeklyRetention {
+  """
+  Users who sent DONATION in the week-before-latest but NOT in
+  the latest completed week. "Lost this week, was engaged last week."
+  """
+  churnedSenders: Int!
+
+  """
+  Users who sent DONATION in the latest completed week AND in
+  the week before it. "Engaged this week, was engaged last week."
+  """
+  retainedSenders: Int!
+}
+
+"""
+DONATION activity within the parametric window driven by
+`SysAdminDashboardInput.windowDays`. Both the current window and
+the immediately preceding window of equal length are returned so
+the client can derive growth rates without a second query.
+
+  current  = [asOf - windowDays JST日, asOf + 1 JST日)
+  previous = [asOf - 2 * windowDays, asOf - windowDays)
+"""
+type SysAdminWindowActivity {
+  """
+  New JOINED memberships (t_memberships.created_at within the
+  current window, status='JOINED').
+  """
+  newMemberCount: Int!
+
+  """Same metric for the previous window."""
+  newMemberCountPrev: Int!
+
+  """
+  Unique users with at least one outgoing DONATION transaction
+  during the current window (donation_out_count > 0 in
+  mv_user_transaction_daily).
+  """
+  senderCount: Int!
+
+  """Same metric for the previous window of equal length."""
+  senderCountPrev: Int!
 }
 
 enum SysRole {

--- a/src/__tests__/unit/sysadmin/presenter.test.ts
+++ b/src/__tests__/unit/sysadmin/presenter.test.ts
@@ -7,7 +7,6 @@ import type {
   SysAdminPlatformTotalsRow,
 } from "@/application/domain/sysadmin/data/type";
 import type {
-  AlertFlags,
   MemberListResult,
   MonthlyCohortPoint,
   StageBreakdown,
@@ -271,8 +270,8 @@ describe("SysAdminPresenter", () => {
     });
   });
 
-  describe("overviewRow — cumulative count passthrough", () => {
-    it("copies tier1/tier2/passive counts to BOTH segmentCounts and top-level convenience fields", () => {
+  describe("overviewRow — nested raw signal passthrough", () => {
+    it("forwards stage / window / weekly retention / latest cohort counts unchanged", () => {
       const counts: StageCounts = {
         total: 10,
         tier1Count: 2,
@@ -280,28 +279,40 @@ describe("SysAdminPresenter", () => {
         activeCount: 7,
         passiveCount: 3,
       };
-      const alerts: AlertFlags = {
-        churnSpike: false,
-        activeDrop: true,
-        noNewMembers: false,
-      };
       const out = SysAdminPresenter.overviewRow({
         communityId: "c1",
         communityName: "C",
         totalMembers: 10,
         stageCounts: counts,
-        communityActivityRate: 0.3,
-        growthRateActivity: -0.25,
-        latestCohortRetentionM1: 0.5,
-        alerts,
+        windowActivity: {
+          senderCount: 4,
+          senderCountPrev: 6,
+          newMemberCount: 1,
+          newMemberCountPrev: 2,
+        },
+        weeklyRetention: {
+          retainedSenders: 3,
+          churnedSenders: 5,
+        },
+        latestCohort: {
+          size: 8,
+          activeAtM1: 4,
+        },
       });
-      expect(out.tier1Count).toBe(2);
       expect(out.segmentCounts.tier1Count).toBe(2);
-      expect(out.tier2Count).toBe(5);
       expect(out.segmentCounts.tier2Count).toBe(5);
-      expect(out.passiveCount).toBe(3);
       expect(out.segmentCounts.passiveCount).toBe(3);
-      expect(out.alerts.activeDrop).toBe(true);
+      expect(out.windowActivity).toEqual({
+        senderCount: 4,
+        senderCountPrev: 6,
+        newMemberCount: 1,
+        newMemberCountPrev: 2,
+      });
+      expect(out.weeklyRetention).toEqual({
+        retainedSenders: 3,
+        churnedSenders: 5,
+      });
+      expect(out.latestCohort).toEqual({ size: 8, activeAtM1: 4 });
     });
   });
 });

--- a/src/application/domain/sysadmin/presenter.ts
+++ b/src/application/domain/sysadmin/presenter.ts
@@ -6,6 +6,7 @@ import {
   GqlSysAdminCommunityOverview,
   GqlSysAdminCommunitySummaryCard,
   GqlSysAdminDashboardPayload,
+  GqlSysAdminLatestCohort,
   GqlSysAdminMemberList,
   GqlSysAdminMemberRow,
   GqlSysAdminMonthlyActivityPoint,
@@ -14,6 +15,8 @@ import {
   GqlSysAdminSegmentCounts,
   GqlSysAdminStageBucket,
   GqlSysAdminStageDistribution,
+  GqlSysAdminWeeklyRetention,
+  GqlSysAdminWindowActivity,
 } from "@/types/graphql";
 import {
   SysAdminAllTimeTotalsRow,
@@ -23,12 +26,15 @@ import {
 } from "@/application/domain/sysadmin/data/type";
 import {
   AlertFlags,
+  LatestCohortCounts,
   MemberListResult,
   MonthlyCohortPoint,
   StageBreakdown,
   StageBucketStats,
   StageCounts,
+  WeeklyRetentionCounts,
   WeeklyRetentionPoint,
+  WindowActivityCounts,
 } from "@/application/domain/sysadmin/service";
 
 /**
@@ -65,28 +71,46 @@ export default class SysAdminPresenter {
     };
   }
 
+  static windowActivity(counts: WindowActivityCounts): GqlSysAdminWindowActivity {
+    return {
+      senderCount: counts.senderCount,
+      senderCountPrev: counts.senderCountPrev,
+      newMemberCount: counts.newMemberCount,
+      newMemberCountPrev: counts.newMemberCountPrev,
+    };
+  }
+
+  static weeklyRetention(counts: WeeklyRetentionCounts): GqlSysAdminWeeklyRetention {
+    return {
+      retainedSenders: counts.retainedSenders,
+      churnedSenders: counts.churnedSenders,
+    };
+  }
+
+  static latestCohort(counts: LatestCohortCounts): GqlSysAdminLatestCohort {
+    return {
+      size: counts.size,
+      activeAtM1: counts.activeAtM1,
+    };
+  }
+
   static overviewRow(params: {
     communityId: string;
     communityName: string;
     totalMembers: number;
     stageCounts: StageCounts;
-    communityActivityRate: number;
-    growthRateActivity: number | null;
-    latestCohortRetentionM1: number | null;
-    alerts: AlertFlags;
+    windowActivity: WindowActivityCounts;
+    weeklyRetention: WeeklyRetentionCounts;
+    latestCohort: LatestCohortCounts;
   }): GqlSysAdminCommunityOverview {
     return {
       communityId: params.communityId,
       communityName: params.communityName,
       totalMembers: params.totalMembers,
       segmentCounts: SysAdminPresenter.segmentCounts(params.stageCounts),
-      tier1Count: params.stageCounts.tier1Count,
-      tier2Count: params.stageCounts.tier2Count,
-      passiveCount: params.stageCounts.passiveCount,
-      communityActivityRate: params.communityActivityRate,
-      growthRateActivity: params.growthRateActivity,
-      latestCohortRetentionM1: params.latestCohortRetentionM1,
-      alerts: SysAdminPresenter.alerts(params.alerts),
+      windowActivity: SysAdminPresenter.windowActivity(params.windowActivity),
+      weeklyRetention: SysAdminPresenter.weeklyRetention(params.weeklyRetention),
+      latestCohort: SysAdminPresenter.latestCohort(params.latestCohort),
     };
   }
 

--- a/src/application/domain/sysadmin/schema/type.graphql
+++ b/src/application/domain/sysadmin/schema/type.graphql
@@ -45,15 +45,24 @@ Input for the L1 all-community overview (`sysAdminDashboard`).
 """
 input SysAdminDashboardInput {
   """
-  The "as of" timestamp. All trailing-window calculations are anchored
-  here: the "latest month" is the JST calendar month containing asOf,
-  and "latest week" is the ISO-week containing asOf. Defaults to now
-  when omitted.
+  As-of timestamp anchor. All trailing-window calculations are
+  anchored here:
+    - parametric activity window: [asOf - windowDays, asOf + 1 JST日)
+    - weekly retention: latest completed ISO week before asOf
+    - latest cohort: (asOf JST月 - 2) so its M+1 window is fully past
+  Defaults to now when omitted.
   """
   asOf: Datetime
 
   """
-  Stage-count thresholds (see SysAdminSegmentThresholdsInput).
+  Length of the rolling activity window in JST days. Effective
+  range 7-90; values outside are silently clamped on the server.
+  Defaults to 28 (= 4 weeks, absorbs day-of-week variance).
+  """
+  windowDays: Int = 28
+
+  """
+  Stage classification thresholds (see SysAdminSegmentThresholdsInput).
   """
   segmentThresholds: SysAdminSegmentThresholdsInput
 }
@@ -258,71 +267,134 @@ type SysAdminPlatformSummary {
 }
 
 """
-One row of the L1 all-community table. See the module docstring for the
-distinction between `communityActivityRate` (this type) and
-`userSendRate` (SysAdminMemberRow).
+DONATION activity within the parametric window driven by
+`SysAdminDashboardInput.windowDays`. Both the current window and
+the immediately preceding window of equal length are returned so
+the client can derive growth rates without a second query.
+
+  current  = [asOf - windowDays JST日, asOf + 1 JST日)
+  previous = [asOf - 2 * windowDays, asOf - windowDays)
+"""
+type SysAdminWindowActivity {
+  """
+  Unique users with at least one outgoing DONATION transaction
+  during the current window (donation_out_count > 0 in
+  mv_user_transaction_daily).
+  """
+  senderCount: Int!
+
+  """
+  Same metric for the previous window of equal length.
+  """
+  senderCountPrev: Int!
+
+  """
+  New JOINED memberships (t_memberships.created_at within the
+  current window, status='JOINED').
+  """
+  newMemberCount: Int!
+
+  """
+  Same metric for the previous window.
+  """
+  newMemberCountPrev: Int!
+}
+
+"""
+DONATION sender retention against the most recently completed
+ISO week (Monday 00:00 JST). Raw signals only; the client composes
+churn alerts (e.g. churnedSenders > retainedSenders).
+"""
+type SysAdminWeeklyRetention {
+  """
+  Users who sent DONATION in the latest completed week AND in
+  the week before it. "Engaged this week, was engaged last week."
+  """
+  retainedSenders: Int!
+
+  """
+  Users who sent DONATION in the week-before-latest but NOT in
+  the latest completed week. "Lost this week, was engaged last week."
+  """
+  churnedSenders: Int!
+}
+
+"""
+Most recently completed monthly cohort plus its M+1 activity.
+"M+1" follows standard cohort-analysis convention: the calendar
+month immediately after the joining month.
+
+The cohort is selected as (asOf's JST month - 2 months) so its
+M+1 window — the JST month immediately preceding asOf's month —
+is fully past. This avoids reporting an artificially low retention
+during the in-progress month.
+
+Raw counts are returned; the client divides for the retention rate
+and decides how to handle small-N cohorts via `size`.
+"""
+type SysAdminLatestCohort {
+  """
+  Cohort size: status='JOINED' members whose created_at falls
+  within the cohort month. 0 when no one joined that month
+  (callers should treat M+1 retention as null in that case).
+  """
+  size: Int!
+
+  """
+  Of those cohort members, how many sent at least one DONATION
+  during the M+1 month.
+  """
+  activeAtM1: Int!
+}
+
+"""
+One row of the L1 all-community table. Designed for at-a-glance
+intervention judgment: each row carries the raw counts the client
+needs to derive rates, growth, alerts, sort keys, and filter
+predicates without a second round-trip.
+
+Calendar-month metrics live on the L2 detail card
+(SysAdminCommunitySummaryCard) — L1 is rolling-window only.
 """
 type SysAdminCommunityOverview {
   """
   Community id.
   """
   communityId: ID!
+
   """
   Community display name (t_communities.name).
   """
   communityName: String!
 
   """
-  Total status='JOINED' members at asOf.
+  Total status='JOINED' members as of asOf. Members whose
+  created_at is after asOf are excluded from the count.
   """
   totalMembers: Int!
 
   """
-  Stage counts under the supplied thresholds (cumulative, see type doc).
+  Per-stage member counts (tier1 / tier2 / passive, cumulative
+  per the type doc) classified against input.segmentThresholds.
   """
   segmentCounts: SysAdminSegmentCounts!
 
   """
-  Direct member count for the "habitual" stage (userSendRate >= tier1).
-  Convenience field (== segmentCounts.tier1Count).
+  Rolling-window DONATION activity. See SysAdminWindowActivity.
   """
-  tier1Count: Int!
-  """
-  Direct member count for the "regular+habitual" stage
-  (userSendRate >= tier2). Convenience field (== segmentCounts.tier2Count).
-  """
-  tier2Count: Int!
-  """
-  Direct member count for the "latent" stage (never donated).
-  Convenience field (== segmentCounts.passiveCount).
-  """
-  passiveCount: Int!
+  windowActivity: SysAdminWindowActivity!
 
   """
-  Community activity rate for the JST calendar month containing asOf:
-  unique DONATION senders in that month / month-end total_members.
-  0.0–1.0. NOT the individual-level userSendRate.
+  Latest completed-week retention signals for client-side churn
+  detection. See SysAdminWeeklyRetention.
   """
-  communityActivityRate: Float!
+  weeklyRetention: SysAdminWeeklyRetention!
 
   """
-  Month-over-month % change in communityActivityRate.
-  Returned as a fraction (e.g. -0.2 == -20%). null when the prior month
-  has no data to compare against.
+  Latest completed monthly cohort and its M+1 activity. See
+  SysAdminLatestCohort.
   """
-  growthRateActivity: Float
-
-  """
-  Retention rate of the most recent completed cohort (members who joined
-  in asOf's previous JST month) measured in the month after joining.
-  null when that cohort is empty.
-  """
-  latestCohortRetentionM1: Float
-
-  """
-  Alert flags (see SysAdminCommunityAlerts).
-  """
-  alerts: SysAdminCommunityAlerts!
+  latestCohort: SysAdminLatestCohort!
 }
 
 """

--- a/src/application/domain/sysadmin/service.ts
+++ b/src/application/domain/sysadmin/service.ts
@@ -119,6 +119,42 @@ export type MonthActivityWithPrev = {
   growthRateActivity: number | null;
 };
 
+/**
+ * Raw activity counts for the parametric window driven by
+ * `windowDays`. The L1 overview returns these as-is so the client
+ * derives rates / growth rates / threshold alerts on its own (see
+ * SysAdminWindowActivity in schema/type.graphql).
+ */
+export type WindowActivityCounts = {
+  senderCount: number;
+  senderCountPrev: number;
+  newMemberCount: number;
+  newMemberCountPrev: number;
+};
+
+/**
+ * Raw weekly retention counts against the most recent COMPLETED ISO
+ * week. Exposing both halves lets the client compose churn alerts
+ * (e.g. churnedSenders > retainedSenders) without a server-side
+ * threshold judgement.
+ */
+export type WeeklyRetentionCounts = {
+  retainedSenders: number;
+  churnedSenders: number;
+};
+
+/**
+ * Raw counts for the most recently completed monthly cohort and its
+ * M+1 activity. Cohort = (asOf JST月 - 2). Returning the count pair
+ * (size, activeAtM1) instead of the pre-divided ratio lets the client
+ * decide how to handle small-N cohorts (e.g. greying out values when
+ * `size` is below a confidence threshold).
+ */
+export type LatestCohortCounts = {
+  size: number;
+  activeAtM1: number;
+};
+
 export const DEFAULT_WINDOW_MONTHS = 10;
 /**
  * Upper bound on `windowMonths`. Defensive guard against a caller
@@ -132,6 +168,16 @@ export const MAX_WINDOW_MONTHS = 36;
 export const MAX_LIMIT = 200;
 export const ACTIVE_DROP_THRESHOLD = -0.2; // month-over-month fraction
 export const NO_NEW_MEMBERS_WINDOW_DAYS = 14;
+
+/**
+ * Bounds for the L1 overview's parametric activity window. The lower
+ * bound (7) keeps the previous-window comparison meaningful; the upper
+ * bound (90) caps the per-community DB scan even on a malformed input
+ * value. Both are silent clamps applied at the usecase boundary.
+ */
+export const DEFAULT_WINDOW_DAYS = 28;
+export const MIN_WINDOW_DAYS = 7;
+export const MAX_WINDOW_DAYS = 90;
 
 /**
  * Cap on how many DB round-trips the retention-trend and cohort-
@@ -640,34 +686,104 @@ export default class SysAdminService {
   }
 
   /**
-   * Most recent COMPLETED m1 retention: the fraction of members who
-   * joined two JST months before asOf and sent a DONATION during the
-   * month-after-that (= the month just before asOf's month).
+   * Rolling-window DONATION activity for the L1 overview. Returns the
+   * raw sender / new-member counts for both the current window and the
+   * immediately preceding window of equal length. The client divides
+   * by `totalMembers` for rates and computes growth as
+   * `(currRate - prevRate) / prevRate` with a null guard.
    *
-   * Shifted back from "prev-month cohort, asOf-month active" so the
-   * active window is always a fully completed month — matches the L2
-   * cohort-retention convention (README §3.4: "進行中の月は除外") and
-   * avoids reporting artificially low numbers on the 1st of every
-   * month. Returns null when the cohort is empty.
+   *   current  = [asOf - windowDays JST日, asOf + 1 JST日)
+   *   previous = [asOf - 2 * windowDays, asOf - windowDays)
+   *
+   * Both windows reuse `findActivitySnapshot` / `findNewMemberCount`,
+   * so no new SQL is introduced — only the date arguments change.
    */
-  async getLatestCohortRetentionM1(
+  async getWindowActivity(
     ctx: IContext,
     communityId: string,
     asOf: Date,
-  ): Promise<number | null> {
+    windowDays: number,
+  ): Promise<WindowActivityCounts> {
+    const upper = asOfBounds(asOf).asOfJstDayPlusOne;
+    const currLower = addDays(upper, -windowDays);
+    const prevLower = addDays(upper, -windowDays * 2);
+
+    const [curr, prev, currNew, prevNew] = await Promise.all([
+      this.repository.findActivitySnapshot(ctx, communityId, currLower, upper),
+      this.repository.findActivitySnapshot(ctx, communityId, prevLower, currLower),
+      this.repository.findNewMemberCount(ctx, communityId, currLower, upper),
+      this.repository.findNewMemberCount(ctx, communityId, prevLower, currLower),
+    ]);
+
+    return {
+      senderCount: curr.senderCount,
+      senderCountPrev: prev.senderCount,
+      newMemberCount: currNew.count,
+      newMemberCountPrev: prevNew.count,
+    };
+  }
+
+  /**
+   * DONATION sender retention against the most recently completed ISO
+   * week. The asOf-containing week is in progress, so the "latest
+   * completed" week is the one starting `latestWeekStart - 7d`. The
+   * existing `getRetentionAggregate` already returns these counts —
+   * we just pass through the raw integers instead of reducing them to
+   * a boolean alert flag, leaving the threshold judgement to the client.
+   */
+  async getWeeklyRetention(
+    ctx: IContext,
+    communityId: string,
+    asOf: Date,
+  ): Promise<WeeklyRetentionCounts> {
+    const latestWeekStart = isoWeekStartJst(asOf);
+    const prevWeekStart = addDays(latestWeekStart, -7);
+    const prevPrevWeekStart = addDays(prevWeekStart, -7);
+    const twelveWeeksAgo = addDays(prevWeekStart, -7 * 12);
+
+    const retention = await this.reportService.getRetentionAggregate(ctx, communityId, {
+      currentWeekStart: prevWeekStart,
+      nextWeekStart: latestWeekStart,
+      prevWeekStart: prevPrevWeekStart,
+      twelveWeeksAgo,
+    });
+
+    return {
+      retainedSenders: retention.retainedSenders,
+      churnedSenders: retention.churnedSenders,
+    };
+  }
+
+  /**
+   * Most recently completed monthly cohort + its M+1 activity, as raw
+   * counts. The cohort is selected as (asOf JST月 - 2) so the M+1
+   * window — which is (asOf JST月 - 1) — is fully past; this matches
+   * the L2 cohort-retention convention (README §3.4 "進行中の月は除外").
+   *
+   * Returning {size, activeAtM1} instead of a pre-divided Float lets
+   * the client treat empty cohorts (size === 0) as null retention and
+   * grey out small-N cohorts via its own confidence threshold.
+   */
+  async getLatestCohort(
+    ctx: IContext,
+    communityId: string,
+    asOf: Date,
+  ): Promise<LatestCohortCounts> {
     const monthStart = jstMonthStart(asOf);
-    const cohortStart = jstMonthStartOffset(monthStart, -2); // 2 months before asOf
-    const cohortEnd = jstMonthStartOffset(monthStart, -1); // 1 month before asOf
+    const cohortStart = jstMonthStartOffset(monthStart, -2);
+    const cohortEnd = jstMonthStartOffset(monthStart, -1);
     const activeStart = cohortEnd;
-    const activeEnd = monthStart; // last completed month's end
+    const activeEnd = monthStart;
     const row = await this.reportService.getCohortRetention(
       ctx,
       communityId,
       { cohortStart, cohortEnd },
       { activeStart, activeEnd },
     );
-    if (row.cohortSize === 0) return null;
-    return row.activeNextWeek / row.cohortSize;
+    return {
+      size: row.cohortSize,
+      activeAtM1: row.activeNextWeek,
+    };
   }
 
   /**

--- a/src/application/domain/sysadmin/usecase.ts
+++ b/src/application/domain/sysadmin/usecase.ts
@@ -81,8 +81,9 @@ export default class SysAdminUseCase {
     // Sorting moved to the client. The L1 payload no longer carries
     // a single canonical "rate" the server can sort on, and the
     // browser's filter()/sort() over <100 rows is sub-millisecond.
-    // Rows are returned in repository order (community id) for
-    // deterministic display before the client applies its own sort.
+    // Rows are returned in `findAllCommunities` order (community
+    // name ASC, see SysAdminRepository) so the response is
+    // deterministic before the client applies its own sort.
 
     return SysAdminPresenter.dashboard({
       asOf,

--- a/src/application/domain/sysadmin/usecase.ts
+++ b/src/application/domain/sysadmin/usecase.ts
@@ -10,9 +10,12 @@ import {
 } from "@/types/graphql";
 import SysAdminService, {
   DEFAULT_SEGMENT_THRESHOLDS,
+  DEFAULT_WINDOW_DAYS,
   DEFAULT_WINDOW_MONTHS,
   MAX_LIMIT,
+  MAX_WINDOW_DAYS,
   MAX_WINDOW_MONTHS,
+  MIN_WINDOW_DAYS,
   SegmentThresholds,
 } from "@/application/domain/sysadmin/service";
 import SysAdminPresenter from "@/application/domain/sysadmin/presenter";
@@ -39,6 +42,7 @@ export default class SysAdminUseCase {
   ): Promise<GqlSysAdminDashboardPayload> {
     const asOf = input?.asOf ?? new Date();
     const thresholds = resolveThresholds(input?.segmentThresholds);
+    const windowDays = clampWindowDays(input?.windowDays);
 
     const monthStart = jstMonthStart(asOf);
     // Clamp the platform-totals upper bound at asOf+1 JST day so a
@@ -55,31 +59,30 @@ export default class SysAdminUseCase {
 
     const rows = await Promise.all(
       communities.map(async (c): Promise<GqlSysAdminCommunityOverview> => {
-        const [members, currentMonthActivity, latestCohortRetentionM1] = await Promise.all([
+        const [members, windowActivity, weeklyRetention, latestCohort] = await Promise.all([
           this.service.getMemberStats(ctx, c.communityId, asOf),
-          this.service.getMonthActivityWithPrev(ctx, c.communityId, asOf),
-          this.service.getLatestCohortRetentionM1(ctx, c.communityId, asOf),
+          this.service.getWindowActivity(ctx, c.communityId, asOf, windowDays),
+          this.service.getWeeklyRetention(ctx, c.communityId, asOf),
+          this.service.getLatestCohort(ctx, c.communityId, asOf),
         ]);
         const stageCounts = this.service.computeStageCounts(members, thresholds);
-        const alerts = await this.service.getAlerts(ctx, c.communityId, asOf);
         return SysAdminPresenter.overviewRow({
           communityId: c.communityId,
           communityName: c.communityName,
           totalMembers: stageCounts.total,
           stageCounts,
-          communityActivityRate: currentMonthActivity.currentRate,
-          growthRateActivity: currentMonthActivity.growthRateActivity,
-          latestCohortRetentionM1,
-          alerts,
+          windowActivity,
+          weeklyRetention,
+          latestCohort,
         });
       }),
     );
 
-    // Sort by latest-month communityActivityRate descending — matches
-    // the "ソート: 直近月の community_activity_rate 降順（デフォルト）"
-    // behaviour in the requirement doc. Clients can still re-sort in
-    // the browser since the payload is small.
-    rows.sort((a, b) => b.communityActivityRate - a.communityActivityRate);
+    // Sorting moved to the client. The L1 payload no longer carries
+    // a single canonical "rate" the server can sort on, and the
+    // browser's filter()/sort() over <100 rows is sub-millisecond.
+    // Rows are returned in repository order (community id) for
+    // deterministic display before the client applies its own sort.
 
     return SysAdminPresenter.dashboard({
       asOf,
@@ -199,4 +202,16 @@ function resolveThresholds(
 function clampLimit(limit: number | null | undefined): number {
   const n = limit ?? 50;
   return Math.min(Math.max(n, 1), MAX_LIMIT);
+}
+
+/**
+ * L1 dashboard activity-window length, in JST days. Defaults to 28
+ * (= 4 weeks) when omitted, and is silently clamped to
+ * [MIN_WINDOW_DAYS, MAX_WINDOW_DAYS] so a malformed/hostile input can't
+ * fan the per-community DB scan out to year-long ranges. Documented in
+ * the SysAdminDashboardInput.windowDays SDL description.
+ */
+function clampWindowDays(input: number | null | undefined): number {
+  const n = input ?? DEFAULT_WINDOW_DAYS;
+  return Math.min(Math.max(n, MIN_WINDOW_DAYS), MAX_WINDOW_DAYS);
 }

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -3087,55 +3087,42 @@ export type GqlSysAdminCommunityDetailPayload = {
 };
 
 /**
- * One row of the L1 all-community table. See the module docstring for the
- * distinction between `communityActivityRate` (this type) and
- * `userSendRate` (SysAdminMemberRow).
+ * One row of the L1 all-community table. Designed for at-a-glance
+ * intervention judgment: each row carries the raw counts the client
+ * needs to derive rates, growth, alerts, sort keys, and filter
+ * predicates without a second round-trip.
+ *
+ * Calendar-month metrics live on the L2 detail card
+ * (SysAdminCommunitySummaryCard) — L1 is rolling-window only.
  */
 export type GqlSysAdminCommunityOverview = {
   __typename?: 'SysAdminCommunityOverview';
-  /** Alert flags (see SysAdminCommunityAlerts). */
-  alerts: GqlSysAdminCommunityAlerts;
-  /**
-   * Community activity rate for the JST calendar month containing asOf:
-   * unique DONATION senders in that month / month-end total_members.
-   * 0.0–1.0. NOT the individual-level userSendRate.
-   */
-  communityActivityRate: Scalars['Float']['output'];
   /** Community id. */
   communityId: Scalars['ID']['output'];
   /** Community display name (t_communities.name). */
   communityName: Scalars['String']['output'];
   /**
-   * Month-over-month % change in communityActivityRate.
-   * Returned as a fraction (e.g. -0.2 == -20%). null when the prior month
-   * has no data to compare against.
+   * Latest completed monthly cohort and its M+1 activity. See
+   * SysAdminLatestCohort.
    */
-  growthRateActivity?: Maybe<Scalars['Float']['output']>;
+  latestCohort: GqlSysAdminLatestCohort;
   /**
-   * Retention rate of the most recent completed cohort (members who joined
-   * in asOf's previous JST month) measured in the month after joining.
-   * null when that cohort is empty.
+   * Per-stage member counts (tier1 / tier2 / passive, cumulative
+   * per the type doc) classified against input.segmentThresholds.
    */
-  latestCohortRetentionM1?: Maybe<Scalars['Float']['output']>;
-  /**
-   * Direct member count for the "latent" stage (never donated).
-   * Convenience field (== segmentCounts.passiveCount).
-   */
-  passiveCount: Scalars['Int']['output'];
-  /** Stage counts under the supplied thresholds (cumulative, see type doc). */
   segmentCounts: GqlSysAdminSegmentCounts;
   /**
-   * Direct member count for the "habitual" stage (userSendRate >= tier1).
-   * Convenience field (== segmentCounts.tier1Count).
+   * Total status='JOINED' members as of asOf. Members whose
+   * created_at is after asOf are excluded from the count.
    */
-  tier1Count: Scalars['Int']['output'];
-  /**
-   * Direct member count for the "regular+habitual" stage
-   * (userSendRate >= tier2). Convenience field (== segmentCounts.tier2Count).
-   */
-  tier2Count: Scalars['Int']['output'];
-  /** Total status='JOINED' members at asOf. */
   totalMembers: Scalars['Int']['output'];
+  /**
+   * Latest completed-week retention signals for client-side churn
+   * detection. See SysAdminWeeklyRetention.
+   */
+  weeklyRetention: GqlSysAdminWeeklyRetention;
+  /** Rolling-window DONATION activity. See SysAdminWindowActivity. */
+  windowActivity: GqlSysAdminWindowActivity;
 };
 
 /**
@@ -3189,14 +3176,22 @@ export type GqlSysAdminCommunitySummaryCard = {
 /** Input for the L1 all-community overview (`sysAdminDashboard`). */
 export type GqlSysAdminDashboardInput = {
   /**
-   * The "as of" timestamp. All trailing-window calculations are anchored
-   * here: the "latest month" is the JST calendar month containing asOf,
-   * and "latest week" is the ISO-week containing asOf. Defaults to now
-   * when omitted.
+   * As-of timestamp anchor. All trailing-window calculations are
+   * anchored here:
+   *   - parametric activity window: [asOf - windowDays, asOf + 1 JST日)
+   *   - weekly retention: latest completed ISO week before asOf
+   *   - latest cohort: (asOf JST月 - 2) so its M+1 window is fully past
+   * Defaults to now when omitted.
    */
   asOf?: InputMaybe<Scalars['Datetime']['input']>;
-  /** Stage-count thresholds (see SysAdminSegmentThresholdsInput). */
+  /** Stage classification thresholds (see SysAdminSegmentThresholdsInput). */
   segmentThresholds?: InputMaybe<GqlSysAdminSegmentThresholdsInput>;
+  /**
+   * Length of the rolling activity window in JST days. Effective
+   * range 7-90; values outside are silently clamped on the server.
+   * Defaults to 28 (= 4 weeks, absorbs day-of-week variance).
+   */
+  windowDays?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** Root payload for sysAdminDashboard (L1). */
@@ -3208,6 +3203,34 @@ export type GqlSysAdminDashboardPayload = {
   communities: Array<GqlSysAdminCommunityOverview>;
   /** Platform-wide aggregate row. */
   platform: GqlSysAdminPlatformSummary;
+};
+
+/**
+ * Most recently completed monthly cohort plus its M+1 activity.
+ * "M+1" follows standard cohort-analysis convention: the calendar
+ * month immediately after the joining month.
+ *
+ * The cohort is selected as (asOf's JST month - 2 months) so its
+ * M+1 window — the JST month immediately preceding asOf's month —
+ * is fully past. This avoids reporting an artificially low retention
+ * during the in-progress month.
+ *
+ * Raw counts are returned; the client divides for the retention rate
+ * and decides how to handle small-N cohorts via `size`.
+ */
+export type GqlSysAdminLatestCohort = {
+  __typename?: 'SysAdminLatestCohort';
+  /**
+   * Of those cohort members, how many sent at least one DONATION
+   * during the M+1 month.
+   */
+  activeAtM1: Scalars['Int']['output'];
+  /**
+   * Cohort size: status='JOINED' members whose created_at falls
+   * within the cohort month. 0 when no one joined that month
+   * (callers should treat M+1 retention as null in that case).
+   */
+  size: Scalars['Int']['output'];
 };
 
 /** Paginated member list for the L2 detail. */
@@ -3459,6 +3482,53 @@ export const GqlSysAdminUserSortField = {
 } as const;
 
 export type GqlSysAdminUserSortField = typeof GqlSysAdminUserSortField[keyof typeof GqlSysAdminUserSortField];
+/**
+ * DONATION sender retention against the most recently completed
+ * ISO week (Monday 00:00 JST). Raw signals only; the client composes
+ * churn alerts (e.g. churnedSenders > retainedSenders).
+ */
+export type GqlSysAdminWeeklyRetention = {
+  __typename?: 'SysAdminWeeklyRetention';
+  /**
+   * Users who sent DONATION in the week-before-latest but NOT in
+   * the latest completed week. "Lost this week, was engaged last week."
+   */
+  churnedSenders: Scalars['Int']['output'];
+  /**
+   * Users who sent DONATION in the latest completed week AND in
+   * the week before it. "Engaged this week, was engaged last week."
+   */
+  retainedSenders: Scalars['Int']['output'];
+};
+
+/**
+ * DONATION activity within the parametric window driven by
+ * `SysAdminDashboardInput.windowDays`. Both the current window and
+ * the immediately preceding window of equal length are returned so
+ * the client can derive growth rates without a second query.
+ *
+ *   current  = [asOf - windowDays JST日, asOf + 1 JST日)
+ *   previous = [asOf - 2 * windowDays, asOf - windowDays)
+ */
+export type GqlSysAdminWindowActivity = {
+  __typename?: 'SysAdminWindowActivity';
+  /**
+   * New JOINED memberships (t_memberships.created_at within the
+   * current window, status='JOINED').
+   */
+  newMemberCount: Scalars['Int']['output'];
+  /** Same metric for the previous window. */
+  newMemberCountPrev: Scalars['Int']['output'];
+  /**
+   * Unique users with at least one outgoing DONATION transaction
+   * during the current window (donation_out_count > 0 in
+   * mv_user_transaction_daily).
+   */
+  senderCount: Scalars['Int']['output'];
+  /** Same metric for the previous window of equal length. */
+  senderCountPrev: Scalars['Int']['output'];
+};
+
 export const GqlSysRole = {
   SysAdmin: 'SYS_ADMIN',
   User: 'USER'
@@ -4886,6 +4956,7 @@ export type GqlResolversTypes = ResolversObject<{
   SysAdminCommunitySummaryCard: ResolverTypeWrapper<GqlSysAdminCommunitySummaryCard>;
   SysAdminDashboardInput: GqlSysAdminDashboardInput;
   SysAdminDashboardPayload: ResolverTypeWrapper<GqlSysAdminDashboardPayload>;
+  SysAdminLatestCohort: ResolverTypeWrapper<GqlSysAdminLatestCohort>;
   SysAdminMemberList: ResolverTypeWrapper<GqlSysAdminMemberList>;
   SysAdminMemberRow: ResolverTypeWrapper<GqlSysAdminMemberRow>;
   SysAdminMonthlyActivityPoint: ResolverTypeWrapper<GqlSysAdminMonthlyActivityPoint>;
@@ -4899,6 +4970,8 @@ export type GqlResolversTypes = ResolversObject<{
   SysAdminUserListFilter: GqlSysAdminUserListFilter;
   SysAdminUserListSort: GqlSysAdminUserListSort;
   SysAdminUserSortField: GqlSysAdminUserSortField;
+  SysAdminWeeklyRetention: ResolverTypeWrapper<GqlSysAdminWeeklyRetention>;
+  SysAdminWindowActivity: ResolverTypeWrapper<GqlSysAdminWindowActivity>;
   SysRole: GqlSysRole;
   Ticket: ResolverTypeWrapper<Ticket>;
   TicketClaimInput: GqlTicketClaimInput;
@@ -5288,6 +5361,7 @@ export type GqlResolversParentTypes = ResolversObject<{
   SysAdminCommunitySummaryCard: GqlSysAdminCommunitySummaryCard;
   SysAdminDashboardInput: GqlSysAdminDashboardInput;
   SysAdminDashboardPayload: GqlSysAdminDashboardPayload;
+  SysAdminLatestCohort: GqlSysAdminLatestCohort;
   SysAdminMemberList: GqlSysAdminMemberList;
   SysAdminMemberRow: GqlSysAdminMemberRow;
   SysAdminMonthlyActivityPoint: GqlSysAdminMonthlyActivityPoint;
@@ -5299,6 +5373,8 @@ export type GqlResolversParentTypes = ResolversObject<{
   SysAdminStageDistribution: GqlSysAdminStageDistribution;
   SysAdminUserListFilter: GqlSysAdminUserListFilter;
   SysAdminUserListSort: GqlSysAdminUserListSort;
+  SysAdminWeeklyRetention: GqlSysAdminWeeklyRetention;
+  SysAdminWindowActivity: GqlSysAdminWindowActivity;
   Ticket: Ticket;
   TicketClaimInput: GqlTicketClaimInput;
   TicketClaimLink: TicketClaimLink;
@@ -6712,17 +6788,13 @@ export type GqlSysAdminCommunityDetailPayloadResolvers<ContextType = any, Parent
 }>;
 
 export type GqlSysAdminCommunityOverviewResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminCommunityOverview'] = GqlResolversParentTypes['SysAdminCommunityOverview']> = ResolversObject<{
-  alerts?: Resolver<GqlResolversTypes['SysAdminCommunityAlerts'], ParentType, ContextType>;
-  communityActivityRate?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
   communityId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
   communityName?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
-  growthRateActivity?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
-  latestCohortRetentionM1?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
-  passiveCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  latestCohort?: Resolver<GqlResolversTypes['SysAdminLatestCohort'], ParentType, ContextType>;
   segmentCounts?: Resolver<GqlResolversTypes['SysAdminSegmentCounts'], ParentType, ContextType>;
-  tier1Count?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
-  tier2Count?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   totalMembers?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  weeklyRetention?: Resolver<GqlResolversTypes['SysAdminWeeklyRetention'], ParentType, ContextType>;
+  windowActivity?: Resolver<GqlResolversTypes['SysAdminWindowActivity'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -6746,6 +6818,12 @@ export type GqlSysAdminDashboardPayloadResolvers<ContextType = any, ParentType e
   asOf?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
   communities?: Resolver<Array<GqlResolversTypes['SysAdminCommunityOverview']>, ParentType, ContextType>;
   platform?: Resolver<GqlResolversTypes['SysAdminPlatformSummary'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlSysAdminLatestCohortResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminLatestCohort'] = GqlResolversParentTypes['SysAdminLatestCohort']> = ResolversObject<{
+  activeAtM1?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  size?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -6816,6 +6894,20 @@ export type GqlSysAdminStageDistributionResolvers<ContextType = any, ParentType 
   latent?: Resolver<GqlResolversTypes['SysAdminStageBucket'], ParentType, ContextType>;
   occasional?: Resolver<GqlResolversTypes['SysAdminStageBucket'], ParentType, ContextType>;
   regular?: Resolver<GqlResolversTypes['SysAdminStageBucket'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlSysAdminWeeklyRetentionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminWeeklyRetention'] = GqlResolversParentTypes['SysAdminWeeklyRetention']> = ResolversObject<{
+  churnedSenders?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  retainedSenders?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlSysAdminWindowActivityResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminWindowActivity'] = GqlResolversParentTypes['SysAdminWindowActivity']> = ResolversObject<{
+  newMemberCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  newMemberCountPrev?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  senderCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  senderCountPrev?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -7545,6 +7637,7 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   SysAdminCommunityOverview?: GqlSysAdminCommunityOverviewResolvers<ContextType>;
   SysAdminCommunitySummaryCard?: GqlSysAdminCommunitySummaryCardResolvers<ContextType>;
   SysAdminDashboardPayload?: GqlSysAdminDashboardPayloadResolvers<ContextType>;
+  SysAdminLatestCohort?: GqlSysAdminLatestCohortResolvers<ContextType>;
   SysAdminMemberList?: GqlSysAdminMemberListResolvers<ContextType>;
   SysAdminMemberRow?: GqlSysAdminMemberRowResolvers<ContextType>;
   SysAdminMonthlyActivityPoint?: GqlSysAdminMonthlyActivityPointResolvers<ContextType>;
@@ -7553,6 +7646,8 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   SysAdminSegmentCounts?: GqlSysAdminSegmentCountsResolvers<ContextType>;
   SysAdminStageBucket?: GqlSysAdminStageBucketResolvers<ContextType>;
   SysAdminStageDistribution?: GqlSysAdminStageDistributionResolvers<ContextType>;
+  SysAdminWeeklyRetention?: GqlSysAdminWeeklyRetentionResolvers<ContextType>;
+  SysAdminWindowActivity?: GqlSysAdminWindowActivityResolvers<ContextType>;
   Ticket?: GqlTicketResolvers<ContextType>;
   TicketClaimLink?: GqlTicketClaimLinkResolvers<ContextType>;
   TicketClaimLinkEdge?: GqlTicketClaimLinkEdgeResolvers<ContextType>;


### PR DESCRIPTION
## Summary
Restructure the `SysAdminCommunityOverview` GraphQL type to return raw activity counts and retention signals instead of pre-computed rates and alerts. This shifts metric derivation (rates, growth, churn detection) to the client, enabling more flexible filtering and sorting on the L1 dashboard.

## Key Changes

- **Removed pre-computed fields** from `SysAdminCommunityOverview`:
  - `communityActivityRate` (monthly rate)
  - `growthRateActivity` (month-over-month change)
  - `latestCohortRetentionM1` (cohort retention ratio)
  - `alerts` (alert flags)
  - Convenience fields: `tier1Count`, `tier2Count`, `passiveCount`

- **Added new nested types** for raw signal passthrough:
  - `SysAdminWindowActivity`: Rolling-window DONATION activity with current/previous window counts
    - `senderCount`, `senderCountPrev`
    - `newMemberCount`, `newMemberCountPrev`
  - `SysAdminWeeklyRetention`: Latest completed ISO week retention signals
    - `retainedSenders`, `churnedSenders`
  - `SysAdminLatestCohort`: Most recent completed monthly cohort + M+1 activity
    - `size`, `activeAtM1`

- **Added parametric window support** to `SysAdminDashboardInput`:
  - New `windowDays` parameter (default 28, range 7-90) for configurable rolling-window calculations
  - Updated `asOf` documentation to clarify all window anchoring semantics

- **Updated service layer** (`SysAdminService`):
  - Replaced `getMonthActivityWithPrev()` call with `getWindowActivity()` for parametric windows
  - Replaced `getLatestCohortRetentionM1()` with `getLatestCohort()` returning raw counts
  - Replaced `getAlerts()` call with `getWeeklyRetention()` for raw retention signals
  - Added bounds constants: `DEFAULT_WINDOW_DAYS`, `MIN_WINDOW_DAYS`, `MAX_WINDOW_DAYS`

- **Updated presenter** to map new service types to GraphQL types without pre-computation

- **Updated usecase** to clamp `windowDays` input and orchestrate the new service methods

## Implementation Details

- Calendar-month metrics remain on the L2 detail card (`SysAdminCommunitySummaryCard`); L1 is now rolling-window only
- Client now derives rates by dividing counts by `totalMembers`
- Client composes churn alerts (e.g., `churnedSenders > retainedSenders`) without server-side threshold logic
- Empty cohorts (`size === 0`) are handled client-side as null retention
- Sorting logic moved to client (previously sorted by `communityActivityRate`)

https://claude.ai/code/session_01HcWsRCxrCZToZNom8HVbc7
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/915" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
