### PR TITLE
refactor(report): #938 の Copilot レビュー指摘への対応

### DIFF
--- a/src/application/domain/report/data/repository.ts
+++ b/src/application/domain/report/data/repository.ts
@@ -1199,8 +1199,10 @@ export default class ReportRepository implements IReportRepository {
    * Per-community summary for `adminReportSummary`. Reads the
    * denormalized last-publish columns on `t_communities` directly so
    * the sort + cursor stay stable, then computes the rolling
-   * 90-day publish count inline via a correlated subquery — that
-   * count moves daily and is not worth denormalizing.
+   * 90-day publish count for the page's communityIds in a single
+   * `GROUP BY` follow-up query — that count moves daily and is not
+   * worth denormalizing, but the per-row correlated subquery shape
+   * was needlessly O(first) under load.
    *
    * Sort `last_published_report_at ASC NULLS FIRST, id ASC` floats
    * dormant / never-published communities to the top so the L1 view
@@ -1248,27 +1250,24 @@ export default class ReportRepository implements IReportRepository {
                 AND c."id" > ${cursor.id}
               )
             )`;
+      // Two-query strategy: first page through communities by the
+      // denormalized last-publish columns (one index range scan),
+      // then aggregate the rolling 90-day publish count for just
+      // that page's communityIds in a single GROUP BY. This keeps
+      // DB round-trips and scan count constant in `first` rather
+      // than O(first) correlated subqueries on the L1 hot path.
       const [rows, totalRow] = await Promise.all([
         tx.$queryRaw<
           {
             id: string;
             last_published_report_id: string | null;
             last_published_report_at: Date | null;
-            published_count_last_90_days: bigint;
           }[]
         >`
           SELECT
             c."id",
             c."last_published_report_id",
-            c."last_published_report_at",
-            COALESCE((
-              SELECT COUNT(*)::bigint
-              FROM "t_reports" r
-              WHERE r."community_id" = c."id"
-                AND r."status" = 'PUBLISHED'
-                AND r."published_at" IS NOT NULL
-                AND r."published_at" >= NOW() - INTERVAL '90 days'
-            ), 0) AS "published_count_last_90_days"
+            c."last_published_report_at"
           FROM "t_communities" c
           WHERE TRUE
             ${cursorClause}
