### PR TITLE
feat(report): adminTemplateFeedbackStats query で template の feedback summary を追加

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -26,6 +26,12 @@ type AdminReportSummaryRow {
   publishedCountLast90Days: Int!
 }
 
+type AdminTemplateFeedbackStats {
+  avgRating: Float
+  ratingDistribution: [ReportFeedbackRatingBucket!]!
+  totalCount: Int!
+}
+
 union ApproveReportPayload = ApproveReportSuccess
 
 type ApproveReportSuccess {
@@ -1621,6 +1627,7 @@ enum PublishStatus {
 type Query {
   adminBrowseReports(communityId: ID, cursor: String, first: Int, publishedAfter: Datetime, publishedBefore: Datetime, status: ReportStatus, variant: ReportVariant): ReportsConnection!
   adminReportSummary(cursor: String, first: Int): AdminReportSummaryConnection!
+  adminTemplateFeedbackStats(kind: ReportTemplateKind = GENERATION, variant: ReportVariant!, version: Int): AdminTemplateFeedbackStats!
   adminTemplateFeedbacks(cursor: String, feedbackType: ReportFeedbackType, first: Int = 20, kind: ReportTemplateKind = GENERATION, maxRating: Int, variant: ReportVariant!, version: Int): ReportFeedbacksConnection!
   article(id: ID!, permission: CheckCommunityPermissionInput!): Article
   articles(cursor: String, filter: ArticleFilterInput, first: Int, sort: ArticleSortInput): ArticlesConnection!
@@ -1782,6 +1789,11 @@ type ReportFeedback {
 type ReportFeedbackEdge implements Edge {
   cursor: String!
   node: ReportFeedback
+}
+
+type ReportFeedbackRatingBucket {
+  count: Int!
+  rating: Int!
 }
 
 enum ReportFeedbackType {

--- a/src/__tests__/unit/report/feedback/feedbackService.test.ts
+++ b/src/__tests__/unit/report/feedback/feedbackService.test.ts
@@ -343,3 +343,74 @@ describe("pearsonCorrelation", () => {
     expect(r!).toBeLessThanOrEqual(1);
   });
 });
+
+describe("ReportFeedbackService.getAdminTemplateFeedbackStats", () => {
+  const fakeCtx = {} as IContext;
+
+  let repository: {
+    createFeedback: jest.Mock;
+    findFeedbackByReportAndUser: jest.Mock;
+    findFeedbacksByReport: jest.Mock;
+    findFeedbacksByReportIds: jest.Mock;
+    getTemplateFeedbackAggregates: jest.Mock;
+    getTemplateBreakdown: jest.Mock;
+    findAdminTemplateFeedbacks: jest.Mock;
+    getAdminTemplateFeedbackStats: jest.Mock;
+  };
+  let service: ReportFeedbackService;
+
+  beforeEach(() => {
+    container.reset();
+    repository = {
+      createFeedback: jest.fn(),
+      findFeedbackByReportAndUser: jest.fn(),
+      findFeedbacksByReport: jest.fn(),
+      findFeedbacksByReportIds: jest.fn(),
+      getTemplateFeedbackAggregates: jest.fn(),
+      getTemplateBreakdown: jest.fn(),
+      findAdminTemplateFeedbacks: jest.fn(),
+      getAdminTemplateFeedbackStats: jest
+        .fn()
+        .mockResolvedValue({ totalCount: 0, avgRating: null, buckets: [] }),
+    };
+    container.register("ReportFeedbackRepository", { useValue: repository });
+    service = container.resolve(ReportFeedbackService);
+  });
+
+  it("forwards variant / version / kind to the repository unchanged", async () => {
+    // Pure pass-through path — the densification / Pearson math
+    // happens in the presenter, not here. Pin the contract so a
+    // future refactor cannot silently drop one of the three filter
+    // dimensions.
+    await service.getAdminTemplateFeedbackStats(fakeCtx, {
+      variant: "WEEKLY_SUMMARY",
+      version: 4,
+      kind: ReportTemplateKind.JUDGE,
+    });
+
+    expect(repository.getAdminTemplateFeedbackStats).toHaveBeenCalledWith(fakeCtx, {
+      variant: "WEEKLY_SUMMARY",
+      version: 4,
+      kind: ReportTemplateKind.JUDGE,
+    });
+  });
+
+  it("returns the repository row unchanged (no derived math at this layer)", async () => {
+    repository.getAdminTemplateFeedbackStats.mockResolvedValue({
+      totalCount: 3,
+      avgRating: 4.0,
+      buckets: [
+        { rating: 3, count: 1 },
+        { rating: 5, count: 2 },
+      ],
+    });
+
+    const result = await service.getAdminTemplateFeedbackStats(fakeCtx, {
+      variant: "WEEKLY_SUMMARY",
+      kind: ReportTemplateKind.GENERATION,
+    });
+    expect(result.totalCount).toBe(3);
+    expect(result.avgRating).toBe(4.0);
+    expect(result.buckets).toHaveLength(2);
+  });
+});

--- a/src/__tests__/unit/report/feedback/feedbackUsecase.test.ts
+++ b/src/__tests__/unit/report/feedback/feedbackUsecase.test.ts
@@ -301,3 +301,110 @@ describe("ReportFeedbackUseCase.viewAdminTemplateFeedbacks", () => {
     expect(result.pageInfo.hasNextPage).toBe(false);
   });
 });
+
+/**
+ * Phase 1.5 admin: population stats summary endpoint. The usecase is
+ * the input-validation seam (positive `version`) and a thin
+ * service+presenter pass-through. These tests pin the validation
+ * contract, the argument shape that flows into the service (no
+ * `feedbackType` / `maxRating`), and the dense 1..5 distribution
+ * shape on the way out.
+ */
+describe("ReportFeedbackUseCase.viewAdminTemplateFeedbackStats", () => {
+  const fakeCtx = {} as IContext;
+
+  let feedbackService: { getAdminTemplateFeedbackStats: jest.Mock };
+  let reportService: { getReportById: jest.Mock };
+  let usecase: ReportFeedbackUseCase;
+
+  beforeEach(() => {
+    container.reset();
+    feedbackService = {
+      getAdminTemplateFeedbackStats: jest.fn().mockResolvedValue({
+        totalCount: 0,
+        avgRating: null,
+        buckets: [],
+      }),
+    };
+    reportService = { getReportById: jest.fn() };
+    container.register("ReportFeedbackService", { useValue: feedbackService });
+    container.register("ReportService", { useValue: reportService });
+    usecase = container.resolve(ReportFeedbackUseCase);
+  });
+
+  function defaultArgs(): Parameters<
+    ReportFeedbackUseCase["viewAdminTemplateFeedbackStats"]
+  >[0] {
+    return { variant: GqlReportVariant.WeeklySummary };
+  }
+
+  it("forwards variant / version / kind to the service unchanged", async () => {
+    await usecase.viewAdminTemplateFeedbackStats(
+      {
+        variant: GqlReportVariant.WeeklySummary,
+        version: 2,
+        kind: ReportTemplateKind.GENERATION,
+      },
+      fakeCtx,
+    );
+    expect(feedbackService.getAdminTemplateFeedbackStats).toHaveBeenCalledWith(fakeCtx, {
+      variant: "WEEKLY_SUMMARY",
+      version: 2,
+      kind: ReportTemplateKind.GENERATION,
+    });
+  });
+
+  it("defaults kind to GENERATION when the caller omits it", async () => {
+    await usecase.viewAdminTemplateFeedbackStats(defaultArgs(), fakeCtx);
+    expect(feedbackService.getAdminTemplateFeedbackStats).toHaveBeenCalledWith(
+      fakeCtx,
+      expect.objectContaining({ kind: ReportTemplateKind.GENERATION }),
+    );
+  });
+
+  it.each([0, -1, 1.5])(
+    "rejects version=%s with ValidationError (not a positive integer)",
+    async (version) => {
+      await expect(
+        usecase.viewAdminTemplateFeedbackStats(
+          { ...defaultArgs(), version: version as number },
+          fakeCtx,
+        ),
+      ).rejects.toThrow(/version/);
+      expect(feedbackService.getAdminTemplateFeedbackStats).not.toHaveBeenCalled();
+    },
+  );
+
+  it("returns dense 1..5 distribution with totalCount + avgRating", async () => {
+    // Sparse repository result: ratings 1, 3, 5 only. Presenter must
+    // pad to dense five-row 1..5 with count: 0 for missing buckets.
+    feedbackService.getAdminTemplateFeedbackStats.mockResolvedValue({
+      totalCount: 6,
+      avgRating: 3.0,
+      buckets: [
+        { rating: 1, count: 1 },
+        { rating: 3, count: 4 },
+        { rating: 5, count: 1 },
+      ],
+    });
+
+    const result = await usecase.viewAdminTemplateFeedbackStats(defaultArgs(), fakeCtx);
+
+    expect(result.totalCount).toBe(6);
+    expect(result.avgRating).toBe(3.0);
+    expect(result.ratingDistribution).toHaveLength(5);
+    expect(result.ratingDistribution.map((b) => b.rating)).toEqual([1, 2, 3, 4, 5]);
+    expect(result.ratingDistribution.map((b) => b.count)).toEqual([1, 0, 4, 0, 1]);
+  });
+
+  it("returns avgRating: null and a 5-row zero-count distribution when no feedback exists", async () => {
+    // Empty population — schema contract: avgRating null, but the
+    // distribution is still a dense five-row array (the bar
+    // renders five empty bars rather than vanishing).
+    const result = await usecase.viewAdminTemplateFeedbackStats(defaultArgs(), fakeCtx);
+    expect(result.totalCount).toBe(0);
+    expect(result.avgRating).toBeNull();
+    expect(result.ratingDistribution).toHaveLength(5);
+    expect(result.ratingDistribution.every((b) => b.count === 0)).toBe(true);
+  });
+});

--- a/src/application/domain/report/feedback/controller/resolver.ts
+++ b/src/application/domain/report/feedback/controller/resolver.ts
@@ -6,6 +6,7 @@ import {
   GqlQueryReportTemplateStatsArgs,
   GqlQueryReportTemplateStatsBreakdownArgs,
   GqlQueryAdminTemplateFeedbacksArgs,
+  GqlQueryAdminTemplateFeedbackStatsArgs,
 } from "@/types/graphql";
 import { PrismaReport } from "@/application/domain/report/data/type";
 import { PrismaReportFeedback } from "@/application/domain/report/feedback/data/type";
@@ -31,6 +32,13 @@ export default class ReportFeedbackResolver {
       ctx: IContext,
     ) => {
       return this.useCase.viewAdminTemplateFeedbacks(args, ctx);
+    },
+    adminTemplateFeedbackStats: (
+      _: unknown,
+      args: GqlQueryAdminTemplateFeedbackStatsArgs,
+      ctx: IContext,
+    ) => {
+      return this.useCase.viewAdminTemplateFeedbackStats(args, ctx);
     },
   };
 

