### PR TITLE
feat(sysadmin): L1/L2 に dormantCount (休眠メンバー数) を追加

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -2065,6 +2065,17 @@ input SysAdminCommunityDetailInput {
   """
   cursor: String
 
+  """
+  Days since a member's most recent DONATION above which they are
+  classified as "dormant". Used to populate
+  `SysAdminCommunityDetailPayload.dormantCount`. See the same-named
+  field on SysAdminDashboardInput for the full semantic.
+  
+  Default 30 (≈ one month of silence). Effective range 1..365;
+  values outside are silently clamped on the server.
+  """
+  dormantThresholdDays: Int = 30
+
   """Member list page size (default 50, max 200)."""
   limit: Int = 50
 
@@ -2103,6 +2114,16 @@ type SysAdminCommunityDetailPayload {
 
   """Community display name."""
   communityName: String!
+
+  """
+  Members who donated at some point but whose most recent
+  DONATION is older than `dormantThresholdDays` (default 30). See
+  the same-named field on `SysAdminCommunityOverview` for the
+  full semantic. Exposed at L2 so the user-scope card can show
+  the dormancy ratio directly without re-aggregating from the
+  member list.
+  """
+  dormantCount: Int!
 
   """Paginated member list — see type doc."""
   memberList: SysAdminMemberList!
@@ -2149,6 +2170,29 @@ type SysAdminCommunityOverview {
 
   """Community display name (t_communities.name)."""
   communityName: String!
+
+  """
+  Members who donated at some point but whose most recent
+  DONATION is older than `dormantThresholdDays` (default 30).
+  Distinct from `segmentCounts.passiveCount` (= "latent", never
+  donated): operators care about the difference because the
+  intervention is different — re-engage the dormant, onboard the
+  latent.
+  
+  Computed as
+    COUNT(DISTINCT user_id)
+    WHERE the user has at least one historical DONATION in this
+      community AND `MAX(donation.created_at) < asOf -
+      dormantThresholdDays`
+      AND status='JOINED' at asOf
+  
+  Invariants the client may assert:
+    0 <= dormantCount <= totalMembers - segmentCounts.passiveCount
+  
+  The upper bound holds because dormant members are by
+  construction ever-donated, which `passiveCount` excludes.
+  """
+  dormantCount: Int!
 
   """
   Number of members classified as a "hub" within the parametric
@@ -2306,6 +2350,23 @@ input SysAdminDashboardInput {
   Defaults to now when omitted.
   """
   asOf: Datetime
+
+  """
+  Days since a member's most recent DONATION above which they are
+  classified as "dormant" — i.e. they donated at some point but
+  have gone quiet. Used to populate
+  `SysAdminCommunityOverview.dormantCount`.
+  
+  Distinct from `segmentCounts.passiveCount` (= "latent", never
+  donated): operators care about the difference because the
+  intervention is different (re-engage a sleeper vs onboard a
+  newcomer). A member with `MAX(donation.created_at) < asOf -
+  dormantThresholdDays` is dormant.
+  
+  Default 30 (≈ one month of silence). Effective range 1..365;
+  values outside are silently clamped on the server.
+  """
+  dormantThresholdDays: Int = 30
 
   """
   Minimum number of distinct DONATION recipients within the

--- a/src/__tests__/unit/sysadmin/presenter.test.ts
+++ b/src/__tests__/unit/sysadmin/presenter.test.ts
@@ -56,6 +56,7 @@ describe("SysAdminPresenter", () => {
         uniqueDonationRecipients: 4,
         daysIn: 365,
         donationOutDays: 40,
+        lastDonationDay: new Date("2026-04-01"),
       };
       const out = SysAdminPresenter.memberRow(row);
       expect(out.totalPointsOut).toBe(5_000);
@@ -76,6 +77,7 @@ describe("SysAdminPresenter", () => {
         uniqueDonationRecipients: 0,
         daysIn: 1,
         donationOutDays: 0,
+        lastDonationDay: null,
       };
       expect(SysAdminPresenter.memberRow(row).name).toBeNull();
     });
@@ -239,6 +241,7 @@ describe("SysAdminPresenter", () => {
             uniqueDonationRecipients: 0,
             daysIn: 30,
             donationOutDays: 1,
+            lastDonationDay: new Date("2026-04-25"),
           },
         ],
         hasNextPage: true,
@@ -318,6 +321,7 @@ describe("SysAdminPresenter", () => {
           m3to12Months: 3,
           gte12Months: 4,
         },
+        dormantCount: 1,
       });
       expect(out.segmentCounts.tier1Count).toBe(2);
       expect(out.segmentCounts.tier2Count).toBe(5);
@@ -341,6 +345,7 @@ describe("SysAdminPresenter", () => {
         m3to12Months: 3,
         gte12Months: 4,
       });
+      expect(out.dormantCount).toBe(1);
     });
   });
 });

