### PR TITLE
feat(sysadmin): L3 deep-dive 用 4 fields を追加 (Issue #4)

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -2510,6 +2510,22 @@ type SysAdminMemberRow {
   """Distinct months with at least one DONATION out."""
   donationOutMonths: Int!
 
+  """
+  JST date (UTC-encoded at JST midnight) of this member's most
+  recent DONATION out in this community. null when the member has
+  never sent a DONATION (= latent on the sender axis).
+  
+  Powers the L3 "/members" dormancy list: clients sort dormant
+  members by `lastDonationAt ASC` to surface the longest-quiet
+  senders first, and compute days-since-last-donation as
+  `(asOf - lastDonationAt) / 1 day` for the per-row badge. Same
+  underlying signal as `dormantCount`'s threshold check
+  (`MAX(donation.created_at) < asOf - dormantThresholdDays`),
+  exposed as the raw timestamp so the client can derive multiple
+  derived views without a server-side recomputation per request.
+  """
+  lastDonationAt: Datetime
+
   """Tenure in JST calendar months (floor, minimum 1)."""
   monthsIn: Int!
 
@@ -2852,6 +2868,46 @@ type SysAdminTenureDistribution {
 
   """Members with `90 <= daysIn < 365` — established members."""
   m3to12Months: Int!
+
+  """
+  Detailed monthly histogram for the L3 tenure deep-dive.
+  
+  Each entry counts currently-JOINED members whose tenure
+  (`floor(daysIn / 30)`) falls into the bucket. The 12 bucket
+  aggregates all members with tenure of 12 months or longer.
+  Returned in ascending bucket order (`monthsIn` 0..12), with
+  every bucket emitted (count = 0 for buckets with no members)
+  so the client can render a contiguous histogram axis without
+  zero-padding.
+  
+  Sum of `count` equals `totalMembers` minus members with a
+  negative tenure (data anomaly — should be impossible because
+  `daysIn` is floor-1-clamped at the SQL boundary, but the
+  contract notes the exclusion explicitly so the invariant is
+  documented).
+  
+  The existing 4 coarse buckets (`lt1Month` / `m1to3Months` /
+  `m3to12Months` / `gte12Months`) remain for L1 / L2 callers; the
+  monthly histogram is additional, not a replacement.
+  """
+  monthlyHistogram: [SysAdminTenureHistogramBucket!]!
+}
+
+"""
+One bucket of the L3 tenure histogram. See
+`SysAdminTenureDistribution.monthlyHistogram`.
+"""
+type SysAdminTenureHistogramBucket {
+  """Number of currently-JOINED members in this bucket."""
+  count: Int!
+
+  """
+  Tenure in JST calendar months, computed as `floor(daysIn / 30)`.
+  Range 0..12. The 12 bucket aggregates all members with tenure
+  of 12 months or longer; values 0..11 represent exact monthly
+  buckets.
+  """
+  monthsIn: Int!
 }
 
 """

--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -2012,6 +2012,25 @@ type SubmitReportFeedbackSuccess {
   feedback: ReportFeedback!
 }
 
+"""
+One bucket of the all-time DONATION chain-depth histogram. See
+`SysAdminCommunityDetailPayload.chainDepthDistribution`.
+"""
+type SysAdminChainDepthBucket {
+  """
+  Number of all-time DONATION transactions whose `chain_depth`
+  falls into this bucket. Always non-negative.
+  """
+  count: Int!
+
+  """
+  Chain-depth bucket key. Range 1..5; the 5 bucket aggregates
+  `chain_depth >= 5`. See `SysAdminCommunitySummaryCard
+  .maxChainDepthAllTime` for the underlying semantic.
+  """
+  depth: Int!
+}
+
 """One entry-month cohort's retention curve."""
 type SysAdminCohortRetentionPoint {
   """Entry month, first day JST (e.g. 2025-10-01T00:00+09:00)."""
@@ -2110,6 +2129,29 @@ type SysAdminCommunityDetailPayload {
 
   """As-of timestamp echoed back."""
   asOf: Datetime!
+
+  """
+  Distribution of DONATION `chain_depth` values across all-time
+  DONATION transactions in this community. Each bucket counts
+  distinct DONATION transactions whose `chain_depth` falls into
+  the bucket key (see `SysAdminCommunitySummaryCard.maxChainDepthAllTime`
+  for the depth semantic — depth 1 is a root donation, depth N+1
+  means the sender's most recent received DONATION had depth N).
+  
+  Buckets are `{depth: 1..5, count}`; the depth-5 bucket
+  aggregates all transactions with `chain_depth >= 5`. Buckets
+  are returned in ascending depth order, with every bucket
+  emitted (count = 0 for depths with no transactions) so the
+  client can render a contiguous histogram axis without
+  zero-padding logic. Adjust the ceiling upward (e.g., to 10+)
+  in a follow-up if real-data inspection of `maxChainDepthAllTime`
+  shows meaningful population in the 5+ bucket.
+  
+  Powers the L3 "/network" chain-depth histogram: visualizes
+  whether donations propagate deeply (multi-hop reciprocity, tail
+  populated) or shallowly (one-shot direct gifts, mass at depth 1).
+  """
+  chainDepthDistribution: [SysAdminChainDepthBucket!]!
 
   """
   One entry per entry month (length <= windowMonths), newest last.

--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -2031,6 +2031,53 @@ type SysAdminChainDepthBucket {
   depth: Int!
 }
 
+"""
+One cohort's funnel progression. See
+`SysAdminCommunityDetailPayload.cohortFunnel` for the stage
+semantics and the JOINED-at-asOf scoping rule.
+"""
+type SysAdminCohortFunnelPoint {
+  """
+  Cohort size: number of JOINED memberships whose `created_at`
+  falls within this cohort month. The funnel's entry stage —
+  the denominator the client divides downstream stages by to
+  derive percentages.
+  """
+  acquired: Int!
+
+  """
+  Of the cohort, members who sent at least one DONATION within
+  30 days of their join (per-member, measured from each
+  individual's `created_at` rather than a calendar-clamped
+  window). The "first-30-day activation" funnel stage.
+  """
+  activatedD30: Int!
+
+  """
+  JST first day of the cohort's entry month, e.g.
+  2025-10-01T00:00+09:00. UTC-encoded at JST midnight, same
+  convention as `SysAdminMonthlyActivityPoint.month` and
+  `SysAdminCohortRetentionPoint.cohortMonth`.
+  """
+  cohortMonth: Datetime!
+
+  """
+  Of the cohort, members currently in the habitual segment
+  (`userSendRate >= segmentThresholds.tier1` AND tenure floor).
+  THRESHOLD-DEPENDENT — see the parent field's doc.
+  """
+  habitual: Int!
+
+  """
+  Of the cohort, members who sent DONATION in >= 2 distinct JST
+  months as of asOf. The "came back at least once" stage.
+  Cumulative — once a member has 2+ donation months in their
+  history they stay counted in this stage even if they later go
+  quiet.
+  """
+  repeated: Int!
+}
+
 """One entry-month cohort's retention curve."""
 type SysAdminCohortRetentionPoint {
   """Entry month, first day JST (e.g. 2025-10-01T00:00+09:00)."""
@@ -2152,6 +2199,39 @@ type SysAdminCommunityDetailPayload {
   populated) or shallowly (one-shot direct gifts, mass at depth 1).
   """
   chainDepthDistribution: [SysAdminChainDepthBucket!]!
+
+  """
+  Per-cohort funnel progression for the L3 "/activity" deep-dive.
+  One entry per JST entry-month within the trailing `windowMonths`
+  range, returned in ascending order (newest cohort last). Stages
+  match the L2 send-funnel structure:
+  
+    acquisition  — cohort size at entry (JOINED memberships
+                   created during the cohort month)
+    activatedD30 — cohort members who sent >= 1 DONATION within
+                   30 days of their join (per-member, not
+                   calendar-clamped)
+    repeated     — cohort members who sent DONATION in >= 2
+                   distinct JST months (cumulative as of asOf)
+    habitual     — cohort members currently in the habitual
+                   segment (`userSendRate >= segmentThresholds
+                   .tier1` AND tenure floor)
+  
+  ⚠ The `habitual` stage is THRESHOLD-DEPENDENT: it is derived
+  from the request's `segmentThresholds.tier1` (default 0.7),
+  same behaviour as `stages.habitual` and the L2 habitual count
+  card. Cross-request comparisons of the funnel's last stage
+  require matching threshold inputs. The `acquisition`,
+  `activatedD30`, and `repeated` stages are threshold-
+  independent by construction.
+  
+  All counts are JOINED-at-asOf scoped — a cohort member who
+  later left the community is excluded from `activatedD30` /
+  `repeated` / `habitual` even if they donated during the
+  measurement window. Same membership filter as `dormantCount`
+  / L1 `senderCount` / L2 monthly `hubMemberCount`.
+  """
+  cohortFunnel: [SysAdminCohortFunnelPoint!]!
 
   """
   One entry per entry month (length <= windowMonths), newest last.

--- a/src/__tests__/unit/sysadmin/presenter.test.ts
+++ b/src/__tests__/unit/sysadmin/presenter.test.ts
@@ -422,12 +422,11 @@ describe("SysAdminPresenter", () => {
       });
       expect(out.latestCohort).toEqual({ size: 8, activeAtM1: 4 });
       expect(out.hubMemberCount).toBe(2);
-      expect(out.tenureDistribution).toEqual({
-        lt1Month: 1,
-        m1to3Months: 2,
-        m3to12Months: 3,
-        gte12Months: 4,
-      });
+      expect(out.tenureDistribution.lt1Month).toBe(1);
+      expect(out.tenureDistribution.m1to3Months).toBe(2);
+      expect(out.tenureDistribution.m3to12Months).toBe(3);
+      expect(out.tenureDistribution.gte12Months).toBe(4);
+      expect(out.tenureDistribution.monthlyHistogram).toHaveLength(13);
       expect(out.dormantCount).toBe(1);
     });
   });

--- a/src/__tests__/unit/sysadmin/presenter.test.ts
+++ b/src/__tests__/unit/sysadmin/presenter.test.ts
@@ -61,6 +61,8 @@ describe("SysAdminPresenter", () => {
         donationInDays: 18,
         uniqueDonationSenders: 3,
         lastDonationDay: new Date("2026-04-01"),
+        firstDonationDay: new Date("2025-09-01"),
+        joinedAt: new Date("2025-09-01T00:00:00Z"),
       };
       const out = SysAdminPresenter.memberRow(row);
       expect(out.totalPointsOut).toBe(5_000);
@@ -98,6 +100,8 @@ describe("SysAdminPresenter", () => {
         donationInDays: 0,
         uniqueDonationSenders: 0,
         lastDonationDay: null,
+        firstDonationDay: null,
+        joinedAt: new Date("2026-01-01T00:00:00Z"),
       };
       expect(() => SysAdminPresenter.memberRow(row)).toThrow(RangeError);
     });
@@ -118,6 +122,8 @@ describe("SysAdminPresenter", () => {
         donationInDays: 0,
         uniqueDonationSenders: 0,
         lastDonationDay: null,
+        firstDonationDay: null,
+        joinedAt: new Date("2026-01-01T00:00:00Z"),
       };
       expect(SysAdminPresenter.memberRow(row).name).toBeNull();
     });
