### PR TITLE
fix(sysadmin): findChainDepthDistribution の GROUP BY を positional reference に (hotfix)

### DIFF
--- a/src/application/domain/sysadmin/data/repository.ts
+++ b/src/application/domain/sysadmin/data/repository.ts
@@ -1177,17 +1177,19 @@ export default class SysAdminRepository implements ISysAdminRepository {
           SELECT generate_series(1, ${maxBucketDepth}::int) AS depth
         ),
         depth_counts AS (
-          -- GROUP BY uses positional reference (1) rather than
-          -- repeating the LEAST(...) expression. Prisma assigns a
-          -- new bind parameter to every Prisma substitution slot,
+          -- GROUP BY references the SELECT alias (depth) instead
+          -- of repeating the LEAST(...) expression. Prisma assigns
+          -- a new bind parameter to every Prisma substitution slot,
           -- so writing the same LEAST(...) expression twice (once
           -- in SELECT, once in GROUP BY) yields two different
           -- parameter slots ($1, $3) at the wire level. PostgreSQL
           -- then refuses to recognise the GROUP BY expression as
           -- matching the SELECT one syntactically, raising
           -- "column t.chain_depth must appear in the GROUP BY
-          -- clause". Positional GROUP BY sidesteps the parameter
-          -- duplication entirely.
+          -- clause". Alias reference (PostgreSQL-supported since
+          -- 9.x) sidesteps the parameter duplication and stays
+          -- robust to future SELECT-column reorders, unlike
+          -- positional GROUP BY.
           SELECT
             LEAST(t."chain_depth", ${maxBucketDepth}::int) AS depth,
             COUNT(*)::int AS n
@@ -1199,7 +1201,7 @@ export default class SysAdminRepository implements ISysAdminRepository {
           WHERE t."reason" = 'DONATION'
             AND t."chain_depth" >= 1
             AND t."created_at" < ab.upper_ts
-          GROUP BY 1
+          GROUP BY depth
         )
         SELECT
           bk.depth AS depth,

--- a/src/application/domain/sysadmin/data/repository.ts
+++ b/src/application/domain/sysadmin/data/repository.ts
@@ -1177,6 +1177,17 @@ export default class SysAdminRepository implements ISysAdminRepository {
           SELECT generate_series(1, ${maxBucketDepth}::int) AS depth
         ),
         depth_counts AS (
+          -- GROUP BY uses positional reference (1) rather than
+          -- repeating the LEAST(...) expression. Prisma assigns a
+          -- new bind parameter to every Prisma substitution slot,
+          -- so writing the same LEAST(...) expression twice (once
+          -- in SELECT, once in GROUP BY) yields two different
+          -- parameter slots ($1, $3) at the wire level. PostgreSQL
+          -- then refuses to recognise the GROUP BY expression as
+          -- matching the SELECT one syntactically, raising
+          -- "column t.chain_depth must appear in the GROUP BY
+          -- clause". Positional GROUP BY sidesteps the parameter
+          -- duplication entirely.
           SELECT
             LEAST(t."chain_depth", ${maxBucketDepth}::int) AS depth,
             COUNT(*)::int AS n
@@ -1188,7 +1199,7 @@ export default class SysAdminRepository implements ISysAdminRepository {
           WHERE t."reason" = 'DONATION'
             AND t."chain_depth" >= 1
             AND t."created_at" < ab.upper_ts
-          GROUP BY LEAST(t."chain_depth", ${maxBucketDepth}::int)
+          GROUP BY 1
         )
         SELECT
           bk.depth AS depth,


### PR DESCRIPTION
## Summary

Cloud Run dev で `sysAdminCommunityDetail` クエリ実行時に PostgreSQL エラーが発生していたのを修正:

```
ERROR: column "t.chain_depth" must appear in the GROUP BY clause
       or be used in an aggregate function at character 396
```

## 原因

Prisma の `$queryRaw` は同じ `${...}` substitution 値でも**出現するごとに別の bind parameter ($1, $2, ...)** に展開します。`findChainDepthDistribution` の SQL は `LEAST(t."chain_depth", ${maxBucketDepth}::int)` を **SELECT と GROUP BY の両方**に書いていたため、wire level では:

```sql
SELECT LEAST(t."chain_depth", $1::int) AS depth, ...
GROUP BY LEAST(t."chain_depth", $3::int)  -- ← 別 parameter
```

となり、PostgreSQL が syntactically 同一の expression と認識せず "not in GROUP BY" エラーを raise していました。

## 修正

`GROUP BY` を positional reference (`GROUP BY 1`) に変更し、SELECT 側の式に直接参照するように:

```sql
SELECT LEAST(t."chain_depth", ${maxBucketDepth}::int) AS depth, COUNT(*)::int AS n
...
GROUP BY 1
```

bind parameter の重複が解消され、PostgreSQL が SELECT 列を直接参照します。

## なぜ検出できなかったか

unit test (`service.test.ts`) では `findChainDepthDistribution` 自体を `jest.fn()` でモックしていたため、SQL の wire-level 展開はテストされていませんでした。Cloud Run dev に initial deploy 後、実 DB に対して走らせた段階で初めて発覚。

**follow-up**: integration test (実 DB あり) で sysadmin 系 SQL を一通り実行する suite を別 issue で追加検討。

## Test plan

- [x] `pnpm tsc --noEmit` clean (sysadmin scope)
- [x] `pnpm test src/__tests__/unit/sysadmin --runInBand` — 88 tests PASS (既存テストは mock 経由で影響なし)
- [ ] dev デプロイ後、`sysAdminCommunityDetail` クエリが 200 を返すことを確認

## 緊急度

dev 環境で L2 detail 全体が 500 を返している状態なので、merge 後は速やかに dev 反映を推奨。

---
_Generated by [Claude Code](https://claude.ai/code/session_0119ku3UYiHxdQv37cmQkfHY)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/928" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