--- a/src/__tests__/unit/sysadmin/service.test.ts
+++ b/src/__tests__/unit/sysadmin/service.test.ts
@@ -427,6 +427,28 @@ describe("SysAdminService", () => {
       expect(service.computeDormantCount(members, asOf, 365)).toBe(0);
     });
 
+    it("treats edge case as active even when asOf has a nonzero time-of-day (regression)", () => {
+      // Production asOf is `new Date()` with the wall-clock time
+      // component preserved (e.g. 06:17:55Z). lastDonationDay is a
+      // JST calendar day at UTC 00:00 (the SQL ::date cast in
+      // findMemberStats strips the time). Without truncating asOf
+      // to its JST date before subtracting days, a member who
+      // donated on the cutoff day has lastDonationDay = cutoff-day
+      // 00:00Z < cutoff-day HH:MM:SSZ → they'd be misclassified as
+      // dormant whenever asOf carried any nonzero time component.
+      // This test pins down the truncate-then-subtract contract.
+      const asOfWithTime = new Date("2026-04-26T06:17:55Z");
+      const members = [
+        member({
+          userId: "edge",
+          donationOutMonths: 1,
+          // 30 days before 2026-04-26 in JST is 2026-03-27 → at UTC 00:00
+          lastDonationDay: new Date("2026-03-27T00:00:00Z"),
+        }),
+      ];
+      expect(service.computeDormantCount(members, asOfWithTime, 30)).toBe(0);
+    });
+
     it("respects the dormantCount <= totalMembers - latent invariant", () => {
       // 3 latent + 2 active + 1 dormant. dormantCount = 1, latent = 3,
       // total = 6, so dormantCount (1) <= total (6) - latent (3) = 3.

--- a/src/__tests__/unit/sysadmin/service.test.ts
+++ b/src/__tests__/unit/sysadmin/service.test.ts
@@ -16,6 +16,11 @@ import type {
  */
 function member(overrides: Partial<SysAdminMemberStatsRow>): SysAdminMemberStatsRow {
   const monthsIn = overrides.monthsIn ?? 1;
+  // lastDonationDay defaults to undefined → null so a member that
+  // hasn't been given a donation history is "latent". Override
+  // explicitly when testing isDormant / computeDormantCount.
+  const lastDonationDay =
+    overrides.lastDonationDay === undefined ? null : overrides.lastDonationDay;
   return {
     userId: overrides.userId ?? "u",
     name: overrides.name ?? null,
@@ -31,6 +36,7 @@ function member(overrides: Partial<SysAdminMemberStatsRow>): SysAdminMemberStats
     // (monthsIn high, daysIn low).
     daysIn: overrides.daysIn ?? monthsIn * 30,
     donationOutDays: overrides.donationOutDays ?? 0,
+    lastDonationDay,
   };
 }
 
@@ -348,6 +354,94 @@ describe("SysAdminService", () => {
       expect(dist.lt1Month + dist.m1to3Months + dist.m3to12Months + dist.gte12Months).toBe(
         members.length,
       );
+    });
+  });
+
+  // ========================================================================
+  // isDormant + computeDormantCount: latent vs dormant distinction
+  // (issue #918 follow-up: separate "never donated" from "went quiet")
+  // ========================================================================
+  describe("computeDormantCount", () => {
+    const asOf = new Date("2026-04-26T00:00:00Z");
+    const dayBefore = (n: number) => new Date(asOf.getTime() - n * 24 * 60 * 60 * 1000);
+
+    it("counts only members whose last donation is older than the threshold", () => {
+      const members = [
+        // never donated → latent, NOT dormant
+        member({ userId: "latent", donationOutMonths: 0, lastDonationDay: null }),
+        // donated 5 days ago → still active
+        member({
+          userId: "active",
+          donationOutMonths: 3,
+          lastDonationDay: dayBefore(5),
+        }),
+        // donated 31 days ago → dormant under default 30
+        member({
+          userId: "dormant",
+          donationOutMonths: 3,
+          lastDonationDay: dayBefore(31),
+        }),
+        // donated 90 days ago → dormant
+        member({
+          userId: "very-dormant",
+          donationOutMonths: 3,
+          lastDonationDay: dayBefore(90),
+        }),
+      ];
+      expect(service.computeDormantCount(members, asOf, 30)).toBe(2);
+    });
+
+    it("treats last-donation-exactly-N-days-ago as STILL ACTIVE (strict <)", () => {
+      // The cutoff is asOf - N days. lastDonationDay must be
+      // strictly older than the cutoff to qualify. A member who
+      // donated exactly N days ago sits at the cutoff and is not
+      // dormant — gives operators a deterministic boundary.
+      const members = [
+        member({
+          userId: "edge",
+          donationOutMonths: 1,
+          lastDonationDay: dayBefore(30),
+        }),
+      ];
+      expect(service.computeDormantCount(members, asOf, 30)).toBe(0);
+    });
+
+    it("never counts latent members regardless of threshold", () => {
+      // donationOutMonths === 0 short-circuits to false even when
+      // lastDonationDay is somehow set (defensive).
+      const members = [
+        member({ userId: "n1", donationOutMonths: 0, lastDonationDay: null }),
+        member({ userId: "n2", donationOutMonths: 0, lastDonationDay: null }),
+      ];
+      expect(service.computeDormantCount(members, asOf, 1)).toBe(0);
+      expect(service.computeDormantCount(members, asOf, 365)).toBe(0);
+    });
+
+    it("scales with the threshold — larger thresholds shrink the dormant set", () => {
+      const members = [
+        member({ userId: "a", donationOutMonths: 1, lastDonationDay: dayBefore(45) }),
+        member({ userId: "b", donationOutMonths: 1, lastDonationDay: dayBefore(120) }),
+      ];
+      expect(service.computeDormantCount(members, asOf, 30)).toBe(2);
+      expect(service.computeDormantCount(members, asOf, 60)).toBe(1);
+      expect(service.computeDormantCount(members, asOf, 365)).toBe(0);
+    });
+
+    it("respects the dormantCount <= totalMembers - latent invariant", () => {
+      // 3 latent + 2 active + 1 dormant. dormantCount = 1, latent = 3,
+      // total = 6, so dormantCount (1) <= total (6) - latent (3) = 3.
+      const members = [
+        member({ userId: "l1", donationOutMonths: 0, lastDonationDay: null }),
+        member({ userId: "l2", donationOutMonths: 0, lastDonationDay: null }),
+        member({ userId: "l3", donationOutMonths: 0, lastDonationDay: null }),
+        member({ userId: "a1", donationOutMonths: 2, lastDonationDay: dayBefore(5) }),
+        member({ userId: "a2", donationOutMonths: 2, lastDonationDay: dayBefore(10) }),
+        member({ userId: "d1", donationOutMonths: 2, lastDonationDay: dayBefore(60) }),
+      ];
+      const dormant = service.computeDormantCount(members, asOf, 30);
+      const latent = members.filter((m) => m.donationOutMonths === 0).length;
+      expect(dormant).toBe(1);
+      expect(dormant).toBeLessThanOrEqual(members.length - latent);
     });
   });
 

--- a/src/application/domain/sysadmin/data/repository.ts
+++ b/src/application/domain/sysadmin/data/repository.ts
@@ -95,6 +95,7 @@ export default class SysAdminRepository implements ISysAdminRepository {
           total_points_out: bigint;
           user_send_rate: number;
           unique_donation_recipients: number;
+          last_donation_day: Date | null;
         }[]
       >`
         WITH asof_jst AS (
@@ -281,7 +282,14 @@ export default class SysAdminRepository implements ISysAdminRepository {
           -- BY) propagates that single value through the per-user
           -- grouping cleanly and matches the COALESCE/MAX pattern
           -- used elsewhere when joining a pre-aggregated CTE.
-          COALESCE(MAX(dr.unique_recipients), 0)::int AS unique_donation_recipients
+          COALESCE(MAX(dr.unique_recipients), 0)::int AS unique_donation_recipients,
+          -- MAX over the per-(user, jst_day) rows in donation_activity
+          -- gives the most recent JST day this user sent a DONATION.
+          -- NULL when the LEFT JOIN found no donation_activity rows
+          -- (= the member never donated, the latent case). The service
+          -- layer derives dormantCount from this without re-scanning
+          -- t_transactions.
+          MAX(da.jst_day) AS last_donation_day
         FROM members m
         INNER JOIN member_tenure mt ON mt."user_id" = m."user_id"
         LEFT JOIN donation_activity da ON da.user_id = m."user_id"
@@ -300,6 +308,7 @@ export default class SysAdminRepository implements ISysAdminRepository {
         totalPointsOut: r.total_points_out,
         userSendRate: r.user_send_rate,
         uniqueDonationRecipients: r.unique_donation_recipients,
+        lastDonationDay: r.last_donation_day,
       }));
     });
   }

--- a/src/application/domain/sysadmin/data/type.ts
+++ b/src/application/domain/sysadmin/data/type.ts
@@ -30,6 +30,14 @@ export type SysAdminMemberStatsRow = {
   uniqueDonationRecipients: number;
   daysIn: number;
   donationOutDays: number;
+  /**
+   * The most recent JST calendar day the member sent a DONATION
+   * (UTC-encoded date at JST midnight, same convention as the rest
+   * of the sysadmin domain). null when the member has never
+   * donated. Internal raw signal; not exposed in GraphQL today —
+   * `dormantCount` is derived from it in the service layer.
+   */
+  lastDonationDay: Date | null;
 };
 
 /** Monthly activity counters, sourced from `mv_*` + `t_memberships`.

--- a/src/application/domain/sysadmin/presenter.ts
+++ b/src/application/domain/sysadmin/presenter.ts
@@ -116,6 +116,7 @@ export default class SysAdminPresenter {
     latestCohort: LatestCohortCounts;
     hubMemberCount: number;
     tenureDistribution: TenureDistribution;
+    dormantCount: number;
   }): GqlSysAdminCommunityOverview {
     return {
       communityId: params.communityId,
@@ -127,6 +128,7 @@ export default class SysAdminPresenter {
       latestCohort: SysAdminPresenter.latestCohort(params.latestCohort),
       hubMemberCount: params.hubMemberCount,
       tenureDistribution: SysAdminPresenter.tenureDistribution(params.tenureDistribution),
+      dormantCount: params.dormantCount,
     };
   }
 
@@ -269,6 +271,7 @@ export default class SysAdminPresenter {
     cohortRetention: GqlSysAdminCohortRetentionPoint[];
     memberList: GqlSysAdminMemberList;
     alerts: GqlSysAdminCommunityAlerts;
+    dormantCount: number;
   }): GqlSysAdminCommunityDetailPayload {
     return {
       communityId: params.communityId,
@@ -282,6 +285,7 @@ export default class SysAdminPresenter {
       cohortRetention: params.cohortRetention,
       memberList: params.memberList,
       alerts: params.alerts,
+      dormantCount: params.dormantCount,
     };
   }
 }

--- a/src/application/domain/sysadmin/schema/type.graphql
+++ b/src/application/domain/sysadmin/schema/type.graphql
@@ -116,6 +116,23 @@ input SysAdminDashboardInput {
   than the raw count.
   """
   hubBreadthThreshold: Int = 3
+
+  """
+  Days since a member's most recent DONATION above which they are
+  classified as "dormant" — i.e. they donated at some point but
+  have gone quiet. Used to populate
+  `SysAdminCommunityOverview.dormantCount`.
+
+  Distinct from `segmentCounts.passiveCount` (= "latent", never
+  donated): operators care about the difference because the
+  intervention is different (re-engage a sleeper vs onboard a
+  newcomer). A member with `MAX(donation.created_at) < asOf -
+  dormantThresholdDays` is dormant.
+
+  Default 30 (≈ one month of silence). Effective range 1..365;
+  values outside are silently clamped on the server.
+  """
+  dormantThresholdDays: Int = 30
 }
 
 """
@@ -217,6 +234,17 @@ input SysAdminCommunityDetailInput {
   Stage-count thresholds for the stage distribution and tier counts.
   """
   segmentThresholds: SysAdminSegmentThresholdsInput
+
+  """
+  Days since a member's most recent DONATION above which they are
+  classified as "dormant". Used to populate
+  `SysAdminCommunityDetailPayload.dormantCount`. See the same-named
+  field on SysAdminDashboardInput for the full semantic.
+
+  Default 30 (≈ one month of silence). Effective range 1..365;
+  values outside are silently clamped on the server.
+  """
+  dormantThresholdDays: Int = 30
 
   """
   Member list filter. Defaults to `minSendRate = 0.7` (habitual only).
@@ -535,6 +563,29 @@ type SysAdminCommunityOverview {
   an N+1 round trip per community to compute distribution).
   """
   tenureDistribution: SysAdminTenureDistribution!
+
+  """
+  Members who donated at some point but whose most recent
+  DONATION is older than `dormantThresholdDays` (default 30).
+  Distinct from `segmentCounts.passiveCount` (= "latent", never
+  donated): operators care about the difference because the
+  intervention is different — re-engage the dormant, onboard the
+  latent.
+
+  Computed as
+    COUNT(DISTINCT user_id)
+    WHERE the user has at least one historical DONATION in this
+      community AND `MAX(donation.created_at) < asOf -
+      dormantThresholdDays`
+      AND status='JOINED' at asOf
+
+  Invariants the client may assert:
+    0 <= dormantCount <= totalMembers - segmentCounts.passiveCount
+
+  The upper bound holds because dormant members are by
+  construction ever-donated, which `passiveCount` excludes.
+  """
+  dormantCount: Int!
 }
 
 """
@@ -936,4 +987,14 @@ type SysAdminCommunityDetailPayload {
   Alert flags (same structure as L1, evaluated for this community).
   """
   alerts: SysAdminCommunityAlerts!
+
+  """
+  Members who donated at some point but whose most recent
+  DONATION is older than `dormantThresholdDays` (default 30). See
+  the same-named field on `SysAdminCommunityOverview` for the
+  full semantic. Exposed at L2 so the user-scope card can show
+  the dormancy ratio directly without re-aggregating from the
+  member list.
+  """
+  dormantCount: Int!
 }

--- a/src/application/domain/sysadmin/service.ts
+++ b/src/application/domain/sysadmin/service.ts
@@ -150,6 +150,27 @@ export function classifyMember(
   return "occasional";
 }
 
+/**
+ * "Has this member donated before but gone quiet?" — the
+ * latent-vs-dormant distinction operators care about for choosing
+ * between onboarding and re-engagement interventions.
+ *
+ * False for never-donated members (latent / passive), regardless
+ * of how long ago they joined. True only when the member's most
+ * recent DONATION is strictly older than the threshold; equality
+ * is treated as "still active" so a member who donated exactly
+ * `dormantThresholdDays` days ago does NOT qualify.
+ */
+export function isDormant(
+  m: SysAdminMemberStatsRow,
+  asOf: Date,
+  dormantThresholdDays: number,
+): boolean {
+  if (m.donationOutMonths === 0 || m.lastDonationDay === null) return false;
+  const cutoff = addDays(asOf, -dormantThresholdDays);
+  return m.lastDonationDay < cutoff;
+}
+
 export type WeeklyRetentionPoint = {
   weekStart: Date;
   retainedSenders: number;
@@ -281,6 +302,17 @@ export const MAX_WINDOW_DAYS = 90;
 export const DEFAULT_HUB_BREADTH_THRESHOLD = 3;
 export const MIN_HUB_BREADTH_THRESHOLD = 1;
 export const MAX_HUB_BREADTH_THRESHOLD = 1000;
+
+/**
+ * Days-of-silence threshold above which an ever-donated member is
+ * classified as "dormant" (= sender who went quiet, distinct from
+ * the never-donated "latent" cohort). Default 30 (≈ one month).
+ * Effective range 1..365 enforced at the usecase boundary the same
+ * way `windowDays` is.
+ */
+export const DEFAULT_DORMANT_THRESHOLD_DAYS = 30;
+export const MIN_DORMANT_THRESHOLD_DAYS = 1;
+export const MAX_DORMANT_THRESHOLD_DAYS = 365;
 
 /**
  * Cap on how many DB round-trips the retention-trend and cohort-
@@ -485,6 +517,27 @@ export default class SysAdminService {
       else gte12Months++;
     }
     return { lt1Month, m1to3Months, m3to12Months, gte12Months };
+  }
+
+  /**
+   * Count of members who donated at some point in the past but
+   * whose most recent DONATION is older than `dormantThresholdDays`.
+   * Excludes never-donated members (they're "latent" / passiveCount,
+   * not dormant — different intervention surface).
+   *
+   * Pure function over the member rows already fetched for the
+   * dashboard; no extra SQL.
+   */
+  computeDormantCount(
+    members: SysAdminMemberStatsRow[],
+    asOf: Date,
+    dormantThresholdDays: number,
+  ): number {
+    let dormant = 0;
+    for (const m of members) {
+      if (isDormant(m, asOf, dormantThresholdDays)) dormant++;
+    }
+    return dormant;
   }
 
   /**

--- a/src/application/domain/sysadmin/service.ts
+++ b/src/application/domain/sysadmin/service.ts
@@ -14,6 +14,7 @@ import {
   jstMonthStartOffset,
   jstNextMonthStart,
   percentChange,
+  truncateToJstDate,
 } from "@/application/domain/report/util";
 import { asOfBounds } from "@/application/domain/sysadmin/bounds";
 
@@ -160,6 +161,15 @@ export function classifyMember(
  * recent DONATION is strictly older than the threshold; equality
  * is treated as "still active" so a member who donated exactly
  * `dormantThresholdDays` days ago does NOT qualify.
+ *
+ * The cutoff is computed off the JST-truncated asOf so the
+ * comparison stays deterministic regardless of the request's
+ * wall-clock time. `lastDonationDay` is a JST calendar day at
+ * UTC 00:00 (PostgreSQL `::date` cast); truncating asOf the same
+ * way is the only way the strict-less-than has a stable boundary
+ * — without it, a member who donated on the cutoff day would be
+ * (incorrectly) dormant whenever `asOf` carried a nonzero
+ * time-of-day component (i.e. essentially always in production).
  */
 export function isDormant(
   m: SysAdminMemberStatsRow,
@@ -167,7 +177,7 @@ export function isDormant(
   dormantThresholdDays: number,
 ): boolean {
   if (m.donationOutMonths === 0 || m.lastDonationDay === null) return false;
-  const cutoff = addDays(asOf, -dormantThresholdDays);
+  const cutoff = addDays(truncateToJstDate(asOf), -dormantThresholdDays);
   return m.lastDonationDay < cutoff;
 }
 

--- a/src/application/domain/sysadmin/usecase.ts
+++ b/src/application/domain/sysadmin/usecase.ts
@@ -9,15 +9,18 @@ import {
   GqlSysAdminDashboardPayload,
 } from "@/types/graphql";
 import SysAdminService, {
+  DEFAULT_DORMANT_THRESHOLD_DAYS,
   DEFAULT_HUB_BREADTH_THRESHOLD,
   DEFAULT_SEGMENT_THRESHOLDS,
   DEFAULT_WINDOW_DAYS,
   DEFAULT_WINDOW_MONTHS,
+  MAX_DORMANT_THRESHOLD_DAYS,
   MAX_HUB_BREADTH_THRESHOLD,
   MAX_LIMIT,
   MAX_MIN_MONTHS_IN,
   MAX_WINDOW_DAYS,
   MAX_WINDOW_MONTHS,
+  MIN_DORMANT_THRESHOLD_DAYS,
   MIN_HUB_BREADTH_THRESHOLD,
   MIN_MIN_MONTHS_IN,
   MIN_WINDOW_DAYS,
@@ -49,6 +52,7 @@ export default class SysAdminUseCase {
     const thresholds = resolveThresholds(input?.segmentThresholds);
     const windowDays = clampWindowDays(input?.windowDays);
     const hubBreadthThreshold = clampHubBreadthThreshold(input?.hubBreadthThreshold);
+    const dormantThresholdDays = clampDormantThresholdDays(input?.dormantThresholdDays);
 
     const monthStart = jstMonthStart(asOf);
     // Clamp the platform-totals upper bound at asOf+1 JST day so a
@@ -81,6 +85,11 @@ export default class SysAdminUseCase {
           ]);
         const stageCounts = this.service.computeStageCounts(members, thresholds);
         const tenureDistribution = this.service.computeTenureDistribution(members);
+        const dormantCount = this.service.computeDormantCount(
+          members,
+          asOf,
+          dormantThresholdDays,
+        );
         return SysAdminPresenter.overviewRow({
           communityId: c.communityId,
           communityName: c.communityName,
@@ -91,6 +100,7 @@ export default class SysAdminUseCase {
           latestCohort,
           hubMemberCount,
           tenureDistribution,
+          dormantCount,
         });
       }),
     );
@@ -120,6 +130,7 @@ export default class SysAdminUseCase {
   ): Promise<GqlSysAdminCommunityDetailPayload> {
     const asOf = input.asOf ?? new Date();
     const thresholds = resolveThresholds(input.segmentThresholds);
+    const dormantThresholdDays = clampDormantThresholdDays(input.dormantThresholdDays);
     // Clamp to [1, MAX_WINDOW_MONTHS]. getCohortRetention and the
     // retention-trend fan-out both scale linearly with this value, so
     // a cap prevents a single request from exhausting the connection
@@ -155,6 +166,7 @@ export default class SysAdminUseCase {
 
     const stageCounts = this.service.computeStageCounts(members, thresholds);
     const stageBreakdown = this.service.computeStageBreakdown(members, thresholds);
+    const dormantCount = this.service.computeDormantCount(members, asOf, dormantThresholdDays);
 
     const alerts = await this.service.getAlerts(ctx, community.communityId, asOf);
 
@@ -192,6 +204,7 @@ export default class SysAdminUseCase {
       cohortRetention: cohortRetention.map(SysAdminPresenter.cohortPoint),
       memberList: SysAdminPresenter.memberList(memberList),
       alerts: SysAdminPresenter.alerts(alerts),
+      dormantCount,
     });
   }
 }
@@ -259,4 +272,18 @@ function clampWindowDays(input: number | null | undefined): number {
 function clampHubBreadthThreshold(input: number | null | undefined): number {
   const n = input ?? DEFAULT_HUB_BREADTH_THRESHOLD;
   return Math.min(Math.max(n, MIN_HUB_BREADTH_THRESHOLD), MAX_HUB_BREADTH_THRESHOLD);
+}
+
+/**
+ * Days-of-silence threshold for the dormant-vs-active distinction.
+ * Defaults to DEFAULT_DORMANT_THRESHOLD_DAYS when omitted, and
+ * clamped to [MIN_DORMANT_THRESHOLD_DAYS, MAX_DORMANT_THRESHOLD_DAYS]
+ * so a malformed/hostile input can't classify every member as
+ * dormant (negative threshold) or none of them (gigantic threshold).
+ * Documented in the SysAdminDashboardInput.dormantThresholdDays SDL
+ * description.
+ */
+function clampDormantThresholdDays(input: number | null | undefined): number {
+  const n = input ?? DEFAULT_DORMANT_THRESHOLD_DAYS;
+  return Math.min(Math.max(n, MIN_DORMANT_THRESHOLD_DAYS), MAX_DORMANT_THRESHOLD_DAYS);
 }

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -3030,6 +3030,16 @@ export type GqlSysAdminCommunityDetailInput = {
    * returned by the previous response unchanged.
    */
   cursor?: InputMaybe<Scalars['String']['input']>;
+  /**
+   * Days since a member's most recent DONATION above which they are
+   * classified as "dormant". Used to populate
+   * `SysAdminCommunityDetailPayload.dormantCount`. See the same-named
+   * field on SysAdminDashboardInput for the full semantic.
+   *
+   * Default 30 (≈ one month of silence). Effective range 1..365;
+   * values outside are silently clamped on the server.
+   */
+  dormantThresholdDays?: InputMaybe<Scalars['Int']['input']>;
   /** Member list page size (default 50, max 200). */
   limit?: InputMaybe<Scalars['Int']['input']>;
   /** Stage-count thresholds for the stage distribution and tier counts. */
@@ -3061,6 +3071,15 @@ export type GqlSysAdminCommunityDetailPayload = {
   communityId: Scalars['ID']['output'];
   /** Community display name. */
   communityName: Scalars['String']['output'];
+  /**
+   * Members who donated at some point but whose most recent
+   * DONATION is older than `dormantThresholdDays` (default 30). See
+   * the same-named field on `SysAdminCommunityOverview` for the
+   * full semantic. Exposed at L2 so the user-scope card can show
+   * the dormancy ratio directly without re-aggregating from the
+   * member list.
+   */
+  dormantCount: Scalars['Int']['output'];
   /** Paginated member list — see type doc. */
   memberList: GqlSysAdminMemberList;
   /**
@@ -3101,6 +3120,28 @@ export type GqlSysAdminCommunityOverview = {
   communityId: Scalars['ID']['output'];
   /** Community display name (t_communities.name). */
   communityName: Scalars['String']['output'];
+  /**
+   * Members who donated at some point but whose most recent
+   * DONATION is older than `dormantThresholdDays` (default 30).
+   * Distinct from `segmentCounts.passiveCount` (= "latent", never
+   * donated): operators care about the difference because the
+   * intervention is different — re-engage the dormant, onboard the
+   * latent.
+   *
+   * Computed as
+   *   COUNT(DISTINCT user_id)
+   *   WHERE the user has at least one historical DONATION in this
+   *     community AND `MAX(donation.created_at) < asOf -
+   *     dormantThresholdDays`
+   *     AND status='JOINED' at asOf
+   *
+   * Invariants the client may assert:
+   *   0 <= dormantCount <= totalMembers - segmentCounts.passiveCount
+   *
+   * The upper bound holds because dormant members are by
+   * construction ever-donated, which `passiveCount` excludes.
+   */
+  dormantCount: Scalars['Int']['output'];
   /**
    * Number of members classified as a "hub" within the parametric
    * window (`windowDays`):
@@ -3241,6 +3282,22 @@ export type GqlSysAdminDashboardInput = {
    * Defaults to now when omitted.
    */
   asOf?: InputMaybe<Scalars['Datetime']['input']>;
+  /**
+   * Days since a member's most recent DONATION above which they are
+   * classified as "dormant" — i.e. they donated at some point but
+   * have gone quiet. Used to populate
+   * `SysAdminCommunityOverview.dormantCount`.
+   *
+   * Distinct from `segmentCounts.passiveCount` (= "latent", never
+   * donated): operators care about the difference because the
+   * intervention is different (re-engage a sleeper vs onboard a
+   * newcomer). A member with `MAX(donation.created_at) < asOf -
+   * dormantThresholdDays` is dormant.
+   *
+   * Default 30 (≈ one month of silence). Effective range 1..365;
+   * values outside are silently clamped on the server.
+   */
+  dormantThresholdDays?: InputMaybe<Scalars['Int']['input']>;
   /**
    * Minimum number of distinct DONATION recipients within the
    * parametric window (`windowDays`) for a member to be classified
@@ -6959,6 +7016,7 @@ export type GqlSysAdminCommunityDetailPayloadResolvers<ContextType = any, Parent
   cohortRetention?: Resolver<Array<GqlResolversTypes['SysAdminCohortRetentionPoint']>, ParentType, ContextType>;
   communityId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
   communityName?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  dormantCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   memberList?: Resolver<GqlResolversTypes['SysAdminMemberList'], ParentType, ContextType>;
   monthlyActivityTrend?: Resolver<Array<GqlResolversTypes['SysAdminMonthlyActivityPoint']>, ParentType, ContextType>;
   retentionTrend?: Resolver<Array<GqlResolversTypes['SysAdminRetentionTrendPoint']>, ParentType, ContextType>;
@@ -6971,6 +7029,7 @@ export type GqlSysAdminCommunityDetailPayloadResolvers<ContextType = any, Parent
 export type GqlSysAdminCommunityOverviewResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminCommunityOverview'] = GqlResolversParentTypes['SysAdminCommunityOverview']> = ResolversObject<{
   communityId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
   communityName?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  dormantCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   hubMemberCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   latestCohort?: Resolver<GqlResolversTypes['SysAdminLatestCohort'], ParentType, ContextType>;
   segmentCounts?: Resolver<GqlResolversTypes['SysAdminSegmentCounts'], ParentType, ContextType>;


### PR DESCRIPTION
## 概要

L1/L2 の `SysAdminCommunityOverview` / `SysAdminCommunityDetailPayload` に **`dormantCount`** を追加。「過去に送付経験あり ∧ 直近 N 日送付なし」の **休眠メンバー** を `passiveCount` (= 一度も送付せずの latent) と区別して expose する。

運営者観点で **介入アクションが完全に違う** (latent → onboarding / dormant → re-engagement) ので、別 bucket として可視化する価値がある、という portal 側からの提案を実装。

## Changes

### Schema additions

```graphql
input SysAdminDashboardInput {
  ...existing
  dormantThresholdDays: Int = 30  # NEW
}
input SysAdminCommunityDetailInput {
  ...existing
  dormantThresholdDays: Int = 30  # NEW
}
type SysAdminCommunityOverview {
  ...existing
  dormantCount: Int!  # NEW (L1)
}
type SysAdminCommunityDetailPayload {
  ...existing
  dormantCount: Int!  # NEW (L2)
}
```

### 計算定義

```
dormantCount(asOf, dormantThresholdDays) =
  COUNT(DISTINCT user_id)
  WHERE user has at least one DONATION in t_transactions historically
    AND MAX(donation.created_at) < asOf - dormantThresholdDays
    AND user.status = 'JOINED' at asOf
```

### 不変条件

```
0 <= dormantCount <= totalMembers - segmentCounts.passiveCount
```

(latent と dormant は互いに排他: passive は「donate 経験なし」、dormant は「donate 経験あり」)。schema docstring に明記、test でも assert。

## 実装ハイライト

### 新規 SQL ゼロ

PR #919 で統合した `donation_activity` CTE (per-(user, jst_day, jst_month) grain) に `MAX(da.jst_day)` 集約を追加するだけで `last_donation_day` を内部 raw signal として取得できる。**`findMemberStats` への scan 増加なし**。

### 内部 raw signal vs 公開 field

`SysAdminMemberStatsRow.lastDonationDay: Date | null` は内部にとどめ、GraphQL では公開せず。aggregate (`dormantCount`) のみ expose。将来 per-member の dormant フラグや `lastDonationAt` を expose したい場合は別 PR で追加可能 (issue #918 で議論した「将来課題」)。

### Service 層の純粋関数

```typescript
isDormant(member, asOf, dormantThresholdDays): boolean
computeDormantCount(members, asOf, dormantThresholdDays): number
```

両方 pure。L1/L2 usecase は `getMemberStats` で既に member rows を fetch しているので **集計のみ**で計算完了。境界扱いは strict `<` (lastDonationDay が cutoff ちょうどの場合は active 扱い) で運営者向けに deterministic。

### Threshold clamp

`MIN/MAX = 1/365` で usecase 層 clamp。`windowDays` / `hubBreadthThreshold` と同じパターン。

## Commits 構成

| commit | 内容 |
|---|---|
| `dc30c3e` | schema 追加 (input + output + 充実 docstring) + `gql:generate` |
| `820f5c9` | impl: repository SQL 拡張 (`MAX(da.jst_day)`) + service `isDormant` / `computeDormantCount` + constants + usecase clamp / wiring + presenter passthrough |
| `6e16cdc` | tests: `member()` helper 拡張 + 5 cases for `computeDormantCount` (基本・境界・latent 短絡・threshold scaling・invariant) + presenter fixture 更新 |

## I/O / パフォーマンス影響

- **新規 SQL ゼロ**
- 既存 `donation_activity` CTE への `MAX` 集約追加のみ (1 列追加、scan 範囲不変)
- per-community per-load の SQL 数増加: **0**
- in-memory 集計 (`computeDormantCount`) は member 数 N に対して O(N)、~100 members で 100 ns オーダー

## Default 値の判断

- `dormantThresholdDays = 30`: 「約 1 ヶ月の沈黙」が運営者の直感的な「最近見ない」感覚と整合。`windowDays = 28` の rolling activity window より少し長めにすることで、「rolling 28d で active」と「dormant 認定」が二者択一に近い意味になる
- 範囲 1..365: 1 (ほぼ毎日 donate を期待) から 365 (1 年無音で休眠) まで。実用は 7-90 程度を想定

## Test plan

- [ ] CI lint / build / unit / integration / e2e / auth all green
- [ ] `pnpm test --runInBand src/__tests__/unit/sysadmin/` で sysadmin unit tests (especially `computeDormantCount` の 5 cases) pass
- [ ] portal 側で新 field (`dormantCount`) と input (`dormantThresholdDays`) の動作確認
- [ ] portal 側で invariant `dormantCount <= totalMembers - segmentCounts.passiveCount` を表示時 assert (regression check として有効)

## 確認したい点 (reviewer 向け)

- `dormantThresholdDays` の default `30` で OK か (28 / 60 など別案ありえる)
- 境界扱い: `lastDonationDay = asOf - 30 days` ちょうど → **active 扱い** (strict `<`) で OK か
- 内部の `lastDonationDay` を per-member raw signal として L2 `SysAdminMemberRow` に expose する必要は今回見送り (= "将来課題") で OK か

https://claude.ai/code/session_01HcWsRCxrCZToZNom8HVbc7

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcWsRCxrCZToZNom8HVbc7)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
