### PR TITLE
feat(sysadmin): SysAdminMemberRow に受領側 fields + 月次復帰/休眠 fields を追加

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -2076,7 +2076,15 @@ input SysAdminCommunityDetailInput {
   """
   dormantThresholdDays: Int = 30
 
-  """Member list page size (default 50, max 200)."""
+  """
+  Member list page size (default 50, max 1000). Raised from the
+  previous max of 200 so client-side aggregations that need every
+  member of a community (e.g. the "受領→送付 転換率" /
+  recipient-to-sender conversion rate, hub-persistence cohorts,
+  new-member retention breakdowns) can pull a single full page
+  without N round-trips. Communities larger than 1000 members
+  still need cursor pagination.
+  """
   limit: Int = 50
 
   """Stage-count thresholds for the stage distribution and tier counts."""
@@ -2477,6 +2485,21 @@ type SysAdminMemberRow {
   daysIn: Int!
 
   """
+  Distinct JST days the member received at least one DONATION.
+  Daily-grain counterpart to `donationInMonths`. Receiver-side
+  counterpart to `donationOutDays`.
+  """
+  donationInDays: Int!
+
+  """
+  Distinct months with at least one DONATION in. Receiver-side
+  counterpart to `donationOutMonths`. Combined with
+  `totalPointsIn`, identifies members who have been part of the
+  receiving side of the gift economy and over how broad a span.
+  """
+  donationInMonths: Int!
+
+  """
   Distinct JST days the member sent at least one DONATION.
   Daily-grain counterpart to `donationOutMonths`. Combined with
   `daysIn`, the client can compute `donationOutDays / daysIn` as
@@ -2492,6 +2515,17 @@ type SysAdminMemberRow {
 
   """User display name (users.name). null when the user has no name set."""
   name: String
+
+  """
+  All-time DONATION points received by this user in this community.
+  Receiver-side counterpart to `totalPointsOut`. Sums
+  `to_point_change` across DONATION transactions whose receiver
+  wallet belongs to this user in this community. Burn / system
+  sources (sender wallets without a user_id) are excluded so a
+  member who only received from a system grant scores 0 — same
+  scope as `totalPointsOut`.
+  """
+  totalPointsIn: Float!
 
   """All-time DONATION points sent by this user in this community."""
   totalPointsOut: Float!
@@ -2512,6 +2546,20 @@ type SysAdminMemberRow {
   user_id).
   """
   uniqueDonationRecipients: Int!
+
+  """
+  All-time count of distinct OTHER users that have sent at least
+  one DONATION to this member in this community. The receiver-side
+  counterpart to `uniqueDonationRecipients`. Counts unique sender
+  user_id, excludes burn / system sources (sender wallets without
+  a user_id) and self-donations (a user who somehow sent to their
+  own wallet does not increment the count). Used by the L2
+  dashboard to compute the "受領→送付 転換率" (recipient-to-sender
+  conversion rate) — share of DONATION recipients who have also
+  sent at least one DONATION — distinguishing reciprocal
+  participation networks from one-way distribution structures.
+  """
+  uniqueDonationSenders: Int!
 
   """User id."""
   userId: ID!
@@ -2542,11 +2590,50 @@ type SysAdminMonthlyActivityPoint {
   """Sum of DONATION points transferred in the month."""
   donationPointsSum: Float!
 
+  """
+  Members who had no DONATION out in the trailing 30 days as of
+  the END of this month. Snapshot of the dormant base at
+  month-end. Pair with the NEXT month's `returnedMembers` to
+  compute the monthly recovery rate
+  (`returnedMembers[N] / dormantCount[N-1]`).
+  
+  Aligns with `SysAdminCommunityOverview.dormantCount` /
+  `SysAdminCommunityDetailPayload.dormantCount` semantics: an
+  ever-donated member whose most recent DONATION is older than
+  30 days as of the month-end timestamp. The latest month's
+  value should equal `SysAdminCommunityDetailPayload.dormantCount`
+  when `asOf` falls at or near the JST month-end, modulo the
+  difference between the request's `dormantThresholdDays` input
+  (which the trend ignores in favor of a fixed 30-day window so
+  monthly returnedMembers / dormantCount stay comparable across
+  requests).
+  """
+  dormantCount: Int!
+
   """First day (JST) of the calendar month, e.g. 2025-10-01T00:00+09:00."""
   month: Datetime!
 
   """t_memberships.created_at (status='JOINED') rows falling in the month."""
   newMembers: Int!
+
+  """
+  Members who were dormant at the END of the previous calendar
+  month but had at least one DONATION out in this month. Monthly
+  counterpart to `SysAdminRetentionTrendPoint.returnedSenders`.
+  null for the first month in the series (no prior month to
+  reference).
+  
+  "Dormant at the end of previous month" uses the same threshold
+  semantic as `SysAdminCommunityOverview.dormantCount` /
+  `SysAdminMonthlyActivityPoint.dormantCount` — no DONATION out in
+  the trailing 30 days as of the previous month-end. This may
+  diverge slightly from the sum of weekly `returnedSenders` over
+  the month because the weekly metric uses a 12-week look-back at
+  ISO-week granularity while this monthly metric uses the
+  30-day-trailing dormant snapshot at month-end. The discrepancy
+  is week/month boundary alignment only.
+  """
+  returnedMembers: Int
 
   """Distinct DONATION senders in the month."""
   senderCount: Int!

--- a/src/__tests__/unit/sysadmin/presenter.test.ts
+++ b/src/__tests__/unit/sysadmin/presenter.test.ts
@@ -56,6 +56,10 @@ describe("SysAdminPresenter", () => {
         uniqueDonationRecipients: 4,
         daysIn: 365,
         donationOutDays: 40,
+        totalPointsIn: BigInt(2_500),
+        donationInMonths: 6,
+        donationInDays: 18,
+        uniqueDonationSenders: 3,
         lastDonationDay: new Date("2026-04-01"),
       };
       const out = SysAdminPresenter.memberRow(row);
@@ -64,6 +68,38 @@ describe("SysAdminPresenter", () => {
       expect(out.uniqueDonationRecipients).toBe(4);
       expect(out.daysIn).toBe(365);
       expect(out.donationOutDays).toBe(40);
+      // Receiver-side fields land alongside the sender-side ones.
+      // bigint goes through bigintToSafeNumber for the same loud-
+      // overflow contract as totalPointsOut.
+      expect(out.totalPointsIn).toBe(2_500);
+      expect(typeof out.totalPointsIn).toBe("number");
+      expect(out.donationInMonths).toBe(6);
+      expect(out.donationInDays).toBe(18);
+      expect(out.uniqueDonationSenders).toBe(3);
+    });
+
+    it("throws RangeError when totalPointsIn overflows safe integer", () => {
+      // Symmetric loud-overflow guarantee with totalPointsOut.
+      // A pure receiver who somehow accumulated a bigint past
+      // Number.MAX_SAFE_INTEGER must surface as a RangeError, not
+      // silently truncate in the externally-reported total.
+      const row: SysAdminMemberStatsRow = {
+        userId: "u1",
+        name: null,
+        monthsIn: 1,
+        donationOutMonths: 0,
+        userSendRate: 0,
+        totalPointsOut: BigInt(0),
+        uniqueDonationRecipients: 0,
+        daysIn: 1,
+        donationOutDays: 0,
+        totalPointsIn: BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1),
+        donationInMonths: 0,
+        donationInDays: 0,
+        uniqueDonationSenders: 0,
+        lastDonationDay: null,
+      };
+      expect(() => SysAdminPresenter.memberRow(row)).toThrow(RangeError);
     });
 
     it("passes null name through untouched", () => {
@@ -77,6 +113,10 @@ describe("SysAdminPresenter", () => {
         uniqueDonationRecipients: 0,
         daysIn: 1,
         donationOutDays: 0,
+        totalPointsIn: BigInt(0),
+        donationInMonths: 0,
+        donationInDays: 0,
+        uniqueDonationSenders: 0,
         lastDonationDay: null,
       };
       expect(SysAdminPresenter.memberRow(row).name).toBeNull();
@@ -151,6 +191,10 @@ describe("SysAdminPresenter", () => {
       donationPointsSum: BigInt(0),
       donationTxCount: BigInt(0),
       donationChainTxCount: BigInt(0),
+      // Default to "no dormant base / no returners" for the
+      // baseline fixture; specific tests override per-row.
+      dormantCountEndOfMonth: 0,
+      returnedMembers: null,
     };
 
     it("returns null chainPct when no DONATION tx occurred that month", () => {
@@ -183,6 +227,35 @@ describe("SysAdminPresenter", () => {
       expect(out.communityActivityRate).toBeCloseTo(0.2);
       expect(out.chainPct).toBeCloseTo(0.3);
       expect(out.donationPointsSum).toBe(5_000);
+    });
+
+    it("passes dormantCountEndOfMonth + returnedMembers through to dormantCount + returnedMembers", () => {
+      // The presenter is the only place dormantCountEndOfMonth ->
+      // dormantCount renaming happens; pinning it here keeps the
+      // "internal name has 'EndOfMonth' suffix, GraphQL field
+      // doesn't" contract from drifting silently. Returns from
+      // the row pass straight through (no derivation).
+      const out = SysAdminPresenter.monthlyActivityPoint({
+        ...baseRow,
+        dormantCountEndOfMonth: 7,
+        returnedMembers: 3,
+      });
+      expect(out.dormantCount).toBe(7);
+      expect(out.returnedMembers).toBe(3);
+    });
+
+    it("preserves null returnedMembers (= first month in series) without coercing to 0", () => {
+      // The repository emits null for the first month so the
+      // client can render "no prior month to compare" rather
+      // than misinterpret 0 as "zero returners". The presenter
+      // must propagate that null untouched.
+      const out = SysAdminPresenter.monthlyActivityPoint({
+        ...baseRow,
+        dormantCountEndOfMonth: 5,
+        returnedMembers: null,
+      });
+      expect(out.returnedMembers).toBeNull();
+      expect(out.dormantCount).toBe(5);
     });
 
     it("throws RangeError when donation tx count overflows safe integer", () => {
@@ -241,6 +314,10 @@ describe("SysAdminPresenter", () => {
             uniqueDonationRecipients: 0,
             daysIn: 30,
             donationOutDays: 1,
+            totalPointsIn: BigInt(0),
+            donationInMonths: 0,
+            donationInDays: 0,
+            uniqueDonationSenders: 0,
             lastDonationDay: new Date("2026-04-25"),
           },
         ],

--- a/src/__tests__/unit/sysadmin/service.test.ts
+++ b/src/__tests__/unit/sysadmin/service.test.ts
@@ -2,6 +2,7 @@ import "reflect-metadata";
 import { container } from "tsyringe";
 import SysAdminService, {
   DEFAULT_SEGMENT_THRESHOLDS,
+  MAX_LIMIT,
   classifyMember,
 } from "@/application/domain/sysadmin/service";
 import type {
@@ -36,6 +37,14 @@ function member(overrides: Partial<SysAdminMemberStatsRow>): SysAdminMemberStats
     // (monthsIn high, daysIn low).
     daysIn: overrides.daysIn ?? monthsIn * 30,
     donationOutDays: overrides.donationOutDays ?? 0,
+    // Receiver-side counters default to 0 (= never received a
+    // DONATION) for the same "fixture stays minimal" reason as
+    // the sender-side defaults above. Override per-test only
+    // when exercising recipient-axis logic.
+    totalPointsIn: overrides.totalPointsIn ?? BigInt(0),
+    donationInMonths: overrides.donationInMonths ?? 0,
+    donationInDays: overrides.donationInDays ?? 0,
+    uniqueDonationSenders: overrides.uniqueDonationSenders ?? 0,
     lastDonationDay,
   };
 }
@@ -670,6 +679,35 @@ describe("SysAdminService", () => {
       expect(page.users.length).toBe(4); // all rows fit
       expect(page.hasNextPage).toBe(false);
     });
+
+    it("respects the raised MAX_LIMIT (1000) so client-side aggregations can pull a full page", () => {
+      // Pin the cap to its post-issue-#1 value so a future
+      // "tighten the limit" change has to update this test
+      // alongside the schema description on
+      // SysAdminCommunityDetailInput.limit, which advertises
+      // "default 50, max 1000" to clients computing all-member
+      // aggregates (e.g. recipient-to-sender conversion rate).
+      expect(MAX_LIMIT).toBe(1000);
+
+      // Build 1500 members so the cap actually bites — at 1500
+      // > 1000, requesting limit=2000 returns 1000 and signals
+      // hasNextPage. Without the raised cap this would have
+      // returned 200 and pretended there were no further pages
+      // when only 200 of 1500 had been emitted, which the issue
+      // discussion flagged as the L2 blocker.
+      const many: SysAdminMemberStatsRow[] = Array.from({ length: 1500 }, (_, i) =>
+        member({ userId: `u${String(i).padStart(4, "0")}` }),
+      );
+      const page = service.paginateMembers(many, {
+        minSendRate: 0,
+        sortField: "SEND_RATE",
+        sortOrder: "DESC",
+        limit: 2000,
+      });
+      expect(page.users.length).toBe(MAX_LIMIT);
+      expect(page.hasNextPage).toBe(true);
+      expect(page.nextCursor).not.toBeNull();
+    });
   });
 
   // ========================================================================
@@ -689,6 +727,12 @@ describe("SysAdminService", () => {
         donationPointsSum: BigInt(0),
         donationTxCount: BigInt(0),
         donationChainTxCount: BigInt(0),
+        // Default to "no dormant base / no returners" — the 3m
+        // avg test only exercises the rate calculation, so these
+        // counters are unused. Returning the right shape keeps the
+        // test compatible with the row contract.
+        dormantCountEndOfMonth: 0,
+        returnedMembers: null,
       };
     }
 

--- a/src/application/domain/sysadmin/data/repository.ts
+++ b/src/application/domain/sysadmin/data/repository.ts
@@ -254,6 +254,7 @@ export default class SysAdminRepository implements ISysAdminRepository {
           INNER JOIN members m ON m."user_id" = tw."user_id"
           INNER JOIN "t_wallets" fw
             ON fw."id" = t."from"
+            AND fw."user_id" IS NOT NULL
             AND (fw."community_id" IS NULL OR fw."community_id" = tw."community_id")
           CROSS JOIN asof_bound ab
           WHERE t."reason" = 'DONATION'

--- a/src/application/domain/sysadmin/data/repository.ts
+++ b/src/application/domain/sysadmin/data/repository.ts
@@ -95,6 +95,10 @@ export default class SysAdminRepository implements ISysAdminRepository {
           total_points_out: bigint;
           user_send_rate: number;
           unique_donation_recipients: number;
+          donation_in_months: number;
+          donation_in_days: number;
+          total_points_in: bigint;
+          unique_donation_senders: number;
           last_donation_day: Date | null;
         }[]
       >`
@@ -214,6 +218,102 @@ export default class SysAdminRepository implements ISysAdminRepository {
             AND (tw."community_id" IS NULL OR tw."community_id" = fw."community_id")
           GROUP BY fw."user_id"
         ),
+        donation_received AS (
+          -- Receiver-side counterpart to donation_activity. Per-(user,
+          -- JST calendar day) DONATION-IN activity for each member of
+          -- this community, with the day's points-in and the JST
+          -- month bucket. Same single-CTE shape so the final SELECT
+          -- can derive donation_in_months / donation_in_days /
+          -- total_points_in without re-introducing the cross-product
+          -- bug that motivated the donation_activity consolidation.
+          --
+          -- Scoping mirrors donation_activity / donation_recipients:
+          --   - DONATION reason only (excludes burn / grant flows that
+          --     are not part of the gift-economy ledger)
+          --   - receiver wallet attached to this community so a member
+          --     who received cross-community grants does not get
+          --     incoming credit they cannot reciprocate
+          --   - sender wallet either in this community or unattached
+          --     (system / burn sources are excluded from the points
+          --     sum for symmetry with donation_activity's wallet
+          --     filter on the sending side)
+          --   - clamped at asOf via asof_bound so a historic asOf
+          --     does not leak future incoming points into the totals
+          SELECT
+            tw."user_id" AS user_id,
+            (t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')::date AS jst_day,
+            DATE_TRUNC(
+              'month',
+              (t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')
+            ) AS jst_month,
+            SUM(t."to_point_change") AS day_points_in
+          FROM "t_transactions" t
+          INNER JOIN "t_wallets" tw
+            ON tw."id" = t."to"
+            AND tw."community_id" = ${communityId}
+          INNER JOIN members m ON m."user_id" = tw."user_id"
+          INNER JOIN "t_wallets" fw
+            ON fw."id" = t."from"
+            AND (fw."community_id" IS NULL OR fw."community_id" = tw."community_id")
+          CROSS JOIN asof_bound ab
+          WHERE t."reason" = 'DONATION'
+            AND t."created_at" < ab.upper_ts
+          GROUP BY tw."user_id", jst_day, jst_month
+        ),
+        donation_in_aggregates AS (
+          -- Pre-aggregate donation_received to one row per user so the
+          -- final SELECT can LEFT JOIN both donation_activity and
+          -- this CTE without re-introducing the multi-row × multi-row
+          -- cross product that the donation_activity consolidation
+          -- comment warns about. donation_activity stays per-day
+          -- because the final SELECT still uses
+          -- COUNT(DISTINCT da.jst_month / da.jst_day) — those are
+          -- cheap and unaffected by row multiplicity. The incoming
+          -- side has no equivalent need; one row per user is all the
+          -- final SELECT consumes.
+          SELECT
+            user_id,
+            COUNT(DISTINCT jst_month)::int AS donation_in_months,
+            COUNT(DISTINCT jst_day)::int AS donation_in_days,
+            COALESCE(SUM(day_points_in), 0)::bigint AS total_points_in
+          FROM donation_received
+          GROUP BY user_id
+        ),
+        donation_senders AS (
+          -- Receiver-side counterpart to donation_recipients. Per-
+          -- recipient count of DISTINCT sender user_ids over the
+          -- whole tenure (clamped at asOf). Backs
+          -- SysAdminMemberRow.uniqueDonationSenders, which the L2
+          -- dashboard uses to compute "受領→送付 転換率"
+          -- (recipient-to-sender conversion rate).
+          --
+          -- Same defensive guards as donation_recipients in mirror:
+          --   - sender wallet must have a user_id (no burn / system
+          --     sources count toward sender breadth, otherwise an
+          --     admin-issued bulk grant would inflate the count)
+          --   - excludes self-donations (matches the "distinct OTHER
+          --     users" wording in
+          --     SysAdminMemberRow.uniqueDonationSenders)
+          --   - sender wallet either in this community or unattached
+          --     (no cross-community leakage)
+          SELECT
+            tw."user_id" AS user_id,
+            COUNT(DISTINCT fw."user_id")::int AS unique_senders
+          FROM "t_transactions" t
+          INNER JOIN "t_wallets" tw
+            ON tw."id" = t."to"
+            AND tw."community_id" = ${communityId}
+          INNER JOIN "t_wallets" fw
+            ON fw."id" = t."from"
+            AND fw."user_id" IS NOT NULL
+            AND fw."user_id" <> tw."user_id"
+          INNER JOIN members m ON m."user_id" = tw."user_id"
+          CROSS JOIN asof_bound ab
+          WHERE t."reason" = 'DONATION'
+            AND t."created_at" < ab.upper_ts
+            AND (fw."community_id" IS NULL OR fw."community_id" = tw."community_id")
+          GROUP BY tw."user_id"
+        ),
         member_tenure AS (
           -- Compute months_in / days_in ONCE per member so the
           -- final SELECT can reuse them as both raw fields and as
@@ -283,6 +383,16 @@ export default class SysAdminRepository implements ISysAdminRepository {
           -- grouping cleanly and matches the COALESCE/MAX pattern
           -- used elsewhere when joining a pre-aggregated CTE.
           COALESCE(MAX(dr.unique_recipients), 0)::int AS unique_donation_recipients,
+          -- donation_in_aggregates is pre-grouped by user_id (one row
+          -- per user), so each value comes through the per-user
+          -- GROUP BY unchanged. MAX is structurally a no-op here and
+          -- mirrors the COALESCE/MAX pattern used for donation_recipients
+          -- and donation_senders below. Default 0 when the receiver
+          -- has never received a DONATION (LEFT JOIN miss).
+          COALESCE(MAX(dia.donation_in_months), 0)::int AS donation_in_months,
+          COALESCE(MAX(dia.donation_in_days), 0)::int AS donation_in_days,
+          COALESCE(MAX(dia.total_points_in), 0)::bigint AS total_points_in,
+          COALESCE(MAX(ds.unique_senders), 0)::int AS unique_donation_senders,
           -- MAX over the per-(user, jst_day) rows in donation_activity
           -- gives the most recent JST day this user sent a DONATION.
           -- NULL when the LEFT JOIN found no donation_activity rows
@@ -294,6 +404,8 @@ export default class SysAdminRepository implements ISysAdminRepository {
         INNER JOIN member_tenure mt ON mt."user_id" = m."user_id"
         LEFT JOIN donation_activity da ON da.user_id = m."user_id"
         LEFT JOIN donation_recipients dr ON dr.user_id = m."user_id"
+        LEFT JOIN donation_in_aggregates dia ON dia.user_id = m."user_id"
+        LEFT JOIN donation_senders ds ON ds.user_id = m."user_id"
         LEFT JOIN "t_users" u ON u."id" = m."user_id"
         GROUP BY m."user_id", mt.months_in, mt.days_in, u."name"
         ORDER BY m."user_id"
@@ -308,6 +420,10 @@ export default class SysAdminRepository implements ISysAdminRepository {
         totalPointsOut: r.total_points_out,
         userSendRate: r.user_send_rate,
         uniqueDonationRecipients: r.unique_donation_recipients,
+        donationInMonths: r.donation_in_months,
+        donationInDays: r.donation_in_days,
+        totalPointsIn: r.total_points_in,
+        uniqueDonationSenders: r.unique_donation_senders,
         lastDonationDay: r.last_donation_day,
       }));
     });
@@ -340,6 +456,8 @@ export default class SysAdminRepository implements ISysAdminRepository {
           donation_points_sum: bigint;
           donation_tx_count: bigint;
           donation_chain_tx_count: bigint;
+          dormant_count_end_of_month: number;
+          returned_members: number | null;
         }[]
       >`
         WITH month_starts AS (
@@ -446,6 +564,105 @@ export default class SysAdminRepository implements ISysAdminRepository {
             AND m."status" = 'JOINED'
             AND m."created_at" <  (mb.member_upper AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
           GROUP BY mb.month_start
+        ),
+        user_month_donations AS (
+          -- Per (user, month_end) the user's latest DONATION-out
+          -- day strictly before that month_end. Used by both
+          -- dormant_counts (snapshot of who's gone quiet at
+          -- month_end) and returned_counts (who came back this
+          -- month vs prev month-end's dormant set).
+          --
+          -- Bounded scan over mv_user_transaction_daily cross-
+          -- joined with the N month boundaries. At MAX_WINDOW_MONTHS
+          -- (36) and a community with K donating members, this is
+          -- 36 x K rows -- typical communities have ~10^2 donating
+          -- users so the CTE stays well under 10^4 rows. The
+          -- (community_id, date) index on the MV keeps the inner
+          -- scan cheap.
+          SELECT
+            mb.month_start,
+            mb.member_upper,
+            mv."user_id",
+            MAX(mv."date") AS last_donation_day
+          FROM month_bounds mb
+          INNER JOIN "mv_user_transaction_daily" mv
+            ON mv."community_id" = ${communityId}
+            AND mv."date" < mb.member_upper
+            AND mv."donation_out_count" > 0
+          GROUP BY mb.month_start, mb.member_upper, mv."user_id"
+        ),
+        dormant_counts AS (
+          -- Snapshot of dormant members at each month-end. Mirrors
+          -- the SysAdminCommunityOverview.dormantCount semantic
+          -- (ever-donated AND last DONATION older than 30 days).
+          -- The 30-day window is fixed here independent of the
+          -- request's dormantThresholdDays so values across the
+          -- monthly trend stay comparable across requests with
+          -- different thresholds.
+          --
+          -- Membership filter mirrors member_counts so the
+          -- dormant set only includes members still in the
+          -- community at month-end (asOf-clamped via member_upper).
+          -- The 30-day cutoff uses date arithmetic
+          -- (member_upper - 30) so both sides of the inequality
+          -- are dates, matching the MV "date" storage type and
+          -- avoiding any timezone-cast cost in the comparison.
+          SELECT
+            umd.month_start,
+            COUNT(DISTINCT umd."user_id")::int AS dormant_count
+          FROM user_month_donations umd
+          INNER JOIN "t_memberships" m
+            ON m."community_id" = ${communityId}
+            AND m."user_id" = umd."user_id"
+            AND m."status" = 'JOINED'
+            AND m."created_at" < (umd.member_upper AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+          WHERE umd.last_donation_day < (umd.member_upper - 30)
+          GROUP BY umd.month_start
+        ),
+        returned_counts AS (
+          -- Members who were dormant at the END of the previous
+          -- month in the series AND had at least one DONATION out
+          -- this month. Backs
+          -- SysAdminMonthlyActivityPoint.returnedMembers.
+          --
+          -- The INNER JOIN on prev_mb (matched via
+          -- prev_mb.next_month_start = mb.month_start) means the
+          -- first month in the series emits no row -> the LEFT JOIN
+          -- in the final SELECT resolves it to NULL, matching the
+          -- "null for the first month" contract documented on the
+          -- field. Reuses user_month_donations for the prev
+          -- month's snapshot so the dormant predicate stays in one
+          -- place; an extra MV scan over [month_start, member_upper)
+          -- gates "this month had a DONATION out".
+          SELECT
+            mb.month_start,
+            COUNT(DISTINCT mv."user_id")::int AS returned_count
+          FROM month_bounds mb
+          INNER JOIN month_bounds prev_mb
+            ON prev_mb.next_month_start = mb.month_start
+          INNER JOIN user_month_donations umd
+            ON umd.month_start = prev_mb.month_start
+            AND umd.last_donation_day < (prev_mb.member_upper - 30)
+          INNER JOIN "t_memberships" m
+            ON m."community_id" = ${communityId}
+            AND m."user_id" = umd."user_id"
+            AND m."status" = 'JOINED'
+            AND m."created_at" < (prev_mb.member_upper AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+          INNER JOIN "mv_user_transaction_daily" mv
+            ON mv."community_id" = ${communityId}
+            AND mv."user_id" = umd."user_id"
+            AND mv."date" >= mb.month_start
+            AND mv."date" <  mb.member_upper
+            AND mv."donation_out_count" > 0
+          GROUP BY mb.month_start
+        ),
+        first_month AS (
+          -- Earliest month in the series. The CASE in the final
+          -- SELECT uses this to force returned_members to NULL on
+          -- the first row instead of returning a misleading 0
+          -- (would imply "no returners", but actually means "no
+          -- prior month to compare against").
+          SELECT MIN(month_start) AS first_start FROM month_bounds
         )
         SELECT
           mb.month_start,
@@ -454,11 +671,19 @@ export default class SysAdminRepository implements ISysAdminRepository {
           COALESCE(mc.new_members, 0)::int AS new_members,
           COALESCE(tt.donation_points_sum, 0)::bigint AS donation_points_sum,
           COALESCE(tt.donation_tx_count, 0)::bigint AS donation_tx_count,
-          COALESCE(tt.donation_chain_tx_count, 0)::bigint AS donation_chain_tx_count
+          COALESCE(tt.donation_chain_tx_count, 0)::bigint AS donation_chain_tx_count,
+          COALESCE(dc.dormant_count, 0)::int AS dormant_count_end_of_month,
+          CASE
+            WHEN mb.month_start = fm.first_start THEN NULL
+            ELSE COALESCE(rc.returned_count, 0)::int
+          END AS returned_members
         FROM month_bounds mb
         LEFT JOIN senders s USING (month_start)
         LEFT JOIN tx_totals tt USING (month_start)
         LEFT JOIN member_counts mc USING (month_start)
+        LEFT JOIN dormant_counts dc USING (month_start)
+        LEFT JOIN returned_counts rc USING (month_start)
+        CROSS JOIN first_month fm
         ORDER BY mb.month_start ASC
       `;
       return rows.map((r) => ({
@@ -469,6 +694,8 @@ export default class SysAdminRepository implements ISysAdminRepository {
         donationPointsSum: r.donation_points_sum,
         donationTxCount: r.donation_tx_count,
         donationChainTxCount: r.donation_chain_tx_count,
+        dormantCountEndOfMonth: r.dormant_count_end_of_month,
+        returnedMembers: r.returned_members,
       }));
     });
   }

--- a/src/application/domain/sysadmin/data/type.ts
+++ b/src/application/domain/sysadmin/data/type.ts
@@ -31,6 +31,20 @@ export type SysAdminMemberStatsRow = {
   daysIn: number;
   donationOutDays: number;
   /**
+   * Receiver-side counterparts to the donation-out counters above.
+   * Backs `SysAdminMemberRow.totalPointsIn` /
+   * `donationInMonths` / `donationInDays` / `uniqueDonationSenders`
+   * — see those field docs for scope details (DONATION reason
+   * only, in-community sender wallets, sender wallets without a
+   * user_id excluded, self-donations excluded). All four are 0 for
+   * members who have never received a DONATION; this is the
+   * receiver-side analogue of "latent" on the sender axis.
+   */
+  totalPointsIn: bigint;
+  donationInMonths: number;
+  donationInDays: number;
+  uniqueDonationSenders: number;
+  /**
    * The most recent JST calendar day the member sent a DONATION
    * (UTC-encoded date at JST midnight, same convention as the rest
    * of the sysadmin domain). null when the member has never
@@ -57,6 +71,23 @@ export type SysAdminMonthlyActivityRow = {
   donationPointsSum: bigint;
   donationTxCount: bigint;
   donationChainTxCount: bigint;
+  /**
+   * Members who had no DONATION out in the trailing 30 days as of
+   * this month's END (the cutoff timestamp is `monthEnd` =
+   * the JST first-of-next-month at 00:00). Always returned as a
+   * non-negative count. Backs
+   * `SysAdminMonthlyActivityPoint.dormantCount`.
+   */
+  dormantCountEndOfMonth: number;
+  /**
+   * Members who were dormant at the END of the PREVIOUS calendar
+   * month (same 30-day-trailing definition as
+   * `dormantCountEndOfMonth`) but had at least one DONATION out
+   * during this month. null for the first month in the trend
+   * series — there is no prior month-end snapshot to reference.
+   * Backs `SysAdminMonthlyActivityPoint.returnedMembers`.
+   */
+  returnedMembers: number | null;
 };
 
 /** All-time totals for the summary card, keyed by community. */

--- a/src/application/domain/sysadmin/presenter.ts
+++ b/src/application/domain/sysadmin/presenter.ts
@@ -213,6 +213,12 @@ export default class SysAdminPresenter {
       newMembers: row.newMembers,
       donationPointsSum: bigintToSafeNumber(row.donationPointsSum),
       chainPct,
+      // Pass-throughs from the repository row. `returnedMembers` is
+      // already nullable on the row (= null for the first month in
+      // the series); `dormantCountEndOfMonth` is always a
+      // non-negative count.
+      dormantCount: row.dormantCountEndOfMonth,
+      returnedMembers: row.returnedMembers,
     };
   }
 
@@ -248,6 +254,16 @@ export default class SysAdminPresenter {
       uniqueDonationRecipients: row.uniqueDonationRecipients,
       daysIn: row.daysIn,
       donationOutDays: row.donationOutDays,
+      // Receiver-side counterparts route through bigintToSafeNumber
+      // for the same reason as totalPointsOut: cumulative
+      // points-in for a community lifetime can exceed Int32 long
+      // before they touch Number.MAX_SAFE_INTEGER, but we still
+      // want loud overflow rather than silent precision loss in
+      // the externally-reported totals.
+      totalPointsIn: bigintToSafeNumber(row.totalPointsIn),
+      donationInMonths: row.donationInMonths,
+      donationInDays: row.donationInDays,
+      uniqueDonationSenders: row.uniqueDonationSenders,
     };
   }
 

--- a/src/application/domain/sysadmin/schema/type.graphql
+++ b/src/application/domain/sysadmin/schema/type.graphql
@@ -257,7 +257,13 @@ input SysAdminCommunityDetailInput {
   userSort: SysAdminUserListSort
 
   """
-  Member list page size (default 50, max 200).
+  Member list page size (default 50, max 1000). Raised from the
+  previous max of 200 so client-side aggregations that need every
+  member of a community (e.g. the "受領→送付 転換率" /
+  recipient-to-sender conversion rate, hub-persistence cohorts,
+  new-member retention breakdowns) can pull a single full page
+  without N round-trips. Communities larger than 1000 members
+  still need cursor pagination.
   """
   limit: Int = 50
 
@@ -781,6 +787,45 @@ type SysAdminMonthlyActivityPoint {
   > 0) in the month. 0.0–1.0.
   """
   chainPct: Float
+
+  """
+  Members who were dormant at the END of the previous calendar
+  month but had at least one DONATION out in this month. Monthly
+  counterpart to `SysAdminRetentionTrendPoint.returnedSenders`.
+  null for the first month in the series (no prior month to
+  reference).
+
+  "Dormant at the end of previous month" uses the same threshold
+  semantic as `SysAdminCommunityOverview.dormantCount` /
+  `SysAdminMonthlyActivityPoint.dormantCount` — no DONATION out in
+  the trailing 30 days as of the previous month-end. This may
+  diverge slightly from the sum of weekly `returnedSenders` over
+  the month because the weekly metric uses a 12-week look-back at
+  ISO-week granularity while this monthly metric uses the
+  30-day-trailing dormant snapshot at month-end. The discrepancy
+  is week/month boundary alignment only.
+  """
+  returnedMembers: Int
+
+  """
+  Members who had no DONATION out in the trailing 30 days as of
+  the END of this month. Snapshot of the dormant base at
+  month-end. Pair with the NEXT month's `returnedMembers` to
+  compute the monthly recovery rate
+  (`returnedMembers[N] / dormantCount[N-1]`).
+
+  Aligns with `SysAdminCommunityOverview.dormantCount` /
+  `SysAdminCommunityDetailPayload.dormantCount` semantics: an
+  ever-donated member whose most recent DONATION is older than
+  30 days as of the month-end timestamp. The latest month's
+  value should equal `SysAdminCommunityDetailPayload.dormantCount`
+  when `asOf` falls at or near the JST month-end, modulo the
+  difference between the request's `dormantThresholdDays` input
+  (which the trend ignores in favor of a fixed 30-day window so
+  monthly returnedMembers / dormantCount stay comparable across
+  requests).
+  """
+  dormantCount: Int!
 }
 
 """
@@ -910,6 +955,46 @@ type SysAdminMemberRow {
   a daily-cadence rate, complementing the monthly `userSendRate`.
   """
   donationOutDays: Int!
+
+  """
+  All-time DONATION points received by this user in this community.
+  Receiver-side counterpart to `totalPointsOut`. Sums
+  `to_point_change` across DONATION transactions whose receiver
+  wallet belongs to this user in this community. Burn / system
+  sources (sender wallets without a user_id) are excluded so a
+  member who only received from a system grant scores 0 — same
+  scope as `totalPointsOut`.
+  """
+  totalPointsIn: Float!
+
+  """
+  Distinct months with at least one DONATION in. Receiver-side
+  counterpart to `donationOutMonths`. Combined with
+  `totalPointsIn`, identifies members who have been part of the
+  receiving side of the gift economy and over how broad a span.
+  """
+  donationInMonths: Int!
+
+  """
+  Distinct JST days the member received at least one DONATION.
+  Daily-grain counterpart to `donationInMonths`. Receiver-side
+  counterpart to `donationOutDays`.
+  """
+  donationInDays: Int!
+
+  """
+  All-time count of distinct OTHER users that have sent at least
+  one DONATION to this member in this community. The receiver-side
+  counterpart to `uniqueDonationRecipients`. Counts unique sender
+  user_id, excludes burn / system sources (sender wallets without
+  a user_id) and self-donations (a user who somehow sent to their
+  own wallet does not increment the count). Used by the L2
+  dashboard to compute the "受領→送付 転換率" (recipient-to-sender
+  conversion rate) — share of DONATION recipients who have also
+  sent at least one DONATION — distinguishing reciprocal
+  participation networks from one-way distribution structures.
+  """
+  uniqueDonationSenders: Int!
 }
 
 """

--- a/src/application/domain/sysadmin/service.ts
+++ b/src/application/domain/sysadmin/service.ts
@@ -285,7 +285,18 @@ export const DEFAULT_WINDOW_MONTHS = 10;
  * analytics need the spec references today.
  */
 export const MAX_WINDOW_MONTHS = 36;
-export const MAX_LIMIT = 200;
+/**
+ * Member-list page-size cap. Raised from the historical 200 to 1000
+ * so client-side aggregations that span the full membership (e.g.
+ * the L2 "受領→送付 転換率" / recipient-to-sender conversion rate
+ * derived from `SysAdminMemberRow.uniqueDonationSenders` +
+ * `totalPointsOut`) can pull a single page without N round-trips
+ * for typical communities. Communities larger than 1000 members
+ * still need cursor pagination — the cap exists to prevent a
+ * malformed/hostile request from materialising the full member set
+ * for an arbitrarily large community in one response.
+ */
+export const MAX_LIMIT = 1000;
 export const ACTIVE_DROP_THRESHOLD = -0.2; // month-over-month fraction
 export const NO_NEW_MEMBERS_WINDOW_DAYS = 14;
 

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -3040,7 +3040,15 @@ export type GqlSysAdminCommunityDetailInput = {
    * values outside are silently clamped on the server.
    */
   dormantThresholdDays?: InputMaybe<Scalars['Int']['input']>;
-  /** Member list page size (default 50, max 200). */
+  /**
+   * Member list page size (default 50, max 1000). Raised from the
+   * previous max of 200 so client-side aggregations that need every
+   * member of a community (e.g. the "受領→送付 転換率" /
+   * recipient-to-sender conversion rate, hub-persistence cohorts,
+   * new-member retention breakdowns) can pull a single full page
+   * without N round-trips. Communities larger than 1000 members
+   * still need cursor pagination.
+   */
   limit?: InputMaybe<Scalars['Int']['input']>;
   /** Stage-count thresholds for the stage distribution and tier counts. */
   segmentThresholds?: InputMaybe<GqlSysAdminSegmentThresholdsInput>;
@@ -3403,6 +3411,19 @@ export type GqlSysAdminMemberRow = {
    */
   daysIn: Scalars['Int']['output'];
   /**
+   * Distinct JST days the member received at least one DONATION.
+   * Daily-grain counterpart to `donationInMonths`. Receiver-side
+   * counterpart to `donationOutDays`.
+   */
+  donationInDays: Scalars['Int']['output'];
+  /**
+   * Distinct months with at least one DONATION in. Receiver-side
+   * counterpart to `donationOutMonths`. Combined with
+   * `totalPointsIn`, identifies members who have been part of the
+   * receiving side of the gift economy and over how broad a span.
+   */
+  donationInMonths: Scalars['Int']['output'];
+  /**
    * Distinct JST days the member sent at least one DONATION.
    * Daily-grain counterpart to `donationOutMonths`. Combined with
    * `daysIn`, the client can compute `donationOutDays / daysIn` as
@@ -3415,6 +3436,16 @@ export type GqlSysAdminMemberRow = {
   monthsIn: Scalars['Int']['output'];
   /** User display name (users.name). null when the user has no name set. */
   name?: Maybe<Scalars['String']['output']>;
+  /**
+   * All-time DONATION points received by this user in this community.
+   * Receiver-side counterpart to `totalPointsOut`. Sums
+   * `to_point_change` across DONATION transactions whose receiver
+   * wallet belongs to this user in this community. Burn / system
+   * sources (sender wallets without a user_id) are excluded so a
+   * member who only received from a system grant scores 0 — same
+   * scope as `totalPointsOut`.
+   */
+  totalPointsIn: Scalars['Float']['output'];
   /** All-time DONATION points sent by this user in this community. */
   totalPointsOut: Scalars['Float']['output'];
   /**
@@ -3433,6 +3464,19 @@ export type GqlSysAdminMemberRow = {
    * user_id).
    */
   uniqueDonationRecipients: Scalars['Int']['output'];
+  /**
+   * All-time count of distinct OTHER users that have sent at least
+   * one DONATION to this member in this community. The receiver-side
+   * counterpart to `uniqueDonationRecipients`. Counts unique sender
+   * user_id, excludes burn / system sources (sender wallets without
+   * a user_id) and self-donations (a user who somehow sent to their
+   * own wallet does not increment the count). Used by the L2
+   * dashboard to compute the "受領→送付 転換率" (recipient-to-sender
+   * conversion rate) — share of DONATION recipients who have also
+   * sent at least one DONATION — distinguishing reciprocal
+   * participation networks from one-way distribution structures.
+   */
+  uniqueDonationSenders: Scalars['Int']['output'];
   /** User id. */
   userId: Scalars['ID']['output'];
   /**
@@ -3459,10 +3503,47 @@ export type GqlSysAdminMonthlyActivityPoint = {
   communityActivityRate: Scalars['Float']['output'];
   /** Sum of DONATION points transferred in the month. */
   donationPointsSum: Scalars['Float']['output'];
+  /**
+   * Members who had no DONATION out in the trailing 30 days as of
+   * the END of this month. Snapshot of the dormant base at
+   * month-end. Pair with the NEXT month's `returnedMembers` to
+   * compute the monthly recovery rate
+   * (`returnedMembers[N] / dormantCount[N-1]`).
+   *
+   * Aligns with `SysAdminCommunityOverview.dormantCount` /
+   * `SysAdminCommunityDetailPayload.dormantCount` semantics: an
+   * ever-donated member whose most recent DONATION is older than
+   * 30 days as of the month-end timestamp. The latest month's
+   * value should equal `SysAdminCommunityDetailPayload.dormantCount`
+   * when `asOf` falls at or near the JST month-end, modulo the
+   * difference between the request's `dormantThresholdDays` input
+   * (which the trend ignores in favor of a fixed 30-day window so
+   * monthly returnedMembers / dormantCount stay comparable across
+   * requests).
+   */
+  dormantCount: Scalars['Int']['output'];
   /** First day (JST) of the calendar month, e.g. 2025-10-01T00:00+09:00. */
   month: Scalars['Datetime']['output'];
   /** t_memberships.created_at (status='JOINED') rows falling in the month. */
   newMembers: Scalars['Int']['output'];
+  /**
+   * Members who were dormant at the END of the previous calendar
+   * month but had at least one DONATION out in this month. Monthly
+   * counterpart to `SysAdminRetentionTrendPoint.returnedSenders`.
+   * null for the first month in the series (no prior month to
+   * reference).
+   *
+   * "Dormant at the end of previous month" uses the same threshold
+   * semantic as `SysAdminCommunityOverview.dormantCount` /
+   * `SysAdminMonthlyActivityPoint.dormantCount` — no DONATION out in
+   * the trailing 30 days as of the previous month-end. This may
+   * diverge slightly from the sum of weekly `returnedSenders` over
+   * the month because the weekly metric uses a 12-week look-back at
+   * ISO-week granularity while this monthly metric uses the
+   * 30-day-trailing dormant snapshot at month-end. The discrepancy
+   * is week/month boundary alignment only.
+   */
+  returnedMembers?: Maybe<Scalars['Int']['output']>;
   /** Distinct DONATION senders in the month. */
   senderCount: Scalars['Int']['output'];
 };
@@ -7078,12 +7159,16 @@ export type GqlSysAdminMemberListResolvers<ContextType = any, ParentType extends
 
 export type GqlSysAdminMemberRowResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminMemberRow'] = GqlResolversParentTypes['SysAdminMemberRow']> = ResolversObject<{
   daysIn?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  donationInDays?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  donationInMonths?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   donationOutDays?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   donationOutMonths?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   monthsIn?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   name?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  totalPointsIn?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
   totalPointsOut?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
   uniqueDonationRecipients?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  uniqueDonationSenders?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   userId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
   userSendRate?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
@@ -7093,8 +7178,10 @@ export type GqlSysAdminMonthlyActivityPointResolvers<ContextType = any, ParentTy
   chainPct?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
   communityActivityRate?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
   donationPointsSum?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  dormantCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   month?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
   newMembers?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  returnedMembers?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
   senderCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;


### PR DESCRIPTION
## Summary

L2 ダッシュボードの「受領→送付 転換率」(recipient-to-sender conversion rate) と月次復帰率を支えるため、sysadmin スキーマに 6 fields を追加 + memberList 上限を 200 → 1000 に引き上げ。

### Issue #1 (P1) — Option A 実装
- `SysAdminMemberRow` に受領側 4 fields:
  - `totalPointsIn: Float!`
  - `donationInMonths: Int!`
  - `donationInDays: Int!`
  - `uniqueDonationSenders: Int!`
- `findMemberStats` SQL に `donation_received` / `donation_in_aggregates` / `donation_senders` CTE を追加(送信側と対称な community-scope / burn-target / self-donation の防御ガード込み)
- `MAX_LIMIT` を **200 → 1000** に引き上げ。コミュニティ全体での転換率計算が単一ページで取れるように

### Issue #2 (P2)
- `SysAdminMonthlyActivityPoint` に `returnedMembers: Int` (nullable) と `dormantCount: Int!` を追加
- 30 日固定の dormant 定義(`SysAdminCommunityOverview.dormantCount` と semantically 整合)
- series 最初の月は `returnedMembers = null`(前月 snapshot が存在しない)
- `findMonthlyActivity` SQL に `user_month_donations` / `dormant_counts` / `returned_counts` / `first_month` CTE を追加

### スキーマコメント
- 全フィールドに issue 本文と同等粒度の description を付与(GraphQL Playground で読んで scope が一意に取れる)
- `dormantCount` と `SysAdminCommunityOverview.dormantCount` の semantics 一致を明記
- 30 日固定であること(リクエストの `dormantThresholdDays` を無視)を明記

## Test plan
- [x] `pnpm test src/__tests__/unit/sysadmin/` — 83 tests pass
  - presenter: `totalPointsIn` overflow guard、`dormantCount` / `returnedMembers` null passthrough を新規追加
  - service: `MAX_LIMIT === 1000` のクランプを 1500 メンバー fixture で検証
- [x] `pnpm test src/__tests__/unit` — 600 / 600 全 unit テスト pass
- [x] `pnpm tsc --noEmit` — sysadmin 配下に新規エラーなし(リポジトリ全体に残る pre-existing typed-SQL エラーは本変更と無関係)
- [ ] DB 接続環境での integration テスト(SQL は本ブランチでは実 DB に当てて検証していない — レビュー時に dev 環境で動作確認推奨)
- [ ] `monthlyActivityTrend[latest].dormantCount` と `SysAdminCommunityOverview.dormantCount` の値一致確認(asOf が月末近辺の場合)

## メモ
- Acceptance criteria 内「受領経験者ゼロのコミュニティで null を返す test case」は Option B(community-level conversion rate を直接 expose)の項目なので、Option A 実装では該当なし。null 表示はクライアント側で分母 0 のときに行う想定です。

https://claude.ai/code/session_01YZBhg7turQrhv6t9A9SR7v

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZBhg7turQrhv6t9A9SR7v)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/924" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