--- a/src/application/domain/report/feedback/data/interface.ts
+++ b/src/application/domain/report/feedback/data/interface.ts
@@ -4,6 +4,7 @@ import {
   PrismaReportFeedback,
   TemplateBreakdownRow,
   JudgeFeedbackPairRow,
+  AdminTemplateFeedbackStatsRow,
 } from "@/application/domain/report/feedback/data/type";
 
 export { JudgeFeedbackPairRow };
@@ -116,4 +117,22 @@ export interface IReportFeedbackRepository {
       first: number;
     },
   ): Promise<{ items: PrismaReportFeedback[]; totalCount: number }>;
+
+  /**
+   * Phase 1.5 admin: aggregate stats over the same template scope as
+   * `findAdminTemplateFeedbacks` but without the row-level
+   * `feedbackType` / `maxRating` filters — the population stats power
+   * a "Customer Reviews"-style summary that must reflect the full
+   * 1..5 spread. Returns total count, mean rating (null when no
+   * observations), and a sparse bucket list (zero-count ratings
+   * omitted; the presenter densifies to 1..5).
+   */
+  getAdminTemplateFeedbackStats(
+    ctx: IContext,
+    params: {
+      variant: string;
+      version?: number;
+      kind: ReportTemplateKind;
+    },
+  ): Promise<AdminTemplateFeedbackStatsRow>;
 }

