### PR TITLE
feat(sysadmin): L2 SysAdminMemberRow に uniqueDonationRecipients を追加

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -2151,6 +2151,36 @@ type SysAdminCommunityOverview {
   communityName: String!
 
   """
+  Number of members classified as a "hub" within the parametric
+  window (`windowDays`):
+  
+    hubMemberCount = COUNT(member)
+      WHERE windowUniqueDonationRecipients >= input.hubBreadthThreshold
+  
+  `windowUniqueDonationRecipients` is the count of DISTINCT users
+  this member sent a DONATION to during
+  `[asOf - windowDays JST日, asOf + 1 JST日)` — distinct from the
+  L2 `SysAdminMemberRow.uniqueDonationRecipients` field which is
+  tenure-wide. The window-scoped variant is computed on demand in
+  this aggregate but not exposed per-member at L1 (members
+  themselves are an L2 concern).
+  
+  Hub classification deliberately uses BREADTH only — a member
+  who reached `hubBreadthThreshold` distinct recipients during
+  the window necessarily transacted at least that many times,
+  making an explicit frequency floor redundant. This keeps the
+  threshold knobs to one (`hubBreadthThreshold`).
+  
+  Invariants (the client may assert these):
+    hubMemberCount <= windowActivity.senderCount <= totalMembers
+  
+  The first holds because any hub member donated >= 3 times in
+  the window and is therefore a window sender; the second because
+  any window sender is a JOINED member at asOf.
+  """
+  hubMemberCount: Int!
+
+  """
   Latest completed monthly cohort and its M+1 activity. See
   SysAdminLatestCohort.
   """
@@ -2247,6 +2277,30 @@ input SysAdminDashboardInput {
   Defaults to now when omitted.
   """
   asOf: Datetime
+
+  """
+  Minimum number of distinct DONATION recipients within the
+  parametric window (`windowDays`) for a member to be classified
+  as a hub. Used to populate `SysAdminCommunityOverview.hubMemberCount`.
+  
+  Defaults to 3, meaning "sent DONATION to at least 3 different
+  people during the window". The threshold is on **unique
+  counterparties** (set cardinality), not transaction count, so a
+  member who donated 100 times to the same recipient does not
+  qualify on this axis alone.
+  
+  Effective range 1..1000; values outside are silently clamped on
+  the server.
+  
+  This is intentionally an absolute threshold rather than a
+  community-relative percentile: a percentile-based hub would
+  always classify ~N% of members as hubs by definition, defeating
+  cross-community comparison ("which communities have the highest
+  hub ratio?"). Community size differences are absorbed
+  client-side by displaying `hubMemberCount / totalMembers` rather
+  than the raw count.
+  """
+  hubBreadthThreshold: Int = 3
 
   """Stage classification thresholds (see SysAdminSegmentThresholdsInput)."""
   segmentThresholds: SysAdminSegmentThresholdsInput

--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -2335,6 +2335,23 @@ type SysAdminMemberRow {
   """All-time DONATION points sent by this user in this community."""
   totalPointsOut: Float!
 
+  """
+  All-time count of distinct OTHER users this member has sent at
+  least one DONATION to in this community. The "network breadth"
+  half of the donor profile (paired with frequency-based
+  `userSendRate` and volume-based `totalPointsOut`):
+  
+    breadth × frequency × volume → the client's per-member
+    classification space (e.g. true hub vs single-target loyal vs
+    rare-but-far-reaching).
+  
+  Counts unique counterparty user_id, not transaction count, so a
+  member who sent 100 donations to the same recipient still scores
+  1. Excludes burn / system targets (recipient wallets without a
+  user_id).
+  """
+  uniqueDonationRecipients: Int!
+
   """User id."""
   userId: ID!
 

--- a/src/__tests__/unit/sysadmin/presenter.test.ts
+++ b/src/__tests__/unit/sysadmin/presenter.test.ts
@@ -53,10 +53,12 @@ describe("SysAdminPresenter", () => {
         donationOutMonths: 10,
         userSendRate: 0.833,
         totalPointsOut: BigInt(5_000),
+        uniqueDonationRecipients: 4,
       };
       const out = SysAdminPresenter.memberRow(row);
       expect(out.totalPointsOut).toBe(5_000);
       expect(typeof out.totalPointsOut).toBe("number");
+      expect(out.uniqueDonationRecipients).toBe(4);
     });
 
     it("passes null name through untouched", () => {
@@ -67,6 +69,7 @@ describe("SysAdminPresenter", () => {
         donationOutMonths: 0,
         userSendRate: 0,
         totalPointsOut: BigInt(0),
+        uniqueDonationRecipients: 0,
       };
       expect(SysAdminPresenter.memberRow(row).name).toBeNull();
     });
@@ -227,6 +230,7 @@ describe("SysAdminPresenter", () => {
             donationOutMonths: 1,
             userSendRate: 1,
             totalPointsOut: BigInt(0),
+            uniqueDonationRecipients: 0,
           },
         ],
         hasNextPage: true,

--- a/src/__tests__/unit/sysadmin/presenter.test.ts
+++ b/src/__tests__/unit/sysadmin/presenter.test.ts
@@ -303,6 +303,7 @@ describe("SysAdminPresenter", () => {
           size: 8,
           activeAtM1: 4,
         },
+        hubMemberCount: 2,
       });
       expect(out.segmentCounts.tier1Count).toBe(2);
       expect(out.segmentCounts.tier2Count).toBe(5);
@@ -319,6 +320,7 @@ describe("SysAdminPresenter", () => {
         churnedSenders: 5,
       });
       expect(out.latestCohort).toEqual({ size: 8, activeAtM1: 4 });
+      expect(out.hubMemberCount).toBe(2);
     });
   });
 });

--- a/src/__tests__/unit/sysadmin/service.test.ts
+++ b/src/__tests__/unit/sysadmin/service.test.ts
@@ -21,6 +21,7 @@ function member(overrides: Partial<SysAdminMemberStatsRow>): SysAdminMemberStats
     donationOutMonths: overrides.donationOutMonths ?? 0,
     totalPointsOut: overrides.totalPointsOut ?? BigInt(0),
     userSendRate: overrides.userSendRate ?? 0,
+    uniqueDonationRecipients: overrides.uniqueDonationRecipients ?? 0,
   };
 }
 

--- a/src/__tests__/unit/sysadmin/service.test.ts
+++ b/src/__tests__/unit/sysadmin/service.test.ts
@@ -38,6 +38,7 @@ class MockSysAdminRepository {
   findActivitySnapshot = jest.fn();
   findNewMemberCount = jest.fn();
   findWindowActivityCounts = jest.fn();
+  findWindowHubMemberCount = jest.fn();
   findAllTimeTotals = jest.fn();
   findPlatformTotals = jest.fn();
 }

--- a/src/application/domain/sysadmin/data/interface.ts
+++ b/src/application/domain/sysadmin/data/interface.ts
@@ -4,6 +4,7 @@ import {
   SysAdminCommunityRow,
   SysAdminMemberStatsRow,
   SysAdminActivitySnapshotRow,
+  SysAdminHubMemberCountRow,
   SysAdminMonthlyActivityRow,
   SysAdminNewMemberCountRow,
   SysAdminPlatformTotalsRow,
@@ -76,6 +77,28 @@ export interface ISysAdminRepository {
     from: Date,
     to: Date,
   ): Promise<SysAdminNewMemberCountRow>;
+
+  /**
+   * Per-community count of members whose distinct DONATION
+   * recipient count within `[currLower, upper)` reaches
+   * `hubBreadthThreshold`. Backs
+   * `SysAdminCommunityOverview.hubMemberCount`.
+   *
+   * The recipient count is computed against `t_transactions`
+   * directly (not `mv_user_transaction_daily`) because the MV's
+   * per-day `unique_counterparties` does not compose into a
+   * window-wide DISTINCT — the same recipient across multiple days
+   * would double-count under SUM. Same reasoning as the
+   * `donation_recipients` CTE in `findMemberStats`, restricted to
+   * the parametric window instead of the full tenure.
+   */
+  findWindowHubMemberCount(
+    ctx: IContext,
+    communityId: string,
+    currLower: Date,
+    upper: Date,
+    hubBreadthThreshold: number,
+  ): Promise<SysAdminHubMemberCountRow>;
 
   /**
    * All five raw counts the L1 `SysAdminWindowActivity` payload needs

--- a/src/application/domain/sysadmin/data/repository.ts
+++ b/src/application/domain/sysadmin/data/repository.ts
@@ -6,6 +6,7 @@ import {
   SysAdminMemberStatsRow,
   SysAdminActivitySnapshotRow,
   SysAdminMonthlyActivityRow,
+  SysAdminHubMemberCountRow,
   SysAdminNewMemberCountRow,
   SysAdminPlatformTotalsRow,
   SysAdminWindowActivityCountsRow,
@@ -544,6 +545,53 @@ export default class SysAdminRepository implements ISysAdminRepository {
         newMemberCount: r?.curr_new_member_count ?? 0,
         newMemberCountPrev: r?.prev_new_member_count ?? 0,
       };
+    });
+  }
+
+  async findWindowHubMemberCount(
+    ctx: IContext,
+    communityId: string,
+    currLower: Date,
+    upper: Date,
+    hubBreadthThreshold: number,
+  ): Promise<SysAdminHubMemberCountRow> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      const rows = await tx.$queryRaw<{ n: number }[]>`
+        WITH window_recipients AS (
+          -- Per-sender DISTINCT recipient count over the parametric
+          -- window. Same shape as the donation_recipients CTE in
+          -- findMemberStats but window-clamped on both sides instead
+          -- of tenure-clamped (upper only). Cannot reuse
+          -- mv_user_transaction_daily because its per-day
+          -- unique_counterparties does not compose into a window-wide
+          -- DISTINCT (same recipient across multiple days would
+          -- double-count under SUM).
+          --
+          -- Cross-community + burn-target guards mirror the defenses
+          -- on mv_user_transaction_daily / v_transaction_comments so
+          -- a system-target wallet (no user_id) does not silently
+          -- inflate the recipient count.
+          SELECT
+            fw."user_id" AS user_id,
+            COUNT(DISTINCT tw."user_id")::int AS unique_recipients
+          FROM "t_transactions" t
+          INNER JOIN "t_wallets" fw
+            ON fw."id" = t."from"
+            AND fw."community_id" = ${communityId}
+          INNER JOIN "t_wallets" tw
+            ON tw."id" = t."to"
+            AND tw."user_id" IS NOT NULL
+          WHERE t."reason" = 'DONATION'
+            AND t."created_at" >= (${currLower}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+            AND t."created_at" <  (${upper}::date     AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+            AND (tw."community_id" IS NULL OR tw."community_id" = fw."community_id")
+          GROUP BY fw."user_id"
+        )
+        SELECT COUNT(*)::int AS n
+        FROM window_recipients
+        WHERE unique_recipients >= ${hubBreadthThreshold}
+      `;
+      return { count: rows[0]?.n ?? 0 };
     });
   }
 

--- a/src/application/domain/sysadmin/data/repository.ts
+++ b/src/application/domain/sysadmin/data/repository.ts
@@ -91,6 +91,7 @@ export default class SysAdminRepository implements ISysAdminRepository {
           donation_out_months: number;
           total_points_out: bigint;
           user_send_rate: number;
+          unique_donation_recipients: number;
         }[]
       >`
         WITH asof_jst AS (
@@ -151,6 +152,39 @@ export default class SysAdminRepository implements ISysAdminRepository {
             -- denominator agree on what "as of asOf" includes.
           GROUP BY fw."user_id", jst_month
         ),
+        donation_recipients AS (
+          -- Per-sender count of DISTINCT recipient user_ids over the
+          -- whole tenure (clamped at asOf). This is the "network
+          -- breadth" half of the donor profile and cannot be derived
+          -- from mv_user_transaction_daily — that MV's
+          -- unique_counterparties column is per-day and does not
+          -- compose into an all-time DISTINCT (the same recipient
+          -- across multiple days would double-count under SUM).
+          --
+          -- Scoped to (a) DONATION transactions only, (b) sender wallet
+          -- in this community, and (c) recipient wallet either
+          -- in-community or unattached — same "no cross-community
+          -- leakage" guard that mv_user_transaction_daily and
+          -- v_transaction_comments apply at the view layer. Wallets
+          -- without a user_id (burn / system targets) are excluded so
+          -- a member who only donated into a burn target scores 0.
+          SELECT
+            fw."user_id" AS user_id,
+            COUNT(DISTINCT tw."user_id")::int AS unique_recipients
+          FROM "t_transactions" t
+          INNER JOIN "t_wallets" fw
+            ON fw."id" = t."from"
+            AND fw."community_id" = ${communityId}
+          INNER JOIN "t_wallets" tw
+            ON tw."id" = t."to"
+            AND tw."user_id" IS NOT NULL
+          INNER JOIN members m ON m."user_id" = fw."user_id"
+          CROSS JOIN asof_bound ab
+          WHERE t."reason" = 'DONATION'
+            AND t."created_at" < ab.upper_ts
+            AND (tw."community_id" IS NULL OR tw."community_id" = fw."community_id")
+          GROUP BY fw."user_id"
+        ),
         member_tenure AS (
           -- Compute months_in ONCE per member so the final SELECT can
           -- reuse it as both months_in and the denominator of
@@ -192,10 +226,18 @@ export default class SysAdminRepository implements ISysAdminRepository {
             COALESCE(COUNT(DISTINCT dm.jst_month), 0)::numeric
               / mt.months_in::numeric,
             3
-          )::double precision AS user_send_rate
+          )::double precision AS user_send_rate,
+          -- donation_recipients is pre-grouped by user_id, so each
+          -- sender appears at most once on the right side of the
+          -- LEFT JOIN. MAX() (rather than adding the column to GROUP
+          -- BY) propagates that single value through the per-user
+          -- grouping cleanly and matches the COALESCE/MAX pattern
+          -- used elsewhere when joining a pre-aggregated CTE.
+          COALESCE(MAX(dr.unique_recipients), 0)::int AS unique_donation_recipients
         FROM members m
         INNER JOIN member_tenure mt ON mt."user_id" = m."user_id"
         LEFT JOIN donation_months dm ON dm.user_id = m."user_id"
+        LEFT JOIN donation_recipients dr ON dr.user_id = m."user_id"
         LEFT JOIN "t_users" u ON u."id" = m."user_id"
         GROUP BY m."user_id", mt.months_in, u."name"
         ORDER BY m."user_id"
@@ -207,6 +249,7 @@ export default class SysAdminRepository implements ISysAdminRepository {
         donationOutMonths: r.donation_out_months,
         totalPointsOut: r.total_points_out,
         userSendRate: r.user_send_rate,
+        uniqueDonationRecipients: r.unique_donation_recipients,
       }));
     });
   }

--- a/src/application/domain/sysadmin/data/repository.ts
+++ b/src/application/domain/sysadmin/data/repository.ts
@@ -169,6 +169,11 @@ export default class SysAdminRepository implements ISysAdminRepository {
           -- v_transaction_comments apply at the view layer. Wallets
           -- without a user_id (burn / system targets) are excluded so
           -- a member who only donated into a burn target scores 0.
+          -- Self-donations (fw.user_id = tw.user_id) are excluded so
+          -- the count matches the "distinct OTHER users" wording in
+          -- SysAdminMemberRow.uniqueDonationRecipients — the wallet
+          -- validator does not block same-user transfers, so the
+          -- guard has to live here.
           SELECT
             fw."user_id" AS user_id,
             COUNT(DISTINCT tw."user_id")::int AS unique_recipients
@@ -179,6 +184,7 @@ export default class SysAdminRepository implements ISysAdminRepository {
           INNER JOIN "t_wallets" tw
             ON tw."id" = t."to"
             AND tw."user_id" IS NOT NULL
+            AND tw."user_id" <> fw."user_id"
           INNER JOIN members m ON m."user_id" = fw."user_id"
           CROSS JOIN asof_bound ab
           WHERE t."reason" = 'DONATION'
@@ -570,7 +576,13 @@ export default class SysAdminRepository implements ISysAdminRepository {
           -- Cross-community + burn-target guards mirror the defenses
           -- on mv_user_transaction_daily / v_transaction_comments so
           -- a system-target wallet (no user_id) does not silently
-          -- inflate the recipient count.
+          -- inflate the recipient count. Self-donations are excluded
+          -- (matches the "different people" wording in
+          -- SysAdminCommunityOverview.hubMemberCount and the
+          -- "distinct OTHER users" definition in
+          -- SysAdminMemberRow.uniqueDonationRecipients) — the wallet
+          -- validator does not block same-user transfers, so the
+          -- guard has to live in this query.
           SELECT
             fw."user_id" AS user_id,
             COUNT(DISTINCT tw."user_id")::int AS unique_recipients
@@ -581,6 +593,7 @@ export default class SysAdminRepository implements ISysAdminRepository {
           INNER JOIN "t_wallets" tw
             ON tw."id" = t."to"
             AND tw."user_id" IS NOT NULL
+            AND tw."user_id" <> fw."user_id"
           WHERE t."reason" = 'DONATION'
             AND t."created_at" >= (${currLower}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
             AND t."created_at" <  (${upper}::date     AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')

--- a/src/application/domain/sysadmin/data/type.ts
+++ b/src/application/domain/sysadmin/data/type.ts
@@ -27,6 +27,7 @@ export type SysAdminMemberStatsRow = {
   donationOutMonths: number;
   totalPointsOut: bigint;
   userSendRate: number;
+  uniqueDonationRecipients: number;
 };
 
 /** Monthly activity counters, sourced from `mv_*` + `t_memberships`.

--- a/src/application/domain/sysadmin/data/type.ts
+++ b/src/application/domain/sysadmin/data/type.ts
@@ -69,6 +69,16 @@ export type SysAdminNewMemberCountRow = {
 };
 
 /**
+ * Window-scoped count of members classified as hubs. A member is a
+ * hub if they sent DONATION to at least `hubBreadthThreshold` DISTINCT
+ * counterparties during `[currLower, upper)` JST. Powers
+ * `SysAdminCommunityOverview.hubMemberCount`.
+ */
+export type SysAdminHubMemberCountRow = {
+  count: number;
+};
+
+/**
  * All five raw counts the L1 `SysAdminWindowActivity` payload needs,
  * derived from a single MV scan + a single membership scan over
  * `[prevLower, upper)`. Consolidates what used to be 3 overlapping

--- a/src/application/domain/sysadmin/presenter.ts
+++ b/src/application/domain/sysadmin/presenter.ts
@@ -228,6 +228,7 @@ export default class SysAdminPresenter {
       monthsIn: row.monthsIn,
       donationOutMonths: row.donationOutMonths,
       totalPointsOut: bigintToSafeNumber(row.totalPointsOut),
+      uniqueDonationRecipients: row.uniqueDonationRecipients,
     };
   }
 

--- a/src/application/domain/sysadmin/presenter.ts
+++ b/src/application/domain/sysadmin/presenter.ts
@@ -103,6 +103,7 @@ export default class SysAdminPresenter {
     windowActivity: WindowActivityCounts;
     weeklyRetention: WeeklyRetentionCounts;
     latestCohort: LatestCohortCounts;
+    hubMemberCount: number;
   }): GqlSysAdminCommunityOverview {
     return {
       communityId: params.communityId,
@@ -112,6 +113,7 @@ export default class SysAdminPresenter {
       windowActivity: SysAdminPresenter.windowActivity(params.windowActivity),
       weeklyRetention: SysAdminPresenter.weeklyRetention(params.weeklyRetention),
       latestCohort: SysAdminPresenter.latestCohort(params.latestCohort),
+      hubMemberCount: params.hubMemberCount,
     };
   }
 

--- a/src/application/domain/sysadmin/schema/type.graphql
+++ b/src/application/domain/sysadmin/schema/type.graphql
@@ -678,6 +678,22 @@ type SysAdminMemberRow {
   All-time DONATION points sent by this user in this community.
   """
   totalPointsOut: Float!
+  """
+  All-time count of distinct OTHER users this member has sent at
+  least one DONATION to in this community. The "network breadth"
+  half of the donor profile (paired with frequency-based
+  `userSendRate` and volume-based `totalPointsOut`):
+
+    breadth × frequency × volume → the client's per-member
+    classification space (e.g. true hub vs single-target loyal vs
+    rare-but-far-reaching).
+
+  Counts unique counterparty user_id, not transaction count, so a
+  member who sent 100 donations to the same recipient still scores
+  1. Excludes burn / system targets (recipient wallets without a
+  user_id).
+  """
+  uniqueDonationRecipients: Int!
 }
 
 """

--- a/src/application/domain/sysadmin/schema/type.graphql
+++ b/src/application/domain/sysadmin/schema/type.graphql
@@ -65,6 +65,30 @@ input SysAdminDashboardInput {
   Stage classification thresholds (see SysAdminSegmentThresholdsInput).
   """
   segmentThresholds: SysAdminSegmentThresholdsInput
+
+  """
+  Minimum number of distinct DONATION recipients within the
+  parametric window (`windowDays`) for a member to be classified
+  as a hub. Used to populate `SysAdminCommunityOverview.hubMemberCount`.
+
+  Defaults to 3, meaning "sent DONATION to at least 3 different
+  people during the window". The threshold is on **unique
+  counterparties** (set cardinality), not transaction count, so a
+  member who donated 100 times to the same recipient does not
+  qualify on this axis alone.
+
+  Effective range 1..1000; values outside are silently clamped on
+  the server.
+
+  This is intentionally an absolute threshold rather than a
+  community-relative percentile: a percentile-based hub would
+  always classify ~N% of members as hubs by definition, defeating
+  cross-community comparison ("which communities have the highest
+  hub ratio?"). Community size differences are absorbed
+  client-side by displaying `hubMemberCount / totalMembers` rather
+  than the raw count.
+  """
+  hubBreadthThreshold: Int = 3
 }
 
 """
@@ -406,6 +430,36 @@ type SysAdminCommunityOverview {
   SysAdminLatestCohort.
   """
   latestCohort: SysAdminLatestCohort!
+
+  """
+  Number of members classified as a "hub" within the parametric
+  window (`windowDays`):
+
+    hubMemberCount = COUNT(member)
+      WHERE windowUniqueDonationRecipients >= input.hubBreadthThreshold
+
+  `windowUniqueDonationRecipients` is the count of DISTINCT users
+  this member sent a DONATION to during
+  `[asOf - windowDays JST日, asOf + 1 JST日)` — distinct from the
+  L2 `SysAdminMemberRow.uniqueDonationRecipients` field which is
+  tenure-wide. The window-scoped variant is computed on demand in
+  this aggregate but not exposed per-member at L1 (members
+  themselves are an L2 concern).
+
+  Hub classification deliberately uses BREADTH only — a member
+  who reached `hubBreadthThreshold` distinct recipients during
+  the window necessarily transacted at least that many times,
+  making an explicit frequency floor redundant. This keeps the
+  threshold knobs to one (`hubBreadthThreshold`).
+
+  Invariants (the client may assert these):
+    hubMemberCount <= windowActivity.senderCount <= totalMembers
+
+  The first holds because any hub member donated >= 3 times in
+  the window and is therefore a window sender; the second because
+  any window sender is a JOINED member at asOf.
+  """
+  hubMemberCount: Int!
 }
 
 """

--- a/src/application/domain/sysadmin/service.ts
+++ b/src/application/domain/sysadmin/service.ts
@@ -181,6 +181,20 @@ export const MIN_WINDOW_DAYS = 7;
 export const MAX_WINDOW_DAYS = 90;
 
 /**
+ * Hub breadth threshold defaults & defensive bounds. The threshold
+ * decides how many DISTINCT DONATION recipients within the window
+ * a member needs to qualify as a hub. Default is intentionally low
+ * (3) because civicship's per-member donation cadence is sparse;
+ * portal can tune via SysAdminDashboardInput.hubBreadthThreshold
+ * once real-data hub distribution is observed. Effective range
+ * 1..1000 — values outside are clamped at the usecase boundary the
+ * same way `windowDays` is.
+ */
+export const DEFAULT_HUB_BREADTH_THRESHOLD = 3;
+export const MIN_HUB_BREADTH_THRESHOLD = 1;
+export const MAX_HUB_BREADTH_THRESHOLD = 1000;
+
+/**
  * Cap on how many DB round-trips the retention-trend and cohort-
  * retention orchestrators will keep in flight at once. At the MAX
  * windowMonths (36) those loops otherwise fan out to ~310 concurrent
@@ -721,6 +735,40 @@ export default class SysAdminService {
       currLower,
       upper,
     );
+  }
+
+  /**
+   * Count of members classified as hubs within the parametric
+   * window: those who sent DONATION to at least
+   * `hubBreadthThreshold` DISTINCT counterparties during
+   * `[asOf - windowDays, asOf + 1 JST日)`.
+   *
+   * Single-axis classification (breadth only) — reaching the
+   * threshold inherently requires that many transactions, so a
+   * separate frequency floor would be redundant. The service's
+   * only job is the date arithmetic; the count itself comes from a
+   * dedicated repository SQL because it needs DISTINCT recipient
+   * aggregation against `t_transactions` (which the per-day MV
+   * cannot compose into a window-wide DISTINCT).
+   */
+  async getWindowHubMemberCount(
+    ctx: IContext,
+    communityId: string,
+    asOf: Date,
+    windowDays: number,
+    hubBreadthThreshold: number,
+  ): Promise<number> {
+    const upper = asOfBounds(asOf).asOfJstDayPlusOne;
+    const currLower = addDays(upper, -windowDays);
+
+    const row = await this.repository.findWindowHubMemberCount(
+      ctx,
+      communityId,
+      currLower,
+      upper,
+      hubBreadthThreshold,
+    );
+    return row.count;
   }
 
   /**

--- a/src/application/domain/sysadmin/usecase.ts
+++ b/src/application/domain/sysadmin/usecase.ts
@@ -9,12 +9,15 @@ import {
   GqlSysAdminDashboardPayload,
 } from "@/types/graphql";
 import SysAdminService, {
+  DEFAULT_HUB_BREADTH_THRESHOLD,
   DEFAULT_SEGMENT_THRESHOLDS,
   DEFAULT_WINDOW_DAYS,
   DEFAULT_WINDOW_MONTHS,
+  MAX_HUB_BREADTH_THRESHOLD,
   MAX_LIMIT,
   MAX_WINDOW_DAYS,
   MAX_WINDOW_MONTHS,
+  MIN_HUB_BREADTH_THRESHOLD,
   MIN_WINDOW_DAYS,
   SegmentThresholds,
 } from "@/application/domain/sysadmin/service";
@@ -43,6 +46,7 @@ export default class SysAdminUseCase {
     const asOf = input?.asOf ?? new Date();
     const thresholds = resolveThresholds(input?.segmentThresholds);
     const windowDays = clampWindowDays(input?.windowDays);
+    const hubBreadthThreshold = clampHubBreadthThreshold(input?.hubBreadthThreshold);
 
     const monthStart = jstMonthStart(asOf);
     // Clamp the platform-totals upper bound at asOf+1 JST day so a
@@ -59,12 +63,20 @@ export default class SysAdminUseCase {
 
     const rows = await Promise.all(
       communities.map(async (c): Promise<GqlSysAdminCommunityOverview> => {
-        const [members, windowActivity, weeklyRetention, latestCohort] = await Promise.all([
-          this.service.getMemberStats(ctx, c.communityId, asOf),
-          this.service.getWindowActivity(ctx, c.communityId, asOf, windowDays),
-          this.service.getWeeklyRetention(ctx, c.communityId, asOf),
-          this.service.getLatestCohort(ctx, c.communityId, asOf),
-        ]);
+        const [members, windowActivity, weeklyRetention, latestCohort, hubMemberCount] =
+          await Promise.all([
+            this.service.getMemberStats(ctx, c.communityId, asOf),
+            this.service.getWindowActivity(ctx, c.communityId, asOf, windowDays),
+            this.service.getWeeklyRetention(ctx, c.communityId, asOf),
+            this.service.getLatestCohort(ctx, c.communityId, asOf),
+            this.service.getWindowHubMemberCount(
+              ctx,
+              c.communityId,
+              asOf,
+              windowDays,
+              hubBreadthThreshold,
+            ),
+          ]);
         const stageCounts = this.service.computeStageCounts(members, thresholds);
         return SysAdminPresenter.overviewRow({
           communityId: c.communityId,
@@ -74,6 +86,7 @@ export default class SysAdminUseCase {
           windowActivity,
           weeklyRetention,
           latestCohort,
+          hubMemberCount,
         });
       }),
     );
@@ -215,4 +228,19 @@ function clampLimit(limit: number | null | undefined): number {
 function clampWindowDays(input: number | null | undefined): number {
   const n = input ?? DEFAULT_WINDOW_DAYS;
   return Math.min(Math.max(n, MIN_WINDOW_DAYS), MAX_WINDOW_DAYS);
+}
+
+/**
+ * Hub-classification breadth threshold, in distinct DONATION
+ * recipients within the parametric window. Defaults to 3 when
+ * omitted, and clamped to
+ * [MIN_HUB_BREADTH_THRESHOLD, MAX_HUB_BREADTH_THRESHOLD] so a
+ * malformed/hostile input can't disable hub classification entirely
+ * (negative threshold) or scan-stall the comparison (gigantic
+ * threshold). Documented in the SysAdminDashboardInput
+ * .hubBreadthThreshold SDL description.
+ */
+function clampHubBreadthThreshold(input: number | null | undefined): number {
+  const n = input ?? DEFAULT_HUB_BREADTH_THRESHOLD;
+  return Math.min(Math.max(n, MIN_HUB_BREADTH_THRESHOLD), MAX_HUB_BREADTH_THRESHOLD);
 }

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -3265,6 +3265,22 @@ export type GqlSysAdminMemberRow = {
   name?: Maybe<Scalars['String']['output']>;
   /** All-time DONATION points sent by this user in this community. */
   totalPointsOut: Scalars['Float']['output'];
+  /**
+   * All-time count of distinct OTHER users this member has sent at
+   * least one DONATION to in this community. The "network breadth"
+   * half of the donor profile (paired with frequency-based
+   * `userSendRate` and volume-based `totalPointsOut`):
+   *
+   *   breadth × frequency × volume → the client's per-member
+   *   classification space (e.g. true hub vs single-target loyal vs
+   *   rare-but-far-reaching).
+   *
+   * Counts unique counterparty user_id, not transaction count, so a
+   * member who sent 100 donations to the same recipient still scores
+   * 1. Excludes burn / system targets (recipient wallets without a
+   * user_id).
+   */
+  uniqueDonationRecipients: Scalars['Int']['output'];
   /** User id. */
   userId: Scalars['ID']['output'];
   /**
@@ -6849,6 +6865,7 @@ export type GqlSysAdminMemberRowResolvers<ContextType = any, ParentType extends 
   monthsIn?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   name?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   totalPointsOut?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  uniqueDonationRecipients?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   userId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
   userSendRate?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -3102,6 +3102,35 @@ export type GqlSysAdminCommunityOverview = {
   /** Community display name (t_communities.name). */
   communityName: Scalars['String']['output'];
   /**
+   * Number of members classified as a "hub" within the parametric
+   * window (`windowDays`):
+   *
+   *   hubMemberCount = COUNT(member)
+   *     WHERE windowUniqueDonationRecipients >= input.hubBreadthThreshold
+   *
+   * `windowUniqueDonationRecipients` is the count of DISTINCT users
+   * this member sent a DONATION to during
+   * `[asOf - windowDays JST日, asOf + 1 JST日)` — distinct from the
+   * L2 `SysAdminMemberRow.uniqueDonationRecipients` field which is
+   * tenure-wide. The window-scoped variant is computed on demand in
+   * this aggregate but not exposed per-member at L1 (members
+   * themselves are an L2 concern).
+   *
+   * Hub classification deliberately uses BREADTH only — a member
+   * who reached `hubBreadthThreshold` distinct recipients during
+   * the window necessarily transacted at least that many times,
+   * making an explicit frequency floor redundant. This keeps the
+   * threshold knobs to one (`hubBreadthThreshold`).
+   *
+   * Invariants (the client may assert these):
+   *   hubMemberCount <= windowActivity.senderCount <= totalMembers
+   *
+   * The first holds because any hub member donated >= 3 times in
+   * the window and is therefore a window sender; the second because
+   * any window sender is a JOINED member at asOf.
+   */
+  hubMemberCount: Scalars['Int']['output'];
+  /**
    * Latest completed monthly cohort and its M+1 activity. See
    * SysAdminLatestCohort.
    */
@@ -3184,6 +3213,29 @@ export type GqlSysAdminDashboardInput = {
    * Defaults to now when omitted.
    */
   asOf?: InputMaybe<Scalars['Datetime']['input']>;
+  /**
+   * Minimum number of distinct DONATION recipients within the
+   * parametric window (`windowDays`) for a member to be classified
+   * as a hub. Used to populate `SysAdminCommunityOverview.hubMemberCount`.
+   *
+   * Defaults to 3, meaning "sent DONATION to at least 3 different
+   * people during the window". The threshold is on **unique
+   * counterparties** (set cardinality), not transaction count, so a
+   * member who donated 100 times to the same recipient does not
+   * qualify on this axis alone.
+   *
+   * Effective range 1..1000; values outside are silently clamped on
+   * the server.
+   *
+   * This is intentionally an absolute threshold rather than a
+   * community-relative percentile: a percentile-based hub would
+   * always classify ~N% of members as hubs by definition, defeating
+   * cross-community comparison ("which communities have the highest
+   * hub ratio?"). Community size differences are absorbed
+   * client-side by displaying `hubMemberCount / totalMembers` rather
+   * than the raw count.
+   */
+  hubBreadthThreshold?: InputMaybe<Scalars['Int']['input']>;
   /** Stage classification thresholds (see SysAdminSegmentThresholdsInput). */
   segmentThresholds?: InputMaybe<GqlSysAdminSegmentThresholdsInput>;
   /**
@@ -6816,6 +6868,7 @@ export type GqlSysAdminCommunityDetailPayloadResolvers<ContextType = any, Parent
 export type GqlSysAdminCommunityOverviewResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminCommunityOverview'] = GqlResolversParentTypes['SysAdminCommunityOverview']> = ResolversObject<{
   communityId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
   communityName?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  hubMemberCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   latestCohort?: Resolver<GqlResolversTypes['SysAdminLatestCohort'], ParentType, ContextType>;
   segmentCounts?: Resolver<GqlResolversTypes['SysAdminSegmentCounts'], ParentType, ContextType>;
   totalMembers?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;


### PR DESCRIPTION
## 概要

L2 `SysAdminMemberRow` に `uniqueDonationRecipients: Int!` を追加し、各 member の **「ネットワーク広さ (= 何人に DONATION を送ったか)」** を tenure 全体で expose します。

## 背景

これまで L2 の per-member データは個体品質 (`userSendRate`) と量 (`totalPointsOut`) のみで、**ネットワーク広さ**の指標が欠けていました。frontend 側で「同じ人をノードとして、個体品質とネットワーク品質の 2 軸で評価する」モデルを構築するための raw signal として 1 field 追加します。

これにより L2 row は 3 つの独立した次元を持ちます:

| 次元 | field | 役割 |
|---|---|---|
| 頻度 | `userSendRate` | どれだけ「定期的」に動くか (個体品質) |
| 量 | `totalPointsOut` | どれだけ「大きく」動くか (強度) |
| **広さ** | **`uniqueDonationRecipients`** | **どれだけ「多くの人」と関わるか (ネットワーク品質)** |

frontend は 3 軸を任意に組み合わせて分類可能になります (例: true hub / single-target loyal / rare-but-far-reaching 等)。

## 変更内容

- `SysAdminMemberRow.uniqueDonationRecipients: Int!` を schema に追加 (description 込み)
- `SysAdminMemberStatsRow` (data type) に `uniqueDonationRecipients: number` 追加
- `findMemberStats` SQL に CTE `donation_recipients` 追加
- presenter `memberRow` で passthrough
- 関連テスト fixture 更新
- `pnpm gql:generate` で `src/types/graphql.ts` / `docs/schema.graphql` 自動再生成

## 実装の要点

### なぜ既存 MV (`mv_user_transaction_daily`) を使わないか

`mv_user_transaction_daily.unique_counterparties` は **per-day per-user** で集計されており、tenure 全体への合算が **DISTINCT に composable ではありません** (同一 recipient が複数日に登場すると SUM で重複カウントされる)。よって all-time の unique recipient 数は `t_transactions` への直接 query が必要です。

### CTE 設計

```sql
donation_recipients AS (
  SELECT
    fw."user_id" AS user_id,
    COUNT(DISTINCT tw."user_id")::int AS unique_recipients
  FROM "t_transactions" t
  INNER JOIN "t_wallets" fw ON fw."id" = t."from" AND fw."community_id" = ${communityId}
  INNER JOIN "t_wallets" tw ON tw."id" = t."to" AND tw."user_id" IS NOT NULL
  INNER JOIN members m ON m."user_id" = fw."user_id"
  CROSS JOIN asof_bound ab
  WHERE t."reason" = 'DONATION'
    AND t."created_at" < ab.upper_ts
    AND (tw."community_id" IS NULL OR tw."community_id" = fw."community_id")
  GROUP BY fw."user_id"
)
```

- 既存 CTE (`asof_jst`, `asof_bound`, `members`) を再利用、tenure clamp は他 field と同じ
- cross-community DONATION 漏れ防止 + burn target (recipient wallet without `user_id`) 除外を `mv_user_transaction_daily` / `v_transaction_comments` と同じガードで適用
- LEFT JOIN + `COALESCE(MAX(dr.unique_recipients), 0)` で per-user 集約済み CTE を既存 GROUP BY にクリーンに乗せる (GROUP BY キー拡大なし)

## パフォーマンス

community 1 つあたり SQL クエリ数の増加はゼロ (既存 `findMemberStats` 内に CTE を 1 個追加するだけ)。`t_transactions` への scan は `community_id` + `reason='DONATION'` で絞られて index 効くので、現スケール (community ~6 / member 数百) で実用上の影響なし。

## Test plan

- [ ] `pnpm test --runInBand src/__tests__/unit/sysadmin/` で sysadmin 関連 unit test pass
- [ ] CI lint / build / unit / integration / e2e / auth all green
- [ ] gql:generate 出力 (`src/types/graphql.ts` / `docs/schema.graphql`) が手動編集なし、自動生成のみで一致

## 確認したい点 (reviewer 向け)

- CTE の cross-community ガード (`tw.community_id IS NULL OR tw.community_id = fw.community_id`) は `mv_user_transaction_daily` の防御と意図的に同じです。仮に運用上 cross-community DONATION が発生し得ない前提なら冗長ですが、defense-in-depth として残しています
- `COALESCE(MAX(dr.unique_recipients), 0)` の `MAX` は `donation_recipients` CTE が user_id で pre-grouped なので 1 レコード保証されている前提。コメントに記載済み

https://claude.ai/code/session_01HcWsRCxrCZToZNom8HVbc7

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcWsRCxrCZToZNom8HVbc7)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/917" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