@@ -319,6 +325,8 @@ describe("SysAdminPresenter", () => {
             donationInDays: 0,
             uniqueDonationSenders: 0,
             lastDonationDay: new Date("2026-04-25"),
+            firstDonationDay: new Date("2025-04-01"),
+            joinedAt: new Date("2025-04-01T00:00:00Z"),
           },
         ],
         hasNextPage: true,

--- a/src/__tests__/unit/sysadmin/presenter.test.ts
+++ b/src/__tests__/unit/sysadmin/presenter.test.ts
@@ -397,6 +397,12 @@ describe("SysAdminPresenter", () => {
           m1to3Months: 2,
           m3to12Months: 3,
           gte12Months: 4,
+          // 13-bucket histogram: empty fixture is fine for this
+          // overviewRow test — it doesn't read monthlyHistogram.
+          monthlyHistogram: Array.from({ length: 13 }, (_, monthsIn) => ({
+            monthsIn,
+            count: 0,
+          })),
         },
         dormantCount: 1,
       });

--- a/src/__tests__/unit/sysadmin/service.test.ts
+++ b/src/__tests__/unit/sysadmin/service.test.ts
@@ -65,6 +65,7 @@ class MockSysAdminRepository {
   findWindowHubMemberCount = jest.fn();
   findAllTimeTotals = jest.fn();
   findPlatformTotals = jest.fn();
+  findChainDepthDistribution = jest.fn();
 }
 
 /**
@@ -322,24 +323,45 @@ describe("SysAdminService", () => {
   // computeTenureDistribution: 4-bucket daysIn classification (issue #918, refinement 2)
   // ========================================================================
   describe("computeTenureDistribution", () => {
+    function emptyHistogram() {
+      return Array.from({ length: 13 }, (_, monthsIn) => ({ monthsIn, count: 0 }));
+    }
+
     it("buckets members by daysIn boundaries", () => {
       const members = [
-        member({ userId: "a", daysIn: 1 }), // lt1Month
-        member({ userId: "b", daysIn: 29 }), // lt1Month
-        member({ userId: "c", daysIn: 30 }), // m1to3Months (boundary, inclusive)
-        member({ userId: "d", daysIn: 89 }), // m1to3Months
-        member({ userId: "e", daysIn: 90 }), // m3to12Months (boundary)
-        member({ userId: "f", daysIn: 364 }), // m3to12Months
-        member({ userId: "g", daysIn: 365 }), // gte12Months (boundary)
-        member({ userId: "h", daysIn: 1500 }), // gte12Months
+        member({ userId: "a", daysIn: 1 }), // lt1Month / hist[0]
+        member({ userId: "b", daysIn: 29 }), // lt1Month / hist[0]
+        member({ userId: "c", daysIn: 30 }), // m1to3Months / hist[1]
+        member({ userId: "d", daysIn: 89 }), // m1to3Months / hist[2]
+        member({ userId: "e", daysIn: 90 }), // m3to12Months / hist[3]
+        member({ userId: "f", daysIn: 364 }), // m3to12Months / hist[12] (12+, capped)
+        member({ userId: "g", daysIn: 365 }), // gte12Months / hist[12]
+        member({ userId: "h", daysIn: 1500 }), // gte12Months / hist[12]
       ];
       const dist = service.computeTenureDistribution(members);
-      expect(dist).toEqual({
-        lt1Month: 2,
-        m1to3Months: 2,
-        m3to12Months: 2,
-        gte12Months: 2,
-      });
+      expect(dist.lt1Month).toBe(2);
+      expect(dist.m1to3Months).toBe(2);
+      expect(dist.m3to12Months).toBe(2);
+      expect(dist.gte12Months).toBe(2);
+      // monthlyHistogram check: bucket = min(floor(daysIn / 30), 12).
+      // Deliberate semantic mismatch with the coarse `m3to12Months`
+      // bucket: that uses calendar-day < 365, while the histogram
+      // 12 bucket aggregates floor(daysIn/30) >= 12 (= daysIn >= 360).
+      // Members in [360, 365) days land in coarse `m3to12Months` but
+      // histogram bucket 12 — both definitions are intentional and
+      // documented; the test pins both shapes so a future refactor
+      // doesn't silently merge them.
+      const expectedCounts = new Map<number, number>([
+        [0, 2], // 1d, 29d
+        [1, 1], // 30d
+        [2, 1], // 89d
+        [3, 1], // 90d
+        [12, 3], // 364d, 365d, 1500d (all daysIn >= 360)
+      ]);
+      for (const bucket of dist.monthlyHistogram) {
+        expect(bucket.count).toBe(expectedCounts.get(bucket.monthsIn) ?? 0);
+      }
+      expect(dist.monthlyHistogram).toHaveLength(13);
     });
 
     it("returns all-zero buckets for empty input", () => {
@@ -348,6 +370,7 @@ describe("SysAdminService", () => {
         m1to3Months: 0,
         m3to12Months: 0,
         gte12Months: 0,
+        monthlyHistogram: emptyHistogram(),
       });
     });
 

--- a/src/__tests__/unit/sysadmin/service.test.ts
+++ b/src/__tests__/unit/sysadmin/service.test.ts
@@ -22,6 +22,12 @@ function member(overrides: Partial<SysAdminMemberStatsRow>): SysAdminMemberStats
   // explicitly when testing isDormant / computeDormantCount.
   const lastDonationDay =
     overrides.lastDonationDay === undefined ? null : overrides.lastDonationDay;
+  const firstDonationDay =
+    overrides.firstDonationDay === undefined ? null : overrides.firstDonationDay;
+  // joinedAt defaults to a fixed date so cohort-funnel tests that
+  // don't care about the exact value get a stable bucket. Override
+  // when testing cohort-bucketing.
+  const joinedAt = overrides.joinedAt ?? new Date("2026-01-01T00:00:00Z");
   return {
     userId: overrides.userId ?? "u",
     name: overrides.name ?? null,
@@ -46,6 +52,8 @@ function member(overrides: Partial<SysAdminMemberStatsRow>): SysAdminMemberStats
     donationInDays: overrides.donationInDays ?? 0,
     uniqueDonationSenders: overrides.uniqueDonationSenders ?? 0,
     lastDonationDay,
+    firstDonationDay,
+    joinedAt,
   };
 }
 
@@ -386,6 +394,110 @@ describe("SysAdminService", () => {
       expect(dist.lt1Month + dist.m1to3Months + dist.m3to12Months + dist.gte12Months).toBe(
         members.length,
       );
+    });
+  });
+
+  // ========================================================================
+  // computeCohortFunnel: per-cohort acquisition / activation / repeat /
+  // habitual progression for the L3 deep-dive
+  // ========================================================================
+  describe("computeCohortFunnel", () => {
+    const asOf = new Date("2026-04-15T00:00:00Z");
+    const thresholds = { tier1: 0.7, tier2: 0.4, minMonthsIn: 1 };
+
+    it("buckets members by their JST cohort month and counts each stage", () => {
+      const members = [
+        // Cohort 2026-02: one acquired, activated D30, repeated, habitual.
+        member({
+          userId: "a",
+          joinedAt: new Date("2026-02-05T00:00:00Z"),
+          firstDonationDay: new Date("2026-02-10T00:00:00Z"),
+          lastDonationDay: new Date("2026-04-10T00:00:00Z"),
+          donationOutMonths: 3,
+          monthsIn: 3,
+          daysIn: 70,
+          userSendRate: 1.0, // habitual
+        }),
+        // Cohort 2026-03: acquired only — no donation yet.
+        member({
+          userId: "b",
+          joinedAt: new Date("2026-03-20T00:00:00Z"),
+          firstDonationDay: null,
+          lastDonationDay: null,
+          donationOutMonths: 0,
+          monthsIn: 1,
+          daysIn: 26,
+          userSendRate: 0,
+        }),
+        // Cohort 2026-03: activated (D30) but only 1 donation month, not repeated, not habitual.
+        member({
+          userId: "c",
+          joinedAt: new Date("2026-03-01T00:00:00Z"),
+          firstDonationDay: new Date("2026-03-15T00:00:00Z"),
+          lastDonationDay: new Date("2026-03-15T00:00:00Z"),
+          donationOutMonths: 1,
+          monthsIn: 2,
+          daysIn: 45,
+          userSendRate: 0.5, // regular
+        }),
+        // Outside the window — should be excluded.
+        member({
+          userId: "d",
+          joinedAt: new Date("2025-01-01T00:00:00Z"),
+          firstDonationDay: null,
+          lastDonationDay: null,
+          donationOutMonths: 0,
+        }),
+      ];
+      const funnel = service.computeCohortFunnel(members, asOf, 3, thresholds);
+      expect(funnel).toHaveLength(3);
+      // Newest-last orientation: [Feb, Mar, Apr]. Cohort month is
+      // encoded as UTC midnight on the first of the JST month
+      // (matches `jstMonthStart` convention used by sibling trend
+      // arrays — the SDL "2025-10-01T00:00+09:00" wording is the
+      // displayed JST equivalent of this UTC instant).
+      expect(funnel[0].cohortMonth.toISOString()).toBe("2026-02-01T00:00:00.000Z");
+      expect(funnel[0]).toMatchObject({
+        acquired: 1,
+        activatedD30: 1,
+        repeated: 1,
+        habitual: 1,
+      });
+      expect(funnel[1].cohortMonth.toISOString()).toBe("2026-03-01T00:00:00.000Z");
+      expect(funnel[1]).toMatchObject({
+        acquired: 2,
+        activatedD30: 1,
+        repeated: 0,
+        habitual: 0,
+      });
+      // Apr cohort empty in this fixture.
+      expect(funnel[2].cohortMonth.toISOString()).toBe("2026-04-01T00:00:00.000Z");
+      expect(funnel[2]).toMatchObject({
+        acquired: 0,
+        activatedD30: 0,
+        repeated: 0,
+        habitual: 0,
+      });
+    });
+
+    it("does not count activatedD30 when first donation is on day 30 or later", () => {
+      // Cutoff is strict-less-than 30 × 86400000 ms. Day 30 ≡ exactly
+      // at the boundary → not counted (matches the SDL "within 30
+      // days" wording: 30 itself is excluded).
+      const members = [
+        member({
+          userId: "a",
+          joinedAt: new Date("2026-02-01T00:00:00Z"),
+          firstDonationDay: new Date(
+            new Date("2026-02-01T00:00:00Z").getTime() + 30 * 24 * 60 * 60 * 1000,
+          ),
+          donationOutMonths: 1,
+        }),
+      ];
+      const funnel = service.computeCohortFunnel(members, asOf, 3, thresholds);
+      const feb = funnel.find((f) => f.cohortMonth.getUTCMonth() === 1)!;
+      expect(feb.acquired).toBe(1);
+      expect(feb.activatedD30).toBe(0);
     });
   });
 

--- a/src/__tests__/unit/sysadmin/service.test.ts
+++ b/src/__tests__/unit/sysadmin/service.test.ts
@@ -342,7 +342,7 @@ describe("SysAdminService", () => {
         member({ userId: "c", daysIn: 30 }), // m1to3Months / hist[1]
         member({ userId: "d", daysIn: 89 }), // m1to3Months / hist[2]
         member({ userId: "e", daysIn: 90 }), // m3to12Months / hist[3]
-        member({ userId: "f", daysIn: 364 }), // m3to12Months / hist[12] (12+, capped)
+        member({ userId: "f", daysIn: 364 }), // m3to12Months / hist[11] (clamped, 365 boundary)
         member({ userId: "g", daysIn: 365 }), // gte12Months / hist[12]
         member({ userId: "h", daysIn: 1500 }), // gte12Months / hist[12]
       ];
@@ -351,25 +351,29 @@ describe("SysAdminService", () => {
       expect(dist.m1to3Months).toBe(2);
       expect(dist.m3to12Months).toBe(2);
       expect(dist.gte12Months).toBe(2);
-      // monthlyHistogram check: bucket = min(floor(daysIn / 30), 12).
-      // Deliberate semantic mismatch with the coarse `m3to12Months`
-      // bucket: that uses calendar-day < 365, while the histogram
-      // 12 bucket aggregates floor(daysIn/30) >= 12 (= daysIn >= 360).
-      // Members in [360, 365) days land in coarse `m3to12Months` but
-      // histogram bucket 12 — both definitions are intentional and
-      // documented; the test pins both shapes so a future refactor
-      // doesn't silently merge them.
+      // monthlyHistogram check. Boundary is aligned with the coarse
+      // gte12Months bucket: bucket 12 ≡ daysIn >= 365, NOT
+      // floor(daysIn/30) >= 12. Members at 360..364 days fall into
+      // bucket 11 (clamped) and coarse m3to12Months — both
+      // representations agree. So `gte12Months == histogram[12]`
+      // and the histogram buckets 0..11 sum to lt1Month +
+      // m1to3Months + m3to12Months.
       const expectedCounts = new Map<number, number>([
         [0, 2], // 1d, 29d
         [1, 1], // 30d
         [2, 1], // 89d
         [3, 1], // 90d
-        [12, 3], // 364d, 365d, 1500d (all daysIn >= 360)
+        [11, 1], // 364d (clamped to 11, NOT 12, since daysIn < 365)
+        [12, 2], // 365d, 1500d (daysIn >= 365)
       ]);
       for (const bucket of dist.monthlyHistogram) {
         expect(bucket.count).toBe(expectedCounts.get(bucket.monthsIn) ?? 0);
       }
       expect(dist.monthlyHistogram).toHaveLength(13);
+      // Invariant: histogram[12] == gte12Months (boundaries
+      // aligned). Test pins this so a future tweak that drifts
+      // them apart breaks loudly.
+      expect(dist.monthlyHistogram[12].count).toBe(dist.gte12Months);
     });
 
     it("returns all-zero buckets for empty input", () => {

--- a/src/application/domain/sysadmin/data/interface.ts
+++ b/src/application/domain/sysadmin/data/interface.ts
@@ -1,6 +1,7 @@
 import { IContext } from "@/types/server";
 import {
   SysAdminAllTimeTotalsRow,
+  SysAdminChainDepthBucketRow,
   SysAdminCommunityRow,
   SysAdminMemberStatsRow,
   SysAdminActivitySnapshotRow,
@@ -133,4 +134,19 @@ export interface ISysAdminRepository {
     jstMonthStart: Date,
     jstNextMonthStart: Date,
   ): Promise<SysAdminPlatformTotalsRow>;
+
+  /**
+   * All-time DONATION chain-depth histogram for one community,
+   * clamped at `asOf` for historic-asOf consistency. Returns
+   * exactly `maxBucketDepth` rows (depth 1..maxBucketDepth, with
+   * the last bucket aggregating chain_depth >= maxBucketDepth) so
+   * the service / presenter doesn't need to fill gaps. Backs
+   * `SysAdminCommunityDetailPayload.chainDepthDistribution`.
+   */
+  findChainDepthDistribution(
+    ctx: IContext,
+    communityId: string,
+    asOf: Date,
+    maxBucketDepth: number,
+  ): Promise<SysAdminChainDepthBucketRow[]>;
 }