--- a/src/application/domain/report/feedback/data/repository.ts
+++ b/src/application/domain/report/feedback/data/repository.ts
@@ -477,11 +477,21 @@ export default class ReportFeedbackRepository implements IReportFeedbackReposito
         rating: Number(r.rating),
         count: Number(r.count),
       }));
-      const totalCount = buckets.reduce((sum, b) => sum + b.count, 0);
-      const avgRating =
-        totalCount === 0
-          ? null
-          : buckets.reduce((sum, b) => sum + b.rating * b.count, 0) / totalCount;
+      // Single-pass accumulation of `totalCount` + `weightedSum`. The
+      // bucket array is at most five rows (rating 1..5), so the
+      // single-pass form is functionally equivalent to two separate
+      // reduces — kept here mainly because the combined reducer reads
+      // as one "compute both totals" intent rather than two
+      // independent passes.
+      const { totalCount, weightedSum } = buckets.reduce(
+        (acc, b) => {
+          acc.totalCount += b.count;
+          acc.weightedSum += b.rating * b.count;
+          return acc;
+        },
+        { totalCount: 0, weightedSum: 0 },
+      );
+      const avgRating = totalCount === 0 ? null : weightedSum / totalCount;
 
       return { totalCount, avgRating, buckets };
     });

--- a/src/application/domain/report/feedback/data/repository.ts
+++ b/src/application/domain/report/feedback/data/repository.ts
@@ -10,6 +10,7 @@ import {
   reportFeedbackSelect,
   JudgeFeedbackPairRow,
   TemplateBreakdownRow,
+  AdminTemplateFeedbackStatsRow,
 } from "@/application/domain/report/feedback/data/type";
 
 @injectable()
@@ -422,6 +423,67 @@ export default class ReportFeedbackRepository implements IReportFeedbackReposito
       ]);
 
       return { items, totalCount };
+    });
+  }
+
+  /**
+   * Phase 1.5 admin: population stats for a template's feedback —
+   * total count, mean rating, and a per-rating bucket list. The
+   * rating distribution is the headline output: a single SQL pass
+   * computes both the AVG and the GROUP BY rating histogram so the
+   * caller does not pay the join cost twice.
+   *
+   * `t_reports.template_id` is index-served (`idx_t_reports_template_id`),
+   * so the join from `t_report_templates` resolves to a small
+   * `template_id IN (...)` set without a t_reports seq scan.
+   *
+   * Authorization: `internal` issuer mirrors the rest of the
+   * `IsAdmin`-gated admin paths (`findAdminTemplateFeedbacks`,
+   * `getTemplateBreakdown`) so SYS_ADMIN sessions are not implicitly
+   * filtered to their own community memberships.
+   */
+  async getAdminTemplateFeedbackStats(
+    ctx: IContext,
+    params: { variant: string; version?: number; kind: ReportTemplateKind },
+  ): Promise<AdminTemplateFeedbackStatsRow> {
+    return ctx.issuer.internal(async (tx) => {
+      // INNER JOIN on the templates table is intentional — feedback
+      // rows whose Report has no `template_id` (legacy rows from
+      // before PR-F3) are excluded. The query is admin-scope only,
+      // and its purpose is "stats for a *specific* template", so a
+      // null-template row carries no signal here.
+      const rows = await tx.$queryRaw<
+        { rating: number; count: bigint }[]
+      >`
+        SELECT
+          f."rating"::int AS "rating",
+          COUNT(*)::bigint AS "count"
+        FROM "t_report_feedbacks" f
+        INNER JOIN "t_reports" r ON r."id" = f."report_id"
+        INNER JOIN "t_report_templates" t ON t."id" = r."template_id"
+        WHERE t."variant" = ${params.variant}
+          AND t."kind"::text = ${params.kind}
+          ${params.version !== undefined ? Prisma.sql`AND t."version" = ${params.version}` : Prisma.empty}
+        GROUP BY f."rating"
+      `;
+
+      // Derive total count + weighted average from the bucket rows
+      // rather than issuing a second SELECT — the buckets already
+      // carry every observation. `avgRating` is null when there are
+      // no observations, mirroring the GraphQL schema's nullable
+      // `avgRating: Float` (a 0 average would falsely imply "every
+      // reviewer scored 0", which is not even a legal value).
+      const buckets = rows.map((r) => ({
+        rating: Number(r.rating),
+        count: Number(r.count),
+      }));
+      const totalCount = buckets.reduce((sum, b) => sum + b.count, 0);
+      const avgRating =
+        totalCount === 0
+          ? null
+          : buckets.reduce((sum, b) => sum + b.rating * b.count, 0) / totalCount;
+
+      return { totalCount, avgRating, buckets };
     });
   }
 }

