### PR TITLE
docs(sysadmin): SDL 記述と実装の不整合 5 件を修正 (PR #927 Copilot review follow-up)

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -2364,9 +2364,11 @@ type SysAdminCommunityOverview {
   Invariants (the client may assert these):
     hubMemberCount <= windowActivity.senderCount <= totalMembers
   
-  The first holds because any hub member donated >= 3 times in
-  the window and is therefore a window sender; the second
-  because both `hubMemberCount` and `windowActivity.senderCount`
+  The first holds because any hub member sent DONATION to
+  `>= hubBreadthThreshold` distinct counterparties during the
+  window — which requires at least that many DONATION
+  transactions — so they are necessarily a window sender. The
+  second because both `hubMemberCount` and `windowActivity.senderCount`
   are computed from senders restricted to JOINED-at-asOf members
   (a former member who left the community before asOf is excluded
   even if they donated during the window) and totalMembers is
@@ -2776,7 +2778,7 @@ type SysAdminMonthlyActivityPoint {
   `SysAdminCommunityOverview.hubMemberCount`, evaluated at
   month-end rather than at request `asOf`.
   
-  Window: `[monthEnd - 28 JST日, monthEnd)`. The 28-day window is
+  Window: `[monthEnd - 28 JST days, monthEnd)`. The 28-day window is
   fixed (independent of any request input) so monthly
   hubMemberCount values across the trend stay comparable to each
   other — same precedent as `dormantCount`'s fixed 30-day window.
@@ -3051,19 +3053,29 @@ type SysAdminTenureDistribution {
   """
   Detailed monthly histogram for the L3 tenure deep-dive.
   
-  Each entry counts currently-JOINED members whose tenure
-  (`floor(daysIn / 30)`) falls into the bucket. The 12 bucket
-  aggregates all members with tenure of 12 months or longer.
-  Returned in ascending bucket order (`monthsIn` 0..12), with
-  every bucket emitted (count = 0 for buckets with no members)
-  so the client can render a contiguous histogram axis without
+  Each entry counts currently-JOINED members whose `daysIn` falls
+  into the bucket. Bucket boundaries are aligned with the coarse
+  `gte12Months` cutoff so the histogram and coarse buckets agree:
+  
+    - bucket 0:  daysIn <  30
+    - bucket k (1..11):  k * 30 <= daysIn < min((k + 1) * 30, 365)
+    - bucket 12: daysIn >= 365
+  
+  The 12 bucket therefore matches `gte12Months` exactly; bucket 11
+  covers `[330, 365)` so a member at 360..364 days lands in 11
+  rather than 12 (`floor(daysIn / 30)` would otherwise have placed
+  them in 12, creating an asymmetry with the coarse `m3to12Months`
+  cutoff at 365).
+  
+  Returned in ascending bucket order (`monthsIn` 0..12), with every
+  bucket emitted (count = 0 for buckets with no members) so the
+  client can render a contiguous histogram axis without
   zero-padding.
   
-  Sum of `count` equals `totalMembers` minus members with a
-  negative tenure (data anomaly — should be impossible because
-  `daysIn` is floor-1-clamped at the SQL boundary, but the
-  contract notes the exclusion explicitly so the invariant is
-  documented).
+  Sum of `count` equals `totalMembers`. A member with `daysIn < 0`
+  (data anomaly — `daysIn` is floor-1-clamped at the SQL boundary
+  so this should be impossible) is clamped into bucket 0 rather
+  than excluded, matching the service implementation.
   
   The existing 4 coarse buckets (`lt1Month` / `m1to3Months` /
   `m3to12Months` / `gte12Months`) remain for L1 / L2 callers; the
@@ -3081,10 +3093,11 @@ type SysAdminTenureHistogramBucket {
   count: Int!
 
   """
-  Tenure in JST calendar months, computed as `floor(daysIn / 30)`.
-  Range 0..12. The 12 bucket aggregates all members with tenure
-  of 12 months or longer; values 0..11 represent exact monthly
-  buckets.
+  Tenure bucket index, range 0..12. The 0 bucket aggregates
+  `daysIn < 30`; buckets 1..11 cover `k * 30 <= daysIn <
+  min((k + 1) * 30, 365)`; the 12 bucket aggregates `daysIn >=
+  365` (matching the coarse `gte12Months` boundary). Members at
+  330..364 days land in bucket 11, not bucket 12.
   """
   monthsIn: Int!
 }

--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -3058,14 +3058,16 @@ type SysAdminTenureDistribution {
   `gte12Months` cutoff so the histogram and coarse buckets agree:
   
     - bucket 0:  daysIn <  30
-    - bucket k (1..11):  k * 30 <= daysIn < min((k + 1) * 30, 365)
+    - bucket k (1..10):  k * 30 <= daysIn < (k + 1) * 30
+    - bucket 11: 330 <= daysIn < 365
     - bucket 12: daysIn >= 365
   
   The 12 bucket therefore matches `gte12Months` exactly; bucket 11
-  covers `[330, 365)` so a member at 360..364 days lands in 11
-  rather than 12 (`floor(daysIn / 30)` would otherwise have placed
-  them in 12, creating an asymmetry with the coarse `m3to12Months`
-  cutoff at 365).
+  is widened from the bare `[330, 360)` slot to `[330, 365)` so a
+  member at 360..364 days lands in 11 rather than 12
+  (`floor(daysIn / 30)` would otherwise have placed them in 12,
+  creating an asymmetry with the coarse `m3to12Months` cutoff at
+  365).
   
   Returned in ascending bucket order (`monthsIn` 0..12), with every
   bucket emitted (count = 0 for buckets with no members) so the
@@ -3094,10 +3096,11 @@ type SysAdminTenureHistogramBucket {
 
   """
   Tenure bucket index, range 0..12. The 0 bucket aggregates
-  `daysIn < 30`; buckets 1..11 cover `k * 30 <= daysIn <
-  min((k + 1) * 30, 365)`; the 12 bucket aggregates `daysIn >=
-  365` (matching the coarse `gte12Months` boundary). Members at
-  330..364 days land in bucket 11, not bucket 12.
+  `daysIn < 30`; buckets 1..10 cover `k * 30 <= daysIn <
+  (k + 1) * 30`; bucket 11 covers `330 <= daysIn < 365`; the 12
+  bucket aggregates `daysIn >= 365` (matching the coarse
+  `gte12Months` boundary). Members at 330..364 days land in
+  bucket 11, not bucket 12.
   """
   monthsIn: Int!
 }

--- a/src/application/domain/sysadmin/schema/type.graphql
+++ b/src/application/domain/sysadmin/schema/type.graphql
@@ -511,14 +511,16 @@ type SysAdminTenureDistribution {
   `gte12Months` cutoff so the histogram and coarse buckets agree:
 
     - bucket 0:  daysIn <  30
-    - bucket k (1..11):  k * 30 <= daysIn < min((k + 1) * 30, 365)
+    - bucket k (1..10):  k * 30 <= daysIn < (k + 1) * 30
+    - bucket 11: 330 <= daysIn < 365
     - bucket 12: daysIn >= 365
 
   The 12 bucket therefore matches `gte12Months` exactly; bucket 11
-  covers `[330, 365)` so a member at 360..364 days lands in 11
-  rather than 12 (`floor(daysIn / 30)` would otherwise have placed
-  them in 12, creating an asymmetry with the coarse `m3to12Months`
-  cutoff at 365).
+  is widened from the bare `[330, 360)` slot to `[330, 365)` so a
+  member at 360..364 days lands in 11 rather than 12
+  (`floor(daysIn / 30)` would otherwise have placed them in 12,
+  creating an asymmetry with the coarse `m3to12Months` cutoff at
+  365).
 
   Returned in ascending bucket order (`monthsIn` 0..12), with every
   bucket emitted (count = 0 for buckets with no members) so the
@@ -544,10 +546,11 @@ One bucket of the L3 tenure histogram. See
 type SysAdminTenureHistogramBucket {
   """
   Tenure bucket index, range 0..12. The 0 bucket aggregates
-  `daysIn < 30`; buckets 1..11 cover `k * 30 <= daysIn <
-  min((k + 1) * 30, 365)`; the 12 bucket aggregates `daysIn >=
-  365` (matching the coarse `gte12Months` boundary). Members at
-  330..364 days land in bucket 11, not bucket 12.
+  `daysIn < 30`; buckets 1..10 cover `k * 30 <= daysIn <
+  (k + 1) * 30`; bucket 11 covers `330 <= daysIn < 365`; the 12
+  bucket aggregates `daysIn >= 365` (matching the coarse
+  `gte12Months` boundary). Members at 330..364 days land in
+  bucket 11, not bucket 12.
   """
   monthsIn: Int!
   """

--- a/src/application/domain/sysadmin/schema/type.graphql
+++ b/src/application/domain/sysadmin/schema/type.graphql
@@ -506,19 +506,29 @@ type SysAdminTenureDistribution {
   """
   Detailed monthly histogram for the L3 tenure deep-dive.
 
-  Each entry counts currently-JOINED members whose tenure
-  (`floor(daysIn / 30)`) falls into the bucket. The 12 bucket
-  aggregates all members with tenure of 12 months or longer.
-  Returned in ascending bucket order (`monthsIn` 0..12), with
-  every bucket emitted (count = 0 for buckets with no members)
-  so the client can render a contiguous histogram axis without
+  Each entry counts currently-JOINED members whose `daysIn` falls
+  into the bucket. Bucket boundaries are aligned with the coarse
+  `gte12Months` cutoff so the histogram and coarse buckets agree:
+
+    - bucket 0:  daysIn <  30
+    - bucket k (1..11):  k * 30 <= daysIn < min((k + 1) * 30, 365)
+    - bucket 12: daysIn >= 365
+
+  The 12 bucket therefore matches `gte12Months` exactly; bucket 11
+  covers `[330, 365)` so a member at 360..364 days lands in 11
+  rather than 12 (`floor(daysIn / 30)` would otherwise have placed
+  them in 12, creating an asymmetry with the coarse `m3to12Months`
+  cutoff at 365).
+
+  Returned in ascending bucket order (`monthsIn` 0..12), with every
+  bucket emitted (count = 0 for buckets with no members) so the
+  client can render a contiguous histogram axis without
   zero-padding.
 
-  Sum of `count` equals `totalMembers` minus members with a
-  negative tenure (data anomaly — should be impossible because
-  `daysIn` is floor-1-clamped at the SQL boundary, but the
-  contract notes the exclusion explicitly so the invariant is
-  documented).
+  Sum of `count` equals `totalMembers`. A member with `daysIn < 0`
+  (data anomaly — `daysIn` is floor-1-clamped at the SQL boundary
+  so this should be impossible) is clamped into bucket 0 rather
+  than excluded, matching the service implementation.
 
   The existing 4 coarse buckets (`lt1Month` / `m1to3Months` /
   `m3to12Months` / `gte12Months`) remain for L1 / L2 callers; the
@@ -533,10 +543,11 @@ One bucket of the L3 tenure histogram. See
 """
 type SysAdminTenureHistogramBucket {
   """
-  Tenure in JST calendar months, computed as `floor(daysIn / 30)`.
-  Range 0..12. The 12 bucket aggregates all members with tenure
-  of 12 months or longer; values 0..11 represent exact monthly
-  buckets.
+  Tenure bucket index, range 0..12. The 0 bucket aggregates
+  `daysIn < 30`; buckets 1..11 cover `k * 30 <= daysIn <
+  min((k + 1) * 30, 365)`; the 12 bucket aggregates `daysIn >=
+  365` (matching the coarse `gte12Months` boundary). Members at
+  330..364 days land in bucket 11, not bucket 12.
   """
   monthsIn: Int!
   """
@@ -618,9 +629,11 @@ type SysAdminCommunityOverview {
   Invariants (the client may assert these):
     hubMemberCount <= windowActivity.senderCount <= totalMembers
 
-  The first holds because any hub member donated >= 3 times in
-  the window and is therefore a window sender; the second
-  because both `hubMemberCount` and `windowActivity.senderCount`
+  The first holds because any hub member sent DONATION to
+  `>= hubBreadthThreshold` distinct counterparties during the
+  window — which requires at least that many DONATION
+  transactions — so they are necessarily a window sender. The
+  second because both `hubMemberCount` and `windowActivity.senderCount`
   are computed from senders restricted to JOINED-at-asOf members
   (a former member who left the community before asOf is excluded
   even if they donated during the window) and totalMembers is
@@ -903,7 +916,7 @@ type SysAdminMonthlyActivityPoint {
   `SysAdminCommunityOverview.hubMemberCount`, evaluated at
   month-end rather than at request `asOf`.
 
-  Window: `[monthEnd - 28 JST日, monthEnd)`. The 28-day window is
+  Window: `[monthEnd - 28 JST days, monthEnd)`. The 28-day window is
   fixed (independent of any request input) so monthly
   hubMemberCount values across the trend stay comparable to each
   other — same precedent as `dormantCount`'s fixed 30-day window.

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -3306,9 +3306,11 @@ export type GqlSysAdminCommunityOverview = {
    * Invariants (the client may assert these):
    *   hubMemberCount <= windowActivity.senderCount <= totalMembers
    *
-   * The first holds because any hub member donated >= 3 times in
-   * the window and is therefore a window sender; the second
-   * because both `hubMemberCount` and `windowActivity.senderCount`
+   * The first holds because any hub member sent DONATION to
+   * `>= hubBreadthThreshold` distinct counterparties during the
+   * window — which requires at least that many DONATION
+   * transactions — so they are necessarily a window sender. The
+   * second because both `hubMemberCount` and `windowActivity.senderCount`
    * are computed from senders restricted to JOINED-at-asOf members
    * (a former member who left the community before asOf is excluded
    * even if they donated during the window) and totalMembers is
@@ -3681,7 +3683,7 @@ export type GqlSysAdminMonthlyActivityPoint = {
    * `SysAdminCommunityOverview.hubMemberCount`, evaluated at
    * month-end rather than at request `asOf`.
    *
-   * Window: `[monthEnd - 28 JST日, monthEnd)`. The 28-day window is
+   * Window: `[monthEnd - 28 JST days, monthEnd)`. The 28-day window is
    * fixed (independent of any request input) so monthly
    * hubMemberCount values across the trend stay comparable to each
    * other — same precedent as `dormantCount`'s fixed 30-day window.
@@ -3934,19 +3936,29 @@ export type GqlSysAdminTenureDistribution = {
   /**
    * Detailed monthly histogram for the L3 tenure deep-dive.
    *
-   * Each entry counts currently-JOINED members whose tenure
-   * (`floor(daysIn / 30)`) falls into the bucket. The 12 bucket
-   * aggregates all members with tenure of 12 months or longer.
-   * Returned in ascending bucket order (`monthsIn` 0..12), with
-   * every bucket emitted (count = 0 for buckets with no members)
-   * so the client can render a contiguous histogram axis without
+   * Each entry counts currently-JOINED members whose `daysIn` falls
+   * into the bucket. Bucket boundaries are aligned with the coarse
+   * `gte12Months` cutoff so the histogram and coarse buckets agree:
+   *
+   *   - bucket 0:  daysIn <  30
+   *   - bucket k (1..11):  k * 30 <= daysIn < min((k + 1) * 30, 365)
+   *   - bucket 12: daysIn >= 365
+   *
+   * The 12 bucket therefore matches `gte12Months` exactly; bucket 11
+   * covers `[330, 365)` so a member at 360..364 days lands in 11
+   * rather than 12 (`floor(daysIn / 30)` would otherwise have placed
+   * them in 12, creating an asymmetry with the coarse `m3to12Months`
+   * cutoff at 365).
+   *
+   * Returned in ascending bucket order (`monthsIn` 0..12), with every
+   * bucket emitted (count = 0 for buckets with no members) so the
+   * client can render a contiguous histogram axis without
    * zero-padding.
    *
-   * Sum of `count` equals `totalMembers` minus members with a
-   * negative tenure (data anomaly — should be impossible because
-   * `daysIn` is floor-1-clamped at the SQL boundary, but the
-   * contract notes the exclusion explicitly so the invariant is
-   * documented).
+   * Sum of `count` equals `totalMembers`. A member with `daysIn < 0`
+   * (data anomaly — `daysIn` is floor-1-clamped at the SQL boundary
+   * so this should be impossible) is clamped into bucket 0 rather
+   * than excluded, matching the service implementation.
    *
    * The existing 4 coarse buckets (`lt1Month` / `m1to3Months` /
    * `m3to12Months` / `gte12Months`) remain for L1 / L2 callers; the
@@ -3964,10 +3976,11 @@ export type GqlSysAdminTenureHistogramBucket = {
   /** Number of currently-JOINED members in this bucket. */
   count: Scalars['Int']['output'];
   /**
-   * Tenure in JST calendar months, computed as `floor(daysIn / 30)`.
-   * Range 0..12. The 12 bucket aggregates all members with tenure
-   * of 12 months or longer; values 0..11 represent exact monthly
-   * buckets.
+   * Tenure bucket index, range 0..12. The 0 bucket aggregates
+   * `daysIn < 30`; buckets 1..11 cover `k * 30 <= daysIn <
+   * min((k + 1) * 30, 365)`; the 12 bucket aggregates `daysIn >=
+   * 365` (matching the coarse `gte12Months` boundary). Members at
+   * 330..364 days land in bucket 11, not bucket 12.
    */
   monthsIn: Scalars['Int']['output'];
 };

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -3941,14 +3941,16 @@ export type GqlSysAdminTenureDistribution = {
    * `gte12Months` cutoff so the histogram and coarse buckets agree:
    *
    *   - bucket 0:  daysIn <  30
-   *   - bucket k (1..11):  k * 30 <= daysIn < min((k + 1) * 30, 365)
+   *   - bucket k (1..10):  k * 30 <= daysIn < (k + 1) * 30
+   *   - bucket 11: 330 <= daysIn < 365
    *   - bucket 12: daysIn >= 365
    *
    * The 12 bucket therefore matches `gte12Months` exactly; bucket 11
-   * covers `[330, 365)` so a member at 360..364 days lands in 11
-   * rather than 12 (`floor(daysIn / 30)` would otherwise have placed
-   * them in 12, creating an asymmetry with the coarse `m3to12Months`
-   * cutoff at 365).
+   * is widened from the bare `[330, 360)` slot to `[330, 365)` so a
+   * member at 360..364 days lands in 11 rather than 12
+   * (`floor(daysIn / 30)` would otherwise have placed them in 12,
+   * creating an asymmetry with the coarse `m3to12Months` cutoff at
+   * 365).
    *
    * Returned in ascending bucket order (`monthsIn` 0..12), with every
    * bucket emitted (count = 0 for buckets with no members) so the
@@ -3977,10 +3979,11 @@ export type GqlSysAdminTenureHistogramBucket = {
   count: Scalars['Int']['output'];
   /**
    * Tenure bucket index, range 0..12. The 0 bucket aggregates
-   * `daysIn < 30`; buckets 1..11 cover `k * 30 <= daysIn <
-   * min((k + 1) * 30, 365)`; the 12 bucket aggregates `daysIn >=
-   * 365` (matching the coarse `gte12Months` boundary). Members at
-   * 330..364 days land in bucket 11, not bucket 12.
+   * `daysIn < 30`; buckets 1..10 cover `k * 30 <= daysIn <
+   * (k + 1) * 30`; bucket 11 covers `330 <= daysIn < 365`; the 12
+   * bucket aggregates `daysIn >= 365` (matching the coarse
+   * `gte12Months` boundary). Members at 330..364 days land in
+   * bucket 11, not bucket 12.
    */
   monthsIn: Scalars['Int']['output'];
 };


### PR DESCRIPTION
## Summary

PR #927 (Issue #4) と PR #926 (Issue #3) の Copilot review で指摘された **SDL 記述と実装の不整合 5 件**を修正。挙動変更なし、ドキュメンテーション専用 PR。

## 修正内容

| # | 場所 | Before | After |
|---|---|---|---|
| 1 | `SysAdminCommunityOverview.hubMemberCount` invariant | `"donated >= 3 times"` (hardcoded) | `">= hubBreadthThreshold distinct counterparties"` |
| 2 | `monthlyHistogram` 説明 | `floor(daysIn / 30)` ルール | 境界ベースの説明 (bucket 12 = `daysIn >= 365`、bucket 11 = `[330, 365)`) |
| 3 | `TenureHistogramBucket.monthsIn` 説明 | `floor(daysIn / 30)` ルール | 境界ベースの説明 |
| 4 | `monthlyHistogram` 「negative tenure 除外」 | doc が "exclude" | 実装は `Math.max(0, ...)` で bucket 0 クランプ → "clamped to bucket 0" に修正、`sum(count) == totalMembers` 明記 |
| 5 | `SysAdminMonthlyActivityPoint.hubMemberCount` docstring | `28 JST日` (英文中の表記揺れ) | `28 JST days` |

## 詳細

### 修正 1: hubMemberCount invariant
`hubBreadthThreshold` が L1 / L2 入力で可変になったため、invariant 説明から default 値 (3) のリテラルを除去。

### 修正 2-3: tenure histogram の境界
PR #927 のレビューで gemini-code-assist が指摘した「coarse `gte12Months` (365+) と histogram[12] (360+) の不整合」を 365 day boundary に統一した実装変更が、SDL 側で反映されていなかった。doc を実装に追従。

### 修正 4: negative-daysIn の挙動
PR #927 のレビューで Devin が指摘した「coarse bucket は increment されるが histogram は continue で skip → invariant 違反」の修正で、`Math.max(0, ...)` で bucket 0 にクランプする実装に変更したが、SDL は依然 "exclude" のままだった。

### 修正 5: 表記揺れ
英文 docstring 内の `28 JST日` を `28 JST days` に統一 (Copilot 指摘)。

## Test plan

- [x] `pnpm gql:generate` — `src/types/graphql.ts` / `docs/schema.graphql` を再生成
- [x] `pnpm tsc --noEmit` clean (sysadmin scope)
- [x] `pnpm test src/__tests__/unit/sysadmin --runInBand` — 88 tests PASS

ドキュメント専用変更なので CI も軽量に通るはず。

---
_Generated by [Claude Code](https://claude.ai/code/session_0119ku3UYiHxdQv37cmQkfHY)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/930" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
