### PR TITLE
feat(sysadmin): add retainedSenders to SysAdminWindowActivity

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -2616,6 +2616,17 @@ type SysAdminWindowActivity {
   newMemberCountPrev: Int!
 
   """
+  Users who sent at least one DONATION in BOTH the current window
+  AND the previous window (set intersection on user_id). Same
+  shape as SysAdminWeeklyRetention.retainedSenders but at
+  windowDays scale, enabling client-side leaky-bucket derivation:
+  
+    newlyActivatedSenders = senderCount     - retainedSenders
+    churnedSenders        = senderCountPrev - retainedSenders
+  """
+  retainedSenders: Int!
+
+  """
   Unique users with at least one outgoing DONATION transaction
   during the current window (donation_out_count > 0 in
   mv_user_transaction_daily).

--- a/src/__tests__/unit/sysadmin/presenter.test.ts
+++ b/src/__tests__/unit/sysadmin/presenter.test.ts
@@ -289,6 +289,7 @@ describe("SysAdminPresenter", () => {
           senderCountPrev: 6,
           newMemberCount: 1,
           newMemberCountPrev: 2,
+          retainedSenders: 3,
         },
         weeklyRetention: {
           retainedSenders: 3,
@@ -307,6 +308,7 @@ describe("SysAdminPresenter", () => {
         senderCountPrev: 6,
         newMemberCount: 1,
         newMemberCountPrev: 2,
+        retainedSenders: 3,
       });
       expect(out.weeklyRetention).toEqual({
         retainedSenders: 3,

--- a/src/__tests__/unit/sysadmin/service.test.ts
+++ b/src/__tests__/unit/sysadmin/service.test.ts
@@ -36,6 +36,7 @@ class MockSysAdminRepository {
   findMonthlyActivity = jest.fn();
   findActivitySnapshot = jest.fn();
   findNewMemberCount = jest.fn();
+  findRetainedSenderCount = jest.fn();
   findAllTimeTotals = jest.fn();
   findPlatformTotals = jest.fn();
 }

--- a/src/__tests__/unit/sysadmin/service.test.ts
+++ b/src/__tests__/unit/sysadmin/service.test.ts
@@ -36,7 +36,7 @@ class MockSysAdminRepository {
   findMonthlyActivity = jest.fn();
   findActivitySnapshot = jest.fn();
   findNewMemberCount = jest.fn();
-  findRetainedSenderCount = jest.fn();
+  findWindowActivityCounts = jest.fn();
   findAllTimeTotals = jest.fn();
   findPlatformTotals = jest.fn();
 }

--- a/src/application/domain/sysadmin/data/interface.ts
+++ b/src/application/domain/sysadmin/data/interface.ts
@@ -7,7 +7,7 @@ import {
   SysAdminMonthlyActivityRow,
   SysAdminNewMemberCountRow,
   SysAdminPlatformTotalsRow,
-  SysAdminRetainedSenderCountRow,
+  SysAdminWindowActivityCountsRow,
 } from "@/application/domain/sysadmin/data/type";
 
 /**
@@ -78,18 +78,22 @@ export interface ISysAdminRepository {
   ): Promise<SysAdminNewMemberCountRow>;
 
   /**
-   * Unique users who sent at least one DONATION in BOTH windows
-   * `[currLower, currUpper)` AND `[prevLower, prevUpper)`. Powers
-   * `SysAdminWindowActivity.retainedSenders`.
+   * All five raw counts the L1 `SysAdminWindowActivity` payload needs
+   * for the parametric window pair driven by `windowDays`. Issues a
+   * single SQL with two scans (one over `mv_user_transaction_daily`
+   * and one over `t_memberships`), each spanning `[prevLower, upper)`.
+   *
+   * Replaces three separate `findActivitySnapshot` / intersection
+   * calls and two `findNewMemberCount` calls; the previous design
+   * scanned the same MV three times for overlapping windows.
    */
-  findRetainedSenderCount(
+  findWindowActivityCounts(
     ctx: IContext,
     communityId: string,
-    currLower: Date,
-    currUpper: Date,
     prevLower: Date,
-    prevUpper: Date,
-  ): Promise<SysAdminRetainedSenderCountRow>;
+    currLower: Date,
+    upper: Date,
+  ): Promise<SysAdminWindowActivityCountsRow>;
 
   /** All-time DONATION totals + MV data window for the summary card,
    * clamped at `asOf` for historic-asOf consistency with the rest of

--- a/src/application/domain/sysadmin/data/interface.ts
+++ b/src/application/domain/sysadmin/data/interface.ts
@@ -7,6 +7,7 @@ import {
   SysAdminMonthlyActivityRow,
   SysAdminNewMemberCountRow,
   SysAdminPlatformTotalsRow,
+  SysAdminRetainedSenderCountRow,
 } from "@/application/domain/sysadmin/data/type";
 
 /**
@@ -75,6 +76,20 @@ export interface ISysAdminRepository {
     from: Date,
     to: Date,
   ): Promise<SysAdminNewMemberCountRow>;
+
+  /**
+   * Unique users who sent at least one DONATION in BOTH windows
+   * `[currLower, currUpper)` AND `[prevLower, prevUpper)`. Powers
+   * `SysAdminWindowActivity.retainedSenders`.
+   */
+  findRetainedSenderCount(
+    ctx: IContext,
+    communityId: string,
+    currLower: Date,
+    currUpper: Date,
+    prevLower: Date,
+    prevUpper: Date,
+  ): Promise<SysAdminRetainedSenderCountRow>;
 
   /** All-time DONATION totals + MV data window for the summary card,
    * clamped at `asOf` for historic-asOf consistency with the rest of

--- a/src/application/domain/sysadmin/data/repository.ts
+++ b/src/application/domain/sysadmin/data/repository.ts
@@ -8,7 +8,7 @@ import {
   SysAdminMonthlyActivityRow,
   SysAdminNewMemberCountRow,
   SysAdminPlatformTotalsRow,
-  SysAdminRetainedSenderCountRow,
+  SysAdminWindowActivityCountsRow,
 } from "@/application/domain/sysadmin/data/type";
 import { ISysAdminRepository } from "@/application/domain/sysadmin/data/interface";
 
@@ -424,34 +424,83 @@ export default class SysAdminRepository implements ISysAdminRepository {
     });
   }
 
-  async findRetainedSenderCount(
+  async findWindowActivityCounts(
     ctx: IContext,
     communityId: string,
-    currLower: Date,
-    currUpper: Date,
     prevLower: Date,
-    prevUpper: Date,
-  ): Promise<SysAdminRetainedSenderCountRow> {
+    currLower: Date,
+    upper: Date,
+  ): Promise<SysAdminWindowActivityCountsRow> {
     return ctx.issuer.public(ctx, async (tx) => {
-      const rows = await tx.$queryRaw<{ n: number }[]>`
-        SELECT COUNT(*)::int AS n
-        FROM (
-          SELECT "user_id"
-          FROM "mv_user_transaction_daily"
-          WHERE "community_id" = ${communityId}
-            AND "donation_out_count" > 0
-            AND "date" >= ${currLower}::date
-            AND "date" <  ${currUpper}::date
-          INTERSECT
-          SELECT "user_id"
+      const rows = await tx.$queryRaw<
+        {
+          curr_sender_count: number;
+          prev_sender_count: number;
+          retained_count: number;
+          curr_new_member_count: number;
+          prev_new_member_count: number;
+        }[]
+      >`
+        WITH window_senders AS (
+          -- One MV scan over [prevLower, upper). Per-user aggregation
+          -- collapses each user's daily rows into two booleans
+          -- recording whether they sent a DONATION in the current /
+          -- previous window. The outer FILTER clauses then count
+          -- senders, prev-senders, and the intersection (retained)
+          -- without rescanning the MV.
+          SELECT
+            "user_id",
+            bool_or("date" >= ${currLower}::date AND "date" <  ${upper}::date) AS in_curr,
+            bool_or("date" >= ${prevLower}::date AND "date" <  ${currLower}::date) AS in_prev
           FROM "mv_user_transaction_daily"
           WHERE "community_id" = ${communityId}
             AND "donation_out_count" > 0
             AND "date" >= ${prevLower}::date
-            AND "date" <  ${prevUpper}::date
-        ) AS intersection
+            AND "date" <  ${upper}::date
+          GROUP BY "user_id"
+        ),
+        sender_aggregates AS (
+          SELECT
+            COUNT(*) FILTER (WHERE in_curr)::int                AS curr_sender_count,
+            COUNT(*) FILTER (WHERE in_prev)::int                AS prev_sender_count,
+            COUNT(*) FILTER (WHERE in_curr AND in_prev)::int    AS retained_count
+          FROM window_senders
+        ),
+        new_members AS (
+          -- One t_memberships scan over [prevLower, upper).
+          -- Same FILTER pattern: split current vs previous in one pass.
+          SELECT
+            COUNT(*) FILTER (
+              WHERE "created_at" >= (${currLower}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+                AND "created_at" <  (${upper}::date     AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+            )::int AS curr_new_member_count,
+            COUNT(*) FILTER (
+              WHERE "created_at" >= (${prevLower}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+                AND "created_at" <  (${currLower}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+            )::int AS prev_new_member_count
+          FROM "t_memberships"
+          WHERE "community_id" = ${communityId}
+            AND "status" = 'JOINED'
+            AND "created_at" >= (${prevLower}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+            AND "created_at" <  (${upper}::date     AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+        )
+        SELECT
+          COALESCE(s.curr_sender_count, 0)     AS curr_sender_count,
+          COALESCE(s.prev_sender_count, 0)     AS prev_sender_count,
+          COALESCE(s.retained_count, 0)        AS retained_count,
+          COALESCE(n.curr_new_member_count, 0) AS curr_new_member_count,
+          COALESCE(n.prev_new_member_count, 0) AS prev_new_member_count
+        FROM sender_aggregates s
+        CROSS JOIN new_members n
       `;
-      return { count: rows[0]?.n ?? 0 };
+      const r = rows[0];
+      return {
+        senderCount: r?.curr_sender_count ?? 0,
+        senderCountPrev: r?.prev_sender_count ?? 0,
+        retainedSenders: r?.retained_count ?? 0,
+        newMemberCount: r?.curr_new_member_count ?? 0,
+        newMemberCountPrev: r?.prev_new_member_count ?? 0,
+      };
     });
   }
 

--- a/src/application/domain/sysadmin/data/repository.ts
+++ b/src/application/domain/sysadmin/data/repository.ts
@@ -434,25 +434,22 @@ export default class SysAdminRepository implements ISysAdminRepository {
   ): Promise<SysAdminRetainedSenderCountRow> {
     return ctx.issuer.public(ctx, async (tx) => {
       const rows = await tx.$queryRaw<{ n: number }[]>`
-        WITH curr_senders AS (
-          SELECT DISTINCT "user_id"
+        SELECT COUNT(*)::int AS n
+        FROM (
+          SELECT "user_id"
           FROM "mv_user_transaction_daily"
           WHERE "community_id" = ${communityId}
             AND "donation_out_count" > 0
             AND "date" >= ${currLower}::date
             AND "date" <  ${currUpper}::date
-        ),
-        prev_senders AS (
-          SELECT DISTINCT "user_id"
+          INTERSECT
+          SELECT "user_id"
           FROM "mv_user_transaction_daily"
           WHERE "community_id" = ${communityId}
             AND "donation_out_count" > 0
             AND "date" >= ${prevLower}::date
             AND "date" <  ${prevUpper}::date
-        )
-        SELECT COUNT(*)::int AS n
-        FROM curr_senders c
-        INNER JOIN prev_senders p USING ("user_id")
+        ) AS intersection
       `;
       return { count: rows[0]?.n ?? 0 };
     });

--- a/src/application/domain/sysadmin/data/repository.ts
+++ b/src/application/domain/sysadmin/data/repository.ts
@@ -8,6 +8,7 @@ import {
   SysAdminMonthlyActivityRow,
   SysAdminNewMemberCountRow,
   SysAdminPlatformTotalsRow,
+  SysAdminRetainedSenderCountRow,
 } from "@/application/domain/sysadmin/data/type";
 import { ISysAdminRepository } from "@/application/domain/sysadmin/data/interface";
 
@@ -418,6 +419,40 @@ export default class SysAdminRepository implements ISysAdminRepository {
           AND "status" = 'JOINED'
           AND "created_at" >= (${from}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
           AND "created_at" <  (${to}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+      `;
+      return { count: rows[0]?.n ?? 0 };
+    });
+  }
+
+  async findRetainedSenderCount(
+    ctx: IContext,
+    communityId: string,
+    currLower: Date,
+    currUpper: Date,
+    prevLower: Date,
+    prevUpper: Date,
+  ): Promise<SysAdminRetainedSenderCountRow> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      const rows = await tx.$queryRaw<{ n: number }[]>`
+        WITH curr_senders AS (
+          SELECT DISTINCT "user_id"
+          FROM "mv_user_transaction_daily"
+          WHERE "community_id" = ${communityId}
+            AND "donation_out_count" > 0
+            AND "date" >= ${currLower}::date
+            AND "date" <  ${currUpper}::date
+        ),
+        prev_senders AS (
+          SELECT DISTINCT "user_id"
+          FROM "mv_user_transaction_daily"
+          WHERE "community_id" = ${communityId}
+            AND "donation_out_count" > 0
+            AND "date" >= ${prevLower}::date
+            AND "date" <  ${prevUpper}::date
+        )
+        SELECT COUNT(*)::int AS n
+        FROM curr_senders c
+        INNER JOIN prev_senders p USING ("user_id")
       `;
       return { count: rows[0]?.n ?? 0 };
     });

--- a/src/application/domain/sysadmin/data/type.ts
+++ b/src/application/domain/sysadmin/data/type.ts
@@ -68,6 +68,17 @@ export type SysAdminNewMemberCountRow = {
 };
 
 /**
+ * Count of unique users who sent at least one DONATION in BOTH of two
+ * supplied windows (set intersection on user_id). Powers
+ * `SysAdminWindowActivity.retainedSenders` so the client can derive
+ * window-scale activity flow (newly activated vs. churned) without
+ * a second round-trip.
+ */
+export type SysAdminRetainedSenderCountRow = {
+  count: number;
+};
+
+/**
  * Platform-wide totals for the L1 dashboard header. Derived in one CTE
  * query rather than summing per-community payloads in memory so the
  * answer stays atomic with a single asOf timestamp.

--- a/src/application/domain/sysadmin/data/type.ts
+++ b/src/application/domain/sysadmin/data/type.ts
@@ -68,14 +68,23 @@ export type SysAdminNewMemberCountRow = {
 };
 
 /**
- * Count of unique users who sent at least one DONATION in BOTH of two
- * supplied windows (set intersection on user_id). Powers
- * `SysAdminWindowActivity.retainedSenders` so the client can derive
- * window-scale activity flow (newly activated vs. churned) without
- * a second round-trip.
+ * All five raw counts the L1 `SysAdminWindowActivity` payload needs,
+ * derived from a single MV scan + a single membership scan over
+ * `[prevLower, upper)`. Consolidates what used to be 3 overlapping
+ * mv_user_transaction_daily reads (curr senders, prev senders,
+ * intersection) and 2 overlapping t_memberships reads (curr/prev
+ * new members) into one method so the dashboard load cost grows
+ * linearly with community count instead of with a 5x multiplier.
+ *
+ * Field shape mirrors `WindowActivityCounts` so the service can
+ * pass the row through without re-mapping.
  */
-export type SysAdminRetainedSenderCountRow = {
-  count: number;
+export type SysAdminWindowActivityCountsRow = {
+  senderCount: number;
+  senderCountPrev: number;
+  retainedSenders: number;
+  newMemberCount: number;
+  newMemberCountPrev: number;
 };
 
 /**

--- a/src/application/domain/sysadmin/presenter.ts
+++ b/src/application/domain/sysadmin/presenter.ts
@@ -77,6 +77,7 @@ export default class SysAdminPresenter {
       senderCountPrev: counts.senderCountPrev,
       newMemberCount: counts.newMemberCount,
       newMemberCountPrev: counts.newMemberCountPrev,
+      retainedSenders: counts.retainedSenders,
     };
   }
 

--- a/src/application/domain/sysadmin/schema/type.graphql
+++ b/src/application/domain/sysadmin/schema/type.graphql
@@ -298,6 +298,17 @@ type SysAdminWindowActivity {
   Same metric for the previous window.
   """
   newMemberCountPrev: Int!
+
+  """
+  Users who sent at least one DONATION in BOTH the current window
+  AND the previous window (set intersection on user_id). Same
+  shape as SysAdminWeeklyRetention.retainedSenders but at
+  windowDays scale, enabling client-side leaky-bucket derivation:
+
+    newlyActivatedSenders = senderCount     - retainedSenders
+    churnedSenders        = senderCountPrev - retainedSenders
+  """
+  retainedSenders: Int!
 }
 
 """

--- a/src/application/domain/sysadmin/service.ts
+++ b/src/application/domain/sysadmin/service.ts
@@ -696,8 +696,13 @@ export default class SysAdminService {
    *   current  = [asOf - windowDays JST日, asOf + 1 JST日)
    *   previous = [asOf - 2 * windowDays, asOf - windowDays)
    *
-   * Both windows reuse `findActivitySnapshot` / `findNewMemberCount`,
-   * so no new SQL is introduced — only the date arguments change.
+   * All five counts come from a single repository call
+   * (`findWindowActivityCounts`) which scans `mv_user_transaction_daily`
+   * once over `[prevLower, upper)` and `t_memberships` once over the
+   * same span — collapsing what used to be five overlapping scans
+   * (curr senders + prev senders + intersection + curr new members +
+   * prev new members) into two. The service's only job here is the
+   * date-window arithmetic.
    */
   async getWindowActivity(
     ctx: IContext,
@@ -709,28 +714,13 @@ export default class SysAdminService {
     const currLower = addDays(upper, -windowDays);
     const prevLower = addDays(upper, -windowDays * 2);
 
-    const [curr, prev, currNew, prevNew, retained] = await Promise.all([
-      this.repository.findActivitySnapshot(ctx, communityId, currLower, upper),
-      this.repository.findActivitySnapshot(ctx, communityId, prevLower, currLower),
-      this.repository.findNewMemberCount(ctx, communityId, currLower, upper),
-      this.repository.findNewMemberCount(ctx, communityId, prevLower, currLower),
-      this.repository.findRetainedSenderCount(
-        ctx,
-        communityId,
-        currLower,
-        upper,
-        prevLower,
-        currLower,
-      ),
-    ]);
-
-    return {
-      senderCount: curr.senderCount,
-      senderCountPrev: prev.senderCount,
-      newMemberCount: currNew.count,
-      newMemberCountPrev: prevNew.count,
-      retainedSenders: retained.count,
-    };
+    return this.repository.findWindowActivityCounts(
+      ctx,
+      communityId,
+      prevLower,
+      currLower,
+      upper,
+    );
   }
 
   /**

--- a/src/application/domain/sysadmin/service.ts
+++ b/src/application/domain/sysadmin/service.ts
@@ -130,6 +130,7 @@ export type WindowActivityCounts = {
   senderCountPrev: number;
   newMemberCount: number;
   newMemberCountPrev: number;
+  retainedSenders: number;
 };
 
 /**
@@ -708,11 +709,19 @@ export default class SysAdminService {
     const currLower = addDays(upper, -windowDays);
     const prevLower = addDays(upper, -windowDays * 2);
 
-    const [curr, prev, currNew, prevNew] = await Promise.all([
+    const [curr, prev, currNew, prevNew, retained] = await Promise.all([
       this.repository.findActivitySnapshot(ctx, communityId, currLower, upper),
       this.repository.findActivitySnapshot(ctx, communityId, prevLower, currLower),
       this.repository.findNewMemberCount(ctx, communityId, currLower, upper),
       this.repository.findNewMemberCount(ctx, communityId, prevLower, currLower),
+      this.repository.findRetainedSenderCount(
+        ctx,
+        communityId,
+        currLower,
+        upper,
+        prevLower,
+        currLower,
+      ),
     ]);
 
     return {
@@ -720,6 +729,7 @@ export default class SysAdminService {
       senderCountPrev: prev.senderCount,
       newMemberCount: currNew.count,
       newMemberCountPrev: prevNew.count,
+      retainedSenders: retained.count,
     };
   }
 

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -3520,6 +3520,16 @@ export type GqlSysAdminWindowActivity = {
   /** Same metric for the previous window. */
   newMemberCountPrev: Scalars['Int']['output'];
   /**
+   * Users who sent at least one DONATION in BOTH the current window
+   * AND the previous window (set intersection on user_id). Same
+   * shape as SysAdminWeeklyRetention.retainedSenders but at
+   * windowDays scale, enabling client-side leaky-bucket derivation:
+   *
+   *   newlyActivatedSenders = senderCount     - retainedSenders
+   *   churnedSenders        = senderCountPrev - retainedSenders
+   */
+  retainedSenders: Scalars['Int']['output'];
+  /**
    * Unique users with at least one outgoing DONATION transaction
    * during the current window (donation_out_count > 0 in
    * mv_user_transaction_daily).
@@ -6906,6 +6916,7 @@ export type GqlSysAdminWeeklyRetentionResolvers<ContextType = any, ParentType ex
 export type GqlSysAdminWindowActivityResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminWindowActivity'] = GqlResolversParentTypes['SysAdminWindowActivity']> = ResolversObject<{
   newMemberCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   newMemberCountPrev?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  retainedSenders?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   senderCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   senderCountPrev?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;


### PR DESCRIPTION
Adds `retainedSenders: Int!` to the L1 SysAdminWindowActivity type:
the count of unique users who sent at least one DONATION in BOTH
the current window AND the previous window of equal length (set
intersection on user_id).

Mirrors the SysAdminWeeklyRetention.retainedSenders shape at
windowDays scale, enabling client-side leaky-bucket derivation
without an extra round trip:

  newlyActivatedSenders = senderCount     - retainedSenders
  churnedSenders        = senderCountPrev - retainedSenders

Implementation:
- New repository method findRetainedSenderCount issues one CTE
  intersection query against mv_user_transaction_daily.
- getWindowActivity fans this in alongside the four existing
  per-window snapshot calls (Promise.all, +1 SQL/community/load).
- Presenter passes the count through unchanged.

https://claude.ai/code/session_01HcWsRCxrCZToZNom8HVbc7
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