--- a/src/application/domain/report/feedback/data/type.ts
+++ b/src/application/domain/report/feedback/data/type.ts
@@ -63,6 +63,21 @@ export interface JudgeFeedbackPairRow {
  * `judgeHumanCorrelation`. Templates with no Reports / no feedback
  * still appear here (LEFT JOIN-driven) with `feedbackCount: 0`.
  */
+/**
+ * Repository-level row for `adminTemplateFeedbackStats`. `buckets` is
+ * sparse (zero-count ratings omitted) — the presenter pads it to a
+ * dense 1..5 shape before crossing the GraphQL boundary so the wire
+ * format matches the documented "always five entries" contract. Keeping
+ * the dense fill in the presenter rather than the SQL keeps the raw
+ * aggregate cheap (`COUNT(*) GROUP BY rating` returns at most five
+ * rows; padding with the schema-driven enum at the edge is trivial).
+ */
+export interface AdminTemplateFeedbackStatsRow {
+  totalCount: number;
+  avgRating: number | null;
+  buckets: Array<{ rating: number; count: number }>;
+}
+
 export interface TemplateBreakdownRow {
   templateId: string;
   version: number;

--- a/src/application/domain/report/feedback/data/type.ts
+++ b/src/application/domain/report/feedback/data/type.ts
@@ -63,21 +63,6 @@ export interface JudgeFeedbackPairRow {
  * `judgeHumanCorrelation`. Templates with no Reports / no feedback
  * still appear here (LEFT JOIN-driven) with `feedbackCount: 0`.
  */
-/**
- * Repository-level row for `adminTemplateFeedbackStats`. `buckets` is
- * sparse (zero-count ratings omitted) — the presenter pads it to a
- * dense 1..5 shape before crossing the GraphQL boundary so the wire
- * format matches the documented "always five entries" contract. Keeping
- * the dense fill in the presenter rather than the SQL keeps the raw
- * aggregate cheap (`COUNT(*) GROUP BY rating` returns at most five
- * rows; padding with the schema-driven enum at the edge is trivial).
- */
-export interface AdminTemplateFeedbackStatsRow {
-  totalCount: number;
-  avgRating: number | null;
-  buckets: Array<{ rating: number; count: number }>;
-}
-
 export interface TemplateBreakdownRow {
   templateId: string;
   version: number;
@@ -91,4 +76,19 @@ export interface TemplateBreakdownRow {
   avgRating: number | null;
   avgJudgeScore: number | null;
   pairs: JudgeFeedbackPairRow[];
+}
+
+/**
+ * Repository-level row for `adminTemplateFeedbackStats`. `buckets` is
+ * sparse (zero-count ratings omitted) — the presenter pads it to a
+ * dense 1..5 shape before crossing the GraphQL boundary so the wire
+ * format matches the documented "always five entries" contract. Keeping
+ * the dense fill in the presenter rather than the SQL keeps the raw
+ * aggregate cheap (`COUNT(*) GROUP BY rating` returns at most five
+ * rows; padding with the schema-driven enum at the edge is trivial).
+ */
+export interface AdminTemplateFeedbackStatsRow {
+  totalCount: number;
+  avgRating: number | null;
+  buckets: Array<{ rating: number; count: number }>;
 }

--- a/src/application/domain/report/feedback/presenter.ts
+++ b/src/application/domain/report/feedback/presenter.ts
@@ -7,12 +7,22 @@ import {
   GqlReportTemplateKind,
   GqlReportTemplateStatsBreakdownRow,
   GqlReportTemplateStatsBreakdownConnection,
+  GqlAdminTemplateFeedbackStats,
 } from "@/types/graphql";
 import {
   PrismaReportFeedback,
   ReportTemplateStatsRow,
   TemplateBreakdownRow,
+  AdminTemplateFeedbackStatsRow,
 } from "@/application/domain/report/feedback/data/type";
+
+/**
+ * Rating axis for `adminTemplateFeedbackStats`. Hard-coded rather than
+ * derived from a runtime collection because the rating CHECK
+ * constraint pins the legal range to integers 1..5; widening this
+ * would require a coordinated DB migration anyway.
+ */
+const FEEDBACK_RATING_VALUES: ReadonlyArray<number> = [1, 2, 3, 4, 5];
 
 export default class ReportFeedbackPresenter {
   // `user` is resolved by a field resolver via the existing user
@@ -122,6 +132,32 @@ export default class ReportFeedbackPresenter {
         endCursor: page[page.length - 1]?.templateId ?? null,
       },
       totalCount,
+    };
+  }
+
+  /**
+   * Densify the repository's sparse bucket list into the documented
+   * 1..5 wire format. The SQL `GROUP BY rating` only emits ratings
+   * that actually have observations, so we walk the canonical
+   * rating axis and fill missing entries with `count: 0`. The
+   * frontend can then render the distribution bar without padding
+   * the array client-side.
+   *
+   * Ordering is `rating` ASC so consumers can render the bar from
+   * 1★ → 5★ (or reverse it deterministically) without a sort step.
+   */
+  static adminTemplateFeedbackStats(
+    row: AdminTemplateFeedbackStatsRow,
+  ): GqlAdminTemplateFeedbackStats {
+    const countByRating = new Map(row.buckets.map((b) => [b.rating, b.count]));
+    const ratingDistribution = FEEDBACK_RATING_VALUES.map((rating) => ({
+      rating,
+      count: countByRating.get(rating) ?? 0,
+    }));
+    return {
+      totalCount: row.totalCount,
+      avgRating: row.avgRating,
+      ratingDistribution,
     };
   }
 }

--- a/src/application/domain/report/feedback/service.ts
+++ b/src/application/domain/report/feedback/service.ts
@@ -10,6 +10,7 @@ import {
   ReportTemplateStatsRow,
   TemplateBreakdownRow,
   JudgeFeedbackPairRow,
+  AdminTemplateFeedbackStatsRow,
 } from "@/application/domain/report/feedback/data/type";
 
 /**
@@ -106,6 +107,19 @@ export default class ReportFeedbackService {
    * the same way (3-pair minimum, 0.7 threshold) — admins get
    * comparable signals across the aggregate KPI and the breakdown.
    */
+  /**
+   * Phase 1.5 admin: population stats for a template's feedback set.
+   * Pure pass-through to the repository — no derived math at this
+   * layer (the SQL already returns total / mean / buckets in one
+   * pass). The presenter handles the dense 1..5 bucket fill.
+   */
+  async getAdminTemplateFeedbackStats(
+    ctx: IContext,
+    params: { variant: string; version?: number; kind: ReportTemplateKind },
+  ): Promise<AdminTemplateFeedbackStatsRow> {
+    return this.repository.getAdminTemplateFeedbackStats(ctx, params);
+  }
+
   /**
    * Phase 1.5 admin: review-style individual feedback list scoped to
    * a template. Pure pass-through to the repository — no Pearson /

--- a/src/application/domain/report/feedback/service.ts
+++ b/src/application/domain/report/feedback/service.ts
@@ -107,40 +107,6 @@ export default class ReportFeedbackService {
    * the same way (3-pair minimum, 0.7 threshold) — admins get
    * comparable signals across the aggregate KPI and the breakdown.
    */
-  /**
-   * Phase 1.5 admin: population stats for a template's feedback set.
-   * Pure pass-through to the repository — no derived math at this
-   * layer (the SQL already returns total / mean / buckets in one
-   * pass). The presenter handles the dense 1..5 bucket fill.
-   */
-  async getAdminTemplateFeedbackStats(
-    ctx: IContext,
-    params: { variant: string; version?: number; kind: ReportTemplateKind },
-  ): Promise<AdminTemplateFeedbackStatsRow> {
-    return this.repository.getAdminTemplateFeedbackStats(ctx, params);
-  }
-
-  /**
-   * Phase 1.5 admin: review-style individual feedback list scoped to
-   * a template. Pure pass-through to the repository — no Pearson /
-   * threshold math on this path because the screen renders raw
-   * comments, not derived correlations.
-   */
-  async listAdminTemplateFeedbacks(
-    ctx: IContext,
-    params: {
-      variant: string;
-      version?: number;
-      kind: ReportTemplateKind;
-      feedbackType?: FeedbackType;
-      maxRating?: number;
-      cursor?: string;
-      first: number;
-    },
-  ): Promise<{ items: PrismaReportFeedback[]; totalCount: number }> {
-    return this.repository.findAdminTemplateFeedbacks(ctx, params);
-  }
-
   async getTemplateBreakdown(
     ctx: IContext,
     params: {
@@ -168,6 +134,40 @@ export default class ReportFeedbackService {
       }),
       totalCount: result.totalCount,
     };
+  }
+
+  /**
+   * Phase 1.5 admin: review-style individual feedback list scoped to
+   * a template. Pure pass-through to the repository — no Pearson /
+   * threshold math on this path because the screen renders raw
+   * comments, not derived correlations.
+   */
+  async listAdminTemplateFeedbacks(
+    ctx: IContext,
+    params: {
+      variant: string;
+      version?: number;
+      kind: ReportTemplateKind;
+      feedbackType?: FeedbackType;
+      maxRating?: number;
+      cursor?: string;
+      first: number;
+    },
+  ): Promise<{ items: PrismaReportFeedback[]; totalCount: number }> {
+    return this.repository.findAdminTemplateFeedbacks(ctx, params);
+  }
+
+  /**
+   * Phase 1.5 admin: population stats for a template's feedback set.
+   * Pure pass-through to the repository — no derived math at this
+   * layer (the SQL already returns total / mean / buckets in one
+   * pass). The presenter handles the dense 1..5 bucket fill.
+   */
+  async getAdminTemplateFeedbackStats(
+    ctx: IContext,
+    params: { variant: string; version?: number; kind: ReportTemplateKind },
+  ): Promise<AdminTemplateFeedbackStatsRow> {
+    return this.repository.getAdminTemplateFeedbackStats(ctx, params);
   }
 }
 