@@ -1279,12 +1278,32 @@ export default class ReportRepository implements IReportRepository {
         `,
         tx.community.count(),
       ]);
+      const communityIds = rows.map((r) => r.id);
+      const counts =
+        communityIds.length === 0
+          ? []
+          : await tx.$queryRaw<
+              { community_id: string; count: bigint }[]
+            >`
+              SELECT
+                r."community_id",
+                COUNT(*)::bigint AS "count"
+              FROM "t_reports" r
+              WHERE r."community_id" = ANY(${communityIds}::text[])
+                AND r."status" = 'PUBLISHED'
+                AND r."published_at" IS NOT NULL
+                AND r."published_at" >= NOW() - INTERVAL '90 days'
+              GROUP BY r."community_id"
+            `;
+      const countByCommunity = new Map(
+        counts.map((c) => [c.community_id, Number(c.count)]),
+      );
       return {
         items: rows.map((r) => ({
           communityId: r.id,
           lastPublishedReportId: r.last_published_report_id,
           lastPublishedAt: r.last_published_report_at,
-          publishedCountLast90Days: Number(r.published_count_last_90_days),
+          publishedCountLast90Days: countByCommunity.get(r.id) ?? 0,
         })),
         totalCount: totalRow,
       };

--- a/src/application/domain/report/presenter.ts
+++ b/src/application/domain/report/presenter.ts
@@ -10,20 +10,6 @@ import {
   PrismaReport,
   PrismaReportTemplate,
 } from "@/application/domain/report/data/type";
-
-/**
- * Internal → GraphQL `edge.cursor` (base64url JSON of `{at, id}`).
- * Mirror of `ReportConverter.decodeCommunitySummaryCursor`; kept on
- * the presenter side because `edge.cursor` is a GraphQL output
- * concern and the rest of the report presenters already own the
- * internal-to-Gql wire-format direction. Exported only so the
- * round-trip unit test can assert encode/decode symmetry across the
- * converter / presenter pair without exercising the full
- * connection presenter.
- */
-export function encodeCommunitySummaryCursor(c: CommunitySummaryCursor): string {
-  return Buffer.from(JSON.stringify(c), "utf8").toString("base64url");
-}
 import {
   CohortRetentionRow,
   CommunityContextRow,
@@ -50,6 +36,20 @@ import {
   percentChange,
   toJstIsoDate,
 } from "@/application/domain/report/util";
+
+/**
+ * Internal → GraphQL `edge.cursor` (base64url JSON of `{at, id}`).
+ * Mirror of `ReportConverter.decodeCommunitySummaryCursor`; kept on
+ * the presenter side because `edge.cursor` is a GraphQL output
+ * concern and the rest of the report presenters already own the
+ * internal-to-Gql wire-format direction. Exported only so the
+ * round-trip unit test can assert encode/decode symmetry across the
+ * converter / presenter pair without exercising the full
+ * connection presenter.
+ */
+export function encodeCommunitySummaryCursor(c: CommunitySummaryCursor): string {
+  return Buffer.from(JSON.stringify(c), "utf8").toString("base64url");
+}
 
 export default class ReportPresenter {
   static weeklyPayload(input: {

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -670,10 +670,12 @@ export default class ReportUseCase {
 
   /**
    * Phase 1 admin: list multiple template revisions for the
-   * management UI. The schema default is `kind: GENERATION`, but
-   * GraphQL passes through `null` when the caller omitted the arg
-   * with no default applied (codegen treats every arg as nullable);
-   * coalesce here so the service layer always sees a concrete kind.
+   * management UI. The schema default is `kind: GENERATION`, which
+   * GraphQL applies when the arg is omitted; `null` only reaches us
+   * when the caller sends it explicitly or the usecase is invoked
+   * directly (e.g. from tests) without going through the schema
+   * default. Codegen also types every arg as nullable, so coalesce
+   * here to guarantee the service layer sees a concrete kind.
    */
   async listReportTemplates(
     { variant, communityId, kind, includeInactive }: GqlQueryReportTemplatesArgs,


### PR DESCRIPTION
## 概要

#938（develop → master リリース PR）に対する Copilot レビューコメントの follow-up 対応です。リリース PR 自体には新規コミットを積まず、別ブランチで develop に取り込みます。

## 対応内容

### 1. `adminBrowseReports` の N+1 相関サブクエリを 2 クエリ方式に refactor
**File**: `src/application/domain/report/data/repository.ts`

従来は `t_communities` を取得しつつ各行で 90 日間の publish 件数を相関サブクエリで取っていたため、`first=50` だと 1 ページあたり最大 50 回の index range scan が走る状態でした。L1 sysAdmin ダッシュボードは高頻度に叩かれる前提なので、

1. community のページング（id + last_published_* 列のみ）
2. その communityIds に対して `t_reports` を 1 回だけ `WHERE community_id = ANY(...) AND ... GROUP BY community_id` で集計

の 2 クエリ方式に変更し、DB round-trip とスキャン回数を `first` に対して定数化しました。返却 shape・ソート・カーソル仕様は変更ありません。

### 2. `presenter.ts` の import 順序修正
**File**: `src/application/domain/report/presenter.ts`

`import → 関数定義 → import` の並びになっていて `import/first` 違反になりうる状態だったので、関数定義を全 import の後ろへ移動しました。

### 3. `listReportTemplates` のコメント修正
**File**: `src/application/domain/report/usecase.ts`

「GraphQL は default 値があっても null を渡してくる」というコメントが GraphQL 仕様と異なる説明になっていたので、

- schema default は arg 省略時に適用される
- `null` が来るのは明示的に null が送られた場合 / usecase を直接呼び出した場合（テスト等）
- codegen 上は arg がすべて nullable なので usecase 側で coalesce する

という実挙動に合わせて書き直しました。

## テスト計画

- [x] `pnpm test src/__tests__/unit/report` 全 137 件 pass
- [x] 触ったファイルに新規 lint エラーなし
- [ ] CI 通過の確認
- [ ] adminBrowseReports の動作確認（既存 e2e/integration で担保）

## 関連

- 元のレビュー: #938 (Copilot review)

https://claude.ai/code/session_011gEbdE6KcSJVdM6SAzCJCg

---
_Generated by [Claude Code](https://claude.ai/code/session_011gEbdE6KcSJVdM6SAzCJCg)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