--- a/src/application/domain/sysadmin/data/repository.ts
+++ b/src/application/domain/sysadmin/data/repository.ts
@@ -1047,8 +1047,26 @@ export default class SysAdminRepository implements ISysAdminRepository {
       // chain-depth-3 transaction from a now-departed member is
       // still a real chain-depth-3 event in the historic graph,
       // and excluding it would distort the histogram's shape.
+      //
+      // The asof_bound CTE clamps t.created_at at the JST-day-end
+      // following asOf (= asOf JST day + 1 at JST midnight,
+      // expressed as naive UTC). Mirrors the upper-bound pattern
+      // used by findMemberStats / findAllTimeTotals so
+      // maxChainDepthAllTime (read from findAllTimeTotals) and
+      // chainDepthDistribution agree on which transactions are
+      // "all-time as of asOf" — without this clamp a transaction
+      // landing between asOf and JST-day-end would inflate
+      // maxChainDepthAllTime but be missed by the histogram, an
+      // off-by-one inconsistency within a single L2 payload.
       const rows = await tx.$queryRaw<{ depth: number; count: number }[]>`
-        WITH bucket_keys AS (
+        WITH asof_bound AS (
+          SELECT
+            (
+              ((${asOf}::timestamp AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')::date + 1)
+              AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC'
+            ) AS upper_ts
+        ),
+        bucket_keys AS (
           SELECT generate_series(1, ${maxBucketDepth}::int) AS depth
         ),
         depth_counts AS (
@@ -1059,9 +1077,10 @@ export default class SysAdminRepository implements ISysAdminRepository {
           INNER JOIN "t_wallets" fw
             ON fw."id" = t."from"
             AND fw."community_id" = ${communityId}
+          CROSS JOIN asof_bound ab
           WHERE t."reason" = 'DONATION'
             AND t."chain_depth" >= 1
-            AND t."created_at" <= ${asOf}::timestamp
+            AND t."created_at" < ab.upper_ts
           GROUP BY LEAST(t."chain_depth", ${maxBucketDepth}::int)
         )
         SELECT

--- a/src/application/domain/sysadmin/data/repository.ts
+++ b/src/application/domain/sysadmin/data/repository.ts
@@ -101,6 +101,8 @@ export default class SysAdminRepository implements ISysAdminRepository {
           total_points_in: bigint;
           unique_donation_senders: number;
           last_donation_day: Date | null;
+          first_donation_day: Date | null;
+          joined_at: Date;
         }[]
       >`
         WITH asof_jst AS (
@@ -401,7 +403,19 @@ export default class SysAdminRepository implements ISysAdminRepository {
           -- (= the member never donated, the latent case). The service
           -- layer derives dormantCount from this without re-scanning
           -- t_transactions.
-          MAX(da.jst_day) AS last_donation_day
+          MAX(da.jst_day) AS last_donation_day,
+          -- MIN over the same per-day rows is the FIRST DONATION day,
+          -- powering the cohort funnel's activatedD30 stage in the
+          -- service layer (member is "activated within 30 days" iff
+          -- first_donation_day - joined_at < 30 days). Same NULL
+          -- semantic as last_donation_day for never-donated members.
+          MIN(da.jst_day) AS first_donation_day,
+          -- t_memberships.created_at exposed verbatim so the cohort
+          -- funnel can bucket members by their join month
+          -- (DATE_TRUNC at the JST timezone in service-side TS).
+          -- GROUP BY m."created_at" added below so the aggregate
+          -- doesn't collapse it.
+          m."created_at" AS joined_at
         FROM members m
         INNER JOIN member_tenure mt ON mt."user_id" = m."user_id"
         LEFT JOIN donation_activity da ON da.user_id = m."user_id"
@@ -409,7 +423,7 @@ export default class SysAdminRepository implements ISysAdminRepository {
         LEFT JOIN donation_in_aggregates dia ON dia.user_id = m."user_id"
         LEFT JOIN donation_senders ds ON ds.user_id = m."user_id"
         LEFT JOIN "t_users" u ON u."id" = m."user_id"
-        GROUP BY m."user_id", mt.months_in, mt.days_in, u."name"
+        GROUP BY m."user_id", m."created_at", mt.months_in, mt.days_in, u."name"
         ORDER BY m."user_id"
       `;
       return rows.map((r) => ({
@@ -427,6 +441,8 @@ export default class SysAdminRepository implements ISysAdminRepository {
         totalPointsIn: r.total_points_in,
         uniqueDonationSenders: r.unique_donation_senders,
         lastDonationDay: r.last_donation_day,
+        firstDonationDay: r.first_donation_day,
+        joinedAt: r.joined_at,
       }));
     });
   }

--- a/src/application/domain/sysadmin/data/repository.ts
+++ b/src/application/domain/sysadmin/data/repository.ts
@@ -2,6 +2,7 @@ import { injectable } from "tsyringe";
 import { IContext } from "@/types/server";
 import {
   SysAdminAllTimeTotalsRow,
+  SysAdminChainDepthBucketRow,
   SysAdminCommunityRow,
   SysAdminMemberStatsRow,
   SysAdminActivitySnapshotRow,
@@ -1004,6 +1005,57 @@ export default class SysAdminRepository implements ISysAdminRepository {
         totalMembers: r.total_members,
         latestMonthDonationPoints: r.latest_month_donation_points,
       };
+    });
+  }
+
+  async findChainDepthDistribution(
+    ctx: IContext,
+    communityId: string,
+    asOf: Date,
+    maxBucketDepth: number,
+  ): Promise<SysAdminChainDepthBucketRow[]> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      // generate_series produces depth 1..maxBucketDepth so the
+      // returned array always has a stable shape (every bucket
+      // emitted, count = 0 for empty depths) regardless of
+      // community size or chain-population. The LEFT JOIN against
+      // the per-tx aggregation collapses chain_depth >=
+      // maxBucketDepth into the final bucket via LEAST.
+      //
+      // Sender-side guards mirror findWindowHubMemberCount:
+      // sender wallet must be in this community, and we filter to
+      // reason='DONATION'. No recipient-side or membership filter
+      // is applied because chainDepthDistribution describes the
+      // structure of the donation graph itself (how deep do
+      // chains propagate?), not the current member roster — a
+      // chain-depth-3 transaction from a now-departed member is
+      // still a real chain-depth-3 event in the historic graph,
+      // and excluding it would distort the histogram's shape.
+      const rows = await tx.$queryRaw<{ depth: number; count: number }[]>`
+        WITH bucket_keys AS (
+          SELECT generate_series(1, ${maxBucketDepth}::int) AS depth
+        ),
+        depth_counts AS (
+          SELECT
+            LEAST(t."chain_depth", ${maxBucketDepth}::int) AS depth,
+            COUNT(*)::int AS n
+          FROM "t_transactions" t
+          INNER JOIN "t_wallets" fw
+            ON fw."id" = t."from"
+            AND fw."community_id" = ${communityId}
+          WHERE t."reason" = 'DONATION'
+            AND t."chain_depth" >= 1
+            AND t."created_at" <= ${asOf}::timestamp
+          GROUP BY LEAST(t."chain_depth", ${maxBucketDepth}::int)
+        )
+        SELECT
+          bk.depth AS depth,
+          COALESCE(dc.n, 0)::int AS count
+        FROM bucket_keys bk
+        LEFT JOIN depth_counts dc USING (depth)
+        ORDER BY bk.depth ASC
+      `;
+      return rows.map((r) => ({ depth: r.depth, count: r.count }));
     });
   }
 }

--- a/src/application/domain/sysadmin/data/type.ts
+++ b/src/application/domain/sysadmin/data/type.ts
@@ -52,6 +52,25 @@ export type SysAdminMemberStatsRow = {
    * `dormantCount` is derived from it in the service layer.
    */
   lastDonationDay: Date | null;
+
+  /**
+   * The first JST calendar day the member sent a DONATION (same
+   * UTC-encoded JST-midnight convention as `lastDonationDay`).
+   * null when the member has never donated. Powers the cohort
+   * funnel's `activatedD30` stage — a member is "activated within
+   * 30 days" iff `firstDonationDay - joinedAt < 30 days`.
+   */
+  firstDonationDay: Date | null;
+
+  /**
+   * The member's `t_memberships.created_at` (UTC-encoded
+   * timestamp WITHOUT time zone — same storage as the column).
+   * Powers cohort bucketing in the service layer (the cohort
+   * month is `DATE_TRUNC('month', joinedAt AT TIME ZONE 'UTC' AT
+   * TIME ZONE 'Asia/Tokyo')`). Internal raw signal; not exposed
+   * directly in GraphQL.
+   */
+  joinedAt: Date;
 };
 
 /** Monthly activity counters, sourced from `mv_*` + `t_memberships`.

--- a/src/application/domain/sysadmin/data/type.ts
+++ b/src/application/domain/sysadmin/data/type.ts
@@ -149,3 +149,15 @@ export type SysAdminPlatformTotalsRow = {
   totalMembers: number;
   latestMonthDonationPoints: bigint;
 };
+
+/**
+ * One bucket of the all-time DONATION chain-depth histogram. Backs
+ * `SysAdminCommunityDetailPayload.chainDepthDistribution`. The
+ * repository emits a fixed-shape array (depth 1..N inclusive,
+ * with the last bucket aggregating depth >= N) so the service
+ * layer doesn't need to zero-pad.
+ */
+export type SysAdminChainDepthBucketRow = {
+  depth: number;
+  count: number;
+};

--- a/src/application/domain/sysadmin/presenter.ts
+++ b/src/application/domain/sysadmin/presenter.ts
@@ -34,6 +34,7 @@ import {
   StageBreakdown,
   StageBucketStats,
   StageCounts,
+  SysAdminCohortFunnelPoint,
   TenureDistribution,
   WeeklyRetentionCounts,
   WeeklyRetentionPoint,
@@ -299,6 +300,7 @@ export default class SysAdminPresenter {
     alerts: GqlSysAdminCommunityAlerts;
     dormantCount: number;
     chainDepthDistribution: SysAdminChainDepthBucketRow[];
+    cohortFunnel: SysAdminCohortFunnelPoint[];
   }): GqlSysAdminCommunityDetailPayload {
     return {
       communityId: params.communityId,
@@ -317,6 +319,10 @@ export default class SysAdminPresenter {
       // GraphQL type 1:1 so the array passes through without
       // per-element transformation.
       chainDepthDistribution: params.chainDepthDistribution,
+      // Same passthrough pattern: the cohort funnel point shape
+      // (cohortMonth + 4 stage counts) matches the GraphQL type
+      // 1:1.
+      cohortFunnel: params.cohortFunnel,
     };
   }
 }

--- a/src/application/domain/sysadmin/presenter.ts
+++ b/src/application/domain/sysadmin/presenter.ts
@@ -103,6 +103,10 @@ export default class SysAdminPresenter {
       m1to3Months: d.m1to3Months,
       m3to12Months: d.m3to12Months,
       gte12Months: d.gte12Months,
+      // Histogram bucket shape happens to match the GraphQL type
+      // 1:1 (monthsIn + count), so the array passes through
+      // without per-element transformation.
+      monthlyHistogram: d.monthlyHistogram,
     };
   }
 
@@ -264,6 +268,11 @@ export default class SysAdminPresenter {
       donationInMonths: row.donationInMonths,
       donationInDays: row.donationInDays,
       uniqueDonationSenders: row.uniqueDonationSenders,
+      // lastDonationDay is already a JST-midnight Date on the row
+      // (see findMemberStats); rename to the public-facing
+      // `lastDonationAt` here. null pass-through for never-donated
+      // members.
+      lastDonationAt: row.lastDonationDay,
     };
   }
 

--- a/src/application/domain/sysadmin/presenter.ts
+++ b/src/application/domain/sysadmin/presenter.ts
@@ -21,6 +21,7 @@ import {
 } from "@/types/graphql";
 import {
   SysAdminAllTimeTotalsRow,
+  SysAdminChainDepthBucketRow,
   SysAdminMemberStatsRow,
   SysAdminMonthlyActivityRow,
   SysAdminPlatformTotalsRow,
@@ -297,6 +298,7 @@ export default class SysAdminPresenter {
     memberList: GqlSysAdminMemberList;
     alerts: GqlSysAdminCommunityAlerts;
     dormantCount: number;
+    chainDepthDistribution: SysAdminChainDepthBucketRow[];
   }): GqlSysAdminCommunityDetailPayload {
     return {
       communityId: params.communityId,
@@ -311,6 +313,10 @@ export default class SysAdminPresenter {
       memberList: params.memberList,
       alerts: params.alerts,
       dormantCount: params.dormantCount,
+      // Chain-depth bucket shape (depth + count) matches the
+      // GraphQL type 1:1 so the array passes through without
+      // per-element transformation.
+      chainDepthDistribution: params.chainDepthDistribution,
     };
   }
 }

--- a/src/application/domain/sysadmin/schema/type.graphql
+++ b/src/application/domain/sysadmin/schema/type.graphql
@@ -1139,4 +1139,45 @@ type SysAdminCommunityDetailPayload {
   member list.
   """
   dormantCount: Int!
+
+  """
+  Distribution of DONATION `chain_depth` values across all-time
+  DONATION transactions in this community. Each bucket counts
+  distinct DONATION transactions whose `chain_depth` falls into
+  the bucket key (see `SysAdminCommunitySummaryCard.maxChainDepthAllTime`
+  for the depth semantic — depth 1 is a root donation, depth N+1
+  means the sender's most recent received DONATION had depth N).
+
+  Buckets are `{depth: 1..5, count}`; the depth-5 bucket
+  aggregates all transactions with `chain_depth >= 5`. Buckets
+  are returned in ascending depth order, with every bucket
+  emitted (count = 0 for depths with no transactions) so the
+  client can render a contiguous histogram axis without
+  zero-padding logic. Adjust the ceiling upward (e.g., to 10+)
+  in a follow-up if real-data inspection of `maxChainDepthAllTime`
+  shows meaningful population in the 5+ bucket.
+
+  Powers the L3 "/network" chain-depth histogram: visualizes
+  whether donations propagate deeply (multi-hop reciprocity, tail
+  populated) or shallowly (one-shot direct gifts, mass at depth 1).
+  """
+  chainDepthDistribution: [SysAdminChainDepthBucket!]!
+}
+
+"""
+One bucket of the all-time DONATION chain-depth histogram. See
+`SysAdminCommunityDetailPayload.chainDepthDistribution`.
+"""
+type SysAdminChainDepthBucket {
+  """
+  Chain-depth bucket key. Range 1..5; the 5 bucket aggregates
+  `chain_depth >= 5`. See `SysAdminCommunitySummaryCard
+  .maxChainDepthAllTime` for the underlying semantic.
+  """
+  depth: Int!
+  """
+  Number of all-time DONATION transactions whose `chain_depth`
+  falls into this bucket. Always non-negative.
+  """
+  count: Int!
 }

--- a/src/application/domain/sysadmin/schema/type.graphql
+++ b/src/application/domain/sysadmin/schema/type.graphql
@@ -479,6 +479,47 @@ type SysAdminTenureDistribution {
   with `lt1Month`, signals the community's age structure.
   """
   gte12Months: Int!
+
+  """
+  Detailed monthly histogram for the L3 tenure deep-dive.
+
+  Each entry counts currently-JOINED members whose tenure
+  (`floor(daysIn / 30)`) falls into the bucket. The 12 bucket
+  aggregates all members with tenure of 12 months or longer.
+  Returned in ascending bucket order (`monthsIn` 0..12), with
+  every bucket emitted (count = 0 for buckets with no members)
+  so the client can render a contiguous histogram axis without
+  zero-padding.
+
+  Sum of `count` equals `totalMembers` minus members with a
+  negative tenure (data anomaly — should be impossible because
+  `daysIn` is floor-1-clamped at the SQL boundary, but the
+  contract notes the exclusion explicitly so the invariant is
+  documented).
+
+  The existing 4 coarse buckets (`lt1Month` / `m1to3Months` /
+  `m3to12Months` / `gte12Months`) remain for L1 / L2 callers; the
+  monthly histogram is additional, not a replacement.
+  """
+  monthlyHistogram: [SysAdminTenureHistogramBucket!]!
+}
+
+"""
+One bucket of the L3 tenure histogram. See
+`SysAdminTenureDistribution.monthlyHistogram`.
+"""
+type SysAdminTenureHistogramBucket {
+  """
+  Tenure in JST calendar months, computed as `floor(daysIn / 30)`.
+  Range 0..12. The 12 bucket aggregates all members with tenure
+  of 12 months or longer; values 0..11 represent exact monthly
+  buckets.
+  """
+  monthsIn: Int!
+  """
+  Number of currently-JOINED members in this bucket.
+  """
+  count: Int!
 }
 
 """
@@ -995,6 +1036,22 @@ type SysAdminMemberRow {
   participation networks from one-way distribution structures.
   """
   uniqueDonationSenders: Int!
+
+  """
+  JST date (UTC-encoded at JST midnight) of this member's most
+  recent DONATION out in this community. null when the member has
+  never sent a DONATION (= latent on the sender axis).
+
+  Powers the L3 "/members" dormancy list: clients sort dormant
+  members by `lastDonationAt ASC` to surface the longest-quiet
+  senders first, and compute days-since-last-donation as
+  `(asOf - lastDonationAt) / 1 day` for the per-row badge. Same
+  underlying signal as `dormantCount`'s threshold check
+  (`MAX(donation.created_at) < asOf - dormantThresholdDays`),
+  exposed as the raw timestamp so the client can derive multiple
+  derived views without a server-side recomputation per request.
+  """
+  lastDonationAt: Datetime
 }
 
 """

--- a/src/application/domain/sysadmin/schema/type.graphql
+++ b/src/application/domain/sysadmin/schema/type.graphql
@@ -1162,6 +1162,39 @@ type SysAdminCommunityDetailPayload {
   populated) or shallowly (one-shot direct gifts, mass at depth 1).
   """
   chainDepthDistribution: [SysAdminChainDepthBucket!]!
+
+  """
+  Per-cohort funnel progression for the L3 "/activity" deep-dive.
+  One entry per JST entry-month within the trailing `windowMonths`
+  range, returned in ascending order (newest cohort last). Stages
+  match the L2 send-funnel structure:
+
+    acquisition  — cohort size at entry (JOINED memberships
+                   created during the cohort month)
+    activatedD30 — cohort members who sent >= 1 DONATION within
+                   30 days of their join (per-member, not
+                   calendar-clamped)
+    repeated     — cohort members who sent DONATION in >= 2
+                   distinct JST months (cumulative as of asOf)
+    habitual     — cohort members currently in the habitual
+                   segment (`userSendRate >= segmentThresholds
+                   .tier1` AND tenure floor)
+
+  ⚠ The `habitual` stage is THRESHOLD-DEPENDENT: it is derived
+  from the request's `segmentThresholds.tier1` (default 0.7),
+  same behaviour as `stages.habitual` and the L2 habitual count
+  card. Cross-request comparisons of the funnel's last stage
+  require matching threshold inputs. The `acquisition`,
+  `activatedD30`, and `repeated` stages are threshold-
+  independent by construction.
+
+  All counts are JOINED-at-asOf scoped — a cohort member who
+  later left the community is excluded from `activatedD30` /
+  `repeated` / `habitual` even if they donated during the
+  measurement window. Same membership filter as `dormantCount`
+  / L1 `senderCount` / L2 monthly `hubMemberCount`.
+  """
+  cohortFunnel: [SysAdminCohortFunnelPoint!]!
 }
 
 """
@@ -1180,4 +1213,51 @@ type SysAdminChainDepthBucket {
   falls into this bucket. Always non-negative.
   """
   count: Int!
+}
+
+"""
+One cohort's funnel progression. See
+`SysAdminCommunityDetailPayload.cohortFunnel` for the stage
+semantics and the JOINED-at-asOf scoping rule.
+"""
+type SysAdminCohortFunnelPoint {
+  """
+  JST first day of the cohort's entry month, e.g.
+  2025-10-01T00:00+09:00. UTC-encoded at JST midnight, same
+  convention as `SysAdminMonthlyActivityPoint.month` and
+  `SysAdminCohortRetentionPoint.cohortMonth`.
+  """
+  cohortMonth: Datetime!
+
+  """
+  Cohort size: number of JOINED memberships whose `created_at`
+  falls within this cohort month. The funnel's entry stage —
+  the denominator the client divides downstream stages by to
+  derive percentages.
+  """
+  acquired: Int!
+
+  """
+  Of the cohort, members who sent at least one DONATION within
+  30 days of their join (per-member, measured from each
+  individual's `created_at` rather than a calendar-clamped
+  window). The "first-30-day activation" funnel stage.
+  """
+  activatedD30: Int!
+
+  """
+  Of the cohort, members who sent DONATION in >= 2 distinct JST
+  months as of asOf. The "came back at least once" stage.
+  Cumulative — once a member has 2+ donation months in their
+  history they stay counted in this stage even if they later go
+  quiet.
+  """
+  repeated: Int!
+
+  """
+  Of the cohort, members currently in the habitual segment
+  (`userSendRate >= segmentThresholds.tier1` AND tenure floor).
+  THRESHOLD-DEPENDENT — see the parent field's doc.
+  """
+  habitual: Int!
 }

--- a/src/application/domain/sysadmin/service.ts
+++ b/src/application/domain/sysadmin/service.ts
@@ -222,6 +222,20 @@ export type MonthlyCohortPoint = {
   retentionM6: number | null;
 };
 
+/**
+ * One cohort's funnel progression. Backs
+ * `SysAdminCommunityDetailPayload.cohortFunnel`. Computed by
+ * `SysAdminService.computeCohortFunnel` over the already-fetched
+ * `members` set; no separate repository call.
+ */
+export type SysAdminCohortFunnelPoint = {
+  cohortMonth: Date;
+  acquired: number;
+  activatedD30: number;
+  repeated: number;
+  habitual: number;
+};
+
 export type SortField = "SEND_RATE" | "MONTHS_IN" | "DONATION_OUT_MONTHS" | "TOTAL_POINTS_OUT";
 export type SortOrder = "ASC" | "DESC";
 
@@ -699,6 +713,73 @@ export default class SysAdminService {
       asOf,
       CHAIN_DEPTH_MAX_BUCKET,
     );
+  }
+
+  /**
+   * Per-cohort send-funnel progression for the L3 deep-dive. Pure
+   * function over `members` (already-fetched in the L2 usecase) +
+   * `asOf` + `windowMonths` + `thresholds` — no extra DB scan.
+   *
+   * Cohort = JST month start of the member's `joinedAt`. Members
+   * outside the trailing windowMonths range are dropped. Stage
+   * classification:
+   *
+   *   acquired      — every cohort member counts
+   *   activatedD30  — has firstDonationDay AND
+   *                   firstDonationDay - joinedAt < 30 days
+   *   repeated      — donationOutMonths >= 2
+   *   habitual      — classifyMember(...) === "habitual"
+   *
+   * activatedD30 / repeated / habitual are JOINED-at-asOf scoped
+   * because `members` is itself JOINED-at-asOf (findMemberStats
+   * applies the membership filter).
+   */
+  computeCohortFunnel(
+    members: SysAdminMemberStatsRow[],
+    asOf: Date,
+    windowMonths: number,
+    thresholds: SegmentThresholds,
+  ): SysAdminCohortFunnelPoint[] {
+    // Build the cohort-month axis: [asOf month - (windowMonths-1), ..., asOf month].
+    // Same orientation as `monthlyActivityTrend` (newest last) so the
+    // client can render a single x-axis across both series.
+    const cohortKeys: Date[] = [];
+    for (let i = windowMonths - 1; i >= 0; i--) {
+      cohortKeys.push(jstMonthStartOffset(asOf, -i));
+    }
+    const buckets = new Map<number, SysAdminCohortFunnelPoint>();
+    for (const m of cohortKeys) {
+      buckets.set(m.getTime(), {
+        cohortMonth: m,
+        acquired: 0,
+        activatedD30: 0,
+        repeated: 0,
+        habitual: 0,
+      });
+    }
+    const earliest = cohortKeys[0]?.getTime() ?? 0;
+    const latest = cohortKeys[cohortKeys.length - 1]?.getTime() ?? 0;
+    for (const member of members) {
+      const cohort = jstMonthStart(member.joinedAt).getTime();
+      if (cohort < earliest || cohort > latest) continue;
+      const bucket = buckets.get(cohort);
+      if (!bucket) continue;
+      bucket.acquired++;
+      if (
+        member.firstDonationDay !== null &&
+        member.firstDonationDay.getTime() - member.joinedAt.getTime() <
+          30 * 24 * 60 * 60 * 1000
+      ) {
+        bucket.activatedD30++;
+      }
+      if (member.donationOutMonths >= 2) {
+        bucket.repeated++;
+      }
+      if (classifyMember(member, thresholds) === "habitual") {
+        bucket.habitual++;
+      }
+    }
+    return cohortKeys.map((k) => buckets.get(k.getTime())!);
   }
 
   async getMonthlyActivity(

--- a/src/application/domain/sysadmin/service.ts
+++ b/src/application/domain/sysadmin/service.ts
@@ -121,6 +121,12 @@ export const TENURE_MONTHLY_BUCKETS = 13;
  * population at the ceiling. */
 export const CHAIN_DEPTH_MAX_BUCKET = 5;
 
+/** Day-grain window for the cohort funnel's "activated within 30
+ * days" stage. Pinned as a constant so the value can't drift apart
+ * from the SDL contract on `SysAdminCohortFunnelPoint.activatedD30`
+ * via a bare magic number in the ms math. */
+export const COHORT_ACTIVATION_WINDOW_DAYS = 30;
+
 /**
  * Approximate days-per-month conversion used to translate the
  * operator-facing `minMonthsIn` (calendar months) into the internal
@@ -571,13 +577,15 @@ export default class SysAdminService {
     let gte12Months = 0;
     // monthlyHistogram pre-allocates all 13 buckets (0..12) so the
     // returned array always has a stable shape regardless of input.
-    // Bucket index = floor(daysIn / 30), capped at 12 so 12+ months
-    // collapse into the final aggregating bucket. The 30-day-per-
-    // month conversion matches the lt1Month / m1to3Months / etc.
-    // boundaries above so the coarse buckets stay derivable from
-    // the histogram (lt1Month = histogram[0], m1to3Months =
-    // histogram[1] + histogram[2], m3to12Months = sum(3..11),
-    // gte12Months = histogram[12]).
+    // The 12 bucket aggregates daysIn >= 365 (= 12 calendar months
+    // by the same threshold the coarse `gte12Months` uses) so the
+    // two stay consistent: any member counted in `gte12Months` is
+    // also in histogram[12], and vice versa. Buckets 0..11 cover
+    // the [0, 365) range — bucket k = floor(daysIn / 30), clamped
+    // to 11 so 360..364 days do NOT silently land in the 12+
+    // aggregator (otherwise they'd be in histogram[12] but coarse
+    // `m3to12Months`, an asymmetry that would confuse downstream
+    // consumers stacking the histogram against the coarse bars).
     const monthlyHistogram: TenureHistogramBucket[] = Array.from(
       { length: TENURE_MONTHLY_BUCKETS },
       (_, monthsIn) => ({ monthsIn, count: 0 }),
@@ -588,12 +596,18 @@ export default class SysAdminService {
       else if (m.daysIn < 365) m3to12Months++;
       else gte12Months++;
       // Members with daysIn < 0 (data anomaly — shouldn't occur
-      // because findMemberStats clamps daysIn to >= 1) are dropped
-      // from the histogram so the contract documented in the SDL
-      // ("sum equals totalMembers minus members with negative
-      // tenure") holds.
-      if (m.daysIn < 0) continue;
-      const bucket = Math.min(Math.floor(m.daysIn / 30), TENURE_MONTHLY_BUCKETS - 1);
+      // because findMemberStats clamps daysIn to >= 1) are
+      // already counted in lt1Month above (daysIn < 0 < 30), so
+      // they also flow into histogram bucket 0 via the
+      // Math.max(0, ...) clamp below. Without that clamp,
+      // floor(negative / 30) would land in a negative array
+      // index and silently corrupt the histogram. Counting both
+      // representations keeps the documented derivation
+      // invariant (lt1Month == histogram[0]) intact.
+      const bucket =
+        m.daysIn >= 365
+          ? TENURE_MONTHLY_BUCKETS - 1
+          : Math.min(Math.max(Math.floor(m.daysIn / 30), 0), TENURE_MONTHLY_BUCKETS - 2);
       monthlyHistogram[bucket].count++;
     }
     return { lt1Month, m1to3Months, m3to12Months, gte12Months, monthlyHistogram };
@@ -759,16 +773,26 @@ export default class SysAdminService {
     }
     const earliest = cohortKeys[0]?.getTime() ?? 0;
     const latest = cohortKeys[cohortKeys.length - 1]?.getTime() ?? 0;
+    const activationCutoffMs = COHORT_ACTIVATION_WINDOW_DAYS * 24 * 60 * 60 * 1000;
     for (const member of members) {
       const cohort = jstMonthStart(member.joinedAt).getTime();
       if (cohort < earliest || cohort > latest) continue;
       const bucket = buckets.get(cohort);
       if (!bucket) continue;
       bucket.acquired++;
+      // Both sides are JST-day grain: firstDonationDay is already
+      // a JST date encoded at UTC midnight (see findMemberStats),
+      // and joinedAt is truncated to its JST date here so the
+      // "30 days within join" comparison is symmetric. Without
+      // truncation the joinedAt time-of-day component skewed the
+      // comparison by up to ±9h (JST offset), giving false
+      // positives / negatives at the 30-day boundary. The day-
+      // grain comparison matches the SDL "within 30 days of join"
+      // wording the operator UI exposes.
       if (
         member.firstDonationDay !== null &&
-        member.firstDonationDay.getTime() - member.joinedAt.getTime() <
-          30 * 24 * 60 * 60 * 1000
+        member.firstDonationDay.getTime() - truncateToJstDate(member.joinedAt).getTime() <
+          activationCutoffMs
       ) {
         bucket.activatedD30++;
       }

--- a/src/application/domain/sysadmin/service.ts
+++ b/src/application/domain/sysadmin/service.ts
@@ -89,13 +89,30 @@ export type StageBreakdown = {
  * the input `members.length`. Boundaries are intentionally
  * day-based (not month-based) to side-step the GREATEST(1, ...)
  * floor that `monthsIn` carries.
+ *
+ * `monthlyHistogram` carries the L3 deep-dive breakdown into 13
+ * monthly buckets (0..12, where 12 aggregates 12+ months). Same
+ * member set, finer granularity. The four coarse buckets remain
+ * authoritative for L1 / L2 display; the histogram is additional.
  */
+export type TenureHistogramBucket = {
+  monthsIn: number;
+  count: number;
+};
+
 export type TenureDistribution = {
   lt1Month: number;
   m1to3Months: number;
   m3to12Months: number;
   gte12Months: number;
+  monthlyHistogram: TenureHistogramBucket[];
 };
+
+/** Number of monthly histogram buckets for the L3 deep-dive
+ * (`monthsIn` 0..12; 12 aggregates 12+). Pinned as a constant so
+ * the service computation and the test fixtures agree on the array
+ * shape. */
+export const TENURE_MONTHLY_BUCKETS = 13;
 
 /**
  * Approximate days-per-month conversion used to translate the
@@ -531,13 +548,34 @@ export default class SysAdminService {
     let m1to3Months = 0;
     let m3to12Months = 0;
     let gte12Months = 0;
+    // monthlyHistogram pre-allocates all 13 buckets (0..12) so the
+    // returned array always has a stable shape regardless of input.
+    // Bucket index = floor(daysIn / 30), capped at 12 so 12+ months
+    // collapse into the final aggregating bucket. The 30-day-per-
+    // month conversion matches the lt1Month / m1to3Months / etc.
+    // boundaries above so the coarse buckets stay derivable from
+    // the histogram (lt1Month = histogram[0], m1to3Months =
+    // histogram[1] + histogram[2], m3to12Months = sum(3..11),
+    // gte12Months = histogram[12]).
+    const monthlyHistogram: TenureHistogramBucket[] = Array.from(
+      { length: TENURE_MONTHLY_BUCKETS },
+      (_, monthsIn) => ({ monthsIn, count: 0 }),
+    );
     for (const m of members) {
       if (m.daysIn < 30) lt1Month++;
       else if (m.daysIn < 90) m1to3Months++;
       else if (m.daysIn < 365) m3to12Months++;
       else gte12Months++;
+      // Members with daysIn < 0 (data anomaly — shouldn't occur
+      // because findMemberStats clamps daysIn to >= 1) are dropped
+      // from the histogram so the contract documented in the SDL
+      // ("sum equals totalMembers minus members with negative
+      // tenure") holds.
+      if (m.daysIn < 0) continue;
+      const bucket = Math.min(Math.floor(m.daysIn / 30), TENURE_MONTHLY_BUCKETS - 1);
+      monthlyHistogram[bucket].count++;
     }
-    return { lt1Month, m1to3Months, m3to12Months, gte12Months };
+    return { lt1Month, m1to3Months, m3to12Months, gte12Months, monthlyHistogram };
   }
 
   /**

--- a/src/application/domain/sysadmin/service.ts
+++ b/src/application/domain/sysadmin/service.ts
@@ -114,6 +114,13 @@ export type TenureDistribution = {
  * shape. */
 export const TENURE_MONTHLY_BUCKETS = 13;
 
+/** Maximum chain-depth bucket (inclusive). The L3
+ * chainDepthDistribution emits depth 1..N where N aggregates
+ * `chain_depth >= N`. 5 chosen as a starting point; revisit if
+ * real-data inspection of `maxChainDepthAllTime` shows meaningful
+ * population at the ceiling. */
+export const CHAIN_DEPTH_MAX_BUCKET = 5;
+
 /**
  * Approximate days-per-month conversion used to translate the
  * operator-facing `minMonthsIn` (calendar months) into the internal
@@ -683,6 +690,15 @@ export default class SysAdminService {
 
   async getMemberStats(ctx: IContext, communityId: string, asOf: Date) {
     return this.repository.findMemberStats(ctx, communityId, asOf);
+  }
+
+  async getChainDepthDistribution(ctx: IContext, communityId: string, asOf: Date) {
+    return this.repository.findChainDepthDistribution(
+      ctx,
+      communityId,
+      asOf,
+      CHAIN_DEPTH_MAX_BUCKET,
+    );
   }
 
   async getMonthlyActivity(

--- a/src/application/domain/sysadmin/usecase.ts
+++ b/src/application/domain/sysadmin/usecase.ts
@@ -155,6 +155,7 @@ export default class SysAdminUseCase {
       currentMonthActivity,
       retentionTrend,
       cohortRetention,
+      chainDepthDistribution,
     ] = await Promise.all([
       this.service.getMemberStats(ctx, community.communityId, asOf),
       this.service.getMonthlyActivity(ctx, community.communityId, asOf, windowMonths),
@@ -162,6 +163,7 @@ export default class SysAdminUseCase {
       this.service.getMonthActivityWithPrev(ctx, community.communityId, asOf),
       this.service.getRetentionTrend(ctx, community.communityId, asOf, windowMonths),
       this.service.getCohortRetention(ctx, community.communityId, asOf, windowMonths),
+      this.service.getChainDepthDistribution(ctx, community.communityId, asOf),
     ]);
 
     const stageCounts = this.service.computeStageCounts(members, thresholds);
@@ -205,6 +207,7 @@ export default class SysAdminUseCase {
       memberList: SysAdminPresenter.memberList(memberList),
       alerts: SysAdminPresenter.alerts(alerts),
       dormantCount,
+      chainDepthDistribution,
     });
   }
 }

--- a/src/application/domain/sysadmin/usecase.ts
+++ b/src/application/domain/sysadmin/usecase.ts
@@ -169,6 +169,12 @@ export default class SysAdminUseCase {
     const stageCounts = this.service.computeStageCounts(members, thresholds);
     const stageBreakdown = this.service.computeStageBreakdown(members, thresholds);
     const dormantCount = this.service.computeDormantCount(members, asOf, dormantThresholdDays);
+    const cohortFunnel = this.service.computeCohortFunnel(
+      members,
+      asOf,
+      windowMonths,
+      thresholds,
+    );
 
     const alerts = await this.service.getAlerts(ctx, community.communityId, asOf);
 
@@ -208,6 +214,7 @@ export default class SysAdminUseCase {
       alerts: SysAdminPresenter.alerts(alerts),
       dormantCount,
       chainDepthDistribution,
+      cohortFunnel,
     });
   }
 }

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -2986,6 +2986,25 @@ export type GqlSubmitReportFeedbackSuccess = {
   feedback: GqlReportFeedback;
 };
 
+/**
+ * One bucket of the all-time DONATION chain-depth histogram. See
+ * `SysAdminCommunityDetailPayload.chainDepthDistribution`.
+ */
+export type GqlSysAdminChainDepthBucket = {
+  __typename?: 'SysAdminChainDepthBucket';
+  /**
+   * Number of all-time DONATION transactions whose `chain_depth`
+   * falls into this bucket. Always non-negative.
+   */
+  count: Scalars['Int']['output'];
+  /**
+   * Chain-depth bucket key. Range 1..5; the 5 bucket aggregates
+   * `chain_depth >= 5`. See `SysAdminCommunitySummaryCard
+   * .maxChainDepthAllTime` for the underlying semantic.
+   */
+  depth: Scalars['Int']['output'];
+};
+
 /** One entry-month cohort's retention curve. */
 export type GqlSysAdminCohortRetentionPoint = {
   __typename?: 'SysAdminCohortRetentionPoint';
@@ -3070,6 +3089,28 @@ export type GqlSysAdminCommunityDetailPayload = {
   alerts: GqlSysAdminCommunityAlerts;
   /** As-of timestamp echoed back. */
   asOf: Scalars['Datetime']['output'];
+  /**
+   * Distribution of DONATION `chain_depth` values across all-time
+   * DONATION transactions in this community. Each bucket counts
+   * distinct DONATION transactions whose `chain_depth` falls into
+   * the bucket key (see `SysAdminCommunitySummaryCard.maxChainDepthAllTime`
+   * for the depth semantic — depth 1 is a root donation, depth N+1
+   * means the sender's most recent received DONATION had depth N).
+   *
+   * Buckets are `{depth: 1..5, count}`; the depth-5 bucket
+   * aggregates all transactions with `chain_depth >= 5`. Buckets
+   * are returned in ascending depth order, with every bucket
+   * emitted (count = 0 for depths with no transactions) so the
+   * client can render a contiguous histogram axis without
+   * zero-padding logic. Adjust the ceiling upward (e.g., to 10+)
+   * in a follow-up if real-data inspection of `maxChainDepthAllTime`
+   * shows meaningful population in the 5+ bucket.
+   *
+   * Powers the L3 "/network" chain-depth histogram: visualizes
+   * whether donations propagate deeply (multi-hop reciprocity, tail
+   * populated) or shallowly (one-shot direct gifts, mass at depth 1).
+   */
+  chainDepthDistribution: Array<GqlSysAdminChainDepthBucket>;
   /**
    * One entry per entry month (length <= windowMonths), newest last.
    * `retentionM*` fields are null when the cohort is empty or too recent.
@@ -5319,6 +5360,7 @@ export type GqlResolversTypes = ResolversObject<{
   SubmitReportFeedbackInput: GqlSubmitReportFeedbackInput;
   SubmitReportFeedbackPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['SubmitReportFeedbackPayload']>;
   SubmitReportFeedbackSuccess: ResolverTypeWrapper<Omit<GqlSubmitReportFeedbackSuccess, 'feedback'> & { feedback: GqlResolversTypes['ReportFeedback'] }>;
+  SysAdminChainDepthBucket: ResolverTypeWrapper<GqlSysAdminChainDepthBucket>;
   SysAdminCohortRetentionPoint: ResolverTypeWrapper<GqlSysAdminCohortRetentionPoint>;
   SysAdminCommunityAlerts: ResolverTypeWrapper<GqlSysAdminCommunityAlerts>;
   SysAdminCommunityDetailInput: GqlSysAdminCommunityDetailInput;
@@ -5726,6 +5768,7 @@ export type GqlResolversParentTypes = ResolversObject<{
   SubmitReportFeedbackInput: GqlSubmitReportFeedbackInput;
   SubmitReportFeedbackPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['SubmitReportFeedbackPayload'];
   SubmitReportFeedbackSuccess: Omit<GqlSubmitReportFeedbackSuccess, 'feedback'> & { feedback: GqlResolversParentTypes['ReportFeedback'] };
+  SysAdminChainDepthBucket: GqlSysAdminChainDepthBucket;
   SysAdminCohortRetentionPoint: GqlSysAdminCohortRetentionPoint;
   SysAdminCommunityAlerts: GqlSysAdminCommunityAlerts;
   SysAdminCommunityDetailInput: GqlSysAdminCommunityDetailInput;
@@ -7131,6 +7174,12 @@ export type GqlSubmitReportFeedbackSuccessResolvers<ContextType = any, ParentTyp
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type GqlSysAdminChainDepthBucketResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminChainDepthBucket'] = GqlResolversParentTypes['SysAdminChainDepthBucket']> = ResolversObject<{
+  count?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  depth?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type GqlSysAdminCohortRetentionPointResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminCohortRetentionPoint'] = GqlResolversParentTypes['SysAdminCohortRetentionPoint']> = ResolversObject<{
   cohortMonth?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
   cohortSize?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
@@ -7150,6 +7199,7 @@ export type GqlSysAdminCommunityAlertsResolvers<ContextType = any, ParentType ex
 export type GqlSysAdminCommunityDetailPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminCommunityDetailPayload'] = GqlResolversParentTypes['SysAdminCommunityDetailPayload']> = ResolversObject<{
   alerts?: Resolver<GqlResolversTypes['SysAdminCommunityAlerts'], ParentType, ContextType>;
   asOf?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  chainDepthDistribution?: Resolver<Array<GqlResolversTypes['SysAdminChainDepthBucket']>, ParentType, ContextType>;
   cohortRetention?: Resolver<Array<GqlResolversTypes['SysAdminCohortRetentionPoint']>, ParentType, ContextType>;
   communityId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
   communityName?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
@@ -8036,6 +8086,7 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   StorePhoneAuthTokenPayload?: GqlStorePhoneAuthTokenPayloadResolvers<ContextType>;
   SubmitReportFeedbackPayload?: GqlSubmitReportFeedbackPayloadResolvers<ContextType>;
   SubmitReportFeedbackSuccess?: GqlSubmitReportFeedbackSuccessResolvers<ContextType>;
+  SysAdminChainDepthBucket?: GqlSysAdminChainDepthBucketResolvers<ContextType>;
   SysAdminCohortRetentionPoint?: GqlSysAdminCohortRetentionPointResolvers<ContextType>;
   SysAdminCommunityAlerts?: GqlSysAdminCommunityAlertsResolvers<ContextType>;
   SysAdminCommunityDetailPayload?: GqlSysAdminCommunityDetailPayloadResolvers<ContextType>;

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -3005,6 +3005,50 @@ export type GqlSysAdminChainDepthBucket = {
   depth: Scalars['Int']['output'];
 };
 
+/**
+ * One cohort's funnel progression. See
+ * `SysAdminCommunityDetailPayload.cohortFunnel` for the stage
+ * semantics and the JOINED-at-asOf scoping rule.
+ */
+export type GqlSysAdminCohortFunnelPoint = {
+  __typename?: 'SysAdminCohortFunnelPoint';
+  /**
+   * Cohort size: number of JOINED memberships whose `created_at`
+   * falls within this cohort month. The funnel's entry stage —
+   * the denominator the client divides downstream stages by to
+   * derive percentages.
+   */
+  acquired: Scalars['Int']['output'];
+  /**
+   * Of the cohort, members who sent at least one DONATION within
+   * 30 days of their join (per-member, measured from each
+   * individual's `created_at` rather than a calendar-clamped
+   * window). The "first-30-day activation" funnel stage.
+   */
+  activatedD30: Scalars['Int']['output'];
+  /**
+   * JST first day of the cohort's entry month, e.g.
+   * 2025-10-01T00:00+09:00. UTC-encoded at JST midnight, same
+   * convention as `SysAdminMonthlyActivityPoint.month` and
+   * `SysAdminCohortRetentionPoint.cohortMonth`.
+   */
+  cohortMonth: Scalars['Datetime']['output'];
+  /**
+   * Of the cohort, members currently in the habitual segment
+   * (`userSendRate >= segmentThresholds.tier1` AND tenure floor).
+   * THRESHOLD-DEPENDENT — see the parent field's doc.
+   */
+  habitual: Scalars['Int']['output'];
+  /**
+   * Of the cohort, members who sent DONATION in >= 2 distinct JST
+   * months as of asOf. The "came back at least once" stage.
+   * Cumulative — once a member has 2+ donation months in their
+   * history they stay counted in this stage even if they later go
+   * quiet.
+   */
+  repeated: Scalars['Int']['output'];
+};
+
 /** One entry-month cohort's retention curve. */
 export type GqlSysAdminCohortRetentionPoint = {
   __typename?: 'SysAdminCohortRetentionPoint';
@@ -3111,6 +3155,38 @@ export type GqlSysAdminCommunityDetailPayload = {
    * populated) or shallowly (one-shot direct gifts, mass at depth 1).
    */
   chainDepthDistribution: Array<GqlSysAdminChainDepthBucket>;
+  /**
+   * Per-cohort funnel progression for the L3 "/activity" deep-dive.
+   * One entry per JST entry-month within the trailing `windowMonths`
+   * range, returned in ascending order (newest cohort last). Stages
+   * match the L2 send-funnel structure:
+   *
+   *   acquisition  — cohort size at entry (JOINED memberships
+   *                  created during the cohort month)
+   *   activatedD30 — cohort members who sent >= 1 DONATION within
+   *                  30 days of their join (per-member, not
+   *                  calendar-clamped)
+   *   repeated     — cohort members who sent DONATION in >= 2
+   *                  distinct JST months (cumulative as of asOf)
+   *   habitual     — cohort members currently in the habitual
+   *                  segment (`userSendRate >= segmentThresholds
+   *                  .tier1` AND tenure floor)
+   *
+   * ⚠ The `habitual` stage is THRESHOLD-DEPENDENT: it is derived
+   * from the request's `segmentThresholds.tier1` (default 0.7),
+   * same behaviour as `stages.habitual` and the L2 habitual count
+   * card. Cross-request comparisons of the funnel's last stage
+   * require matching threshold inputs. The `acquisition`,
+   * `activatedD30`, and `repeated` stages are threshold-
+   * independent by construction.
+   *
+   * All counts are JOINED-at-asOf scoped — a cohort member who
+   * later left the community is excluded from `activatedD30` /
+   * `repeated` / `habitual` even if they donated during the
+   * measurement window. Same membership filter as `dormantCount`
+   * / L1 `senderCount` / L2 monthly `hubMemberCount`.
+   */
+  cohortFunnel: Array<GqlSysAdminCohortFunnelPoint>;
   /**
    * One entry per entry month (length <= windowMonths), newest last.
    * `retentionM*` fields are null when the cohort is empty or too recent.
@@ -5361,6 +5437,7 @@ export type GqlResolversTypes = ResolversObject<{
   SubmitReportFeedbackPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['SubmitReportFeedbackPayload']>;
   SubmitReportFeedbackSuccess: ResolverTypeWrapper<Omit<GqlSubmitReportFeedbackSuccess, 'feedback'> & { feedback: GqlResolversTypes['ReportFeedback'] }>;
   SysAdminChainDepthBucket: ResolverTypeWrapper<GqlSysAdminChainDepthBucket>;
+  SysAdminCohortFunnelPoint: ResolverTypeWrapper<GqlSysAdminCohortFunnelPoint>;
   SysAdminCohortRetentionPoint: ResolverTypeWrapper<GqlSysAdminCohortRetentionPoint>;
   SysAdminCommunityAlerts: ResolverTypeWrapper<GqlSysAdminCommunityAlerts>;
   SysAdminCommunityDetailInput: GqlSysAdminCommunityDetailInput;
@@ -5769,6 +5846,7 @@ export type GqlResolversParentTypes = ResolversObject<{
   SubmitReportFeedbackPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['SubmitReportFeedbackPayload'];
   SubmitReportFeedbackSuccess: Omit<GqlSubmitReportFeedbackSuccess, 'feedback'> & { feedback: GqlResolversParentTypes['ReportFeedback'] };
   SysAdminChainDepthBucket: GqlSysAdminChainDepthBucket;
+  SysAdminCohortFunnelPoint: GqlSysAdminCohortFunnelPoint;
   SysAdminCohortRetentionPoint: GqlSysAdminCohortRetentionPoint;
   SysAdminCommunityAlerts: GqlSysAdminCommunityAlerts;
   SysAdminCommunityDetailInput: GqlSysAdminCommunityDetailInput;
@@ -7180,6 +7258,15 @@ export type GqlSysAdminChainDepthBucketResolvers<ContextType = any, ParentType e
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type GqlSysAdminCohortFunnelPointResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminCohortFunnelPoint'] = GqlResolversParentTypes['SysAdminCohortFunnelPoint']> = ResolversObject<{
+  acquired?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  activatedD30?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  cohortMonth?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  habitual?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  repeated?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type GqlSysAdminCohortRetentionPointResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminCohortRetentionPoint'] = GqlResolversParentTypes['SysAdminCohortRetentionPoint']> = ResolversObject<{
   cohortMonth?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
   cohortSize?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
@@ -7200,6 +7287,7 @@ export type GqlSysAdminCommunityDetailPayloadResolvers<ContextType = any, Parent
   alerts?: Resolver<GqlResolversTypes['SysAdminCommunityAlerts'], ParentType, ContextType>;
   asOf?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
   chainDepthDistribution?: Resolver<Array<GqlResolversTypes['SysAdminChainDepthBucket']>, ParentType, ContextType>;
+  cohortFunnel?: Resolver<Array<GqlResolversTypes['SysAdminCohortFunnelPoint']>, ParentType, ContextType>;
   cohortRetention?: Resolver<Array<GqlResolversTypes['SysAdminCohortRetentionPoint']>, ParentType, ContextType>;
   communityId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
   communityName?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
@@ -8087,6 +8175,7 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   SubmitReportFeedbackPayload?: GqlSubmitReportFeedbackPayloadResolvers<ContextType>;
   SubmitReportFeedbackSuccess?: GqlSubmitReportFeedbackSuccessResolvers<ContextType>;
   SysAdminChainDepthBucket?: GqlSysAdminChainDepthBucketResolvers<ContextType>;
+  SysAdminCohortFunnelPoint?: GqlSysAdminCohortFunnelPointResolvers<ContextType>;
   SysAdminCohortRetentionPoint?: GqlSysAdminCohortRetentionPointResolvers<ContextType>;
   SysAdminCommunityAlerts?: GqlSysAdminCommunityAlertsResolvers<ContextType>;
   SysAdminCommunityDetailPayload?: GqlSysAdminCommunityDetailPayloadResolvers<ContextType>;

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -3432,6 +3432,21 @@ export type GqlSysAdminMemberRow = {
   donationOutDays: Scalars['Int']['output'];
   /** Distinct months with at least one DONATION out. */
   donationOutMonths: Scalars['Int']['output'];
+  /**
+   * JST date (UTC-encoded at JST midnight) of this member's most
+   * recent DONATION out in this community. null when the member has
+   * never sent a DONATION (= latent on the sender axis).
+   *
+   * Powers the L3 "/members" dormancy list: clients sort dormant
+   * members by `lastDonationAt ASC` to surface the longest-quiet
+   * senders first, and compute days-since-last-donation as
+   * `(asOf - lastDonationAt) / 1 day` for the per-row badge. Same
+   * underlying signal as `dormantCount`'s threshold check
+   * (`MAX(donation.created_at) < asOf - dormantThresholdDays`),
+   * exposed as the raw timestamp so the client can derive multiple
+   * derived views without a server-side recomputation per request.
+   */
+  lastDonationAt?: Maybe<Scalars['Datetime']['output']>;
   /** Tenure in JST calendar months (floor, minimum 1). */
   monthsIn: Scalars['Int']['output'];
   /** User display name (users.name). null when the user has no name set. */
@@ -3744,6 +3759,45 @@ export type GqlSysAdminTenureDistribution = {
   m1to3Months: Scalars['Int']['output'];
   /** Members with `90 <= daysIn < 365` — established members. */
   m3to12Months: Scalars['Int']['output'];
+  /**
+   * Detailed monthly histogram for the L3 tenure deep-dive.
+   *
+   * Each entry counts currently-JOINED members whose tenure
+   * (`floor(daysIn / 30)`) falls into the bucket. The 12 bucket
+   * aggregates all members with tenure of 12 months or longer.
+   * Returned in ascending bucket order (`monthsIn` 0..12), with
+   * every bucket emitted (count = 0 for buckets with no members)
+   * so the client can render a contiguous histogram axis without
+   * zero-padding.
+   *
+   * Sum of `count` equals `totalMembers` minus members with a
+   * negative tenure (data anomaly — should be impossible because
+   * `daysIn` is floor-1-clamped at the SQL boundary, but the
+   * contract notes the exclusion explicitly so the invariant is
+   * documented).
+   *
+   * The existing 4 coarse buckets (`lt1Month` / `m1to3Months` /
+   * `m3to12Months` / `gte12Months`) remain for L1 / L2 callers; the
+   * monthly histogram is additional, not a replacement.
+   */
+  monthlyHistogram: Array<GqlSysAdminTenureHistogramBucket>;
+};
+
+/**
+ * One bucket of the L3 tenure histogram. See
+ * `SysAdminTenureDistribution.monthlyHistogram`.
+ */
+export type GqlSysAdminTenureHistogramBucket = {
+  __typename?: 'SysAdminTenureHistogramBucket';
+  /** Number of currently-JOINED members in this bucket. */
+  count: Scalars['Int']['output'];
+  /**
+   * Tenure in JST calendar months, computed as `floor(daysIn / 30)`.
+   * Range 0..12. The 12 bucket aggregates all members with tenure
+   * of 12 months or longer; values 0..11 represent exact monthly
+   * buckets.
+   */
+  monthsIn: Scalars['Int']['output'];
 };
 
 /**
@@ -5285,6 +5339,7 @@ export type GqlResolversTypes = ResolversObject<{
   SysAdminStageBucket: ResolverTypeWrapper<GqlSysAdminStageBucket>;
   SysAdminStageDistribution: ResolverTypeWrapper<GqlSysAdminStageDistribution>;
   SysAdminTenureDistribution: ResolverTypeWrapper<GqlSysAdminTenureDistribution>;
+  SysAdminTenureHistogramBucket: ResolverTypeWrapper<GqlSysAdminTenureHistogramBucket>;
   SysAdminUserListFilter: GqlSysAdminUserListFilter;
   SysAdminUserListSort: GqlSysAdminUserListSort;
   SysAdminUserSortField: GqlSysAdminUserSortField;
@@ -5690,6 +5745,7 @@ export type GqlResolversParentTypes = ResolversObject<{
   SysAdminStageBucket: GqlSysAdminStageBucket;
   SysAdminStageDistribution: GqlSysAdminStageDistribution;
   SysAdminTenureDistribution: GqlSysAdminTenureDistribution;
+  SysAdminTenureHistogramBucket: GqlSysAdminTenureHistogramBucket;
   SysAdminUserListFilter: GqlSysAdminUserListFilter;
   SysAdminUserListSort: GqlSysAdminUserListSort;
   SysAdminWeeklyRetention: GqlSysAdminWeeklyRetention;
@@ -7163,6 +7219,7 @@ export type GqlSysAdminMemberRowResolvers<ContextType = any, ParentType extends 
   donationInMonths?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   donationOutDays?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   donationOutMonths?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  lastDonationAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
   monthsIn?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   name?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
   totalPointsIn?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
@@ -7234,6 +7291,13 @@ export type GqlSysAdminTenureDistributionResolvers<ContextType = any, ParentType
   lt1Month?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   m1to3Months?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   m3to12Months?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  monthlyHistogram?: Resolver<Array<GqlResolversTypes['SysAdminTenureHistogramBucket']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlSysAdminTenureHistogramBucketResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SysAdminTenureHistogramBucket'] = GqlResolversParentTypes['SysAdminTenureHistogramBucket']> = ResolversObject<{
+  count?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  monthsIn?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -7988,6 +8052,7 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   SysAdminStageBucket?: GqlSysAdminStageBucketResolvers<ContextType>;
   SysAdminStageDistribution?: GqlSysAdminStageDistributionResolvers<ContextType>;
   SysAdminTenureDistribution?: GqlSysAdminTenureDistributionResolvers<ContextType>;
+  SysAdminTenureHistogramBucket?: GqlSysAdminTenureHistogramBucketResolvers<ContextType>;
   SysAdminWeeklyRetention?: GqlSysAdminWeeklyRetentionResolvers<ContextType>;
   SysAdminWindowActivity?: GqlSysAdminWindowActivityResolvers<ContextType>;
   Ticket?: GqlTicketResolvers<ContextType>;


### PR DESCRIPTION
## Summary

L3 (`/sysAdmin/[id]/{network,activity,members}`) deep-dive view 用の 4 fields を bundle で追加。Issue #4 着地。

## 4 sub-features (各 commit に分離)

### (1) `chainDepthDistribution` on `SysAdminCommunityDetailPayload`

L3 `/network` の DONATION chain depth ヒストグラム用。Bucket: `[1, 2, 3, 4, 5+]` (5 bucket は `chain_depth >= 5` を集約)。

- 新規 `findChainDepthDistribution` SQL: `generate_series` で全 bucket を必ず emit (LEFT JOIN で空 depth は 0 fill)
- `t_transactions` 直接走査、`reason='DONATION' AND chain_depth >= 1`
- membership / recipient filter は意図的に省略 (チェーン構造の記述なので、退会済みメンバーのチェーンも graph 上は real な事実)
- ceiling 5 は出発点。real-data 観察で 5+ に有意な人口があれば follow-up で 10+ に上げる旨 SDL に明記

### (2) `SysAdminTenureDistribution.monthlyHistogram`

L3 `/members` の tenure 細分ヒストグラム用。13 bucket (`monthsIn` 0..12, `monthsIn=12` は 12+ を集約)。

- `bucket = min(floor(daysIn / 30), 12)` セマンティクス
- 既存 4 coarse bucket (`lt1Month` / `m1to3Months` / `m3to12Months` / `gte12Months`) は L1 / L2 互換のため残置
- coarse buckets と histogram の境界差 (`m3to12Months: daysIn < 365` vs `histogram[12]: floor(daysIn/30) >= 12`) を SDL とテストで固定

### (3) `SysAdminMemberRow.lastDonationAt`

L3 `/members` 休眠 list の sort key 用。`lastDonationDay` は repository 側で既に取れているのを GraphQL に expose するだけ。

### (4) `cohortFunnel` on `SysAdminCommunityDetailPayload`

L3 `/activity` のコホート別ファネル比較用。Stages: `acquired` / `activatedD30` / `repeated` / `habitual`。

- `activatedD30`: 個人の join 日から 30 日以内に初 DONATION
- `repeated`: `donationOutMonths >= 2`
- `habitual`: `classifyMember(...) === "habitual"` ⚠ **threshold-dependent** (request の `segmentThresholds.tier1` に従う、`stages.habitual` と同じ挙動) — SDL に明記
- 全 stage は JOINED-at-asOf scoped (`members` 自体が membership filter 通過済み)
- 計算は service 層 (`computeCohortFunnel`) で実装、既に取得済みの member データを bucket するので追加 DB scan ゼロ
- repository: `findMemberStats` SQL に `first_donation_day` (= `MIN(da.jst_day)`) と `joined_at` (= `m.created_at`) を projection 追加

## Test plan

- [x] `pnpm test src/__tests__/unit/sysadmin` — 既存 + 新規 = 85 PASS
- [x] `pnpm tsc --noEmit` — sysadmin domain 関連の型エラーなし
- [x] `pnpm gql:generate` — 生成型確認
- [ ] 統合テスト (DB 必要): デプロイ後に L3 view で実データ確認

## Acceptance criteria (Issue #4)

- [x] (1) `chainDepthDistribution` を `SysAdminCommunityDetailPayload` に追加
- [x] (2) `SysAdminTenureDistribution.monthlyHistogram` 追加 (既存 4 bucket は互換維持)
- [x] (3) `SysAdminMemberRow.lastDonationAt` 追加 (nullable)
- [x] (4) `cohortFunnel` を `SysAdminCommunityDetailPayload` に追加
- [x] (5) 受領 funnel 用の cohort 受領データは保留 (L3 着手後に判断)
- [x] schema コメントを同等粒度で記述

## Notes

- PR #926 (Issue #3 hubMemberCount monthly history) と独立。あちらが先にマージされてから本 PR を rebase する想定だが、コンフリクト点は少ない (異なるフィールド追加が中心)。
- (1) chainDepthDistribution の bucket ceiling、(4) cohortFunnel の `habitual` threshold 依存性は両方とも SDL に明記済み。


---
_Generated by [Claude Code](https://claude.ai/code/session_0119ku3UYiHxdQv37cmQkfHY)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/927" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