--- a/src/application/domain/report/feedback/usecase.ts
+++ b/src/application/domain/report/feedback/usecase.ts
@@ -14,6 +14,8 @@ import {
   GqlReportTemplateStatsBreakdownConnection,
   GqlQueryAdminTemplateFeedbacksArgs,
   GqlReportFeedbacksConnection,
+  GqlQueryAdminTemplateFeedbackStatsArgs,
+  GqlAdminTemplateFeedbackStats,
 } from "@/types/graphql";
 
 const MAX_FEEDBACKS_PER_PAGE = 100;
@@ -261,6 +263,35 @@ export default class ReportFeedbackUseCase {
       first,
     });
     return ReportFeedbackPresenter.connection(result.items, result.totalCount, first);
+  }
+
+  /**
+   * Phase 1.5 admin: population stats paired with
+   * `adminTemplateFeedbacks` for the template detail page summary
+   * card. Argument scope is intentionally narrower than the list
+   * query — `feedbackType` / `maxRating` are not accepted because a
+   * filtered distribution defeats the bar's purpose. Authorization
+   * is enforced upstream by `@authz IsAdmin` on the GraphQL query;
+   * the usecase trusts the directive.
+   *
+   * Validation mirrors the list path's `version` check: `version`
+   * (when present) must be a positive integer. The DB would return
+   * an empty stats object for a negative version silently, masking
+   * the input bug.
+   */
+  async viewAdminTemplateFeedbackStats(
+    args: GqlQueryAdminTemplateFeedbackStatsArgs,
+    ctx: IContext,
+  ): Promise<GqlAdminTemplateFeedbackStats> {
+    if (args.version !== undefined && args.version !== null) {
+      validateInt(args.version, 1, Number.MAX_SAFE_INTEGER, "version");
+    }
+    const row = await this.feedbackService.getAdminTemplateFeedbackStats(ctx, {
+      variant: args.variant,
+      version: args.version ?? undefined,
+      kind: args.kind ?? ReportTemplateKind.GENERATION,
+    });
+    return ReportFeedbackPresenter.adminTemplateFeedbackStats(row);
   }
 
   // Field-resolver helper used by `Report.feedbacks`. `Report.myFeedback`

--- a/src/application/domain/report/schema/query.graphql
+++ b/src/application/domain/report/schema/query.graphql
@@ -84,6 +84,27 @@ extend type Query {
     first: Int = 20
   ): ReportFeedbacksConnection! @authz(rules: [IsAdmin])
 
