### PR TITLE
ci: run prisma migrate deploy in Cloud Run deploy workflows

### DIFF
--- a/.github/workflows/deploy-to-cloud-run-dev.yml
+++ b/.github/workflows/deploy-to-cloud-run-dev.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Set up gcloud SDK
       uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
 
-    - name: pnpm db:generate
+    - name: pnpm db:generate and db:deploy
       env:
         DATABASE_URL: postgresql://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
       run: |
@@ -85,6 +85,9 @@ jobs:
 
         echo "--- Running prisma generate ---"
         pnpm db:generate
+
+        echo "--- Running prisma migrate deploy ---"
+        pnpm db:deploy
 
         echo "Killing SSH tunnel"
         kill $SSH_PID

--- a/.github/workflows/deploy-to-cloud-run-prd.yml
+++ b/.github/workflows/deploy-to-cloud-run-prd.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Set up gcloud SDK
       uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
 
-    - name: pnpm db:generate
+    - name: pnpm db:generate and db:deploy
       env:
         DATABASE_URL: postgresql://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
       run: |
@@ -85,6 +85,9 @@ jobs:
 
         echo "--- Running prisma generate ---"
         pnpm db:generate
+
+        echo "--- Running prisma migrate deploy ---"
+        pnpm db:deploy
 
         echo "Killing SSH tunnel"
         kill $SSH_PID


### PR DESCRIPTION
## Summary
- dev / prd の Cloud Run デプロイ workflow に `pnpm db:deploy`(=`prisma migrate deploy`) を追加
- 既存の jumpbox SSH トンネル内で `pnpm db:generate` の直後に実行するため、新たな接続セットアップは不要
- アプリ本体の Cloud Run デプロイより前に走るため、マイグレーション失敗時はそこで止まり、新コードが旧スキーマの DB に当たらない

## Notes
- `:dev` / `:prd` サフィックスのスクリプトは `dotenvx run -f .env.dev|.env.prd` を経由するため CI 不可。GitHub Secrets から注入された `DATABASE_URL` で素の `pnpm db:deploy` を呼ぶ
- 後方互換のないマイグレーションを流す場合のロールバック計画はこの PR のスコープ外

## Test plan
- [ ] develop マージ後、dev workflow の `pnpm db:generate and db:deploy` ステップで `prisma migrate deploy` が成功することを確認
- [ ] 適用済みマイグレーションのみの場合に `No pending migrations to apply.` で正常終了することを確認
- [ ] master へのリリース時、prd workflow でも同様に動作することを確認

https://claude.ai/code/session_017P447yKQQYbr2xra32Dtuk

---
_Generated by [Claude Code](https://claude.ai/code/session_017P447yKQQYbr2xra32Dtuk)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/933" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
