### PR TITLE
sysAdmin レポート機能統合: テンプレート管理 + 横断観察 query 追加 (Phase 1 + Phase 2)

### DIFF
--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -387,6 +387,8 @@ OTHER OTHER
     DateTime established_at "❓"
     String website "❓"
     String image_id "❓"
+    DateTime last_published_report_at "❓"
+    String last_published_report_id "❓"
     DateTime created_at 
     DateTime updated_at "❓"
     }

--- a/docs/schema.dbml
+++ b/docs/schema.dbml
@@ -97,6 +97,8 @@ Table t_communities {
   voteTopics t_vote_topics [not null]
   reportTemplates t_report_templates [not null]
   reports t_reports [not null]
+  lastPublishedReportAt DateTime
+  lastPublishedReportId String
   createdAt DateTime [default: `now()`, not null]
   updatedAt DateTime
 }

--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -7,6 +7,25 @@ type AccumulatedPointView {
   walletId: String
 }
 
+type AdminReportSummaryConnection {
+  edges: [AdminReportSummaryEdge]
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type AdminReportSummaryEdge implements Edge {
+  cursor: String!
+  node: AdminReportSummaryRow
+}
+
+type AdminReportSummaryRow {
+  community: Community!
+  daysSinceLastPublish: Int
+  lastPublishedAt: Datetime
+  lastPublishedReport: Report
+  publishedCountLast90Days: Int!
+}
+
 union ApproveReportPayload = ApproveReportSuccess
 
 type ApproveReportSuccess {
@@ -1600,6 +1619,8 @@ enum PublishStatus {
 }
 
 type Query {
+  adminBrowseReports(communityId: ID, cursor: String, first: Int, publishedAfter: Datetime, publishedBefore: Datetime, status: ReportStatus, variant: ReportVariant): ReportsConnection!
+  adminReportSummary(cursor: String, first: Int): AdminReportSummaryConnection!
   article(id: ID!, permission: CheckCommunityPermissionInput!): Article
   articles(cursor: String, filter: ArticleFilterInput, first: Int, sort: ArticleSortInput): ArticlesConnection!
   cities(cursor: String, filter: CitiesInput, first: Int, sort: CitiesSortInput): CitiesConnection!
@@ -1642,6 +1663,8 @@ type Query {
   report(id: ID!): Report
   reportTemplate(communityId: ID, variant: ReportVariant!): ReportTemplate
   reportTemplateStats(variant: ReportVariant!, version: Int): ReportTemplateStats!
+  reportTemplateStatsBreakdown(cursor: String, first: Int = 20, includeInactive: Boolean = false, kind: ReportTemplateKind = GENERATION, variant: ReportVariant!, version: Int): ReportTemplateStatsBreakdownConnection!
+  reportTemplates(communityId: ID, includeInactive: Boolean = false, kind: ReportTemplateKind = GENERATION, variant: ReportVariant!): [ReportTemplate!]!
   reports(communityId: ID!, cursor: String, first: Int, permission: CheckCommunityPermissionInput!, status: ReportStatus, variant: ReportVariant): ReportsConnection!
   reservation(id: ID!): Reservation
   reservationHistories(cursor: String, filter: ReservationHistoryFilterInput, first: Int, sort: ReservationHistorySortInput): ReservationHistoriesConnection!
@@ -1790,6 +1813,7 @@ type ReportTemplate {
   id: ID!
   isActive: Boolean!
   isEnabled: Boolean!
+  kind: ReportTemplateKind!
   maxTokens: Int!
   model: String!
   scope: ReportTemplateScope!
@@ -1802,6 +1826,11 @@ type ReportTemplate {
   userPromptTemplate: String!
   variant: ReportVariant!
   version: Int!
+}
+
+enum ReportTemplateKind {
+  GENERATION
+  JUDGE
 }
 
 enum ReportTemplateScope {
@@ -1817,6 +1846,33 @@ type ReportTemplateStats {
   judgeHumanCorrelation: Float
   variant: ReportVariant!
   version: Int
+}
+
+type ReportTemplateStatsBreakdownConnection {
+  edges: [ReportTemplateStatsBreakdownEdge]
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type ReportTemplateStatsBreakdownEdge implements Edge {
+  cursor: String!
+  node: ReportTemplateStatsBreakdownRow
+}
+
+type ReportTemplateStatsBreakdownRow {
+  avgJudgeScore: Float
+  avgRating: Float
+  correlationWarning: Boolean!
+  experimentKey: String
+  feedbackCount: Int!
+  isActive: Boolean!
+  isEnabled: Boolean!
+  judgeHumanCorrelation: Float
+  kind: ReportTemplateKind!
+  scope: ReportTemplateScope!
+  templateId: ID!
+  trafficWeight: Int!
+  version: Int!
 }
 
 enum ReportVariant {

--- a/src/__tests__/unit/report/communitySummaryCursor.test.ts
+++ b/src/__tests__/unit/report/communitySummaryCursor.test.ts
@@ -1,8 +1,8 @@
-import {
-  CommunitySummaryCursor,
-  encodeCommunitySummaryCursor,
-  decodeCommunitySummaryCursor,
-} from "@/application/domain/report/data/repository";
+import { CommunitySummaryCursor } from "@/application/domain/report/data/type";
+import ReportConverter from "@/application/domain/report/data/converter";
+import { encodeCommunitySummaryCursor } from "@/application/domain/report/presenter";
+
+const decodeCommunitySummaryCursor = ReportConverter.decodeCommunitySummaryCursor;
 
 describe("CommunitySummaryCursor encoding", () => {
   it("round-trips both NULL-tier and chronological-tier cursors", () => {

--- a/src/__tests__/unit/report/communitySummaryCursor.test.ts
+++ b/src/__tests__/unit/report/communitySummaryCursor.test.ts
@@ -1,0 +1,30 @@
+import {
+  CommunitySummaryCursor,
+  encodeCommunitySummaryCursor,
+  decodeCommunitySummaryCursor,
+} from "@/application/domain/report/data/repository";
+
+describe("CommunitySummaryCursor encoding", () => {
+  it("round-trips both NULL-tier and chronological-tier cursors", () => {
+    const cases: CommunitySummaryCursor[] = [
+      { at: null, id: "comm-dormant" },
+      { at: "2026-04-27T14:31:53.000Z", id: "comm-active" },
+    ];
+    for (const c of cases) {
+      const decoded = decodeCommunitySummaryCursor(encodeCommunitySummaryCursor(c));
+      expect(decoded).toEqual(c);
+    }
+  });
+
+  it("returns null on garbage input rather than throwing", () => {
+    // Truncated, manually edited, or stale-schema cursors should fall back
+    // to a fresh first page rather than 500ing the whole query.
+    expect(decodeCommunitySummaryCursor("not-base64!!!")).toBeNull();
+    expect(decodeCommunitySummaryCursor("")).toBeNull();
+    expect(decodeCommunitySummaryCursor(Buffer.from("[]").toString("base64url"))).toBeNull();
+    expect(decodeCommunitySummaryCursor(Buffer.from("{}").toString("base64url"))).toBeNull();
+    // `at` must be string or null — numbers / objects rejected.
+    const badAt = Buffer.from(JSON.stringify({ at: 0, id: "x" })).toString("base64url");
+    expect(decodeCommunitySummaryCursor(badAt)).toBeNull();
+  });
+});

--- a/src/__tests__/unit/report/communitySummaryCursor.test.ts
+++ b/src/__tests__/unit/report/communitySummaryCursor.test.ts
@@ -27,4 +27,15 @@ describe("CommunitySummaryCursor encoding", () => {
     const badAt = Buffer.from(JSON.stringify({ at: 0, id: "x" })).toString("base64url");
     expect(decodeCommunitySummaryCursor(badAt)).toBeNull();
   });
+
+  it("rejects strings that aren't parseable as timestamps", () => {
+    // Without this guard the cursor would reach Postgres as
+    // `'not-a-date'::timestamp` and trigger a 500 — exactly what the
+    // lenient-decode contract is meant to prevent.
+    const cases = ["not-a-date", "", "2026-13-99T99:99:99Z"];
+    for (const at of cases) {
+      const cursor = Buffer.from(JSON.stringify({ at, id: "x" })).toString("base64url");
+      expect(decodeCommunitySummaryCursor(cursor)).toBeNull();
+    }
+  });
 });

--- a/src/__tests__/unit/report/feedback/feedbackService.test.ts
+++ b/src/__tests__/unit/report/feedback/feedbackService.test.ts
@@ -1,5 +1,6 @@
 import "reflect-metadata";
 import { container } from "tsyringe";
+import { ReportTemplateKind, ReportTemplateScope } from "@prisma/client";
 import ReportFeedbackService, {
   pearsonCorrelation,
   JUDGE_HUMAN_CORRELATION_WARNING_THRESHOLD,
@@ -15,6 +16,7 @@ describe("ReportFeedbackService.getTemplateStats", () => {
     findFeedbacksByReport: jest.Mock;
     findFeedbacksByReportIds: jest.Mock;
     getTemplateFeedbackAggregates: jest.Mock;
+    getTemplateBreakdown: jest.Mock;
   };
   let service: ReportFeedbackService;
 
@@ -26,6 +28,7 @@ describe("ReportFeedbackService.getTemplateStats", () => {
       findFeedbacksByReport: jest.fn(),
       findFeedbacksByReportIds: jest.fn(),
       getTemplateFeedbackAggregates: jest.fn(),
+      getTemplateBreakdown: jest.fn(),
     };
     container.register("ReportFeedbackRepository", { useValue: repository });
     service = container.resolve(ReportFeedbackService);
@@ -90,6 +93,148 @@ describe("ReportFeedbackService.getTemplateStats", () => {
       JUDGE_HUMAN_CORRELATION_WARNING_THRESHOLD,
     );
     expect(result.correlationWarning).toBe(true);
+  });
+});
+
+describe("ReportFeedbackService.getTemplateBreakdown", () => {
+  const fakeCtx = {} as IContext;
+
+  let repository: {
+    createFeedback: jest.Mock;
+    findFeedbackByReportAndUser: jest.Mock;
+    findFeedbacksByReport: jest.Mock;
+    findFeedbacksByReportIds: jest.Mock;
+    getTemplateFeedbackAggregates: jest.Mock;
+    getTemplateBreakdown: jest.Mock;
+  };
+  let service: ReportFeedbackService;
+
+  // Compact factory keeps the test rows readable while satisfying the
+  // full TemplateBreakdownRow shape — the breakdown service runs
+  // Pearson over the embedded `pairs` array, so non-pair fields just
+  // need to round-trip unchanged.
+  const row = (overrides: {
+    templateId: string;
+    pairs?: Array<{ reportId: string; judgeScore: number; avgRating: number }>;
+    feedbackCount?: number;
+    version?: number;
+  }) => ({
+    templateId: overrides.templateId,
+    version: overrides.version ?? 1,
+    scope: ReportTemplateScope.SYSTEM,
+    kind: ReportTemplateKind.GENERATION,
+    experimentKey: null,
+    isActive: true,
+    isEnabled: true,
+    trafficWeight: 100,
+    feedbackCount: overrides.feedbackCount ?? overrides.pairs?.length ?? 0,
+    avgRating: null,
+    avgJudgeScore: null,
+    pairs: overrides.pairs ?? [],
+  });
+
+  beforeEach(() => {
+    container.reset();
+    repository = {
+      createFeedback: jest.fn(),
+      findFeedbackByReportAndUser: jest.fn(),
+      findFeedbacksByReport: jest.fn(),
+      findFeedbacksByReportIds: jest.fn(),
+      getTemplateFeedbackAggregates: jest.fn(),
+      getTemplateBreakdown: jest.fn(),
+    };
+    container.register("ReportFeedbackRepository", { useValue: repository });
+    service = container.resolve(ReportFeedbackService);
+  });
+
+  it("computes per-template Pearson independently across rows", async () => {
+    repository.getTemplateBreakdown.mockResolvedValue({
+      items: [
+        // Strong positive correlation → r ≈ 1, no warning.
+        row({
+          templateId: "tmpl-v1",
+          pairs: [
+            { reportId: "r1", judgeScore: 60, avgRating: 2 },
+            { reportId: "r2", judgeScore: 75, avgRating: 3.5 },
+            { reportId: "r3", judgeScore: 90, avgRating: 5 },
+          ],
+        }),
+        // Anti-correlation → r ≈ -1, warning ON.
+        row({
+          templateId: "tmpl-v2",
+          pairs: [
+            { reportId: "r4", judgeScore: 90, avgRating: 1 },
+            { reportId: "r5", judgeScore: 70, avgRating: 3 },
+            { reportId: "r6", judgeScore: 50, avgRating: 5 },
+          ],
+        }),
+      ],
+      totalCount: 2,
+    });
+
+    const result = await service.getTemplateBreakdown(fakeCtx, {
+      variant: "WEEKLY_SUMMARY",
+      kind: ReportTemplateKind.GENERATION,
+      includeInactive: false,
+      first: 20,
+    });
+
+    expect(result.items).toHaveLength(2);
+    expect(result.items[0].templateId).toBe("tmpl-v1");
+    expect(result.items[0].judgeHumanCorrelation).not.toBeNull();
+    expect(result.items[0].judgeHumanCorrelation!).toBeGreaterThan(0.99);
+    expect(result.items[0].correlationWarning).toBe(false);
+
+    expect(result.items[1].templateId).toBe("tmpl-v2");
+    expect(result.items[1].judgeHumanCorrelation).not.toBeNull();
+    expect(result.items[1].correlationWarning).toBe(true);
+  });
+
+  it("returns null correlation when a row has fewer than 3 pairs", async () => {
+    repository.getTemplateBreakdown.mockResolvedValue({
+      items: [
+        row({
+          templateId: "tmpl-thin",
+          pairs: [
+            { reportId: "r1", judgeScore: 60, avgRating: 3 },
+            { reportId: "r2", judgeScore: 80, avgRating: 4 },
+          ],
+        }),
+      ],
+      totalCount: 1,
+    });
+
+    const result = await service.getTemplateBreakdown(fakeCtx, {
+      variant: "WEEKLY_SUMMARY",
+      kind: ReportTemplateKind.GENERATION,
+      includeInactive: false,
+      first: 20,
+    });
+
+    expect(result.items[0].judgeHumanCorrelation).toBeNull();
+    expect(result.items[0].correlationWarning).toBe(false);
+  });
+
+  it("forwards pagination params to the repository unchanged", async () => {
+    repository.getTemplateBreakdown.mockResolvedValue({ items: [], totalCount: 0 });
+
+    await service.getTemplateBreakdown(fakeCtx, {
+      variant: "WEEKLY_SUMMARY",
+      version: 3,
+      kind: ReportTemplateKind.JUDGE,
+      includeInactive: true,
+      cursor: "tmpl-cursor",
+      first: 50,
+    });
+
+    expect(repository.getTemplateBreakdown).toHaveBeenCalledWith(fakeCtx, {
+      variant: "WEEKLY_SUMMARY",
+      version: 3,
+      kind: ReportTemplateKind.JUDGE,
+      includeInactive: true,
+      cursor: "tmpl-cursor",
+      first: 50,
+    });
   });
 });
 

--- a/src/__tests__/unit/report/usecase.test.ts
+++ b/src/__tests__/unit/report/usecase.test.ts
@@ -543,3 +543,329 @@ describe("ReportUseCase.updateReportTemplate trafficWeight validation (PR-F3)", 
     expect(service.upsertTemplate).toHaveBeenCalled();
   });
 });
+
+/**
+ * A-3 maintenance contract: when `supersedeParentIfRegenerating`
+ * transitions a parent to SUPERSEDED, the community's denormalized
+ * last-publish pointer (`t_communities.last_published_report_*`) only
+ * needs to be re-derived when the parent was actually PUBLISHED. For
+ * DRAFT / APPROVED / SKIPPED parents the pointer was never on this
+ * row, so the extra UPDATE would be wasted. publishReport itself
+ * always recalcs because it just produced a new PUBLISHED row.
+ */
+describe("ReportUseCase A-3 community last-publish pointer maintenance", () => {
+  const communityId = "kibotcha";
+  const fakeTx = {} as never;
+  const fakeCtx = {
+    issuer: {
+      onlyBelongingCommunity: (
+        _ctx: IContext,
+        fn: (tx: unknown) => Promise<unknown>,
+      ): Promise<unknown> => fn(fakeTx),
+      admin: (
+        _ctx: IContext,
+        fn: (tx: unknown) => Promise<unknown>,
+      ): Promise<unknown> => fn(fakeTx),
+    },
+    currentUser: { id: "admin-user" },
+  } as unknown as IContext;
+
+  const stubTemplate = {
+    id: "tpl-1",
+    variant: "WEEKLY_SUMMARY",
+    scope: "SYSTEM",
+    communityId: null,
+    systemPrompt: "sys",
+    userPromptTemplate: "user ${payload_json}",
+    communityContext: null,
+    model: "claude-sonnet-4-6",
+    temperature: 0.5,
+    maxTokens: 8192,
+    stopSequences: [],
+    isEnabled: true,
+    version: 1,
+    isActive: true,
+    kind: "GENERATION",
+  };
+
+  let service: jest.Mocked<Pick<
+    ReportService,
+    | "getTemplate"
+    | "evaluateSkipReason"
+    | "createReport"
+    | "getReportById"
+    | "assertStatusTransition"
+    | "updateReportStatus"
+    | "saveJudgeResult"
+    | "recalculateCommunityLastPublished"
+  >>;
+  let usecase: ReportUseCase;
+  let llmClient: { complete: jest.Mock };
+  let judgeService: { selectJudgeTemplate: jest.Mock; executeJudge: jest.Mock };
+
+  beforeEach(() => {
+    container.reset();
+    service = {
+      getTemplate: jest.fn().mockResolvedValue(stubTemplate),
+      evaluateSkipReason: jest.fn().mockReturnValue("No activity in period: skip"),
+      createReport: jest.fn().mockImplementation(async (_ctx, data) => ({
+        id: "new-report-id",
+        communityId: data.communityId,
+        variant: data.variant,
+        status: data.status ?? ReportStatus.DRAFT,
+        regenerateCount: data.regenerateCount ?? 0,
+        parentRunId: data.parentRunId ?? null,
+        publishedAt: null,
+      })),
+      getReportById: jest.fn(),
+      assertStatusTransition: jest.fn(),
+      updateReportStatus: jest.fn().mockImplementation(async (_ctx, id, status) => ({
+        id,
+        communityId,
+        status,
+        publishedAt: status === ReportStatus.PUBLISHED ? new Date() : null,
+      })),
+      saveJudgeResult: jest.fn(),
+      recalculateCommunityLastPublished: jest.fn().mockResolvedValue(undefined),
+    } as never;
+
+    llmClient = { complete: jest.fn() };
+    judgeService = {
+      selectJudgeTemplate: jest.fn().mockResolvedValue(null),
+      executeJudge: jest.fn(),
+    };
+    const templateSelector = {
+      selectTemplate: jest.fn().mockResolvedValue(stubTemplate),
+    };
+
+    container.register("ReportService", { useValue: service });
+    container.register("LlmClient", { useValue: llmClient });
+    container.register("ReportJudgeService", { useValue: judgeService });
+    container.register("ReportTemplateSelector", { useValue: templateSelector });
+
+    usecase = container.resolve(ReportUseCase);
+
+    // Stub buildReportPayload so tests don't reach into the
+    // repository layer — the SUPERSEDED → recalc behaviour is
+    // independent of the payload contents, and the skip evaluator is
+    // already forced to return "skip" so no LLM call happens.
+    jest.spyOn(usecase, "buildReportPayload").mockResolvedValue({
+      period: { from: "2026-04-11", to: "2026-04-17" },
+      community_id: communityId,
+      community_context: null,
+      deepest_chain: null,
+      daily_summaries: [],
+      daily_active_users: [],
+      top_users: [],
+      highlight_comments: [],
+      previous_period: null,
+      retention: null,
+    });
+  });
+
+  it("publishReport always re-derives the community pointer in the same transaction", async () => {
+    service.getReportById.mockResolvedValue({
+      id: "report-1",
+      communityId,
+      status: ReportStatus.APPROVED,
+    } as never);
+
+    await usecase.publishReport(
+      { id: "report-1", finalContent: "# Final" },
+      fakeCtx,
+    );
+
+    expect(service.recalculateCommunityLastPublished).toHaveBeenCalledTimes(1);
+    expect(service.recalculateCommunityLastPublished).toHaveBeenCalledWith(
+      expect.anything(),
+      communityId,
+      fakeTx,
+    );
+  });
+
+  it("regenerate from PUBLISHED parent triggers recalc (parent's pointer must move on)", async () => {
+    service.evaluateSkipReason.mockReturnValue("skip");
+    service.getReportById.mockResolvedValue({
+      id: "parent-pub",
+      communityId,
+      variant: "WEEKLY_SUMMARY",
+      status: ReportStatus.PUBLISHED,
+      regenerateCount: 0,
+    } as never);
+
+    await usecase.generateReport(
+      {
+        input: {
+          communityId,
+          variant: GqlReportVariant.WeeklySummary,
+          periodFrom: new Date("2026-04-11"),
+          periodTo: new Date("2026-04-17"),
+          parentRunId: "parent-pub",
+        },
+        permission: { communityId },
+      },
+      fakeCtx,
+    );
+
+    expect(service.recalculateCommunityLastPublished).toHaveBeenCalledTimes(1);
+    expect(service.recalculateCommunityLastPublished).toHaveBeenCalledWith(
+      expect.anything(),
+      communityId,
+      fakeTx,
+    );
+  });
+
+  it.each([
+    ["DRAFT", ReportStatus.DRAFT],
+    ["APPROVED", ReportStatus.APPROVED],
+    ["SKIPPED", ReportStatus.SKIPPED],
+  ])(
+    "regenerate from %s parent does NOT trigger recalc (pointer was never on this row)",
+    async (_label, parentStatus) => {
+      service.evaluateSkipReason.mockReturnValue("skip");
+      service.getReportById.mockResolvedValue({
+        id: "parent-x",
+        communityId,
+        variant: "WEEKLY_SUMMARY",
+        status: parentStatus,
+        regenerateCount: 0,
+      } as never);
+
+      await usecase.generateReport(
+        {
+          input: {
+            communityId,
+            variant: GqlReportVariant.WeeklySummary,
+            periodFrom: new Date("2026-04-11"),
+            periodTo: new Date("2026-04-17"),
+            parentRunId: "parent-x",
+          },
+          permission: { communityId },
+        },
+        fakeCtx,
+      );
+
+      expect(service.recalculateCommunityLastPublished).not.toHaveBeenCalled();
+    },
+  );
+});
+
+/**
+ * Phase 1 + Phase 2 admin query orchestration. These tests don't
+ * exercise the SQL paths (those need integration tests with a live
+ * Postgres) — they verify the usecase forwards args correctly and
+ * coalesces nullable codegen args (the GraphQL schema declares
+ * defaults but codegen still emits each arg as `Maybe<T>`, so the
+ * usecase must apply the default itself).
+ */
+describe("ReportUseCase admin queries (Phase 1 + Phase 2)", () => {
+  const communityId = "kibotcha";
+  const fakeCtx = {} as IContext;
+
+  let service: jest.Mocked<Pick<
+    ReportService,
+    "listTemplates" | "getAllReports" | "getCommunityReportSummary"
+  >>;
+  let usecase: ReportUseCase;
+
+  beforeEach(() => {
+    container.reset();
+    service = {
+      listTemplates: jest.fn().mockResolvedValue([]),
+      getAllReports: jest.fn().mockResolvedValue({ items: [], totalCount: 0 }),
+      getCommunityReportSummary: jest.fn().mockResolvedValue({ items: [], totalCount: 0 }),
+    } as never;
+    container.register("ReportService", { useValue: service });
+    container.register("LlmClient", { useValue: { complete: jest.fn() } });
+    container.register("ReportJudgeService", {
+      useValue: { selectJudgeTemplate: jest.fn(), executeJudge: jest.fn() },
+    });
+    container.register("ReportTemplateSelector", {
+      useValue: { selectTemplate: jest.fn() },
+    });
+    usecase = container.resolve(ReportUseCase);
+  });
+
+  it("listReportTemplates defaults kind to GENERATION when caller omits it", async () => {
+    await usecase.listReportTemplates(
+      {
+        variant: GqlReportVariant.WeeklySummary,
+      },
+      fakeCtx,
+    );
+    // Concrete enum value, not undefined / null — repository contract
+    // requires a non-null kind on the where clause.
+    expect(service.listTemplates).toHaveBeenCalledWith(
+      fakeCtx,
+      GqlReportVariant.WeeklySummary,
+      null,
+      "GENERATION",
+      false,
+    );
+  });
+
+  it("listReportTemplates threads explicit JUDGE kind through", async () => {
+    await usecase.listReportTemplates(
+      {
+        variant: GqlReportVariant.WeeklySummary,
+        kind: "JUDGE" as never,
+        includeInactive: true,
+      },
+      fakeCtx,
+    );
+    expect(service.listTemplates).toHaveBeenCalledWith(
+      fakeCtx,
+      GqlReportVariant.WeeklySummary,
+      null,
+      "JUDGE",
+      true,
+    );
+  });
+
+  it("adminBrowseReports forwards filters and converts ISO strings to Date", async () => {
+    await usecase.adminBrowseReports(
+      {
+        communityId,
+        status: ReportStatus.PUBLISHED,
+        variant: GqlReportVariant.WeeklySummary,
+        publishedAfter: "2026-01-01T00:00:00Z" as never,
+        publishedBefore: "2026-04-01T00:00:00Z" as never,
+        cursor: "cursor-x",
+        first: 30,
+      },
+      fakeCtx,
+    );
+    expect(service.getAllReports).toHaveBeenCalledWith(
+      fakeCtx,
+      expect.objectContaining({
+        communityId,
+        status: ReportStatus.PUBLISHED,
+        variant: GqlReportVariant.WeeklySummary,
+        publishedAfter: expect.any(Date),
+        publishedBefore: expect.any(Date),
+        cursor: "cursor-x",
+        first: 30,
+      }),
+    );
+  });
+
+  it("adminBrowseReports clamps `first` to defaults when omitted and rejects out-of-range values", async () => {
+    await usecase.adminBrowseReports({}, fakeCtx);
+    expect(service.getAllReports.mock.calls[0][1].first).toBe(20);
+
+    await expect(
+      usecase.adminBrowseReports({ first: 500 }, fakeCtx),
+    ).rejects.toThrow(/first must be between 1 and 100/);
+  });
+
+  it("adminViewReportSummary clamps `first` and forwards cursor", async () => {
+    await usecase.adminViewReportSummary(
+      { cursor: "comm-cursor", first: 50 },
+      fakeCtx,
+    );
+    expect(service.getCommunityReportSummary).toHaveBeenCalledWith(
+      fakeCtx,
+      { cursor: "comm-cursor", first: 50 },
+    );
+  });
+});

--- a/src/__tests__/unit/report/usecase.test.ts
+++ b/src/__tests__/unit/report/usecase.test.ts
@@ -855,7 +855,7 @@ describe("ReportUseCase admin queries (Phase 1 + Phase 2)", () => {
 
     await expect(
       usecase.adminBrowseReports({ first: 500 }, fakeCtx),
-    ).rejects.toThrow(/first must be between 1 and 100/);
+    ).rejects.toThrow(/first must be an integer between 1 and 100/);
   });
 
   it("adminViewReportSummary clamps `first` and forwards cursor", async () => {

--- a/src/__tests__/unit/sysadmin/memberListCursor.test.ts
+++ b/src/__tests__/unit/sysadmin/memberListCursor.test.ts
@@ -1,0 +1,28 @@
+import SysAdminConverter from "@/application/domain/sysadmin/data/converter";
+import { encodeMemberListCursor } from "@/application/domain/sysadmin/presenter";
+
+describe("MemberList cursor encoding", () => {
+  it("round-trips offsets across the converter ↔ presenter pair", () => {
+    for (const offset of [0, 1, 50, 1000, 9999]) {
+      expect(SysAdminConverter.parseMemberListCursor(encodeMemberListCursor(offset))).toBe(
+        offset,
+      );
+    }
+  });
+
+  it("collapses null / undefined / empty cursor to offset 0", () => {
+    // Caller may pass an absent cursor when starting from the first
+    // page; the converter must accept all three.
+    expect(SysAdminConverter.parseMemberListCursor(null)).toBe(0);
+    expect(SysAdminConverter.parseMemberListCursor(undefined)).toBe(0);
+    expect(SysAdminConverter.parseMemberListCursor("")).toBe(0);
+  });
+
+  it("falls back to 0 on garbage rather than throwing", () => {
+    // Tampered / truncated cursors should restart pagination instead
+    // of bubbling a parse error to the client.
+    expect(SysAdminConverter.parseMemberListCursor("not-base64!!!")).toBe(0);
+    expect(SysAdminConverter.parseMemberListCursor("LWZvbw==")).toBe(0); // base64("-foo") → NaN
+    expect(SysAdminConverter.parseMemberListCursor("LTU=")).toBe(0); // base64("-5") → negative rejected
+  });
+});

--- a/src/__tests__/unit/sysadmin/presenter.test.ts
+++ b/src/__tests__/unit/sysadmin/presenter.test.ts
@@ -330,7 +330,7 @@ describe("SysAdminPresenter", () => {
   });
 
   describe("memberList / stages — passthrough structure", () => {
-    it("passes hasNextPage + nextCursor untouched", () => {
+    it("encodes nextOffset to base64 nextCursor when there is a next page", () => {
       const result: MemberListResult = {
         users: [
           {
@@ -353,10 +353,12 @@ describe("SysAdminPresenter", () => {
           },
         ],
         hasNextPage: true,
-        nextCursor: "MQ==",
+        nextOffset: 1,
       };
       const out = SysAdminPresenter.memberList(result);
       expect(out.hasNextPage).toBe(true);
+      // base64("1") === "MQ==" — keeps the same wire format the
+      // pre-refactor in-service helper produced.
       expect(out.nextCursor).toBe("MQ==");
       expect(out.users).toHaveLength(1);
     });
@@ -365,7 +367,7 @@ describe("SysAdminPresenter", () => {
       const out = SysAdminPresenter.memberList({
         users: [],
         hasNextPage: false,
-        nextCursor: null,
+        nextOffset: null,
       });
       expect(out.nextCursor).toBeNull();
     });

--- a/src/__tests__/unit/sysadmin/service.test.ts
+++ b/src/__tests__/unit/sysadmin/service.test.ts
@@ -768,18 +768,18 @@ describe("SysAdminService", () => {
       });
       expect(page1.users.map((u) => u.userId)).toEqual(["a", "b"]);
       expect(page1.hasNextPage).toBe(true);
-      expect(page1.nextCursor).not.toBeNull();
+      expect(page1.nextOffset).not.toBeNull();
 
       const page2 = service.paginateMembers(baseMembers, {
         minSendRate: 0,
         sortField: "SEND_RATE",
         sortOrder: "DESC",
         limit: 2,
-        cursor: page1.nextCursor!,
+        cursor: page1.nextOffset!,
       });
       expect(page2.users.map((u) => u.userId)).toEqual(["c", "d"]);
       expect(page2.hasNextPage).toBe(false);
-      expect(page2.nextCursor).toBeNull();
+      expect(page2.nextOffset).toBeNull();
     });
 
     it("sorts by MONTHS_IN ASC", () => {
@@ -845,7 +845,7 @@ describe("SysAdminService", () => {
       });
       expect(page.users.length).toBe(MAX_LIMIT);
       expect(page.hasNextPage).toBe(true);
-      expect(page.nextCursor).not.toBeNull();
+      expect(page.nextOffset).not.toBeNull();
     });
   });
 

--- a/src/application/domain/report/controller/resolver.ts
+++ b/src/application/domain/report/controller/resolver.ts
@@ -10,6 +10,9 @@ import {
   GqlQueryReportsArgs,
   GqlQueryReportArgs,
   GqlQueryReportTemplateArgs,
+  GqlQueryReportTemplatesArgs,
+  GqlQueryAdminBrowseReportsArgs,
+  GqlQueryAdminReportSummaryArgs,
 } from "@/types/graphql";
 import { PrismaReport } from "@/application/domain/report/data/type";
 
@@ -26,6 +29,15 @@ export default class ReportResolver {
     },
     reportTemplate: (_: unknown, args: GqlQueryReportTemplateArgs, ctx: IContext) => {
       return this.useCase.viewReportTemplate(args, ctx);
+    },
+    reportTemplates: (_: unknown, args: GqlQueryReportTemplatesArgs, ctx: IContext) => {
+      return this.useCase.listReportTemplates(args, ctx);
+    },
+    adminBrowseReports: (_: unknown, args: GqlQueryAdminBrowseReportsArgs, ctx: IContext) => {
+      return this.useCase.adminBrowseReports(args, ctx);
+    },
+    adminReportSummary: (_: unknown, args: GqlQueryAdminReportSummaryArgs, ctx: IContext) => {
+      return this.useCase.adminViewReportSummary(args, ctx);
     },
   };
 
@@ -75,6 +87,27 @@ export default class ReportResolver {
       parent.communityId ? ctx.loaders.community.load(parent.communityId) : null,
     updatedByUser: (parent: { updatedBy: string | null }, _: unknown, ctx: IContext) =>
       parent.updatedBy ? ctx.loaders.user.load(parent.updatedBy) : null,
+  };
+
+  /**
+   * Field resolvers for `AdminReportSummaryRow`. The presenter only
+   * threads the relation ids (`communityId` / `lastPublishedReportId`)
+   * onto the parent — these resolvers hydrate the actual Community /
+   * Report objects via existing dataloaders so a 50-row page issues
+   * at most two batched lookups regardless of how many distinct
+   * communities show up.
+   */
+  AdminReportSummaryRow = {
+    community: (parent: { communityId: string }, _: unknown, ctx: IContext) =>
+      ctx.loaders.community.load(parent.communityId),
+    lastPublishedReport: (
+      parent: { lastPublishedReportId: string | null },
+      _: unknown,
+      ctx: IContext,
+    ) =>
+      parent.lastPublishedReportId
+        ? ctx.loaders.report.load(parent.lastPublishedReportId)
+        : null,
   };
 
   GenerateReportPayload = { __resolveType: (obj: { __typename: string }) => obj.__typename };

--- a/src/application/domain/report/data/converter.ts
+++ b/src/application/domain/report/data/converter.ts
@@ -1,7 +1,38 @@
 import { Prisma, ReportTemplateScope } from "@prisma/client";
 import { GqlUpdateReportTemplateInput } from "@/types/graphql";
+import { CommunitySummaryCursor } from "@/application/domain/report/data/type";
 
 export default class ReportConverter {
+  /**
+   * Decode the opaque cursor string the GraphQL client hands back as
+   * `args.cursor` for `adminReportSummary`. Returns null on garbage
+   * (truncated, manually edited, stale-schema, unparseable timestamp)
+   * so the repository falls back to a fresh first-page scan instead
+   * of 500ing on an SQL cast error.
+   *
+   * Lives in the converter layer by the project's "GraphQL input →
+   * internal form" contract; the matching encode (internal → GraphQL
+   * output `edge.cursor`) lives in the presenter to keep each layer's
+   * transform direction clean.
+   */
+  static decodeCommunitySummaryCursor(s: string): CommunitySummaryCursor | null {
+    try {
+      const parsed = JSON.parse(Buffer.from(s, "base64url").toString("utf8"));
+      if (!parsed || typeof parsed !== "object") return null;
+      if (typeof parsed.id !== "string") return null;
+      if (parsed.at !== null && typeof parsed.at !== "string") return null;
+      // Tampered cursor where `at` is a string but not a parseable
+      // timestamp (e.g. "", "not-a-date") would otherwise reach
+      // Postgres as `${at}::timestamp` and 500.
+      if (parsed.at !== null && Number.isNaN(new Date(parsed.at).getTime())) {
+        return null;
+      }
+      return { at: parsed.at, id: parsed.id };
+    } catch {
+      return null;
+    }
+  }
+
   static toReportTemplateUpsertData(
     input: GqlUpdateReportTemplateInput,
   ): Omit<Prisma.ReportTemplateCreateInput, "variant" | "scope" | "community"> {

--- a/src/application/domain/report/data/interface.ts
+++ b/src/application/domain/report/data/interface.ts
@@ -7,6 +7,7 @@ import {
 } from "@prisma/client";
 import { IContext } from "@/types/server";
 import {
+  CommunitySummaryCursor,
   PrismaReport,
   PrismaReportGoldenCase,
   PrismaReportTemplate,
@@ -473,7 +474,7 @@ export interface IReportRepository {
    */
   findCommunityReportSummary(
     ctx: IContext,
-    params: { cursor?: string; first: number },
+    params: { cursor: CommunitySummaryCursor | null; first: number },
   ): Promise<{
     items: Array<{
       communityId: string;

--- a/src/application/domain/report/data/interface.ts
+++ b/src/application/domain/report/data/interface.ts
@@ -360,6 +360,34 @@ export interface IReportRepository {
   ): Promise<PrismaReportTemplate[]>;
 
   /**
+   * Admin-facing template list for the Phase 1 management UI. Returns
+   * every (variant, kind) row sorted version-DESC so the screen can show
+   * v3 → v2 → v1 side by side, including the SYSTEM fallback when a
+   * `communityId` is provided. Behaviour vs. the existing methods:
+   *
+   *   - `findActiveTemplates` (selector hot path): scoped strictly to
+   *     `communityId` and forces `isEnabled=true AND isActive=true`.
+   *     Used at generation time, not by admin UI.
+   *   - `findTemplate` (single live row): admin's previous single-row
+   *     accessor; returns the newest active row only.
+   *   - `findTemplates` (this method): returns multiple rows, optionally
+   *     including disabled / inactive ones, with SYSTEM ∪ COMMUNITY
+   *     union when `communityId` is provided.
+   *
+   * `kind` is a parameter (not hardcoded) so the same query can power
+   * both the GENERATION main tab and the JUDGE settings screen. The
+   * usecase surface defaults `kind` to GENERATION; callers asking for
+   * JUDGE rows are routed through the same path.
+   */
+  findTemplates(
+    ctx: IContext,
+    variant: string,
+    communityId: string | null,
+    kind: ReportTemplateKind,
+    includeInactive: boolean,
+  ): Promise<PrismaReportTemplate[]>;
+
+  /**
    * Resolve the active SYSTEM-scope JUDGE template for a variant. Returns
    * null when no such template exists — callers must treat that as a
    * "skip the judge step" signal rather than failing the generation.
@@ -404,6 +432,79 @@ export interface IReportRepository {
     },
     tx?: Prisma.TransactionClient,
   ): Promise<PrismaReportGoldenCase>;
+
+  /**
+   * Phase 2 sysAdmin: cross-community report search backing
+   * `adminBrowseReports`. `findReports` is community-scoped and
+   * permission-gated; this variant accepts an optional communityId
+   * and goes through `ctx.issuer.internal` so the IsAdmin GraphQL
+   * directive is the sole gatekeeper. Sort is `publishedAt DESC NULLS
+   * LAST, createdAt DESC` so DRAFT / SKIPPED rows (no publishedAt)
+   * never lead the page.
+   */
+  findAllReports(
+    ctx: IContext,
+    params: {
+      communityId?: string;
+      status?: ReportStatus;
+      variant?: string;
+      publishedAfter?: Date;
+      publishedBefore?: Date;
+      cursor?: string;
+      first: number;
+    },
+  ): Promise<{ items: PrismaReport[]; totalCount: number }>;
+
+  /**
+   * Phase 2 sysAdmin: per-community last-publish summary for the L1
+   * dashboard. Reads the denormalized `last_published_report_at` /
+   * `last_published_report_id` columns on `t_communities` (maintained
+   * by `recalculateCommunityLastPublished` below), so the sort and
+   * cursor stay stable without a per-community subquery on every page.
+   *
+   * `publishedCountLast90Days` is computed inline (no denormalize) —
+   * it changes too often for a stored column and the count over
+   * `(community_id, status, published_at)` is index-friendly.
+   *
+   * Returned rows carry the `lastPublishedReportId` / `lastPublishedAt`
+   * pair plus the count; the resolver hydrates `community` /
+   * `lastPublishedReport` via dataloaders so a 50-row page costs at
+   * most two batched lookups.
+   */
+  findCommunityReportSummary(
+    ctx: IContext,
+    params: { cursor?: string; first: number },
+  ): Promise<{
+    items: Array<{
+      communityId: string;
+      lastPublishedReportId: string | null;
+      lastPublishedAt: Date | null;
+      publishedCountLast90Days: number;
+    }>;
+    totalCount: number;
+  }>;
+
+  /**
+   * Re-compute and persist the `t_communities.last_published_report_*`
+   * pointer for a community. Picks the newest `status=PUBLISHED` report
+   * (or NULL if none remain). Called from two places, both inside the
+   * same transaction as the report-side update:
+   *
+   *   1. `publishReport` after a transition into PUBLISHED so the
+   *      pointer always reflects the freshly-published report.
+   *   2. `supersedeParentIfRegenerating` after a PUBLISHED → SUPERSEDED
+   *      transition so a regenerated run does not leave the pointer
+   *      stranded on a no-longer-published row.
+   *
+   * Always re-derives from `t_reports`; no need for callers to thread
+   * a publishedAt comparison ("don't overwrite if older") because the
+   * SELECT itself picks the newest remaining PUBLISHED row.
+   */
+  recalculateCommunityLastPublished(
+    ctx: IContext,
+    communityId: string,
+    tx: Prisma.TransactionClient,
+  ): Promise<void>;
 
   upsertTemplate(
     ctx: IContext,

--- a/src/application/domain/report/data/repository.ts
+++ b/src/application/domain/report/data/repository.ts
@@ -22,6 +22,7 @@ import {
   UserTransactionAggregateRow,
 } from "@/application/domain/report/data/interface";
 import {
+  CommunitySummaryCursor,
   PrismaReport,
   PrismaReportGoldenCase,
   PrismaReportTemplate,
@@ -1218,7 +1219,7 @@ export default class ReportRepository implements IReportRepository {
    */
   async findCommunityReportSummary(
     ctx: IContext,
-    params: { cursor?: string; first: number },
+    params: { cursor: CommunitySummaryCursor | null; first: number },
   ): Promise<{
     items: Array<{
       communityId: string;
@@ -1229,9 +1230,10 @@ export default class ReportRepository implements IReportRepository {
     totalCount: number;
   }> {
     return ctx.issuer.internal(async (tx) => {
-      const cursor = params.cursor
-        ? decodeCommunitySummaryCursor(params.cursor)
-        : null;
+      // Wire-format decoding is the converter layer's job; this
+      // method takes the already-decoded structured cursor (or null)
+      // so the SQL composition stays pure data-layer.
+      const { cursor } = params;
       const cursorClause = !cursor
         ? Prisma.empty
         : cursor.at === null
@@ -1360,50 +1362,5 @@ export default class ReportRepository implements IReportRepository {
         orderBy: { createdAt: "desc" },
       }),
     );
-  }
-}
-
-/**
- * Cursor shape for `findCommunityReportSummary`. `at` mirrors the
- * sort's primary key (NULL for the dormant tier, ISO timestamp
- * otherwise); `id` is the tie-breaker. Encoded as base64url JSON so
- * the cursor round-trips through the GraphQL Connection contract
- * (string-typed `cursor: String!`) without leaking the schema.
- */
-export interface CommunitySummaryCursor {
-  at: string | null;
-  id: string;
-}
-
-export function encodeCommunitySummaryCursor(c: CommunitySummaryCursor): string {
-  return Buffer.from(JSON.stringify(c), "utf8").toString("base64url");
-}
-
-/**
- * Lenient decode: callers may receive an opaque user-supplied cursor
- * that doesn't round-trip (truncation, manual edit, stale schema).
- * Returns `null` rather than throwing so the repository falls back to
- * a fresh first-page scan and the user sees a clean restart instead
- * of a 500.
- */
-export function decodeCommunitySummaryCursor(
-  s: string,
-): CommunitySummaryCursor | null {
-  try {
-    const parsed = JSON.parse(Buffer.from(s, "base64url").toString("utf8"));
-    if (!parsed || typeof parsed !== "object") return null;
-    if (typeof parsed.id !== "string") return null;
-    if (parsed.at !== null && typeof parsed.at !== "string") return null;
-    // Tampered / corrupted cursor where `at` is a string but not a
-    // parseable timestamp (e.g. "", "not-a-date") would otherwise
-    // sail through here and explode in Postgres on `${at}::timestamp`,
-    // breaking the "stale cursor → first-page scan" contract this
-    // helper is supposed to enforce. Reject early.
-    if (parsed.at !== null && Number.isNaN(new Date(parsed.at).getTime())) {
-      return null;
-    }
-    return { at: parsed.at, id: parsed.id };
-  } catch {
-    return null;
   }
 }

--- a/src/application/domain/report/data/repository.ts
+++ b/src/application/domain/report/data/repository.ts
@@ -1394,6 +1394,14 @@ export function decodeCommunitySummaryCursor(
     if (!parsed || typeof parsed !== "object") return null;
     if (typeof parsed.id !== "string") return null;
     if (parsed.at !== null && typeof parsed.at !== "string") return null;
+    // Tampered / corrupted cursor where `at` is a string but not a
+    // parseable timestamp (e.g. "", "not-a-date") would otherwise
+    // sail through here and explode in Postgres on `${at}::timestamp`,
+    // breaking the "stale cursor → first-page scan" contract this
+    // helper is supposed to enforce. Reject early.
+    if (parsed.at !== null && Number.isNaN(new Date(parsed.at).getTime())) {
+      return null;
+    }
     return { at: parsed.at, id: parsed.id };
   } catch {
     return null;

--- a/src/application/domain/report/data/repository.ts
+++ b/src/application/domain/report/data/repository.ts
@@ -1318,7 +1318,11 @@ export default class ReportRepository implements IReportRepository {
         WHERE "community_id" = ${communityId}
           AND "status" = 'PUBLISHED'
           AND "published_at" IS NOT NULL
-        ORDER BY "published_at" DESC NULLS LAST
+        -- "id" DESC tie-breaks ties on published_at (e.g. batched
+        -- publishes inside the same millisecond) so two replays of
+        -- the recalc against the same DB state always pick the same
+        -- row, not whichever happens to scan first.
+        ORDER BY "published_at" DESC NULLS LAST, "id" DESC
         LIMIT 1
       ) sub
       WHERE c."id" = ${communityId}

--- a/src/application/domain/report/data/repository.ts
+++ b/src/application/domain/report/data/repository.ts
@@ -836,7 +836,15 @@ export default class ReportRepository implements IReportRepository {
     kind: ReportTemplateKind,
     includeInactive: boolean,
   ): Promise<PrismaReportTemplate[]> {
-    return ctx.issuer.public(ctx, (tx) =>
+    // Admin-only path (the GraphQL query carries `IsAdmin`); use the
+    // internal issuer for consistency with the other Phase 2 admin
+    // reads (`findAllReports`, `findCommunityReportSummary`,
+    // `getTemplateBreakdown`). The legacy single-row `findTemplate` /
+    // selector hot path `findActiveTemplates` continue to use `public`
+    // because they're invoked from non-admin call sites
+    // (`reportTemplate(communityId, variant)` is admin-gated but the
+    // selector path runs during generate from any community member).
+    return ctx.issuer.internal((tx) =>
       tx.reportTemplate.findMany({
         where: {
           variant,
@@ -1172,6 +1180,12 @@ export default class ReportRepository implements IReportRepository {
           orderBy: [
             { publishedAt: { sort: "desc", nulls: "last" } },
             { createdAt: "desc" },
+            // id tie-breaker so `cursor: { id }` advances
+            // deterministically when publishedAt + createdAt collide
+            // (e.g. multiple reports created in the same millisecond
+            // by a batch run, or the SKIPPED rows at the bottom that
+            // share publishedAt=null).
+            { id: "desc" },
           ],
         }),
         tx.report.count({ where }),
@@ -1189,9 +1203,18 @@ export default class ReportRepository implements IReportRepository {
    *
    * Sort `last_published_report_at ASC NULLS FIRST, id ASC` floats
    * dormant / never-published communities to the top so the L1 view
-   * surfaces them first. Cursor pagination uses the community `id`
-   * for stability — when callers reach the dormant tier the visible
-   * order matches the cursor order.
+   * surfaces them first.
+   *
+   * Cursor pagination uses a *composite* cursor `{ at, id }` because
+   * the primary sort key (`last_published_report_at`) is non-unique:
+   * an `id`-only WHERE would skip rows whose at-value places them
+   * after the cursor when their id happens to sort earlier. The two
+   * branches below cover the NULLS-FIRST tier:
+   *   - cursor.at === null (we're inside the dormant tier): keep
+   *     paging through dormant rows by id, then spill over to the
+   *     entire non-NULL tier.
+   *   - cursor.at !== null (we're in the chronological tier): page
+   *     by (at, id) lexicographically.
    */
   async findCommunityReportSummary(
     ctx: IContext,
@@ -1206,9 +1229,23 @@ export default class ReportRepository implements IReportRepository {
     totalCount: number;
   }> {
     return ctx.issuer.internal(async (tx) => {
-      const cursorClause = params.cursor
-        ? Prisma.sql`AND c."id" > ${params.cursor}`
-        : Prisma.empty;
+      const cursor = params.cursor
+        ? decodeCommunitySummaryCursor(params.cursor)
+        : null;
+      const cursorClause = !cursor
+        ? Prisma.empty
+        : cursor.at === null
+          ? Prisma.sql`AND (
+              (c."last_published_report_at" IS NULL AND c."id" > ${cursor.id})
+              OR c."last_published_report_at" IS NOT NULL
+            )`
+          : Prisma.sql`AND (
+              c."last_published_report_at" > ${cursor.at}::timestamp
+              OR (
+                c."last_published_report_at" = ${cursor.at}::timestamp
+                AND c."id" > ${cursor.id}
+              )
+            )`;
       const [rows, totalRow] = await Promise.all([
         tx.$queryRaw<
           {
@@ -1319,5 +1356,42 @@ export default class ReportRepository implements IReportRepository {
         orderBy: { createdAt: "desc" },
       }),
     );
+  }
+}
+
+/**
+ * Cursor shape for `findCommunityReportSummary`. `at` mirrors the
+ * sort's primary key (NULL for the dormant tier, ISO timestamp
+ * otherwise); `id` is the tie-breaker. Encoded as base64url JSON so
+ * the cursor round-trips through the GraphQL Connection contract
+ * (string-typed `cursor: String!`) without leaking the schema.
+ */
+export interface CommunitySummaryCursor {
+  at: string | null;
+  id: string;
+}
+
+export function encodeCommunitySummaryCursor(c: CommunitySummaryCursor): string {
+  return Buffer.from(JSON.stringify(c), "utf8").toString("base64url");
+}
+
+/**
+ * Lenient decode: callers may receive an opaque user-supplied cursor
+ * that doesn't round-trip (truncation, manual edit, stale schema).
+ * Returns `null` rather than throwing so the repository falls back to
+ * a fresh first-page scan and the user sees a clean restart instead
+ * of a 500.
+ */
+export function decodeCommunitySummaryCursor(
+  s: string,
+): CommunitySummaryCursor | null {
+  try {
+    const parsed = JSON.parse(Buffer.from(s, "base64url").toString("utf8"));
+    if (!parsed || typeof parsed !== "object") return null;
+    if (typeof parsed.id !== "string") return null;
+    if (parsed.at !== null && typeof parsed.at !== "string") return null;
+    return { at: parsed.at, id: parsed.id };
+  } catch {
+    return null;
   }
 }

--- a/src/application/domain/report/data/repository.ts
+++ b/src/application/domain/report/data/repository.ts
@@ -809,6 +809,50 @@ export default class ReportRepository implements IReportRepository {
   }
 
   /**
+   * Admin-list backing for `reportTemplates`. Distinct from
+   * `findActiveTemplates` (selector hot path, isActive+isEnabled fixed
+   * to true and scoped strictly to `communityId`):
+   *
+   *   - `communityId === null` returns SYSTEM-only.
+   *   - `communityId === X` returns SYSTEM ∪ COMMUNITY(X) so the admin
+   *     screen can show "what actually runs for this community" — both
+   *     the override row and the SYSTEM fallback the override would
+   *     replace — in a single sweep.
+   *   - `includeInactive=false` (default) keeps the live filter
+   *     `isActive=true AND isEnabled=true` so the screen does not surface
+   *     rolled-back / disabled rows by default.
+   *   - `includeInactive=true` returns every row regardless of state so
+   *     the admin can audit history.
+   *
+   * Sort is `version DESC, createdAt DESC` so the newest revision lands
+   * at the top and same-version rows order by recency. The selector
+   * does NOT call this — production runs go through
+   * `findActiveTemplates`.
+   */
+  async findTemplates(
+    ctx: IContext,
+    variant: string,
+    communityId: string | null,
+    kind: ReportTemplateKind,
+    includeInactive: boolean,
+  ): Promise<PrismaReportTemplate[]> {
+    return ctx.issuer.public(ctx, (tx) =>
+      tx.reportTemplate.findMany({
+        where: {
+          variant,
+          kind,
+          ...(communityId === null
+            ? { communityId: null }
+            : { OR: [{ communityId }, { communityId: null }] }),
+          ...(includeInactive ? {} : { isActive: true, isEnabled: true }),
+        },
+        orderBy: [{ version: "desc" }, { createdAt: "desc" }],
+        select: reportTemplateSelect,
+      }),
+    );
+  }
+
+  /**
    * Resolve the active SYSTEM-scope JUDGE template for a variant.
    * Filters on `isEnabled` AND `isActive` so the F1 versioning bookkeeping
    * also gates judge selection — a JUDGE row marked inactive (e.g. a
@@ -1080,6 +1124,168 @@ export default class ReportRepository implements IReportRepository {
       ]);
       return { items, totalCount };
     });
+  }
+
+  /**
+   * sysAdmin cross-community report search. Distinct from `findReports`
+   * (community-scoped, RLS-public): runs through `ctx.issuer.internal`
+   * because the IsAdmin GraphQL directive is the only gatekeeper here,
+   * and orders by publishedAt DESC NULLS LAST so DRAFT / SKIPPED rows
+   * (publishedAt is null) sink rather than leading the page.
+   *
+   * Filters are all optional. The matching index
+   * `idx_t_reports_published_at_created_at` (added in the
+   * `add_admin_report_summary_columns` migration) backs the unfiltered
+   * sweep; community / variant / status filters narrow before the
+   * index sort completes.
+   */
+  async findAllReports(
+    ctx: IContext,
+    params: {
+      communityId?: string;
+      status?: ReportStatus;
+      variant?: string;
+      publishedAfter?: Date;
+      publishedBefore?: Date;
+      cursor?: string;
+      first: number;
+    },
+  ): Promise<{ items: PrismaReport[]; totalCount: number }> {
+    const where: Prisma.ReportWhereInput = {
+      ...(params.communityId && { communityId: params.communityId }),
+      ...(params.status && { status: params.status }),
+      ...(params.variant && { variant: params.variant }),
+      ...((params.publishedAfter || params.publishedBefore) && {
+        publishedAt: {
+          ...(params.publishedAfter && { gte: params.publishedAfter }),
+          ...(params.publishedBefore && { lte: params.publishedBefore }),
+        },
+      }),
+    };
+    return ctx.issuer.internal(async (tx) => {
+      const [items, totalCount] = await Promise.all([
+        tx.report.findMany({
+          where,
+          select: reportSelect,
+          take: params.first + 1,
+          ...(params.cursor && { skip: 1, cursor: { id: params.cursor } }),
+          orderBy: [
+            { publishedAt: { sort: "desc", nulls: "last" } },
+            { createdAt: "desc" },
+          ],
+        }),
+        tx.report.count({ where }),
+      ]);
+      return { items, totalCount };
+    });
+  }
+
+  /**
+   * Per-community summary for `adminReportSummary`. Reads the
+   * denormalized last-publish columns on `t_communities` directly so
+   * the sort + cursor stay stable, then computes the rolling
+   * 90-day publish count inline via a correlated subquery — that
+   * count moves daily and is not worth denormalizing.
+   *
+   * Sort `last_published_report_at ASC NULLS FIRST, id ASC` floats
+   * dormant / never-published communities to the top so the L1 view
+   * surfaces them first. Cursor pagination uses the community `id`
+   * for stability — when callers reach the dormant tier the visible
+   * order matches the cursor order.
+   */
+  async findCommunityReportSummary(
+    ctx: IContext,
+    params: { cursor?: string; first: number },
+  ): Promise<{
+    items: Array<{
+      communityId: string;
+      lastPublishedReportId: string | null;
+      lastPublishedAt: Date | null;
+      publishedCountLast90Days: number;
+    }>;
+    totalCount: number;
+  }> {
+    return ctx.issuer.internal(async (tx) => {
+      const cursorClause = params.cursor
+        ? Prisma.sql`AND c."id" > ${params.cursor}`
+        : Prisma.empty;
+      const [rows, totalRow] = await Promise.all([
+        tx.$queryRaw<
+          {
+            id: string;
+            last_published_report_id: string | null;
+            last_published_report_at: Date | null;
+            published_count_last_90_days: bigint;
+          }[]
+        >`
+          SELECT
+            c."id",
+            c."last_published_report_id",
+            c."last_published_report_at",
+            COALESCE((
+              SELECT COUNT(*)::bigint
+              FROM "t_reports" r
+              WHERE r."community_id" = c."id"
+                AND r."status" = 'PUBLISHED'
+                AND r."published_at" IS NOT NULL
+                AND r."published_at" >= NOW() - INTERVAL '90 days'
+            ), 0) AS "published_count_last_90_days"
+          FROM "t_communities" c
+          WHERE TRUE
+            ${cursorClause}
+          ORDER BY
+            c."last_published_report_at" ASC NULLS FIRST,
+            c."id" ASC
+          LIMIT ${params.first + 1}
+        `,
+        tx.community.count(),
+      ]);
+      return {
+        items: rows.map((r) => ({
+          communityId: r.id,
+          lastPublishedReportId: r.last_published_report_id,
+          lastPublishedAt: r.last_published_report_at,
+          publishedCountLast90Days: Number(r.published_count_last_90_days),
+        })),
+        totalCount: totalRow,
+      };
+    });
+  }
+
+  /**
+   * Re-derive a community's last-publish pointer from `t_reports`.
+   * Idempotent: callers can invoke it after either a publish (new
+   * PUBLISHED row) or a supersede of a PUBLISHED row, and the column
+   * pair will reflect the current state.
+   *
+   * One UPDATE always runs. When no PUBLISHED row remains, the
+   * `LEFT JOIN ... ON FALSE` collapses `sub` to a single null row so
+   * the SET expressions evaluate to NULL — keeping the operation in
+   * a single statement instead of a conditional second UPDATE.
+   */
+  async recalculateCommunityLastPublished(
+    ctx: IContext,
+    communityId: string,
+    tx: Prisma.TransactionClient,
+  ): Promise<void> {
+    await tx.$executeRaw`
+      UPDATE "t_communities" c
+      SET
+        "last_published_report_id" = sub."id",
+        "last_published_report_at" = sub."published_at"
+      FROM (
+        SELECT NULL::text AS "id", NULL::timestamp AS "published_at"
+        UNION ALL
+        SELECT "id", "published_at"
+        FROM "t_reports"
+        WHERE "community_id" = ${communityId}
+          AND "status" = 'PUBLISHED'
+          AND "published_at" IS NOT NULL
+        ORDER BY "published_at" DESC NULLS LAST
+        LIMIT 1
+      ) sub
+      WHERE c."id" = ${communityId}
+    `;
   }
 
   async updateReportStatus(

--- a/src/application/domain/report/data/type.ts
+++ b/src/application/domain/report/data/type.ts
@@ -83,3 +83,18 @@ export type PrismaReportGoldenCase = Prisma.ReportGoldenCaseGetPayload<{
 export type PrismaReportTemplate = Prisma.ReportTemplateGetPayload<{
   select: typeof reportTemplateSelect;
 }>;
+
+/**
+ * Composite cursor for `findCommunityReportSummary`. The query sorts
+ * by `(last_published_report_at ASC NULLS FIRST, id ASC)`, so a
+ * stable cursor over a non-unique primary key needs both halves of
+ * the tuple. `at` is the ISO timestamp string (or null for the
+ * dormant tier where the community has never published); `id` is
+ * the tie-breaker. The wire format (base64url JSON) is owned by the
+ * converter (decode) and presenter (encode) layers — this type is
+ * the structured form Repository / Service operate on.
+ */
+export interface CommunitySummaryCursor {
+  at: string | null;
+  id: string;
+}

--- a/src/application/domain/report/feedback/controller/resolver.ts
+++ b/src/application/domain/report/feedback/controller/resolver.ts
@@ -4,6 +4,7 @@ import ReportFeedbackUseCase from "@/application/domain/report/feedback/usecase"
 import {
   GqlMutationSubmitReportFeedbackArgs,
   GqlQueryReportTemplateStatsArgs,
+  GqlQueryReportTemplateStatsBreakdownArgs,
 } from "@/types/graphql";
 import { PrismaReport } from "@/application/domain/report/data/type";
 import { PrismaReportFeedback } from "@/application/domain/report/feedback/data/type";
@@ -15,6 +16,13 @@ export default class ReportFeedbackResolver {
   Query = {
     reportTemplateStats: (_: unknown, args: GqlQueryReportTemplateStatsArgs, ctx: IContext) => {
       return this.useCase.viewReportTemplateStats(args, ctx);
+    },
+    reportTemplateStatsBreakdown: (
+      _: unknown,
+      args: GqlQueryReportTemplateStatsBreakdownArgs,
+      ctx: IContext,
+    ) => {
+      return this.useCase.viewReportTemplateStatsBreakdown(args, ctx);
     },
   };
 

--- a/src/application/domain/report/feedback/data/interface.ts
+++ b/src/application/domain/report/feedback/data/interface.ts
@@ -1,6 +1,12 @@
-import { Prisma, FeedbackType } from "@prisma/client";
+import { Prisma, FeedbackType, ReportTemplateKind } from "@prisma/client";
 import { IContext } from "@/types/server";
-import { PrismaReportFeedback } from "@/application/domain/report/feedback/data/type";
+import {
+  PrismaReportFeedback,
+  TemplateBreakdownRow,
+  JudgeFeedbackPairRow,
+} from "@/application/domain/report/feedback/data/type";
+
+export { JudgeFeedbackPairRow };
 
 export interface CreateReportFeedbackInput {
   reportId: string;
@@ -9,19 +15,6 @@ export interface CreateReportFeedbackInput {
   feedbackType?: FeedbackType | null;
   sectionKey?: string | null;
   comment?: string | null;
-}
-
-/**
- * Paired (judgeScore, avgFeedbackRating) rows used by the service to
- * compute Pearson's r between the two series. A report is eligible to
- * appear here only when both signals exist — reports with no feedback are
- * skipped upstream rather than contributing a 0 that would bias the
- * correlation.
- */
-export interface JudgeFeedbackPairRow {
-  reportId: string;
-  judgeScore: number;
-  avgRating: number;
 }
 
 export interface IReportFeedbackRepository {
@@ -69,4 +62,31 @@ export interface IReportFeedbackRepository {
     pairs: JudgeFeedbackPairRow[];
     version: number | null;
   }>;
+
+  /**
+   * Per-template breakdown for the A/B comparison screen
+   * (`reportTemplateStatsBreakdown`). Each row pairs a template's
+   * config snapshot (version / scope / kind / experimentKey / state)
+   * with feedbackCount / avgRating / avgJudgeScore aggregated over
+   * the Reports that used it, plus the per-template (judgeScore,
+   * avgRating) pair set the service runs Pearson's r over.
+   *
+   * Implementation must use a LEFT JOIN from `t_report_templates` so
+   * a template with zero feedback still surfaces (the UI displays
+   * `—` for the metrics rather than omitting the row). Pagination
+   * is `id ASC` based for cursor stability — the breakdown rows are
+   * O(versions × experimentKeys) per variant, which can reach the
+   * hundreds for variants with active experimentation.
+   */
+  getTemplateBreakdown(
+    ctx: IContext,
+    params: {
+      variant: string;
+      version?: number;
+      kind: ReportTemplateKind;
+      includeInactive: boolean;
+      cursor?: string;
+      first: number;
+    },
+  ): Promise<{ items: TemplateBreakdownRow[]; totalCount: number }>;
 }

--- a/src/application/domain/report/feedback/data/repository.ts
+++ b/src/application/domain/report/feedback/data/repository.ts
@@ -1,14 +1,15 @@
-import { Prisma } from "@prisma/client";
+import { Prisma, ReportTemplateKind, ReportTemplateScope } from "@prisma/client";
 import { injectable } from "tsyringe";
 import { IContext } from "@/types/server";
 import {
   CreateReportFeedbackInput,
   IReportFeedbackRepository,
-  JudgeFeedbackPairRow,
 } from "@/application/domain/report/feedback/data/interface";
 import {
   PrismaReportFeedback,
   reportFeedbackSelect,
+  JudgeFeedbackPairRow,
+  TemplateBreakdownRow,
 } from "@/application/domain/report/feedback/data/type";
 
 @injectable()
@@ -181,6 +182,175 @@ export default class ReportFeedbackRepository implements IReportFeedbackReposito
         // relying on a magic sentinel.
         version: version ?? null,
       };
+    });
+  }
+
+  /**
+   * Per-template breakdown for the A/B comparison admin screen. Each
+   * row is a single template revision (one `t_report_templates` row),
+   * plus aggregated feedback stats over the Reports that used it and
+   * the per-Report (judgeScore, avgRating) pair set the service runs
+   * Pearson's r over.
+   *
+   * `t_report_templates` is the LEFT side so a template with zero
+   * Reports / zero feedbacks still appears with `feedbackCount: 0`;
+   * the UI displays `—` for the metrics rather than dropping the row.
+   *
+   * Pagination is `id ASC` for cursor stability — the admin UI sorts
+   * the page client-side by version / metrics. With ~20 rows per page
+   * the cost of resorting in JS is negligible compared with the SQL
+   * complexity of stable cursor pagination over a derived field.
+   */
+  async getTemplateBreakdown(
+    ctx: IContext,
+    params: {
+      variant: string;
+      version?: number;
+      kind: ReportTemplateKind;
+      includeInactive: boolean;
+      cursor?: string;
+      first: number;
+    },
+  ): Promise<{ items: TemplateBreakdownRow[]; totalCount: number }> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      // Compose the where clause once and reuse for both the page query
+      // and the totalCount query so the two stay in lock-step (a where
+      // drift would let totalCount disagree with what edges expose).
+      const where: Prisma.ReportTemplateWhereInput = {
+        variant: params.variant,
+        kind: params.kind,
+        ...(params.version !== undefined ? { version: params.version } : {}),
+        ...(params.includeInactive ? {} : { isActive: true, isEnabled: true }),
+      };
+
+      const [templates, totalCount] = await Promise.all([
+        tx.reportTemplate.findMany({
+          where,
+          select: {
+            id: true,
+            version: true,
+            scope: true,
+            kind: true,
+            experimentKey: true,
+            isActive: true,
+            isEnabled: true,
+            trafficWeight: true,
+          },
+          orderBy: { id: "asc" },
+          take: params.first + 1,
+          ...(params.cursor && { skip: 1, cursor: { id: params.cursor } }),
+        }),
+        tx.reportTemplate.count({ where }),
+      ]);
+
+      if (templates.length === 0) {
+        return { items: [], totalCount };
+      }
+
+      const templateIds = templates.map((t) => t.id);
+
+      // Aggregate feedback (count + avg rating) per template, plus
+      // avg judge score, in two grouped queries. Doing two grouped
+      // aggregates is cheaper than a single join because the ratings
+      // table can have many rows per Report whereas judgeScore is a
+      // per-Report scalar — joining naively would multiply the
+      // Report-level judgeScore by the number of feedback rows.
+      const [feedbackByTemplate, judgeByTemplate, pairRows] = await Promise.all([
+        tx.$queryRaw<
+          { template_id: string; feedback_count: bigint; avg_rating: number | null }[]
+        >`
+          SELECT
+            r."template_id"::text AS "template_id",
+            COUNT(f."id")::bigint AS "feedback_count",
+            AVG(f."rating")::float AS "avg_rating"
+          FROM "t_report_feedbacks" f
+          INNER JOIN "t_reports" r ON r."id" = f."report_id"
+          WHERE r."template_id" = ANY(${templateIds}::text[])
+          GROUP BY r."template_id"
+        `,
+        tx.$queryRaw<
+          { template_id: string; avg_judge_score: number | null }[]
+        >`
+          SELECT
+            "template_id"::text AS "template_id",
+            AVG("judge_score")::float AS "avg_judge_score"
+          FROM "t_reports"
+          WHERE "template_id" = ANY(${templateIds}::text[])
+            AND "judge_score" IS NOT NULL
+          GROUP BY "template_id"
+        `,
+        // Pearson pairs: one (judgeScore, avgRating) per Report that
+        // has both signals. Requires the inner join on feedbacks so
+        // Reports with judgeScore but no feedback are excluded — they
+        // would otherwise need to be coerced to null and bias the
+        // correlation downstream.
+        tx.$queryRaw<
+          {
+            template_id: string;
+            report_id: string;
+            judge_score: number;
+            avg_rating: number;
+          }[]
+        >`
+          SELECT
+            r."template_id"::text AS "template_id",
+            r."id" AS "report_id",
+            r."judge_score"::float AS "judge_score",
+            AVG(f."rating")::float AS "avg_rating"
+          FROM "t_reports" r
+          INNER JOIN "t_report_feedbacks" f ON f."report_id" = r."id"
+          WHERE r."template_id" = ANY(${templateIds}::text[])
+            AND r."judge_score" IS NOT NULL
+          GROUP BY r."template_id", r."id", r."judge_score"
+        `,
+      ]);
+
+      const feedbackMap = new Map(
+        feedbackByTemplate.map((row) => [
+          row.template_id,
+          {
+            feedbackCount: Number(row.feedback_count),
+            avgRating: row.avg_rating,
+          },
+        ]),
+      );
+      const judgeMap = new Map(
+        judgeByTemplate.map((row) => [row.template_id, row.avg_judge_score]),
+      );
+      const pairsByTemplate = new Map<string, JudgeFeedbackPairRow[]>();
+      for (const p of pairRows) {
+        const list = pairsByTemplate.get(p.template_id) ?? [];
+        list.push({
+          reportId: p.report_id,
+          judgeScore: Number(p.judge_score),
+          avgRating: Number(p.avg_rating),
+        });
+        pairsByTemplate.set(p.template_id, list);
+      }
+
+      // `take: first + 1` pagination convention; the presenter trims
+      // the extra row to derive `hasNextPage`. Keep all the templates
+      // here so the trim happens after Pearson math, with consistent
+      // payload shape across the layer.
+      const items: TemplateBreakdownRow[] = templates.map((t) => {
+        const feedback = feedbackMap.get(t.id);
+        return {
+          templateId: t.id,
+          version: t.version,
+          scope: t.scope as ReportTemplateScope,
+          kind: t.kind as ReportTemplateKind,
+          experimentKey: t.experimentKey,
+          isActive: t.isActive,
+          isEnabled: t.isEnabled,
+          trafficWeight: t.trafficWeight,
+          feedbackCount: feedback?.feedbackCount ?? 0,
+          avgRating: feedback?.avgRating ?? null,
+          avgJudgeScore: judgeMap.get(t.id) ?? null,
+          pairs: pairsByTemplate.get(t.id) ?? [],
+        };
+      });
+
+      return { items, totalCount };
     });
   }
 }

--- a/src/application/domain/report/feedback/data/repository.ts
+++ b/src/application/domain/report/feedback/data/repository.ts
@@ -212,7 +212,12 @@ export default class ReportFeedbackRepository implements IReportFeedbackReposito
       first: number;
     },
   ): Promise<{ items: TemplateBreakdownRow[]; totalCount: number }> {
-    return ctx.issuer.public(ctx, async (tx) => {
+    // Admin-only path (`reportTemplateStatsBreakdown` is `IsAdmin`-
+    // gated). Use the internal issuer to match the rest of the Phase 2
+    // admin reads — `public` would risk RLS-driven filtering on the
+    // template / report join when the SYS_ADMIN session lacks an
+    // implicit community membership.
+    return ctx.issuer.internal(async (tx) => {
       // Compose the where clause once and reuse for both the page query
       // and the totalCount query so the two stay in lock-step (a where
       // drift would let totalCount disagree with what edges expose).

--- a/src/application/domain/report/feedback/data/type.ts
+++ b/src/application/domain/report/feedback/data/type.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "@prisma/client";
+import { Prisma, ReportTemplateScope, ReportTemplateKind } from "@prisma/client";
 
 export const reportFeedbackSelect = Prisma.validator<Prisma.ReportFeedbackSelect>()({
   id: true,
@@ -35,4 +35,45 @@ export interface ReportTemplateStatsRow {
   feedbackCount: number;
   avgJudgeScore: number | null;
   judgeHumanCorrelation: number | null;
+}
+
+/**
+ * Paired (judgeScore, avgFeedbackRating) rows used by the service to
+ * compute Pearson's r between the two series. A report is eligible to
+ * appear here only when both signals exist — reports with no feedback are
+ * skipped upstream rather than contributing a 0 that would bias the
+ * correlation.
+ *
+ * Lives in `data/type.ts` rather than `data/interface.ts` so the
+ * breakdown row type defined below — which embeds the pairs in its
+ * own shape — can reference it without forcing `interface.ts` to
+ * `data/type.ts` and back.
+ */
+export interface JudgeFeedbackPairRow {
+  reportId: string;
+  judgeScore: number;
+  avgRating: number;
+}
+
+/**
+ * Per-template breakdown row for the A/B comparison screen. Each row
+ * = one prompt revision (one ReportTemplate row), so v1 / v2 / v3
+ * surface independently. `pairs` carries the per-Report (judgeScore,
+ * avgRating) observations the service runs Pearson's r over for
+ * `judgeHumanCorrelation`. Templates with no Reports / no feedback
+ * still appear here (LEFT JOIN-driven) with `feedbackCount: 0`.
+ */
+export interface TemplateBreakdownRow {
+  templateId: string;
+  version: number;
+  scope: ReportTemplateScope;
+  kind: ReportTemplateKind;
+  experimentKey: string | null;
+  isActive: boolean;
+  isEnabled: boolean;
+  trafficWeight: number;
+  feedbackCount: number;
+  avgRating: number | null;
+  avgJudgeScore: number | null;
+  pairs: JudgeFeedbackPairRow[];
 }

--- a/src/application/domain/report/feedback/presenter.ts
+++ b/src/application/domain/report/feedback/presenter.ts
@@ -3,10 +3,15 @@ import {
   GqlReportFeedbacksConnection,
   GqlReportTemplateStats,
   GqlReportVariant,
+  GqlReportTemplateScope,
+  GqlReportTemplateKind,
+  GqlReportTemplateStatsBreakdownRow,
+  GqlReportTemplateStatsBreakdownConnection,
 } from "@/types/graphql";
 import {
   PrismaReportFeedback,
   ReportTemplateStatsRow,
+  TemplateBreakdownRow,
 } from "@/application/domain/report/feedback/data/type";
 
 export default class ReportFeedbackPresenter {
@@ -54,6 +59,69 @@ export default class ReportFeedbackPresenter {
       avgJudgeScore: row.avgJudgeScore,
       judgeHumanCorrelation: row.judgeHumanCorrelation,
       correlationWarning: row.correlationWarning,
+    };
+  }
+
+  /**
+   * One row of the A/B comparison breakdown. Pure projection from the
+   * service's enriched row (Pearson + warning fields already filled
+   * in upstream). The Prisma → GraphQL enum casts mirror the
+   * `templateStats` pattern — values are guaranteed to be one of the
+   * enum members because they came from a Prisma enum column.
+   */
+  static templateBreakdownRow(
+    row: TemplateBreakdownRow & {
+      judgeHumanCorrelation: number | null;
+      correlationWarning: boolean;
+    },
+  ): GqlReportTemplateStatsBreakdownRow {
+    return {
+      templateId: row.templateId,
+      version: row.version,
+      scope: row.scope as GqlReportTemplateScope,
+      kind: row.kind as GqlReportTemplateKind,
+      experimentKey: row.experimentKey,
+      isActive: row.isActive,
+      isEnabled: row.isEnabled,
+      trafficWeight: row.trafficWeight,
+      feedbackCount: row.feedbackCount,
+      avgRating: row.avgRating,
+      avgJudgeScore: row.avgJudgeScore,
+      judgeHumanCorrelation: row.judgeHumanCorrelation,
+      correlationWarning: row.correlationWarning,
+    };
+  }
+
+  /**
+   * Connection wrapper for `reportTemplateStatsBreakdown`. Same
+   * cursor convention as the existing `connection` (id-based, take=
+   * first+1 for `hasNextPage` derivation). `cursor` is the
+   * `templateId` so the admin UI can paginate stably across A/B
+   * candidate rows even when the underlying ordering would otherwise
+   * shift (e.g. an experimentKey deactivation between pages).
+   */
+  static templateBreakdownConnection(
+    items: Array<TemplateBreakdownRow & {
+      judgeHumanCorrelation: number | null;
+      correlationWarning: boolean;
+    }>,
+    totalCount: number,
+    requestedFirst: number,
+  ): GqlReportTemplateStatsBreakdownConnection {
+    const hasNextPage = items.length > requestedFirst;
+    const page = hasNextPage ? items.slice(0, requestedFirst) : items;
+    return {
+      edges: page.map((row) => ({
+        cursor: row.templateId,
+        node: ReportFeedbackPresenter.templateBreakdownRow(row),
+      })),
+      pageInfo: {
+        hasNextPage,
+        hasPreviousPage: false,
+        startCursor: page[0]?.templateId ?? null,
+        endCursor: page[page.length - 1]?.templateId ?? null,
+      },
+      totalCount,
     };
   }
 }

--- a/src/application/domain/report/feedback/service.ts
+++ b/src/application/domain/report/feedback/service.ts
@@ -1,14 +1,15 @@
-import { Prisma } from "@prisma/client";
+import { Prisma, ReportTemplateKind } from "@prisma/client";
 import { inject, injectable } from "tsyringe";
 import { IContext } from "@/types/server";
 import {
   CreateReportFeedbackInput,
   IReportFeedbackRepository,
-  JudgeFeedbackPairRow,
 } from "@/application/domain/report/feedback/data/interface";
 import {
   PrismaReportFeedback,
   ReportTemplateStatsRow,
+  TemplateBreakdownRow,
+  JudgeFeedbackPairRow,
 } from "@/application/domain/report/feedback/data/type";
 
 /**
@@ -94,6 +95,43 @@ export default class ReportFeedbackService {
       avgJudgeScore: agg.avgJudgeScore,
       judgeHumanCorrelation: correlation,
       correlationWarning,
+    };
+  }
+
+  /**
+   * Per-template breakdown for the A/B comparison admin screen
+   * (`reportTemplateStatsBreakdown`). Wraps the repository's grouped
+   * fetch with the same Pearson + warning-threshold logic the
+   * single-row stats path uses, so both screens compute correlation
+   * the same way (3-pair minimum, 0.7 threshold) — admins get
+   * comparable signals across the aggregate KPI and the breakdown.
+   */
+  async getTemplateBreakdown(
+    ctx: IContext,
+    params: {
+      variant: string;
+      version?: number;
+      kind: ReportTemplateKind;
+      includeInactive: boolean;
+      cursor?: string;
+      first: number;
+    },
+  ): Promise<{
+    items: Array<TemplateBreakdownRow & {
+      judgeHumanCorrelation: number | null;
+      correlationWarning: boolean;
+    }>;
+    totalCount: number;
+  }> {
+    const result = await this.repository.getTemplateBreakdown(ctx, params);
+    return {
+      items: result.items.map((row) => {
+        const correlation = pearsonCorrelation(row.pairs);
+        const correlationWarning =
+          correlation !== null && correlation < JUDGE_HUMAN_CORRELATION_WARNING_THRESHOLD;
+        return { ...row, judgeHumanCorrelation: correlation, correlationWarning };
+      }),
+      totalCount: result.totalCount,
     };
   }
 }

--- a/src/application/domain/report/feedback/usecase.ts
+++ b/src/application/domain/report/feedback/usecase.ts
@@ -1,5 +1,5 @@
 import { inject, injectable } from "tsyringe";
-import { Prisma, FeedbackType } from "@prisma/client";
+import { Prisma, FeedbackType, ReportTemplateKind } from "@prisma/client";
 import { IContext } from "@/types/server";
 import { AuthenticationError, NotFoundError, ValidationError } from "@/errors/graphql";
 import ReportService from "@/application/domain/report/service";
@@ -10,12 +10,21 @@ import {
   GqlSubmitReportFeedbackPayload,
   GqlQueryReportTemplateStatsArgs,
   GqlReportTemplateStats,
+  GqlQueryReportTemplateStatsBreakdownArgs,
+  GqlReportTemplateStatsBreakdownConnection,
 } from "@/types/graphql";
 
 const MAX_FEEDBACKS_PER_PAGE = 100;
 const DEFAULT_FEEDBACKS_PER_PAGE = 20;
 const MAX_COMMENT_LENGTH = 2000;
 const MAX_SECTION_KEY_LENGTH = 128;
+
+// Breakdown rows mirror per-template revisions; communities with active
+// experimentation can reach the hundreds across history. Cap at 100 to
+// keep the per-page Pearson computation bounded and prompt the UI to
+// paginate rather than fetch everything at once.
+const MAX_BREAKDOWN_ROWS_PER_PAGE = 100;
+const DEFAULT_BREAKDOWN_ROWS_PER_PAGE = 20;
 
 @injectable()
 export default class ReportFeedbackUseCase {
@@ -173,6 +182,36 @@ export default class ReportFeedbackUseCase {
       version ?? undefined,
     );
     return ReportFeedbackPresenter.templateStats(row);
+  }
+
+  /**
+   * Phase 1 admin: per-template quality breakdown for the A/B
+   * comparison screen. Pagination defaults align with the rest of the
+   * report domain — same `clampInt` helper, same DEFAULT/MAX bounds —
+   * so the screen and the existing `reports` browse share an
+   * intuitive page-size feel. Authorization is enforced upstream by
+   * the `@authz IsAdmin` rule on the GraphQL query.
+   */
+  async viewReportTemplateStatsBreakdown(
+    args: GqlQueryReportTemplateStatsBreakdownArgs,
+    ctx: IContext,
+  ): Promise<GqlReportTemplateStatsBreakdownConnection> {
+    const first = args.first
+      ? validateInt(args.first, 1, MAX_BREAKDOWN_ROWS_PER_PAGE, "first")
+      : DEFAULT_BREAKDOWN_ROWS_PER_PAGE;
+    const result = await this.feedbackService.getTemplateBreakdown(ctx, {
+      variant: args.variant,
+      version: args.version ?? undefined,
+      kind: args.kind ?? ReportTemplateKind.GENERATION,
+      includeInactive: args.includeInactive ?? false,
+      cursor: args.cursor ?? undefined,
+      first,
+    });
+    return ReportFeedbackPresenter.templateBreakdownConnection(
+      result.items,
+      result.totalCount,
+      first,
+    );
   }
 
   // Field-resolver helper used by `Report.feedbacks`. `Report.myFeedback`

--- a/src/application/domain/report/presenter.ts
+++ b/src/application/domain/report/presenter.ts
@@ -6,6 +6,7 @@ import {
   GqlAdminReportSummaryRow,
 } from "@/types/graphql";
 import { PrismaReport, PrismaReportTemplate } from "@/application/domain/report/data/type";
+import { encodeCommunitySummaryCursor } from "@/application/domain/report/data/repository";
 import {
   CohortRetentionRow,
   CommunityContextRow,
@@ -359,9 +360,20 @@ export default class ReportPresenter {
     const page = hasNextPage ? items.slice(0, requestedFirst) : items;
     const now = Date.now();
     const millisPerDay = 24 * 60 * 60 * 1000;
+    // Composite cursor `{at, id}` matches the SQL sort
+    // (`last_published_report_at ASC NULLS FIRST, id ASC`). Encoding
+    // both halves is required for correctness: a row with `at=null`
+    // and a row with `at=2026-01-01` may share the same `id` ordering
+    // arbitrarily, but only one of them is the true successor of the
+    // cursor when paginating across the dormant / chronological tiers.
+    const buildCursor = (row: { communityId: string; lastPublishedAt: Date | null }) =>
+      encodeCommunitySummaryCursor({
+        at: row.lastPublishedAt?.toISOString() ?? null,
+        id: row.communityId,
+      });
     return {
       edges: page.map((row) => ({
-        cursor: row.communityId,
+        cursor: buildCursor(row),
         // Field resolvers (`community`, `lastPublishedReport`) on
         // AdminReportSummaryRow read `communityId` /
         // `lastPublishedReportId` off the parent and hydrate via
@@ -382,8 +394,8 @@ export default class ReportPresenter {
       pageInfo: {
         hasNextPage,
         hasPreviousPage: false,
-        startCursor: page[0]?.communityId ?? null,
-        endCursor: page[page.length - 1]?.communityId ?? null,
+        startCursor: page[0] ? buildCursor(page[0]) : null,
+        endCursor: page[page.length - 1] ? buildCursor(page[page.length - 1]) : null,
       },
       totalCount,
     };

--- a/src/application/domain/report/presenter.ts
+++ b/src/application/domain/report/presenter.ts
@@ -5,8 +5,25 @@ import {
   GqlAdminReportSummaryConnection,
   GqlAdminReportSummaryRow,
 } from "@/types/graphql";
-import { PrismaReport, PrismaReportTemplate } from "@/application/domain/report/data/type";
-import { encodeCommunitySummaryCursor } from "@/application/domain/report/data/repository";
+import {
+  CommunitySummaryCursor,
+  PrismaReport,
+  PrismaReportTemplate,
+} from "@/application/domain/report/data/type";
+
+/**
+ * Internal → GraphQL `edge.cursor` (base64url JSON of `{at, id}`).
+ * Mirror of `ReportConverter.decodeCommunitySummaryCursor`; kept on
+ * the presenter side because `edge.cursor` is a GraphQL output
+ * concern and the rest of the report presenters already own the
+ * internal-to-Gql wire-format direction. Exported only so the
+ * round-trip unit test can assert encode/decode symmetry across the
+ * converter / presenter pair without exercising the full
+ * connection presenter.
+ */
+export function encodeCommunitySummaryCursor(c: CommunitySummaryCursor): string {
+  return Buffer.from(JSON.stringify(c), "utf8").toString("base64url");
+}
 import {
   CohortRetentionRow,
   CommunityContextRow,

--- a/src/application/domain/report/presenter.ts
+++ b/src/application/domain/report/presenter.ts
@@ -1,4 +1,10 @@
-import { GqlReport, GqlReportTemplate, GqlReportsConnection } from "@/types/graphql";
+import {
+  GqlReport,
+  GqlReportTemplate,
+  GqlReportsConnection,
+  GqlAdminReportSummaryConnection,
+  GqlAdminReportSummaryRow,
+} from "@/types/graphql";
 import { PrismaReport, PrismaReportTemplate } from "@/application/domain/report/data/type";
 import {
   CohortRetentionRow,
@@ -321,6 +327,63 @@ export default class ReportPresenter {
         hasPreviousPage: false,
         startCursor: page[0]?.id ?? null,
         endCursor: page[page.length - 1]?.id ?? null,
+      },
+      totalCount,
+    };
+  }
+
+  /**
+   * Phase 2 sysAdmin: AdminReportSummaryConnection presenter. Each
+   * row carries the denormalized last-publish pointer plus the rolling
+   * 90-day count from the repository; the resolver hydrates the
+   * `community` / `lastPublishedReport` field via dataloader, so the
+   * returned shape only needs the bare ids and scalars.
+   *
+   * `daysSinceLastPublish` is computed here from `lastPublishedAt`
+   * (anchored to the request time) rather than denormalized — it
+   * changes daily and the math is one line. Returns `null` for never-
+   * published communities so the UI can render "—" instead of "0
+   * days" (which would suggest a recent publish).
+   */
+  static adminReportSummaryConnection(
+    items: Array<{
+      communityId: string;
+      lastPublishedReportId: string | null;
+      lastPublishedAt: Date | null;
+      publishedCountLast90Days: number;
+    }>,
+    totalCount: number,
+    requestedFirst: number,
+  ): GqlAdminReportSummaryConnection {
+    const hasNextPage = items.length > requestedFirst;
+    const page = hasNextPage ? items.slice(0, requestedFirst) : items;
+    const now = Date.now();
+    const millisPerDay = 24 * 60 * 60 * 1000;
+    return {
+      edges: page.map((row) => ({
+        cursor: row.communityId,
+        // Field resolvers (`community`, `lastPublishedReport`) on
+        // AdminReportSummaryRow read `communityId` /
+        // `lastPublishedReportId` off the parent and hydrate via
+        // dataloader. Casting through `unknown` matches the
+        // `report` / `reportTemplate` presenters above — the parent
+        // shape carries the relation ids; the field resolvers fill
+        // in the relations themselves at GraphQL execution time.
+        node: {
+          communityId: row.communityId,
+          lastPublishedReportId: row.lastPublishedReportId,
+          lastPublishedAt: row.lastPublishedAt,
+          daysSinceLastPublish: row.lastPublishedAt
+            ? Math.floor((now - row.lastPublishedAt.getTime()) / millisPerDay)
+            : null,
+          publishedCountLast90Days: row.publishedCountLast90Days,
+        } as unknown as GqlAdminReportSummaryRow,
+      })),
+      pageInfo: {
+        hasNextPage,
+        hasPreviousPage: false,
+        startCursor: page[0]?.communityId ?? null,
+        endCursor: page[page.length - 1]?.communityId ?? null,
       },
       totalCount,
     };

--- a/src/application/domain/report/schema/query.graphql
+++ b/src/application/domain/report/schema/query.graphql
@@ -21,4 +21,64 @@ extend type Query {
   # needs re-calibration (correlation < 0.7 → flagged).
   reportTemplateStats(variant: ReportVariant!, version: Int): ReportTemplateStats!
     @authz(rules: [IsAdmin])
+
+  # Phase 1 admin UI: same-variant template list (A/B candidates / past
+  # versions). Single-row `reportTemplate` cannot expose the multiple
+  # `isActive` rows that the trafficWeight selector samples between.
+  # `communityId=null` returns SYSTEM only; `communityId=X` returns the
+  # union of the SYSTEM row(s) and any COMMUNITY-X overrides so the
+  # admin UI can show "what actually runs for this community" in one list.
+  reportTemplates(
+    variant: ReportVariant!
+    communityId: ID
+    kind: ReportTemplateKind = GENERATION
+    includeInactive: Boolean = false
+  ): [ReportTemplate!]! @authz(rules: [IsAdmin])
+
+  # Phase 1 admin UI: per-template quality breakdown for the A/B
+  # comparison screen — rows are templates (one per `prompt version`
+  # within a variant). Each row carries feedbackCount / avgRating /
+  # avgJudgeScore plus per-row Pearson correlation, so v1 and v2 can
+  # be evaluated side by side. Default returns active rows only with
+  # cursor pagination so the response stays bounded even when an
+  # experimentKey set explodes (variants with hundreds of historical
+  # candidates lean on `includeInactive: true` paginated browsing).
+  reportTemplateStatsBreakdown(
+    variant: ReportVariant!
+    version: Int
+    kind: ReportTemplateKind = GENERATION
+    includeInactive: Boolean = false
+    cursor: String
+    first: Int = 20
+  ): ReportTemplateStatsBreakdownConnection! @authz(rules: [IsAdmin])
+
+  # Phase 2 sysAdmin: cross-community report search. Same shape as
+  # `reports` but `permission` is dropped — IsAdmin alone gates access.
+  # Order is `publishedAt DESC NULLS LAST, createdAt DESC` so DRAFT /
+  # SKIPPED rows that have no publishedAt sink to the bottom rather
+  # than leading the page. Filters are all optional so the same query
+  # backs both "show all PUBLISHED across communities" and "drill into
+  # one community + variant" use cases.
+  adminBrowseReports(
+    communityId: ID
+    status: ReportStatus
+    variant: ReportVariant
+    publishedAfter: Datetime
+    publishedBefore: Datetime
+    cursor: String
+    first: Int
+  ): ReportsConnection! @authz(rules: [IsAdmin])
+
+  # Phase 2 sysAdmin: per-community last-publish summary for the L1
+  # dashboard. Sort order `lastPublishedAt ASC NULLS FIRST` floats
+  # dormant / never-published communities to the top so they are the
+  # first things an operator sees. The `lastPublishedReportAt` column
+  # on `t_communities` is a denormalized pointer maintained by
+  # `publishReport` and `supersedeParentIfRegenerating` (A-3); it is
+  # NOT exposed on the `Community` type to keep general community
+  # reads cheap.
+  adminReportSummary(
+    cursor: String
+    first: Int
+  ): AdminReportSummaryConnection! @authz(rules: [IsAdmin])
 }

--- a/src/application/domain/report/schema/type.graphql
+++ b/src/application/domain/report/schema/type.graphql
@@ -24,6 +24,16 @@ enum ReportTemplateScope {
   COMMUNITY
 }
 
+# Phase 1 admin UI exposure (A-1). `kind` distinguishes generation prompts
+# (the body the LLM produces) from judge prompts (the LLM-as-Judge scoring
+# pass). The admin UI keeps GENERATION on the main tab and routes JUDGE
+# through a separate "system" screen, so the enum surfaces here even
+# though prod selection logic continues to filter on it internally.
+enum ReportTemplateKind {
+  GENERATION
+  JUDGE
+}
+
 type Report {
   id: ID!
   community: Community!
@@ -72,6 +82,11 @@ type ReportTemplate {
   id: ID!
   variant: ReportVariant!
   scope: ReportTemplateScope!
+  # GENERATION = body-producing prompt. JUDGE = LLM-as-Judge scoring
+  # prompt. Exposed so the admin UI can mark / route the two kinds
+  # without an extra round trip; Prisma treats `kind` as part of the
+  # uniqueness tuple alongside (variant, communityId, version).
+  kind: ReportTemplateKind!
   community: Community
   systemPrompt: String!
   userPromptTemplate: String!
@@ -198,4 +213,65 @@ type ReportTemplateStats {
   avgJudgeScore: Float
   judgeHumanCorrelation: Float
   correlationWarning: Boolean!
+}
+
+# Per-template quality row for the A/B comparison screen. `templateId`
+# is the row identity (= one prompt revision); fields below describe
+# both the template config (version / scope / kind / experimentKey /
+# isActive / trafficWeight) and the aggregated quality signals over the
+# Reports that used that template. `judgeHumanCorrelation` is null when
+# fewer than 3 paired (judge, rating) observations exist; in that
+# case `correlationWarning` is false. `correlationWarning=true`
+# indicates correlation < 0.7 — judge prompt likely needs re-tuning
+# against the human ratings.
+type ReportTemplateStatsBreakdownRow {
+  templateId: ID!
+  version: Int!
+  scope: ReportTemplateScope!
+  kind: ReportTemplateKind!
+  experimentKey: String
+  isActive: Boolean!
+  isEnabled: Boolean!
+  trafficWeight: Int!
+  feedbackCount: Int!
+  avgRating: Float
+  avgJudgeScore: Float
+  judgeHumanCorrelation: Float
+  correlationWarning: Boolean!
+}
+
+type ReportTemplateStatsBreakdownEdge implements Edge {
+  cursor: String!
+  node: ReportTemplateStatsBreakdownRow
+}
+
+type ReportTemplateStatsBreakdownConnection {
+  edges: [ReportTemplateStatsBreakdownEdge]
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+# Phase 2 sysAdmin L1: per-community last-publish summary. `community`
+# / `lastPublishedReport` are resolved via the existing dataloaders,
+# so a 50-row page issues at most two batched lookups regardless of
+# how many communities show up. `daysSinceLastPublish` is computed in
+# the presenter from `lastPublishedAt` so dormant communities surface
+# the gap directly without the caller doing date math.
+type AdminReportSummaryRow {
+  community: Community!
+  lastPublishedReport: Report
+  lastPublishedAt: Datetime
+  daysSinceLastPublish: Int
+  publishedCountLast90Days: Int!
+}
+
+type AdminReportSummaryEdge implements Edge {
+  cursor: String!
+  node: AdminReportSummaryRow
+}
+
+type AdminReportSummaryConnection {
+  edges: [AdminReportSummaryEdge]
+  pageInfo: PageInfo!
+  totalCount: Int!
 }

--- a/src/application/domain/report/service.ts
+++ b/src/application/domain/report/service.ts
@@ -278,7 +278,17 @@ export default class ReportService {
     }>;
     totalCount: number;
   }> {
-    return this.repository.findCommunityReportSummary(ctx, params);
+    // Wire-format → structured at the converter boundary so the
+    // repository never sees the GraphQL cursor string. A null result
+    // (garbage / stale cursor) collapses to "no cursor"; the repo
+    // falls back to a clean first-page scan.
+    const cursor = params.cursor
+      ? ReportConverter.decodeCommunitySummaryCursor(params.cursor)
+      : null;
+    return this.repository.findCommunityReportSummary(ctx, {
+      cursor,
+      first: params.first,
+    });
   }
 
   /**

--- a/src/application/domain/report/service.ts
+++ b/src/application/domain/report/service.ts
@@ -157,6 +157,23 @@ export default class ReportService {
   }
 
   /**
+   * Phase 1 admin: list multiple template revisions for the management
+   * UI. Pass-through to the repository — the repository handles the
+   * SYSTEM ∪ COMMUNITY semantics and the includeInactive toggle, the
+   * service is here purely so resolver/usecase tests can substitute a
+   * mock without reaching into the repository.
+   */
+  async listTemplates(
+    ctx: IContext,
+    variant: string,
+    communityId: string | null,
+    kind: ReportTemplateKind,
+    includeInactive: boolean,
+  ): Promise<PrismaReportTemplate[]> {
+    return this.repository.findTemplates(ctx, variant, communityId, kind, includeInactive);
+  }
+
+  /**
    * CI-only direct lookup by (variant, kind, version, communityId).
    * Wraps `IReportRepository.findTemplateByVersion` so the Golden Case
    * harness has the same service-shaped seam as the rest of the report
@@ -219,6 +236,68 @@ export default class ReportService {
     },
   ): Promise<{ items: PrismaReport[]; totalCount: number }> {
     return this.repository.findReports(ctx, params);
+  }
+
+  /**
+   * Phase 2 sysAdmin: cross-community report search backing
+   * `adminBrowseReports`. Pass-through to the repository so the usecase
+   * shape stays mock-friendly; the repo enforces the IsAdmin-only
+   * scope via `ctx.issuer.internal` plus the `publishedAt DESC NULLS
+   * LAST` ordering.
+   */
+  async getAllReports(
+    ctx: IContext,
+    params: {
+      communityId?: string;
+      status?: ReportStatus;
+      variant?: string;
+      publishedAfter?: Date;
+      publishedBefore?: Date;
+      cursor?: string;
+      first: number;
+    },
+  ): Promise<{ items: PrismaReport[]; totalCount: number }> {
+    return this.repository.findAllReports(ctx, params);
+  }
+
+  /**
+   * Phase 2 sysAdmin: per-community last-publish summary backing
+   * `adminReportSummary`. Returns the denormalized last-publish
+   * pointer plus the rolling 90-day count; the resolver hydrates the
+   * full Community / Report objects through dataloaders.
+   */
+  async getCommunityReportSummary(
+    ctx: IContext,
+    params: { cursor?: string; first: number },
+  ): Promise<{
+    items: Array<{
+      communityId: string;
+      lastPublishedReportId: string | null;
+      lastPublishedAt: Date | null;
+      publishedCountLast90Days: number;
+    }>;
+    totalCount: number;
+  }> {
+    return this.repository.findCommunityReportSummary(ctx, params);
+  }
+
+  /**
+   * A-3 maintenance helper. Re-derives the community's
+   * `last_published_report_*` pointer from `t_reports`. Must be called
+   * inside the same transaction as the report-side update (publish or
+   * supersede) so the pointer cannot be observed mid-flight by a
+   * concurrent `adminReportSummary` reader.
+   *
+   * Idempotent: invoking it twice in a row is a no-op the second time.
+   * No "don't overwrite if older" semantics — the SELECT inside the
+   * repository always picks the current newest PUBLISHED row.
+   */
+  async recalculateCommunityLastPublished(
+    ctx: IContext,
+    communityId: string,
+    tx: Prisma.TransactionClient,
+  ): Promise<void> {
+    return this.repository.recalculateCommunityLastPublished(ctx, communityId, tx);
   }
 
   async updateReportStatus(

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -25,6 +25,7 @@ import {
   GqlApproveReportPayload,
   GqlPublishReportPayload,
   GqlRejectReportPayload,
+  GqlAdminReportSummaryConnection,
   GqlMutationGenerateReportArgs,
   GqlMutationUpdateReportTemplateArgs,
   GqlMutationApproveReportArgs,
@@ -33,6 +34,9 @@ import {
   GqlQueryReportsArgs,
   GqlQueryReportArgs,
   GqlQueryReportTemplateArgs,
+  GqlQueryReportTemplatesArgs,
+  GqlQueryAdminBrowseReportsArgs,
+  GqlQueryAdminReportSummaryArgs,
 } from "@/types/graphql";
 
 const LLM_TIMEOUT_MS = 180_000;
@@ -608,6 +612,14 @@ export default class ReportUseCase {
       throw new Error("Parent report must belong to the same community and variant");
     }
     if (parent.status !== ReportStatus.SUPERSEDED) {
+      // A-3: capture whether the parent was PUBLISHED *before* we
+      // transition it. The recalc only matters when the row being
+      // superseded was actually the (or a) PUBLISHED row pointed at
+      // by `t_communities.last_published_report_id`; for DRAFT /
+      // APPROVED / SKIPPED parents the pointer was never on this
+      // row and recompute would be a no-op, so we skip the extra
+      // query.
+      const wasPublished = parent.status === ReportStatus.PUBLISHED;
       this.service.assertStatusTransition(parent.status, ReportStatus.SUPERSEDED);
       await this.service.updateReportStatus(
         ctx,
@@ -616,6 +628,9 @@ export default class ReportUseCase {
         undefined,
         tx,
       );
+      if (wasPublished) {
+        await this.service.recalculateCommunityLastPublished(ctx, communityId, tx);
+      }
     }
     return parent.regenerateCount;
   }
@@ -651,6 +666,27 @@ export default class ReportUseCase {
   ): Promise<GqlReportTemplate | null> {
     const template = await this.service.getTemplate(ctx, variant, communityId ?? null);
     return template ? ReportPresenter.reportTemplate(template) : null;
+  }
+
+  /**
+   * Phase 1 admin: list multiple template revisions for the
+   * management UI. The schema default is `kind: GENERATION`, but
+   * GraphQL passes through `null` when the caller omitted the arg
+   * with no default applied (codegen treats every arg as nullable);
+   * coalesce here so the service layer always sees a concrete kind.
+   */
+  async listReportTemplates(
+    { variant, communityId, kind, includeInactive }: GqlQueryReportTemplatesArgs,
+    ctx: IContext,
+  ): Promise<GqlReportTemplate[]> {
+    const templates = await this.service.listTemplates(
+      ctx,
+      variant,
+      communityId ?? null,
+      kind ?? ReportTemplateKind.GENERATION,
+      includeInactive ?? false,
+    );
+    return templates.map(ReportPresenter.reportTemplate);
   }
 
   async updateReportTemplate(
@@ -712,7 +748,7 @@ export default class ReportUseCase {
       const existing = await this.service.getReportById(ctx, id, tx);
       if (!existing) throw new Error(`Report ${id} not found`);
       this.service.assertStatusTransition(existing.status, ReportStatus.PUBLISHED);
-      return this.service.updateReportStatus(
+      const updated = await this.service.updateReportStatus(
         ctx,
         id,
         ReportStatus.PUBLISHED,
@@ -723,6 +759,14 @@ export default class ReportUseCase {
         },
         tx,
       );
+      // A-3: keep the per-community last-publish pointer
+      // (`t_communities.last_published_report_*`) in sync inside the
+      // same transaction. `adminReportSummary` reads from those
+      // columns, so a publish without recalc would surface a stale
+      // pointer until the next maintenance call. Always re-derives
+      // from `t_reports`, so re-running is a no-op.
+      await this.service.recalculateCommunityLastPublished(ctx, updated.communityId, tx);
+      return updated;
     });
     return { __typename: "PublishReportSuccess", report: ReportPresenter.report(report) };
   }
@@ -738,6 +782,56 @@ export default class ReportUseCase {
       return this.service.updateReportStatus(ctx, id, ReportStatus.REJECTED, undefined, tx);
     });
     return { __typename: "RejectReportSuccess", report: ReportPresenter.report(report) };
+  }
+
+  /**
+   * Phase 2 sysAdmin: cross-community report search. The IsAdmin
+   * directive on the GraphQL query is the only authz gate (no
+   * permission.communityId hand-off) — the usecase trusts the
+   * directive and does not re-check sysRole.
+   */
+  async adminBrowseReports(
+    args: GqlQueryAdminBrowseReportsArgs,
+    ctx: IContext,
+  ): Promise<GqlReportsConnection> {
+    const first = args.first
+      ? clampInt(args.first, 1, MAX_REPORTS_PER_PAGE, "first")
+      : DEFAULT_REPORTS_PER_PAGE;
+    const result = await this.service.getAllReports(ctx, {
+      communityId: args.communityId ?? undefined,
+      status: args.status ?? undefined,
+      variant: args.variant ?? undefined,
+      publishedAfter: args.publishedAfter ? new Date(args.publishedAfter) : undefined,
+      publishedBefore: args.publishedBefore ? new Date(args.publishedBefore) : undefined,
+      cursor: args.cursor ?? undefined,
+      first,
+    });
+    return ReportPresenter.reportsConnection(result.items, result.totalCount, first);
+  }
+
+  /**
+   * Phase 2 sysAdmin: per-community last-publish summary for the L1
+   * dashboard. Returns an `AdminReportSummaryConnection` whose nodes
+   * carry the denormalized pointer + 90-day publish count; the
+   * resolver hydrates `community` / `lastPublishedReport` via the
+   * existing dataloaders.
+   */
+  async adminViewReportSummary(
+    args: GqlQueryAdminReportSummaryArgs,
+    ctx: IContext,
+  ): Promise<GqlAdminReportSummaryConnection> {
+    const first = args.first
+      ? clampInt(args.first, 1, MAX_REPORTS_PER_PAGE, "first")
+      : DEFAULT_REPORTS_PER_PAGE;
+    const result = await this.service.getCommunityReportSummary(ctx, {
+      cursor: args.cursor ?? undefined,
+      first,
+    });
+    return ReportPresenter.adminReportSummaryConnection(
+      result.items,
+      result.totalCount,
+      first,
+    );
   }
 
   // =========================================================================

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -795,7 +795,7 @@ export default class ReportUseCase {
     ctx: IContext,
   ): Promise<GqlReportsConnection> {
     const first = args.first
-      ? clampInt(args.first, 1, MAX_REPORTS_PER_PAGE, "first")
+      ? validateIntInRange(args.first, 1, MAX_REPORTS_PER_PAGE, "first")
       : DEFAULT_REPORTS_PER_PAGE;
     const result = await this.service.getAllReports(ctx, {
       communityId: args.communityId ?? undefined,
@@ -821,7 +821,7 @@ export default class ReportUseCase {
     ctx: IContext,
   ): Promise<GqlAdminReportSummaryConnection> {
     const first = args.first
-      ? clampInt(args.first, 1, MAX_REPORTS_PER_PAGE, "first")
+      ? validateIntInRange(args.first, 1, MAX_REPORTS_PER_PAGE, "first")
       : DEFAULT_REPORTS_PER_PAGE;
     const result = await this.service.getCommunityReportSummary(ctx, {
       cursor: args.cursor ?? undefined,
@@ -850,6 +850,31 @@ function clampInt(value: number, min: number, max: number, name: string): number
   }
   if (value < min || value > max) {
     throw new RangeError(`${name} must be between ${min} and ${max}, got ${value}`);
+  }
+  return value;
+}
+
+/**
+ * Mirror of `feedback/usecase.ts`'s `validateInt` so the admin-query
+ * paths in this file (`adminBrowseReports`, `adminViewReportSummary`)
+ * surface a `ValidationError` instead of `clampInt`'s `RangeError` —
+ * `ValidationError` is what the GraphQL error mapper translates into a
+ * client-facing `ValidationError` extension. Existing `clampInt`
+ * call sites (buildReportPayload's window/topN/commentLimit and the
+ * legacy `browseReports`) keep their current behaviour to avoid
+ * widening this PR's scope into a domain-wide refactor.
+ */
+function validateIntInRange(
+  value: number,
+  min: number,
+  max: number,
+  name: string,
+): number {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new ValidationError(
+      `${name} must be an integer between ${min} and ${max}, got ${value}`,
+      [name],
+    );
   }
   return value;
 }

--- a/src/application/domain/sysadmin/data/converter.ts
+++ b/src/application/domain/sysadmin/data/converter.ts
@@ -1,0 +1,25 @@
+/**
+ * Wire-format → internal form for the sysadmin domain. Pure GraphQL
+ * input-side transforms only. The matching internal → GraphQL
+ * output direction (e.g. encoding the next-page cursor) lives in
+ * the presenter to keep each layer's transform direction clean.
+ */
+export default class SysAdminConverter {
+  /**
+   * Decode the opaque base64 cursor a `paginateMembers` caller hands
+   * back from a previous page. The wire format is the offset
+   * stringified and base64-encoded — opaque to clients but trivial
+   * to reverse here. Returns 0 on garbage so a tampered cursor
+   * collapses to "first page" instead of throwing.
+   */
+  static parseMemberListCursor(cursor: string | null | undefined): number {
+    if (!cursor) return 0;
+    try {
+      const decoded = Buffer.from(cursor, "base64").toString("utf8");
+      const n = Number.parseInt(decoded, 10);
+      return Number.isFinite(n) && n >= 0 ? n : 0;
+    } catch {
+      return 0;
+    }
+  }
+}

--- a/src/application/domain/sysadmin/presenter.ts
+++ b/src/application/domain/sysadmin/presenter.ts
@@ -286,7 +286,14 @@ export default class SysAdminPresenter {
     return {
       users: result.users.map(SysAdminPresenter.memberRow),
       hasNextPage: result.hasNextPage,
-      nextCursor: result.nextCursor,
+      // Internal `nextOffset: number | null` → GraphQL
+      // `nextCursor: String | null`. The encode lives here so the
+      // service stays free of wire-format concerns; the matching
+      // decode is in `SysAdminConverter.parseMemberListCursor`.
+      nextCursor:
+        result.nextOffset !== null
+          ? encodeMemberListCursor(result.nextOffset)
+          : null,
     };
   }
 
@@ -329,4 +336,15 @@ export default class SysAdminPresenter {
       cohortFunnel: params.cohortFunnel,
     };
   }
+}
+
+/**
+ * Internal offset → GraphQL `nextCursor` wire format. Base64 of the
+ * offset's stringified form, matching the prior in-service helper.
+ * Exported so the round-trip unit test can assert encode/decode
+ * symmetry against `SysAdminConverter.parseMemberListCursor` without
+ * exercising the full member-list presenter.
+ */
+export function encodeMemberListCursor(offset: number): string {
+  return Buffer.from(String(offset), "utf8").toString("base64");
 }

--- a/src/application/domain/sysadmin/service.ts
+++ b/src/application/domain/sysadmin/service.ts
@@ -253,13 +253,18 @@ export type MemberListParams = {
   sortField: SortField;
   sortOrder: SortOrder;
   limit: number;
-  cursor?: string | null;
+  // Pre-decoded offset; the GraphQL → number wire-format step lives
+  // in `SysAdminConverter.parseMemberListCursor` so the service
+  // operates on internal form only.
+  cursor?: number;
 };
 
 export type MemberListResult = {
   users: SysAdminMemberStatsRow[];
   hasNextPage: boolean;
-  nextCursor: string | null;
+  // Internal form. The GraphQL `nextCursor: String | null` is built
+  // by the presenter, which owns the internal → wire-format step.
+  nextOffset: number | null;
 };
 
 export type AlertFlags = {
@@ -683,14 +688,14 @@ export default class SysAdminService {
       return a.userId.localeCompare(b.userId);
     });
 
-    const start = params.cursor ? parseCursor(params.cursor) : 0;
+    const start = params.cursor ?? 0;
     const limit = Math.min(Math.max(params.limit, 1), MAX_LIMIT);
     const page = sorted.slice(start, start + limit);
     const hasNextPage = start + limit < sorted.length;
     return {
       users: page,
       hasNextPage,
-      nextCursor: hasNextPage ? encodeCursor(start + limit) : null,
+      nextOffset: hasNextPage ? start + limit : null,
     };
   }
 
@@ -1274,18 +1279,3 @@ export default class SysAdminService {
   }
 }
 
-function encodeCursor(offset: number): string {
-  // Simple numeric offset. Base64 to discourage clients from poking
-  // into the value and to match the "opaque cursor" contract.
-  return Buffer.from(String(offset), "utf8").toString("base64");
-}
-
-function parseCursor(cursor: string): number {
-  try {
-    const decoded = Buffer.from(cursor, "base64").toString("utf8");
-    const n = Number.parseInt(decoded, 10);
-    return Number.isFinite(n) && n >= 0 ? n : 0;
-  } catch {
-    return 0;
-  }
-}

--- a/src/application/domain/sysadmin/usecase.ts
+++ b/src/application/domain/sysadmin/usecase.ts
@@ -27,6 +27,7 @@ import SysAdminService, {
   SegmentThresholds,
 } from "@/application/domain/sysadmin/service";
 import SysAdminPresenter from "@/application/domain/sysadmin/presenter";
+import SysAdminConverter from "@/application/domain/sysadmin/data/converter";
 import { jstMonthStart, jstNextMonthStart } from "@/application/domain/report/util";
 import { asOfBounds } from "@/application/domain/sysadmin/bounds";
 
@@ -193,7 +194,9 @@ export default class SysAdminUseCase {
       sortField: input.userSort?.field ?? "SEND_RATE",
       sortOrder: input.userSort?.order ?? "DESC",
       limit: clampLimit(input.limit),
-      cursor: input.cursor ?? null,
+      // Decode at the converter boundary so service operates on a
+      // numeric offset only — no wire-format leakage.
+      cursor: SysAdminConverter.parseMemberListCursor(input.cursor),
     });
 
     const summary = SysAdminPresenter.summaryCard({

--- a/src/infrastructure/prisma/factories/__generated__/index.ts
+++ b/src/infrastructure/prisma/factories/__generated__/index.ts
@@ -1930,6 +1930,8 @@ type CommunityFactoryDefineInput = {
     bio?: string | null;
     establishedAt?: Date | null;
     website?: string | null;
+    lastPublishedReportAt?: Date | null;
+    lastPublishedReportId?: string | null;
     createdAt?: Date;
     updatedAt?: Date | null;
     image?: CommunityimageFactory | Prisma.ImageCreateNestedOneWithoutCommunitiesInput;

--- a/src/infrastructure/prisma/migrations/20260427140819_add_admin_report_summary_columns/migration.sql
+++ b/src/infrastructure/prisma/migrations/20260427140819_add_admin_report_summary_columns/migration.sql
@@ -11,12 +11,20 @@ ALTER TABLE "t_communities"
   ADD COLUMN "last_published_report_id" TEXT;
 
 -- CreateIndex
+-- NULLS LAST aligns the index ordering with adminBrowseReports'
+-- `publishedAt DESC NULLS LAST, createdAt DESC` so the planner can
+-- satisfy the sort directly from the index (PG default for DESC is
+-- NULLS FIRST, which would force a re-sort).
 CREATE INDEX "idx_t_reports_published_at_created_at"
-  ON "t_reports"("published_at" DESC, "created_at" DESC);
+  ON "t_reports"("published_at" DESC NULLS LAST, "created_at" DESC);
 
 -- CreateIndex
+-- NULLS FIRST aligns the index ordering with adminReportSummary's
+-- dormant-first sort `last_published_report_at ASC NULLS FIRST` —
+-- PG default for ASC is NULLS LAST, so an unqualified index would
+-- not be usable for the L1 dashboard's primary sort path.
 CREATE INDEX "idx_t_communities_last_published_report_at"
-  ON "t_communities"("last_published_report_at" ASC);
+  ON "t_communities"("last_published_report_at" ASC NULLS FIRST);
 
 -- Backfill: 各 community で status=PUBLISHED の最新レポートを引き、新規列に流し込む。
 -- DISTINCT ON で per-community に 1 行だけ抽出する Postgres 流の書き方。

--- a/src/infrastructure/prisma/migrations/20260427140819_add_admin_report_summary_columns/migration.sql
+++ b/src/infrastructure/prisma/migrations/20260427140819_add_admin_report_summary_columns/migration.sql
@@ -1,0 +1,36 @@
+-- Phase 2 (依頼 3a + 3b): admin 横断レポート観察用の index と denormalize 列を追加。
+-- - t_reports に publishedAt DESC, createdAt DESC の複合 index を追加
+--   (adminBrowseReports が community 横断で publishedAt 順にスキャンするため)
+-- - t_communities に last_published_report_at / last_published_report_id 列を追加
+--   (adminReportSummary の cursor pagination + sort 用、内部 denormalize)
+-- - 列追加後、既存 PUBLISHED レポートから値を backfill
+
+-- AlterTable
+ALTER TABLE "t_communities"
+  ADD COLUMN "last_published_report_at" TIMESTAMP(3),
+  ADD COLUMN "last_published_report_id" TEXT;
+
+-- CreateIndex
+CREATE INDEX "idx_t_reports_published_at_created_at"
+  ON "t_reports"("published_at" DESC, "created_at" DESC);
+
+-- CreateIndex
+CREATE INDEX "idx_t_communities_last_published_report_at"
+  ON "t_communities"("last_published_report_at" ASC);
+
+-- Backfill: 各 community で status=PUBLISHED の最新レポートを引き、新規列に流し込む。
+-- DISTINCT ON で per-community に 1 行だけ抽出する Postgres 流の書き方。
+UPDATE "t_communities" c
+SET
+  "last_published_report_at" = sub."max_published_at",
+  "last_published_report_id" = sub."report_id"
+FROM (
+  SELECT DISTINCT ON ("community_id")
+    "community_id",
+    "id" AS "report_id",
+    "published_at" AS "max_published_at"
+  FROM "t_reports"
+  WHERE "status" = 'PUBLISHED' AND "published_at" IS NOT NULL
+  ORDER BY "community_id", "published_at" DESC
+) sub
+WHERE c."id" = sub."community_id";

--- a/src/infrastructure/prisma/migrations/20260427140819_add_admin_report_summary_columns/migration.sql
+++ b/src/infrastructure/prisma/migrations/20260427140819_add_admin_report_summary_columns/migration.sql
@@ -26,6 +26,19 @@ CREATE INDEX "idx_t_reports_published_at_created_at"
 CREATE INDEX "idx_t_communities_last_published_report_at"
   ON "t_communities"("last_published_report_at" ASC NULLS FIRST);
 
+-- CreateIndex
+-- Backs `recalculateCommunityLastPublished` (per-community newest
+-- PUBLISHED row) and `findCommunityReportSummary`'s 90-day count
+-- subquery. Existing `(community_id, status)` finds the PUBLISHED
+-- rows but spills the published_at range filter / sort to a heap
+-- pass; this index folds published_at into the leading portion so
+-- the LIMIT 1 lookup and the 90-day range scan are both
+-- index-served. Default ASC ordering — Postgres scans backwards to
+-- satisfy `ORDER BY published_at DESC` without an explicit DESC
+-- declaration.
+CREATE INDEX "idx_t_reports_community_status_published_at"
+  ON "t_reports"("community_id", "status", "published_at");
+
 -- Backfill: 各 community で status=PUBLISHED の最新レポートを引き、新規列に流し込む。
 -- DISTINCT ON で per-community に 1 行だけ抽出する Postgres 流の書き方。
 -- "id" DESC は per-community での ties (同 ms バッチ publish) に対する

--- a/src/infrastructure/prisma/migrations/20260427140819_add_admin_report_summary_columns/migration.sql
+++ b/src/infrastructure/prisma/migrations/20260427140819_add_admin_report_summary_columns/migration.sql
@@ -20,6 +20,10 @@ CREATE INDEX "idx_t_communities_last_published_report_at"
 
 -- Backfill: 各 community で status=PUBLISHED の最新レポートを引き、新規列に流し込む。
 -- DISTINCT ON で per-community に 1 行だけ抽出する Postgres 流の書き方。
+-- "id" DESC は per-community での ties (同 ms バッチ publish) に対する
+-- tie-breaker。recalculateCommunityLastPublished 側の SELECT と同じ
+-- 順序にすることで「migration 適用直後の state == 任意の publish 後の
+-- state」になり、追加の reconciliation を考えなくてよい。
 UPDATE "t_communities" c
 SET
   "last_published_report_at" = sub."max_published_at",
@@ -31,6 +35,6 @@ FROM (
     "published_at" AS "max_published_at"
   FROM "t_reports"
   WHERE "status" = 'PUBLISHED' AND "published_at" IS NOT NULL
-  ORDER BY "community_id", "published_at" DESC
+  ORDER BY "community_id", "published_at" DESC, "id" DESC
 ) sub
 WHERE c."id" = sub."community_id";

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -1858,6 +1858,16 @@ model Report {
   // the index — without it the planner has to re-sort because DESC's
   // default is NULLS FIRST.
   @@index([publishedAt(sort: Desc, nulls: Last), createdAt(sort: Desc)], map: "idx_t_reports_published_at_created_at")
+  // Backs both `recalculateCommunityLastPublished` (per-community
+  // newest PUBLISHED row) and `findCommunityReportSummary`'s 90-day
+  // count subquery. Existing `[communityId, status]` finds the
+  // PUBLISHED rows but loses the published_at range filter / sort to
+  // a heap pass; this index folds published_at into the leading
+  // portion so both the LIMIT 1 lookup and the 90-day range scan are
+  // index-served. Default ASC ordering is fine — Postgres can scan
+  // backwards to satisfy `ORDER BY published_at DESC` without an
+  // explicit `sort: Desc`.
+  @@index([communityId, status, publishedAt], map: "idx_t_reports_community_status_published_at")
   @@map("t_reports")
 }
 

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -200,9 +200,22 @@ model Community {
   reportTemplates ReportTemplate[]
   reports         Report[]
 
+  // Denormalized pointer to the community's most recent PUBLISHED report.
+  // Powers `adminReportSummary` cursor pagination + sort order ("dormant
+  // communities float to the top" via NULLS FIRST). Maintained by the
+  // `recalculateCommunityLastPublished` helper, which is invoked from both
+  // `publishReport` (after a PUBLISHED transition) and
+  // `supersedeParentIfRegenerating` (after a PUBLISHED → SUPERSEDED
+  // transition). The `Report` relation is intentionally NOT declared here
+  // — these columns are admin-internal and exposing them on the GraphQL
+  // `Community` type would push a join cost onto every community read.
+  lastPublishedReportAt DateTime? @map("last_published_report_at")
+  lastPublishedReportId String?   @map("last_published_report_id")
+
   createdAt DateTime  @default(now()) @map("created_at")
   updatedAt DateTime? @updatedAt @map("updated_at")
 
+  @@index([lastPublishedReportAt(sort: Asc)], map: "idx_t_communities_last_published_report_at")
   @@map("t_communities")
 }
 
@@ -1831,6 +1844,11 @@ model Report {
   @@index([communityId, variant, periodFrom(sort: Desc)])
   @@index([communityId, status])
   @@index([parentRunId])
+  // Cross-community admin browse (`adminBrowseReports`) sorts by
+  // publishedAt DESC NULLS LAST, createdAt DESC. The community-scoped
+  // indexes above don't help when communityId is unfiltered, so this
+  // dedicated index backs the sysAdmin sweep.
+  @@index([publishedAt(sort: Desc), createdAt(sort: Desc)], map: "idx_t_reports_published_at_created_at")
   @@map("t_reports")
 }
 

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -215,7 +215,11 @@ model Community {
   createdAt DateTime  @default(now()) @map("created_at")
   updatedAt DateTime? @updatedAt @map("updated_at")
 
-  @@index([lastPublishedReportAt(sort: Asc)], map: "idx_t_communities_last_published_report_at")
+  // `nulls: First` makes the index ordering match the
+  // `adminReportSummary` query's `last_published_report_at ASC NULLS
+  // FIRST` (dormant-first) so the sort is index-served — ASC defaults
+  // to NULLS LAST in PostgreSQL, which would force a re-sort.
+  @@index([lastPublishedReportAt(sort: Asc, nulls: First)], map: "idx_t_communities_last_published_report_at")
   @@map("t_communities")
 }
 
@@ -1848,7 +1852,12 @@ model Report {
   // publishedAt DESC NULLS LAST, createdAt DESC. The community-scoped
   // indexes above don't help when communityId is unfiltered, so this
   // dedicated index backs the sysAdmin sweep.
-  @@index([publishedAt(sort: Desc), createdAt(sort: Desc)], map: "idx_t_reports_published_at_created_at")
+  // `nulls: Last` makes the index ordering match the
+  // `adminBrowseReports` query's `publishedAt DESC NULLS LAST,
+  // createdAt DESC` so PostgreSQL can satisfy the sort directly from
+  // the index — without it the planner has to re-sort because DESC's
+  // default is NULLS FIRST.
+  @@index([publishedAt(sort: Desc, nulls: Last), createdAt(sort: Desc)], map: "idx_t_reports_published_at_created_at")
   @@map("t_reports")
 }
 

--- a/src/presentation/graphql/resolver.ts
+++ b/src/presentation/graphql/resolver.ts
@@ -156,6 +156,7 @@ const resolvers = {
 
   Report: { ...report.Report, ...reportFeedback.Report },
   ReportTemplate: report.ReportTemplate,
+  AdminReportSummaryRow: report.AdminReportSummaryRow,
   ReportFeedback: reportFeedback.ReportFeedback,
   GenerateReportPayload: report.GenerateReportPayload,
   UpdateReportTemplatePayload: report.UpdateReportTemplatePayload,

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -29,6 +29,28 @@ export type GqlAccumulatedPointView = {
   walletId?: Maybe<Scalars['String']['output']>;
 };
 
+export type GqlAdminReportSummaryConnection = {
+  __typename?: 'AdminReportSummaryConnection';
+  edges?: Maybe<Array<Maybe<GqlAdminReportSummaryEdge>>>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type GqlAdminReportSummaryEdge = GqlEdge & {
+  __typename?: 'AdminReportSummaryEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlAdminReportSummaryRow>;
+};
+
+export type GqlAdminReportSummaryRow = {
+  __typename?: 'AdminReportSummaryRow';
+  community: GqlCommunity;
+  daysSinceLastPublish?: Maybe<Scalars['Int']['output']>;
+  lastPublishedAt?: Maybe<Scalars['Datetime']['output']>;
+  lastPublishedReport?: Maybe<GqlReport>;
+  publishedCountLast90Days: Scalars['Int']['output'];
+};
+
 export type GqlApproveReportPayload = GqlApproveReportSuccess;
 
 export type GqlApproveReportSuccess = {
@@ -2136,6 +2158,8 @@ export const GqlPublishStatus = {
 export type GqlPublishStatus = typeof GqlPublishStatus[keyof typeof GqlPublishStatus];
 export type GqlQuery = {
   __typename?: 'Query';
+  adminBrowseReports: GqlReportsConnection;
+  adminReportSummary: GqlAdminReportSummaryConnection;
   article?: Maybe<GqlArticle>;
   articles: GqlArticlesConnection;
   cities: GqlCitiesConnection;
@@ -2177,6 +2201,8 @@ export type GqlQuery = {
   report?: Maybe<GqlReport>;
   reportTemplate?: Maybe<GqlReportTemplate>;
   reportTemplateStats: GqlReportTemplateStats;
+  reportTemplateStatsBreakdown: GqlReportTemplateStatsBreakdownConnection;
+  reportTemplates: Array<GqlReportTemplate>;
   reports: GqlReportsConnection;
   reservation?: Maybe<GqlReservation>;
   reservationHistories: GqlReservationHistoriesConnection;
@@ -2232,6 +2258,23 @@ export type GqlQuery = {
   voteTopics: GqlVoteTopicsConnection;
   wallet?: Maybe<GqlWallet>;
   wallets: GqlWalletsConnection;
+};
+
+
+export type GqlQueryAdminBrowseReportsArgs = {
+  communityId?: InputMaybe<Scalars['ID']['input']>;
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  publishedAfter?: InputMaybe<Scalars['Datetime']['input']>;
+  publishedBefore?: InputMaybe<Scalars['Datetime']['input']>;
+  status?: InputMaybe<GqlReportStatus>;
+  variant?: InputMaybe<GqlReportVariant>;
+};
+
+
+export type GqlQueryAdminReportSummaryArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -2446,6 +2489,24 @@ export type GqlQueryReportTemplateArgs = {
 export type GqlQueryReportTemplateStatsArgs = {
   variant: GqlReportVariant;
   version?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type GqlQueryReportTemplateStatsBreakdownArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  includeInactive?: InputMaybe<Scalars['Boolean']['input']>;
+  kind?: InputMaybe<GqlReportTemplateKind>;
+  variant: GqlReportVariant;
+  version?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type GqlQueryReportTemplatesArgs = {
+  communityId?: InputMaybe<Scalars['ID']['input']>;
+  includeInactive?: InputMaybe<Scalars['Boolean']['input']>;
+  kind?: InputMaybe<GqlReportTemplateKind>;
+  variant: GqlReportVariant;
 };
 
 
@@ -2742,6 +2803,7 @@ export type GqlReportTemplate = {
   id: Scalars['ID']['output'];
   isActive: Scalars['Boolean']['output'];
   isEnabled: Scalars['Boolean']['output'];
+  kind: GqlReportTemplateKind;
   maxTokens: Scalars['Int']['output'];
   model: Scalars['String']['output'];
   scope: GqlReportTemplateScope;
@@ -2756,6 +2818,12 @@ export type GqlReportTemplate = {
   version: Scalars['Int']['output'];
 };
 
+export const GqlReportTemplateKind = {
+  Generation: 'GENERATION',
+  Judge: 'JUDGE'
+} as const;
+
+export type GqlReportTemplateKind = typeof GqlReportTemplateKind[keyof typeof GqlReportTemplateKind];
 export const GqlReportTemplateScope = {
   Community: 'COMMUNITY',
   System: 'SYSTEM'
@@ -2771,6 +2839,36 @@ export type GqlReportTemplateStats = {
   judgeHumanCorrelation?: Maybe<Scalars['Float']['output']>;
   variant: GqlReportVariant;
   version?: Maybe<Scalars['Int']['output']>;
+};
+
+export type GqlReportTemplateStatsBreakdownConnection = {
+  __typename?: 'ReportTemplateStatsBreakdownConnection';
+  edges?: Maybe<Array<Maybe<GqlReportTemplateStatsBreakdownEdge>>>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type GqlReportTemplateStatsBreakdownEdge = GqlEdge & {
+  __typename?: 'ReportTemplateStatsBreakdownEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlReportTemplateStatsBreakdownRow>;
+};
+
+export type GqlReportTemplateStatsBreakdownRow = {
+  __typename?: 'ReportTemplateStatsBreakdownRow';
+  avgJudgeScore?: Maybe<Scalars['Float']['output']>;
+  avgRating?: Maybe<Scalars['Float']['output']>;
+  correlationWarning: Scalars['Boolean']['output'];
+  experimentKey?: Maybe<Scalars['String']['output']>;
+  feedbackCount: Scalars['Int']['output'];
+  isActive: Scalars['Boolean']['output'];
+  isEnabled: Scalars['Boolean']['output'];
+  judgeHumanCorrelation?: Maybe<Scalars['Float']['output']>;
+  kind: GqlReportTemplateKind;
+  scope: GqlReportTemplateScope;
+  templateId: Scalars['ID']['output'];
+  trafficWeight: Scalars['Int']['output'];
+  version: Scalars['Int']['output'];
 };
 
 export const GqlReportVariant = {
@@ -5214,13 +5312,16 @@ export type GqlResolversUnionTypes<_RefType extends Record<string, unknown>> = R
 
 /** Mapping of interface types */
 export type GqlResolversInterfaceTypes<_RefType extends Record<string, unknown>> = ResolversObject<{
-  Edge: ( Omit<GqlArticleEdge, 'node'> & { node?: Maybe<_RefType['Article']> } ) | ( Omit<GqlCityEdge, 'node'> & { node?: Maybe<_RefType['City']> } ) | ( Omit<GqlCommunityEdge, 'node'> & { node?: Maybe<_RefType['Community']> } ) | ( Omit<GqlEvaluationEdge, 'node'> & { node?: Maybe<_RefType['Evaluation']> } ) | ( Omit<GqlEvaluationHistoryEdge, 'node'> & { node?: Maybe<_RefType['EvaluationHistory']> } ) | ( Omit<GqlIncentiveGrantEdge, 'node'> & { node?: Maybe<_RefType['IncentiveGrant']> } ) | ( Omit<GqlMembershipEdge, 'node'> & { node?: Maybe<_RefType['Membership']> } ) | ( Omit<GqlNftInstanceEdge, 'node'> & { node: _RefType['NftInstance'] } ) | ( Omit<GqlNftTokenEdge, 'node'> & { node: _RefType['NftToken'] } ) | ( Omit<GqlOpportunityEdge, 'node'> & { node?: Maybe<_RefType['Opportunity']> } ) | ( Omit<GqlOpportunitySlotEdge, 'node'> & { node?: Maybe<_RefType['OpportunitySlot']> } ) | ( Omit<GqlParticipationEdge, 'node'> & { node?: Maybe<_RefType['Participation']> } ) | ( Omit<GqlParticipationStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['ParticipationStatusHistory']> } ) | ( Omit<GqlPlaceEdge, 'node'> & { node?: Maybe<_RefType['Place']> } ) | ( Omit<GqlPortfolioEdge, 'node'> & { node?: Maybe<_RefType['Portfolio']> } ) | ( Omit<GqlReportEdge, 'node'> & { node?: Maybe<_RefType['Report']> } ) | ( Omit<GqlReportFeedbackEdge, 'node'> & { node?: Maybe<_RefType['ReportFeedback']> } ) | ( Omit<GqlReservationEdge, 'node'> & { node?: Maybe<_RefType['Reservation']> } ) | ( Omit<GqlReservationHistoryEdge, 'node'> & { node?: Maybe<_RefType['ReservationHistory']> } ) | ( Omit<GqlStateEdge, 'node'> & { node?: Maybe<_RefType['State']> } ) | ( Omit<GqlTicketClaimLinkEdge, 'node'> & { node?: Maybe<_RefType['TicketClaimLink']> } ) | ( Omit<GqlTicketEdge, 'node'> & { node?: Maybe<_RefType['Ticket']> } ) | ( Omit<GqlTicketIssuerEdge, 'node'> & { node?: Maybe<_RefType['TicketIssuer']> } ) | ( Omit<GqlTicketStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['TicketStatusHistory']> } ) | ( Omit<GqlTransactionEdge, 'node'> & { node?: Maybe<_RefType['Transaction']> } ) | ( Omit<GqlUserEdge, 'node'> & { node?: Maybe<_RefType['User']> } ) | ( Omit<GqlUtilityEdge, 'node'> & { node?: Maybe<_RefType['Utility']> } ) | ( Omit<GqlVcIssuanceRequestEdge, 'node'> & { node?: Maybe<_RefType['VcIssuanceRequest']> } ) | ( Omit<GqlWalletEdge, 'node'> & { node?: Maybe<_RefType['Wallet']> } );
+  Edge: ( Omit<GqlAdminReportSummaryEdge, 'node'> & { node?: Maybe<_RefType['AdminReportSummaryRow']> } ) | ( Omit<GqlArticleEdge, 'node'> & { node?: Maybe<_RefType['Article']> } ) | ( Omit<GqlCityEdge, 'node'> & { node?: Maybe<_RefType['City']> } ) | ( Omit<GqlCommunityEdge, 'node'> & { node?: Maybe<_RefType['Community']> } ) | ( Omit<GqlEvaluationEdge, 'node'> & { node?: Maybe<_RefType['Evaluation']> } ) | ( Omit<GqlEvaluationHistoryEdge, 'node'> & { node?: Maybe<_RefType['EvaluationHistory']> } ) | ( Omit<GqlIncentiveGrantEdge, 'node'> & { node?: Maybe<_RefType['IncentiveGrant']> } ) | ( Omit<GqlMembershipEdge, 'node'> & { node?: Maybe<_RefType['Membership']> } ) | ( Omit<GqlNftInstanceEdge, 'node'> & { node: _RefType['NftInstance'] } ) | ( Omit<GqlNftTokenEdge, 'node'> & { node: _RefType['NftToken'] } ) | ( Omit<GqlOpportunityEdge, 'node'> & { node?: Maybe<_RefType['Opportunity']> } ) | ( Omit<GqlOpportunitySlotEdge, 'node'> & { node?: Maybe<_RefType['OpportunitySlot']> } ) | ( Omit<GqlParticipationEdge, 'node'> & { node?: Maybe<_RefType['Participation']> } ) | ( Omit<GqlParticipationStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['ParticipationStatusHistory']> } ) | ( Omit<GqlPlaceEdge, 'node'> & { node?: Maybe<_RefType['Place']> } ) | ( Omit<GqlPortfolioEdge, 'node'> & { node?: Maybe<_RefType['Portfolio']> } ) | ( Omit<GqlReportEdge, 'node'> & { node?: Maybe<_RefType['Report']> } ) | ( Omit<GqlReportFeedbackEdge, 'node'> & { node?: Maybe<_RefType['ReportFeedback']> } ) | ( GqlReportTemplateStatsBreakdownEdge ) | ( Omit<GqlReservationEdge, 'node'> & { node?: Maybe<_RefType['Reservation']> } ) | ( Omit<GqlReservationHistoryEdge, 'node'> & { node?: Maybe<_RefType['ReservationHistory']> } ) | ( Omit<GqlStateEdge, 'node'> & { node?: Maybe<_RefType['State']> } ) | ( Omit<GqlTicketClaimLinkEdge, 'node'> & { node?: Maybe<_RefType['TicketClaimLink']> } ) | ( Omit<GqlTicketEdge, 'node'> & { node?: Maybe<_RefType['Ticket']> } ) | ( Omit<GqlTicketIssuerEdge, 'node'> & { node?: Maybe<_RefType['TicketIssuer']> } ) | ( Omit<GqlTicketStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['TicketStatusHistory']> } ) | ( Omit<GqlTransactionEdge, 'node'> & { node?: Maybe<_RefType['Transaction']> } ) | ( Omit<GqlUserEdge, 'node'> & { node?: Maybe<_RefType['User']> } ) | ( Omit<GqlUtilityEdge, 'node'> & { node?: Maybe<_RefType['Utility']> } ) | ( Omit<GqlVcIssuanceRequestEdge, 'node'> & { node?: Maybe<_RefType['VcIssuanceRequest']> } ) | ( Omit<GqlWalletEdge, 'node'> & { node?: Maybe<_RefType['Wallet']> } );
   TransactionChainParticipant: ( GqlTransactionChainCommunity ) | ( GqlTransactionChainUser );
 }>;
 
 /** Mapping between all available schema types and the resolvers types */
 export type GqlResolversTypes = ResolversObject<{
   AccumulatedPointView: ResolverTypeWrapper<AccumulatedPointView>;
+  AdminReportSummaryConnection: ResolverTypeWrapper<Omit<GqlAdminReportSummaryConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['AdminReportSummaryEdge']>>> }>;
+  AdminReportSummaryEdge: ResolverTypeWrapper<Omit<GqlAdminReportSummaryEdge, 'node'> & { node?: Maybe<GqlResolversTypes['AdminReportSummaryRow']> }>;
+  AdminReportSummaryRow: ResolverTypeWrapper<Omit<GqlAdminReportSummaryRow, 'community' | 'lastPublishedReport'> & { community: GqlResolversTypes['Community'], lastPublishedReport?: Maybe<GqlResolversTypes['Report']> }>;
   ApproveReportPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['ApproveReportPayload']>;
   ApproveReportSuccess: ResolverTypeWrapper<Omit<GqlApproveReportSuccess, 'report'> & { report: GqlResolversTypes['Report'] }>;
   Article: ResolverTypeWrapper<Article>;
@@ -5464,8 +5565,12 @@ export type GqlResolversTypes = ResolversObject<{
   ReportFeedbacksConnection: ResolverTypeWrapper<Omit<GqlReportFeedbacksConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['ReportFeedbackEdge']>>> }>;
   ReportStatus: GqlReportStatus;
   ReportTemplate: ResolverTypeWrapper<Omit<GqlReportTemplate, 'community' | 'updatedByUser'> & { community?: Maybe<GqlResolversTypes['Community']>, updatedByUser?: Maybe<GqlResolversTypes['User']> }>;
+  ReportTemplateKind: GqlReportTemplateKind;
   ReportTemplateScope: GqlReportTemplateScope;
   ReportTemplateStats: ResolverTypeWrapper<GqlReportTemplateStats>;
+  ReportTemplateStatsBreakdownConnection: ResolverTypeWrapper<GqlReportTemplateStatsBreakdownConnection>;
+  ReportTemplateStatsBreakdownEdge: ResolverTypeWrapper<GqlReportTemplateStatsBreakdownEdge>;
+  ReportTemplateStatsBreakdownRow: ResolverTypeWrapper<GqlReportTemplateStatsBreakdownRow>;
   ReportVariant: GqlReportVariant;
   ReportsConnection: ResolverTypeWrapper<Omit<GqlReportsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['ReportEdge']>>> }>;
   Reservation: ResolverTypeWrapper<Omit<GqlReservation, 'createdByUser' | 'histories' | 'opportunitySlot' | 'participations'> & { createdByUser?: Maybe<GqlResolversTypes['User']>, histories?: Maybe<Array<GqlResolversTypes['ReservationHistory']>>, opportunitySlot?: Maybe<GqlResolversTypes['OpportunitySlot']>, participations?: Maybe<Array<GqlResolversTypes['Participation']>> }>;
@@ -5663,6 +5768,9 @@ export type GqlResolversTypes = ResolversObject<{
 /** Mapping between all available schema types and the resolvers parents */
 export type GqlResolversParentTypes = ResolversObject<{
   AccumulatedPointView: AccumulatedPointView;
+  AdminReportSummaryConnection: Omit<GqlAdminReportSummaryConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['AdminReportSummaryEdge']>>> };
+  AdminReportSummaryEdge: Omit<GqlAdminReportSummaryEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['AdminReportSummaryRow']> };
+  AdminReportSummaryRow: Omit<GqlAdminReportSummaryRow, 'community' | 'lastPublishedReport'> & { community: GqlResolversParentTypes['Community'], lastPublishedReport?: Maybe<GqlResolversParentTypes['Report']> };
   ApproveReportPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['ApproveReportPayload'];
   ApproveReportSuccess: Omit<GqlApproveReportSuccess, 'report'> & { report: GqlResolversParentTypes['Report'] };
   Article: Article;
@@ -5881,6 +5989,9 @@ export type GqlResolversParentTypes = ResolversObject<{
   ReportFeedbacksConnection: Omit<GqlReportFeedbacksConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['ReportFeedbackEdge']>>> };
   ReportTemplate: Omit<GqlReportTemplate, 'community' | 'updatedByUser'> & { community?: Maybe<GqlResolversParentTypes['Community']>, updatedByUser?: Maybe<GqlResolversParentTypes['User']> };
   ReportTemplateStats: GqlReportTemplateStats;
+  ReportTemplateStatsBreakdownConnection: GqlReportTemplateStatsBreakdownConnection;
+  ReportTemplateStatsBreakdownEdge: GqlReportTemplateStatsBreakdownEdge;
+  ReportTemplateStatsBreakdownRow: GqlReportTemplateStatsBreakdownRow;
   ReportsConnection: Omit<GqlReportsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['ReportEdge']>>> };
   Reservation: Omit<GqlReservation, 'createdByUser' | 'histories' | 'opportunitySlot' | 'participations'> & { createdByUser?: Maybe<GqlResolversParentTypes['User']>, histories?: Maybe<Array<GqlResolversParentTypes['ReservationHistory']>>, opportunitySlot?: Maybe<GqlResolversParentTypes['OpportunitySlot']>, participations?: Maybe<Array<GqlResolversParentTypes['Participation']>> };
   ReservationCancelInput: GqlReservationCancelInput;
@@ -6073,6 +6184,28 @@ export type GqlRequireRoleDirectiveResolver<Result, Parent, ContextType = any, A
 export type GqlAccumulatedPointViewResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AccumulatedPointView'] = GqlResolversParentTypes['AccumulatedPointView']> = ResolversObject<{
   accumulatedPoint?: Resolver<GqlResolversTypes['BigInt'], ParentType, ContextType>;
   walletId?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAdminReportSummaryConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AdminReportSummaryConnection'] = GqlResolversParentTypes['AdminReportSummaryConnection']> = ResolversObject<{
+  edges?: Resolver<Maybe<Array<Maybe<GqlResolversTypes['AdminReportSummaryEdge']>>>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAdminReportSummaryEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AdminReportSummaryEdge'] = GqlResolversParentTypes['AdminReportSummaryEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['AdminReportSummaryRow']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAdminReportSummaryRowResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AdminReportSummaryRow'] = GqlResolversParentTypes['AdminReportSummaryRow']> = ResolversObject<{
+  community?: Resolver<GqlResolversTypes['Community'], ParentType, ContextType>;
+  daysSinceLastPublish?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  lastPublishedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  lastPublishedReport?: Resolver<Maybe<GqlResolversTypes['Report']>, ParentType, ContextType>;
+  publishedCountLast90Days?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -6336,7 +6469,7 @@ export type GqlDidIssuanceRequestResolvers<ContextType = any, ParentType extends
 }>;
 
 export type GqlEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Edge'] = GqlResolversParentTypes['Edge']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'ArticleEdge' | 'CityEdge' | 'CommunityEdge' | 'EvaluationEdge' | 'EvaluationHistoryEdge' | 'IncentiveGrantEdge' | 'MembershipEdge' | 'NftInstanceEdge' | 'NftTokenEdge' | 'OpportunityEdge' | 'OpportunitySlotEdge' | 'ParticipationEdge' | 'ParticipationStatusHistoryEdge' | 'PlaceEdge' | 'PortfolioEdge' | 'ReportEdge' | 'ReportFeedbackEdge' | 'ReservationEdge' | 'ReservationHistoryEdge' | 'StateEdge' | 'TicketClaimLinkEdge' | 'TicketEdge' | 'TicketIssuerEdge' | 'TicketStatusHistoryEdge' | 'TransactionEdge' | 'UserEdge' | 'UtilityEdge' | 'VcIssuanceRequestEdge' | 'WalletEdge', ParentType, ContextType>;
+  __resolveType: TypeResolveFn<'AdminReportSummaryEdge' | 'ArticleEdge' | 'CityEdge' | 'CommunityEdge' | 'EvaluationEdge' | 'EvaluationHistoryEdge' | 'IncentiveGrantEdge' | 'MembershipEdge' | 'NftInstanceEdge' | 'NftTokenEdge' | 'OpportunityEdge' | 'OpportunitySlotEdge' | 'ParticipationEdge' | 'ParticipationStatusHistoryEdge' | 'PlaceEdge' | 'PortfolioEdge' | 'ReportEdge' | 'ReportFeedbackEdge' | 'ReportTemplateStatsBreakdownEdge' | 'ReservationEdge' | 'ReservationHistoryEdge' | 'StateEdge' | 'TicketClaimLinkEdge' | 'TicketEdge' | 'TicketIssuerEdge' | 'TicketStatusHistoryEdge' | 'TransactionEdge' | 'UserEdge' | 'UtilityEdge' | 'VcIssuanceRequestEdge' | 'WalletEdge', ParentType, ContextType>;
   cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
 }>;
 
@@ -7036,6 +7169,8 @@ export type GqlPublishReportSuccessResolvers<ContextType = any, ParentType exten
 }>;
 
 export type GqlQueryResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Query'] = GqlResolversParentTypes['Query']> = ResolversObject<{
+  adminBrowseReports?: Resolver<GqlResolversTypes['ReportsConnection'], ParentType, ContextType, Partial<GqlQueryAdminBrowseReportsArgs>>;
+  adminReportSummary?: Resolver<GqlResolversTypes['AdminReportSummaryConnection'], ParentType, ContextType, Partial<GqlQueryAdminReportSummaryArgs>>;
   article?: Resolver<Maybe<GqlResolversTypes['Article']>, ParentType, ContextType, RequireFields<GqlQueryArticleArgs, 'id' | 'permission'>>;
   articles?: Resolver<GqlResolversTypes['ArticlesConnection'], ParentType, ContextType, Partial<GqlQueryArticlesArgs>>;
   cities?: Resolver<GqlResolversTypes['CitiesConnection'], ParentType, ContextType, Partial<GqlQueryCitiesArgs>>;
@@ -7072,6 +7207,8 @@ export type GqlQueryResolvers<ContextType = any, ParentType extends GqlResolvers
   report?: Resolver<Maybe<GqlResolversTypes['Report']>, ParentType, ContextType, RequireFields<GqlQueryReportArgs, 'id'>>;
   reportTemplate?: Resolver<Maybe<GqlResolversTypes['ReportTemplate']>, ParentType, ContextType, RequireFields<GqlQueryReportTemplateArgs, 'variant'>>;
   reportTemplateStats?: Resolver<GqlResolversTypes['ReportTemplateStats'], ParentType, ContextType, RequireFields<GqlQueryReportTemplateStatsArgs, 'variant'>>;
+  reportTemplateStatsBreakdown?: Resolver<GqlResolversTypes['ReportTemplateStatsBreakdownConnection'], ParentType, ContextType, RequireFields<GqlQueryReportTemplateStatsBreakdownArgs, 'first' | 'includeInactive' | 'kind' | 'variant'>>;
+  reportTemplates?: Resolver<Array<GqlResolversTypes['ReportTemplate']>, ParentType, ContextType, RequireFields<GqlQueryReportTemplatesArgs, 'includeInactive' | 'kind' | 'variant'>>;
   reports?: Resolver<GqlResolversTypes['ReportsConnection'], ParentType, ContextType, RequireFields<GqlQueryReportsArgs, 'communityId' | 'permission'>>;
   reservation?: Resolver<Maybe<GqlResolversTypes['Reservation']>, ParentType, ContextType, RequireFields<GqlQueryReservationArgs, 'id'>>;
   reservationHistories?: Resolver<GqlResolversTypes['ReservationHistoriesConnection'], ParentType, ContextType, Partial<GqlQueryReservationHistoriesArgs>>;
@@ -7181,6 +7318,7 @@ export type GqlReportTemplateResolvers<ContextType = any, ParentType extends Gql
   id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
   isActive?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
   isEnabled?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  kind?: Resolver<GqlResolversTypes['ReportTemplateKind'], ParentType, ContextType>;
   maxTokens?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   model?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
   scope?: Resolver<GqlResolversTypes['ReportTemplateScope'], ParentType, ContextType>;
@@ -7204,6 +7342,36 @@ export type GqlReportTemplateStatsResolvers<ContextType = any, ParentType extend
   judgeHumanCorrelation?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
   variant?: Resolver<GqlResolversTypes['ReportVariant'], ParentType, ContextType>;
   version?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReportTemplateStatsBreakdownConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReportTemplateStatsBreakdownConnection'] = GqlResolversParentTypes['ReportTemplateStatsBreakdownConnection']> = ResolversObject<{
+  edges?: Resolver<Maybe<Array<Maybe<GqlResolversTypes['ReportTemplateStatsBreakdownEdge']>>>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReportTemplateStatsBreakdownEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReportTemplateStatsBreakdownEdge'] = GqlResolversParentTypes['ReportTemplateStatsBreakdownEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['ReportTemplateStatsBreakdownRow']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReportTemplateStatsBreakdownRowResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReportTemplateStatsBreakdownRow'] = GqlResolversParentTypes['ReportTemplateStatsBreakdownRow']> = ResolversObject<{
+  avgJudgeScore?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  avgRating?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  correlationWarning?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  experimentKey?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  feedbackCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  isActive?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  isEnabled?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  judgeHumanCorrelation?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  kind?: Resolver<GqlResolversTypes['ReportTemplateKind'], ParentType, ContextType>;
+  scope?: Resolver<GqlResolversTypes['ReportTemplateScope'], ParentType, ContextType>;
+  templateId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  trafficWeight?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  version?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -8083,6 +8251,9 @@ export type GqlWalletsConnectionResolvers<ContextType = any, ParentType extends 
 
 export type GqlResolvers<ContextType = any> = ResolversObject<{
   AccumulatedPointView?: GqlAccumulatedPointViewResolvers<ContextType>;
+  AdminReportSummaryConnection?: GqlAdminReportSummaryConnectionResolvers<ContextType>;
+  AdminReportSummaryEdge?: GqlAdminReportSummaryEdgeResolvers<ContextType>;
+  AdminReportSummaryRow?: GqlAdminReportSummaryRowResolvers<ContextType>;
   ApproveReportPayload?: GqlApproveReportPayloadResolvers<ContextType>;
   ApproveReportSuccess?: GqlApproveReportSuccessResolvers<ContextType>;
   Article?: GqlArticleResolvers<ContextType>;
@@ -8222,6 +8393,9 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   ReportFeedbacksConnection?: GqlReportFeedbacksConnectionResolvers<ContextType>;
   ReportTemplate?: GqlReportTemplateResolvers<ContextType>;
   ReportTemplateStats?: GqlReportTemplateStatsResolvers<ContextType>;
+  ReportTemplateStatsBreakdownConnection?: GqlReportTemplateStatsBreakdownConnectionResolvers<ContextType>;
+  ReportTemplateStatsBreakdownEdge?: GqlReportTemplateStatsBreakdownEdgeResolvers<ContextType>;
+  ReportTemplateStatsBreakdownRow?: GqlReportTemplateStatsBreakdownRowResolvers<ContextType>;
   ReportsConnection?: GqlReportsConnectionResolvers<ContextType>;
   Reservation?: GqlReservationResolvers<ContextType>;
   ReservationCreatePayload?: GqlReservationCreatePayloadResolvers<ContextType>;


### PR DESCRIPTION
## Summary

sysAdmin にレポート機能を統合する画面を支える backend query を 4 本追加。フロントの Phase 1 (テンプレート管理 UI) と Phase 2 (横断レポート観察) の両方を 1 PR にまとめてリリース。

### Phase 1: テンプレート管理 UI 用

- **`reportTemplates(variant, communityId?, kind?, includeInactive?)`** — 同一 variant に並列存在するテンプレート (A/B 候補 / 過去世代) の一覧。`reportTemplate` (単数) では見えなかった `templateSelector` の trafficWeight 抽選対象を admin UI に露出。`communityId=X` 指定時は SYSTEM ∪ COMMUNITY(X) を返却。
- **`reportTemplateStatsBreakdown(variant, version?, kind?, includeInactive?, cursor?, first?)`** — 各テンプレート世代 (= 1 prompt revision) ごとの品質指標 (avgRating / avgJudgeScore / Pearson 相関) を横並び比較する Connection。実験を頻繁に回す運用で variant あたり数百行に達する想定なので cursor pagination 対応 (`first: 20` default)。
- `ReportTemplate` 型に `kind: ReportTemplateKind!` field を追加。GENERATION / JUDGE を admin UI で識別できるように。

### Phase 2: sysAdmin 横断観察用

- **`adminBrowseReports(communityId?, status?, variant?, publishedAfter?, publishedBefore?, cursor?, first?)`** — `permission.communityId` 必須を外した community 横断レポート検索。`publishedAt DESC NULLS LAST, createdAt DESC` 順で DRAFT / SKIPPED 行が末尾に沈む。
- **`adminReportSummary(cursor?, first?)`** — community ごとの最終発行サマリ。`lastPublishedAt ASC NULLS FIRST` で発行が止まっている / 一度も発行されていない community を上位に。
- L1 軽量化のため `t_communities` に `last_published_report_at` / `last_published_report_id` を **denormalize 列として追加** (GraphQL `Community` 型には expose せず、`adminReportSummary` 内部利用のみ)。`Community` を読む既存 resolver の join コスト発生を回避。

### A-3: SUPERSEDED 遷移時の community pointer 同期

`publishReport` 後に `t_communities.last_published_report_id` を張替するだけだと、後で regenerate されて parent が PUBLISHED → SUPERSEDED に巻き込まれたとき pointer が古い行を指したままになる不整合があった。
共通 helper `recalculateCommunityLastPublished(communityId, tx)` を導入し、以下の両経路から呼ぶことで「常に最新の PUBLISHED 行を指す / 無ければ NULL」を担保:

- `publishReport`: status PUBLISHED 遷移後
- `supersedeParentIfRegenerating`: 親が **PUBLISHED** だったときのみ (DRAFT / APPROVED / SKIPPED は pointer 影響なし → 呼ばずスキップ)

### 構成

| Phase | 影響 |
|---|---|
| 1 | `reportTemplates` / `reportTemplateStatsBreakdown` 追加。DB migration なし |
| 2 | `adminBrowseReports` / `adminReportSummary` 追加。DB migration 1 本 (Report index + Community denormalize 列 + backfill) |
| A-3 | `publishReport` / `supersedeParentIfRegenerating` を拡張。新 helper 1 つ |

### 既存の認可・運用思想を維持

- 全 query `IsAdmin` rule (`SYS_ADMIN` pass)
- 編集 mutation は新設せず `updateReportTemplate` を据え置き (= 過去 / 非アクティブ行の編集は seed 投入経由のまま)
- JUDGE template の admin UI 露出は `kind` 引数のみで実現、内部 selector の SYSTEM-only 制約は変えていない

## Test plan

- [x] `pnpm test src/__tests__/unit/report` で全 113 テスト pass
- [x] feedback service の breakdown 経路テスト (3 件): per-template Pearson 独立計算 / < 3 ペアで null / pagination 引数の forwarding
- [x] usecase の A-3 動作テスト (5 件): `publishReport` で常時 recalc / PUBLISHED 親で recalc / DRAFT・APPROVED・SKIPPED 親で recalc 呼ばれない
- [x] usecase の Phase 1 + Phase 2 admin query テスト (5 件): kind default / JUDGE 透過 / filter forwarding / first clamp / cursor forwarding
- [x] `pnpm gql:generate` で型再生成完了 (新型 8 種確認: `GqlReportTemplateKind`, `GqlReportTemplateStatsBreakdownConnection`, `GqlAdminReportSummaryConnection` 等)
- [ ] ローカル / ステージング DB で migration 適用 + backfill 結果確認
- [ ] Apollo Sandbox で SYS_ADMIN トークンで 4 query を実叩き、認可と返却 shape 確認
- [ ] `adminReportSummary` で `publishReport` mutation 後に該当 community の pointer が同期更新されることを確認
- [ ] regenerate flow (PUBLISHED 親) で SUPERSEDED 遷移後 pointer が次の最新行に張替えされることを確認

https://claude.ai/code/session_011RjFw9SJxM1QLR8UfDowxe

---
_Generated by [Claude Code](https://claude.ai/code/session_011RjFw9SJxM1QLR8UfDowxe)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/931" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