+  # Phase 1.5 sysAdmin: aggregate stats for a template's feedback set,
+  # rendered as a "Customer Reviews"-style summary (avg rating + total
+  # count + 1..5 distribution bar) on the template detail page.
+  # `adminTemplateFeedbacks` returns the paginated list; this query
+  # returns the **population** stats so the summary stays meaningful
+  # regardless of the page the caller is on.
+  #
+  # Argument scope is intentionally narrower than the list query:
+  # `feedbackType` and `maxRating` are NOT accepted here. Reflecting
+  # them would collapse the distribution into a sliver of the rating
+  # axis (e.g. `maxRating: 3` would always show the bar empty above
+  # 3★), which defeats the bar's purpose of showing where reviews
+  # actually fall across the full 1..5 spectrum. The frontend pairs
+  # this query with the list query in parallel from a single filter
+  # object so `variant` / `version` / `kind` stay in lock-step.
+  adminTemplateFeedbackStats(
+    variant: ReportVariant!
+    version: Int
+    kind: ReportTemplateKind = GENERATION
+  ): AdminTemplateFeedbackStats! @authz(rules: [IsAdmin])
+
   # Phase 2 sysAdmin: cross-community report search. Same shape as
   # `reports` but `permission` is dropped — IsAdmin alone gates access.
   # Order is `publishedAt DESC NULLS LAST, createdAt DESC` so DRAFT /

--- a/src/application/domain/report/schema/type.graphql
+++ b/src/application/domain/report/schema/type.graphql
@@ -258,6 +258,23 @@ type ReportTemplateStatsBreakdownConnection {
   totalCount: Int!
 }
 
+# Phase 1.5 sysAdmin: "Customer Reviews"-style summary of a template's
+# feedback population (paired with `adminTemplateFeedbacks`).
+# `avgRating` is null when `totalCount = 0` (no observations to average).
+# `ratingDistribution` is always emitted **dense** with five entries
+# (rating 1..5), filling absent ratings with `count: 0` so the UI can
+# render the distribution bar without padding the array client-side.
+type AdminTemplateFeedbackStats {
+  totalCount: Int!
+  avgRating: Float
+  ratingDistribution: [ReportFeedbackRatingBucket!]!
+}
+
+type ReportFeedbackRatingBucket {
+  rating: Int!
+  count: Int!
+}
+
 # Phase 2 sysAdmin L1: per-community last-publish summary. `community`
 # / `lastPublishedReport` are resolved via the existing dataloaders,
 # so a 50-row page issues at most two batched lookups regardless of

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -51,6 +51,13 @@ export type GqlAdminReportSummaryRow = {
   publishedCountLast90Days: Scalars['Int']['output'];
 };
 
+export type GqlAdminTemplateFeedbackStats = {
+  __typename?: 'AdminTemplateFeedbackStats';
+  avgRating?: Maybe<Scalars['Float']['output']>;
+  ratingDistribution: Array<GqlReportFeedbackRatingBucket>;
+  totalCount: Scalars['Int']['output'];
+};
+
 export type GqlApproveReportPayload = GqlApproveReportSuccess;
 
 export type GqlApproveReportSuccess = {
@@ -2160,6 +2167,7 @@ export type GqlQuery = {
   __typename?: 'Query';
   adminBrowseReports: GqlReportsConnection;
   adminReportSummary: GqlAdminReportSummaryConnection;
+  adminTemplateFeedbackStats: GqlAdminTemplateFeedbackStats;
   adminTemplateFeedbacks: GqlReportFeedbacksConnection;
   article?: Maybe<GqlArticle>;
   articles: GqlArticlesConnection;
@@ -2276,6 +2284,13 @@ export type GqlQueryAdminBrowseReportsArgs = {
 export type GqlQueryAdminReportSummaryArgs = {
   cursor?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type GqlQueryAdminTemplateFeedbackStatsArgs = {
+  kind?: InputMaybe<GqlReportTemplateKind>;
+  variant: GqlReportVariant;
+  version?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -2779,6 +2794,12 @@ export type GqlReportFeedbackEdge = GqlEdge & {
   __typename?: 'ReportFeedbackEdge';
   cursor: Scalars['String']['output'];
   node?: Maybe<GqlReportFeedback>;
+};
+
+export type GqlReportFeedbackRatingBucket = {
+  __typename?: 'ReportFeedbackRatingBucket';
+  count: Scalars['Int']['output'];
+  rating: Scalars['Int']['output'];
 };
 
 export const GqlReportFeedbackType = {
@@ -5351,6 +5372,7 @@ export type GqlResolversTypes = ResolversObject<{
   AdminReportSummaryConnection: ResolverTypeWrapper<Omit<GqlAdminReportSummaryConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['AdminReportSummaryEdge']>>> }>;
   AdminReportSummaryEdge: ResolverTypeWrapper<Omit<GqlAdminReportSummaryEdge, 'node'> & { node?: Maybe<GqlResolversTypes['AdminReportSummaryRow']> }>;
   AdminReportSummaryRow: ResolverTypeWrapper<Omit<GqlAdminReportSummaryRow, 'community' | 'lastPublishedReport'> & { community: GqlResolversTypes['Community'], lastPublishedReport?: Maybe<GqlResolversTypes['Report']> }>;
+  AdminTemplateFeedbackStats: ResolverTypeWrapper<GqlAdminTemplateFeedbackStats>;
   ApproveReportPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['ApproveReportPayload']>;
   ApproveReportSuccess: ResolverTypeWrapper<Omit<GqlApproveReportSuccess, 'report'> & { report: GqlResolversTypes['Report'] }>;
   Article: ResolverTypeWrapper<Article>;
@@ -5590,6 +5612,7 @@ export type GqlResolversTypes = ResolversObject<{
   ReportEdge: ResolverTypeWrapper<Omit<GqlReportEdge, 'node'> & { node?: Maybe<GqlResolversTypes['Report']> }>;
   ReportFeedback: ResolverTypeWrapper<Omit<GqlReportFeedback, 'report' | 'user'> & { report: GqlResolversTypes['Report'], user: GqlResolversTypes['User'] }>;
   ReportFeedbackEdge: ResolverTypeWrapper<Omit<GqlReportFeedbackEdge, 'node'> & { node?: Maybe<GqlResolversTypes['ReportFeedback']> }>;
+  ReportFeedbackRatingBucket: ResolverTypeWrapper<GqlReportFeedbackRatingBucket>;
   ReportFeedbackType: GqlReportFeedbackType;
   ReportFeedbacksConnection: ResolverTypeWrapper<Omit<GqlReportFeedbacksConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['ReportFeedbackEdge']>>> }>;
   ReportStatus: GqlReportStatus;
@@ -5800,6 +5823,7 @@ export type GqlResolversParentTypes = ResolversObject<{
   AdminReportSummaryConnection: Omit<GqlAdminReportSummaryConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['AdminReportSummaryEdge']>>> };
   AdminReportSummaryEdge: Omit<GqlAdminReportSummaryEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['AdminReportSummaryRow']> };
   AdminReportSummaryRow: Omit<GqlAdminReportSummaryRow, 'community' | 'lastPublishedReport'> & { community: GqlResolversParentTypes['Community'], lastPublishedReport?: Maybe<GqlResolversParentTypes['Report']> };
+  AdminTemplateFeedbackStats: GqlAdminTemplateFeedbackStats;
   ApproveReportPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['ApproveReportPayload'];
   ApproveReportSuccess: Omit<GqlApproveReportSuccess, 'report'> & { report: GqlResolversParentTypes['Report'] };
   Article: Article;
@@ -6015,6 +6039,7 @@ export type GqlResolversParentTypes = ResolversObject<{
   ReportEdge: Omit<GqlReportEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['Report']> };
   ReportFeedback: Omit<GqlReportFeedback, 'report' | 'user'> & { report: GqlResolversParentTypes['Report'], user: GqlResolversParentTypes['User'] };
   ReportFeedbackEdge: Omit<GqlReportFeedbackEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['ReportFeedback']> };
+  ReportFeedbackRatingBucket: GqlReportFeedbackRatingBucket;
   ReportFeedbacksConnection: Omit<GqlReportFeedbacksConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['ReportFeedbackEdge']>>> };
   ReportTemplate: Omit<GqlReportTemplate, 'community' | 'updatedByUser'> & { community?: Maybe<GqlResolversParentTypes['Community']>, updatedByUser?: Maybe<GqlResolversParentTypes['User']> };
   ReportTemplateStats: GqlReportTemplateStats;
@@ -6235,6 +6260,13 @@ export type GqlAdminReportSummaryRowResolvers<ContextType = any, ParentType exte
   lastPublishedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
   lastPublishedReport?: Resolver<Maybe<GqlResolversTypes['Report']>, ParentType, ContextType>;
   publishedCountLast90Days?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAdminTemplateFeedbackStatsResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AdminTemplateFeedbackStats'] = GqlResolversParentTypes['AdminTemplateFeedbackStats']> = ResolversObject<{
+  avgRating?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  ratingDistribution?: Resolver<Array<GqlResolversTypes['ReportFeedbackRatingBucket']>, ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -7200,6 +7232,7 @@ export type GqlPublishReportSuccessResolvers<ContextType = any, ParentType exten
 export type GqlQueryResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Query'] = GqlResolversParentTypes['Query']> = ResolversObject<{
   adminBrowseReports?: Resolver<GqlResolversTypes['ReportsConnection'], ParentType, ContextType, Partial<GqlQueryAdminBrowseReportsArgs>>;
   adminReportSummary?: Resolver<GqlResolversTypes['AdminReportSummaryConnection'], ParentType, ContextType, Partial<GqlQueryAdminReportSummaryArgs>>;
+  adminTemplateFeedbackStats?: Resolver<GqlResolversTypes['AdminTemplateFeedbackStats'], ParentType, ContextType, RequireFields<GqlQueryAdminTemplateFeedbackStatsArgs, 'kind' | 'variant'>>;
   adminTemplateFeedbacks?: Resolver<GqlResolversTypes['ReportFeedbacksConnection'], ParentType, ContextType, RequireFields<GqlQueryAdminTemplateFeedbacksArgs, 'first' | 'kind' | 'variant'>>;
   article?: Resolver<Maybe<GqlResolversTypes['Article']>, ParentType, ContextType, RequireFields<GqlQueryArticleArgs, 'id' | 'permission'>>;
   articles?: Resolver<GqlResolversTypes['ArticlesConnection'], ParentType, ContextType, Partial<GqlQueryArticlesArgs>>;
@@ -7331,6 +7364,12 @@ export type GqlReportFeedbackResolvers<ContextType = any, ParentType extends Gql
 export type GqlReportFeedbackEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReportFeedbackEdge'] = GqlResolversParentTypes['ReportFeedbackEdge']> = ResolversObject<{
   cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
   node?: Resolver<Maybe<GqlResolversTypes['ReportFeedback']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReportFeedbackRatingBucketResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReportFeedbackRatingBucket'] = GqlResolversParentTypes['ReportFeedbackRatingBucket']> = ResolversObject<{
+  count?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  rating?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -8285,6 +8324,7 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   AdminReportSummaryConnection?: GqlAdminReportSummaryConnectionResolvers<ContextType>;
   AdminReportSummaryEdge?: GqlAdminReportSummaryEdgeResolvers<ContextType>;
   AdminReportSummaryRow?: GqlAdminReportSummaryRowResolvers<ContextType>;
+  AdminTemplateFeedbackStats?: GqlAdminTemplateFeedbackStatsResolvers<ContextType>;
   ApproveReportPayload?: GqlApproveReportPayloadResolvers<ContextType>;
   ApproveReportSuccess?: GqlApproveReportSuccessResolvers<ContextType>;
   Article?: GqlArticleResolvers<ContextType>;
@@ -8421,6 +8461,7 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   ReportEdge?: GqlReportEdgeResolvers<ContextType>;
   ReportFeedback?: GqlReportFeedbackResolvers<ContextType>;
   ReportFeedbackEdge?: GqlReportFeedbackEdgeResolvers<ContextType>;
+  ReportFeedbackRatingBucket?: GqlReportFeedbackRatingBucketResolvers<ContextType>;
   ReportFeedbacksConnection?: GqlReportFeedbacksConnectionResolvers<ContextType>;
   ReportTemplate?: GqlReportTemplateResolvers<ContextType>;
   ReportTemplateStats?: GqlReportTemplateStatsResolvers<ContextType>;


### PR DESCRIPTION
## 背景 / Why

Phase 1.5 sysAdmin: テンプレート詳細ページに「Customer Reviews」風の
summary section を出したい。中身は **平均評価 + 星 + 件数 + 5★/4★/3★/2★/1★
の distribution bar**。

`adminTemplateFeedbacks` (#936 で landing 済み) の paginated list だけだと
ページ毎に母集団がずれて summary が成立しないため、backend で母集団 stats を
集計して別 query として返します。

frontend は B 案 (重複統合 + Stars / FeedbackCard / FeedbackList /
RatingSummary 刷新) を distribution 抜きで並行で進めており、本 PR landing
後に `RatingSummary` に distribution bar を流し込むだけで完成する想定です。

## 追加した query

```graphql
extend type Query {
  adminTemplateFeedbackStats(
    variant: ReportVariant!
    version: Int                       # null で全 version (list query と整合)
    kind: ReportTemplateKind = GENERATION
  ): AdminTemplateFeedbackStats! @authz(rules: [IsAdmin])
}

type AdminTemplateFeedbackStats {
  totalCount: Int!
  avgRating: Float                     # 0 件のとき null
  ratingDistribution: [ReportFeedbackRatingBucket!]!  # 常に 5 行 (1..5, count=0 含む dense)
}

type ReportFeedbackRatingBucket {
  rating: Int!  # 1..5
  count: Int!
}
```

## 設計判断 (依頼者と握り済み)

| 論点 | 結論 |
|---|---|
| list query への field 追加 vs 別 query | **別 query (案 A)**。`Report.feedbacks` (per-Report) と意味が違う集計を同じ Connection 型に同居させない。Apollo Armor の cost weight も独立に振れる |
| `feedbackType` / `maxRating` を stats に通すか | **通さない (案 b)**。フィルタした distribution は bar の意味 (「全体の中で低評価がどれくらい」) を消す。母集団を返し、UI 側で「N 件のうち N' 件を表示中」を表示する設計 |
| distribution の sparse vs dense | **常に 1..5 の 5 行 dense**。`count: 0` の bucket も省略しない → frontend のパディング処理不要 |
| naming | `RatingBucket` は generic すぎるので `ReportFeedbackRatingBucket` に namespace |
| `version: null` semantics | list query と整合: 省略 / null で全 version |
| `kind` default | list query と揃え `= GENERATION` |
| auth | `IsAdmin` (既存 admin query 群と統一) |

## 実装ハイライト

### Repository (`feedback/data/repository.ts:439-478`)
- 単一 raw SQL で `COUNT(*) GROUP BY rating` を取得
- `totalCount` / `avgRating` は同じ bucket から weighted derivation (二重スキャン回避)
- INNER JOIN on templates (legacy `template_id IS NULL` 行は admin scope として無関係)
- `internal` issuer で SYS_ADMIN session の implicit membership filter を回避

### Presenter (`feedback/presenter.ts`)
- sparse buckets → dense 1..5 fill を presenter 層で実施 (SQL は cheap に保つ)
- `FEEDBACK_RATING_VALUES = [1,2,3,4,5]` を canonical axis としてハードコード (CHECK 制約と整合)

### UseCase (`feedback/usecase.ts:268-296`)
- `version` が指定された場合 1 以上の正整数チェック (DB に届く前に `ValidationError`)
- `kind: null` → `GENERATION` coerce (codegen の null 渡し挙動への対処)

## EXPLAIN 確認

ローカル DB で plan を確認しました — PR #936 で追加した
`idx_t_reports_template_id` が join で活用されています:

```
GroupAggregate
  -> Sort (rating)
    -> Nested Loop
      -> Nested Loop
        -> Index Scan using t_report_templates_variant_community_id_kind_version_key
        -> Index Scan using idx_t_reports_template_id  ← 効いてる
      -> Index Scan using t_report_feedbacks_report_id_user_id_key
```

t_reports / t_report_templates 両方 index scan で seq scan なし。

## Test plan

- [x] Unit tests: `pnpm test src/__tests__/unit/report/feedback/` → **42 passed** (新規 9 件含む)
  - usecase 5 件 (filter forwarding / kind default / version validation / dense distribution / empty population)
  - service 2 件 (filter forwarding / pass-through)
  - 既存 33 件 regression なし
- [x] Report ドメイン全体: **137 passed** (regression なし)
- [x] `npx tsc --noEmit`: clean
- [x] ESLint: clean
- [x] `pnpm gql:generate`: artifact 整合
- [x] EXPLAIN: 既存 index で plan が seq scan に倒れない
- [ ] Frontend swap (`RatingSummary` の distribution bar)

## 既存 query との関係

| Query | 用途 | スコープ |
|---|---|---|
| `reportTemplateStatsBreakdown` | A/B 比較用テンプレ単位集計 (avgRating / Pearson) | 各 template revision |
| `adminTemplateFeedbacks` (#936) | 個別レビュー一覧 (paginated) | list (filter 全部反映) |
| `adminTemplateFeedbackStats` (本 PR) | 「Customer Reviews」風 summary | population (variant/version/kind のみ) |

## Migration / DB 変更

なし。既存 `idx_t_reports_template_id` (PR #936) で十分。

https://claude.ai/code/session_017G7bb5dz6AHD8ZWpFfC4LD

---
_Generated by [Claude Code](https://claude.ai/code/session_017G7bb5dz6AHD8ZWpFfC4LD)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
