### PR TITLE
perf(ci/cd): CI/CD ワークフロー全体の高速化と共通化 (#943)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,19 +2,21 @@
 #
 # node_modules is intentionally NOT excluded from the build context.
 #
-# The current Dockerfile relies on the CI/CD runner having pre-built
-# node_modules (including Prisma TypedSQL generated types at
-# @prisma/client/sql/*.d.ts) that are copied into the image via
-# `COPY . ./`. This is because `prisma generate --sql` requires
-# database connectivity (via jumpbox tunnel) which is not available
-# during `docker build`.
+# The Dockerfile relies on the CI/CD runner having pre-built node_modules
+# (including Prisma TypedSQL generated types at @prisma/client/sql/*.d.ts)
+# AND the compiled output at `dist/` that are copied into the image via
+# `COPY . ./`. This is because `prisma generate --sql` requires database
+# connectivity (via jumpbox tunnel) which is not available during
+# `docker build`. The compiled `dist/` is shipped as-is from the runner so
+# the in-container `RUN pnpm build` is no longer needed.
 #
 # This is intentional tech debt. A multi-stage build with CI artifact
 # injection is the proper fix - see the git log around this file and
 # the associated PR description for context. Do NOT re-enable the
-# `node_modules` exclusion below without first resolving the build
+# `node_modules` / `dist` exclusion below without first resolving the build
 # flow (runner-dependent -> self-contained).
 # node_modules
+# dist  -- shipped from runner; see .dockerignore comment above
 npm-debug.log*
 yarn-debug.log*
 pnpm-debug.log*
@@ -22,9 +24,6 @@ pnpm-debug.log*
 # Logs
 logs
 *.log
-
-# Dependency directories
-dist
 
 # Environment variables
 .env

--- a/.github/actions/jumpbox-db-tunnel/action.yml
+++ b/.github/actions/jumpbox-db-tunnel/action.yml
@@ -1,0 +1,53 @@
+name: 'Open jumpbox SSH tunnel and wait for DB'
+description: >
+  Opens an IAP-tunneled SSH session to the GCE jumpbox and forwards localhost:5432
+  to the Cloud SQL endpoint. Active-waits with `pg_isready` (旧実装の sleep 60 +
+  60s × 5 retry を 2 秒間隔 × 45 で置換) so the caller can run `prisma generate`
+  / `prisma migrate deploy` immediately. Tunnel process is left running until
+  job end (GitHub Actions runner cleans it up automatically).
+
+inputs:
+  jumpbox-instance-name:
+    description: GCE instance name of the jumpbox.
+    required: true
+  jumpbox-zone:
+    description: GCE zone of the jumpbox.
+    required: true
+  db-name:
+    description: Database name to verify readiness against.
+    required: true
+  local-port:
+    description: Local port to forward (defaults to 5432).
+    required: false
+    default: '5432'
+
+runs:
+  using: composite
+  steps:
+    - name: Open SSH tunnel and wait for DB
+      shell: bash
+      env:
+        JUMPBOX_INSTANCE_NAME: ${{ inputs.jumpbox-instance-name }}
+        JUMPBOX_ZONE: ${{ inputs.jumpbox-zone }}
+        DB_NAME: ${{ inputs.db-name }}
+        LOCAL_PORT: ${{ inputs.local-port }}
+      run: |
+        echo "--- Connecting to DB via jumpbox ---"
+        gcloud compute ssh "$JUMPBOX_INSTANCE_NAME" \
+          --tunnel-through-iap \
+          --zone="$JUMPBOX_ZONE" \
+          --quiet -- -N -L "$LOCAL_PORT:localhost:5432" &
+        echo $! > /tmp/jumpbox-ssh.pid
+
+        for _ in {1..45}; do
+          if pg_isready -h localhost -p "$LOCAL_PORT" -d "$DB_NAME" -q; then
+            echo "--- Tunnel ready ---"
+            exit 0
+          fi
+          sleep 2
+        done
+        echo "::error::SSH tunnel never became ready after ~90s"
+        if [ -f /tmp/jumpbox-ssh.pid ]; then
+          kill "$(cat /tmp/jumpbox-ssh.pid)" 2>/dev/null || true
+        fi
+        exit 1

--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -62,6 +62,17 @@ jobs:
       APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
 
     steps:
+      # `audit` mode: log egress (GCP / npm registry / GitHub) without blocking.
+      # `block` mode would require maintaining an allowlist for every gcloud
+      # endpoint and is fragile across SDK updates. `disable-sudo` is left
+      # enabled (default) because the "Create Git tag" step installs tzdata
+      # via apt-get on prd. Audit logs surface in the job summary and let us
+      # detect unexpected egress (e.g. credential exfiltration) post-hoc.
+      - name: Harden runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -157,13 +168,18 @@ jobs:
         # docker push :latest alone does not roll the Cloud Run Job to the new
         # image — Cloud Run Jobs pin the image digest at deploy time, so we
         # need an explicit `run jobs update` to create a new revision.
-        # `--command=node --args=dist/index.js` で旧 Dockerfile.batch の CMD を再現。
+        # `dist/bootstrap/batch.js` 経由で起動することで OpenTelemetry tracing 初期化
+        # (`tracingReady` await) を batch ジョブでも有効にする。`@/` パスエイリアスが
+        # bootstrap 層で使われるため `-r tsconfig-paths/register` も必須。
+        # PROCESS_TYPE=batch は Cloud Run Job 側の env で別途設定されている前提
+        # (bootstrap/batch.ts は ../index に dispatch するだけで、batch 分岐自体は
+        # src/index.ts:main() が PROCESS_TYPE で判定する)。
         run: |
           gcloud run jobs update "${{ env.BATCH_NAME }}" \
             --region="${{ env.GCP_REGION }}" \
             --image="${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest" \
             --command=node \
-            --args=dist/index.js
+            --args=-r,tsconfig-paths/register,dist/bootstrap/batch.js
 
       - name: Create Git tag
         if: ${{ inputs.create-git-tag }}

--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -1,0 +1,183 @@
+name: Deploy to Cloud Run (reusable)
+
+# Reusable workflow called by deploy-to-cloud-run-{dev,prd}.yml.
+# dev/prd 共通の deploy ロジックを 1 ファイルに集約し、差分は inputs として受け取る。
+
+on:
+  workflow_call:
+    inputs:
+      stage:
+        description: '"dev" or "prd" — used for cache scope and STAGE env.'
+        type: string
+        required: true
+      environment:
+        description: GitHub Actions environment name (e.g., "dev", "co-creation-dao-prod").
+        type: string
+        required: true
+      apollo-variant:
+        description: Apollo Studio graph variant (e.g., "dev", "prod").
+        type: string
+        required: true
+      node-env:
+        description: Value to set NODE_ENV in the Cloud Run service.
+        type: string
+        required: true
+      extra-env-vars:
+        description: Additional env vars (newline-separated KEY=VAL) for the Cloud Run service.
+        type: string
+        required: false
+        default: ''
+      create-git-tag:
+        description: Whether to create + push a timestamp git tag (prd only).
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    timeout-minutes: 30
+
+    permissions:
+      id-token: write
+      # contents:write は git tag push に必要 (prd only)。GHA の `permissions:` は
+      # 式で動的に切り替えできないため、両 stage で write を付与する
+      # (dev でも実質 read しか使わないので影響なし)。
+      contents: write
+
+    env:
+      STAGE: ${{ inputs.stage }}
+      GCP_REGION: ${{ secrets.GCP_REGION }}
+      DB_USER: ${{ secrets.DB_USER }}
+      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+      DB_NAME: ${{ secrets.DB_NAME }}
+      CLOUD_SQL_CONNECTION_NAME: ${{ secrets.CLOUD_SQL_CONNECTION_NAME }}
+      ARTIFACT_REGISTRY: ${{ secrets.ARTIFACT_REGISTRY }}
+      APPLICATION_NAME: ${{ secrets.APPLICATION_NAME }}
+      BATCH_ARTIFACT_REGISTRY: ${{ secrets.BATCH_ARTIFACT_REGISTRY }}
+      BATCH_NAME: ${{ secrets.BATCH_NAME }}
+      JUMPBOX_INSTANCE_NAME: ${{ secrets.JUMPBOX_INSTANCE_NAME }}
+      JUMPBOX_ZONE: ${{ secrets.JUMPBOX_ZONE }}
+      APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Authenticate to Google Cloud (Workload Identity Federation)
+        uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70 # v2.1.6
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+
+      - name: Set up gcloud SDK
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
+
+      - name: Open jumpbox tunnel
+        uses: ./.github/actions/jumpbox-db-tunnel
+        with:
+          jumpbox-instance-name: ${{ env.JUMPBOX_INSTANCE_NAME }}
+          jumpbox-zone: ${{ env.JUMPBOX_ZONE }}
+          db-name: ${{ env.DB_NAME }}
+
+      - name: Run prisma generate and migrate deploy
+        env:
+          DATABASE_URL: postgresql://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
+        run: |
+          pnpm db:generate
+          pnpm db:deploy
+
+      - name: Generate GraphQL types
+        run: pnpm gql:generate
+
+      - name: Install and Publish via Rover CLI
+        env:
+          APOLLO_KEY: ${{ env.APOLLO_KEY }}
+        run: |
+          curl -sSL https://rover.apollo.dev/nix/latest | sh
+          export PATH="$HOME/.rover/bin:$PATH"
+          rover graph publish "civicship-api-jq1988@${{ inputs.apollo-variant }}" --schema ./docs/schema.graphql
+
+      - name: Build TypeScript output (consumed by Docker COPY)
+        run: pnpm build
+
+      - name: Configure Docker for GCP Artifact Registry
+        run: |
+          gcloud auth configure-docker "${{ env.ARTIFACT_REGISTRY }}"
+          gcloud auth configure-docker "${{ env.GCP_REGION }}-docker.pkg.dev"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
+
+      # Dockerfile を統一 (旧 Dockerfile.batch を廃止) し、1 度のビルドで
+      # main / batch の両 registry に同じ image を multi-tag push する。
+      # batch (Cloud Run Job) 側は entrypoint を `--command/--args` で
+      # `node dist/index.js` に上書きする (旧 Dockerfile.batch CMD と等価)。
+      - name: Build unified image and push to main + batch registries
+        env:
+          MAIN_IMAGE: ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest
+          BATCH_IMAGE: ${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest
+        run: |
+          docker buildx build \
+            --file Dockerfile \
+            --tag "$MAIN_IMAGE" \
+            --tag "$BATCH_IMAGE" \
+            --cache-from "type=gha,scope=cloud-run-${{ inputs.stage }}" \
+            --cache-to "type=gha,mode=max,scope=cloud-run-${{ inputs.stage }}" \
+            --push \
+            .
+
+      - name: Deploy Internal API to Cloud Run
+        id: deploy
+        uses: google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522 # v2.7.6
+        with:
+          service: ${{ env.APPLICATION_NAME }}
+          image: ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest
+          region: ${{ env.GCP_REGION }}
+          env_vars: |
+            NODE_ENV=${{ inputs.node-env }}
+            ${{ inputs.extra-env-vars }}
+
+      - name: Update Cloud Run Job (batch) to new image
+        # docker push :latest alone does not roll the Cloud Run Job to the new
+        # image — Cloud Run Jobs pin the image digest at deploy time, so we
+        # need an explicit `run jobs update` to create a new revision.
+        # `--command=node --args=dist/index.js` で旧 Dockerfile.batch の CMD を再現。
+        run: |
+          gcloud run jobs update "${{ env.BATCH_NAME }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --image="${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest" \
+            --command=node \
+            --args=dist/index.js
+
+      - name: Create Git tag
+        if: ${{ inputs.create-git-tag }}
+        run: |
+          sudo apt-get update && sudo apt-get install -y tzdata
+          sudo ln -fs /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
+          sudo dpkg-reconfigure -f noninteractive tzdata
+
+          TAG_NAME=$(date +"%Y%m%d%H%M%S")
+
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+
+          git tag "$TAG_NAME"
+          git push origin "$TAG_NAME"
+
+      - name: Cleanup SSH Key
+        if: always()
+        run: rm -f ~/.ssh/google_compute_engine ~/.ssh/google_compute_engine.pub

--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -64,6 +64,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || '' }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0

--- a/.github/workflows/_deploy-external-api.yml
+++ b/.github/workflows/_deploy-external-api.yml
@@ -59,6 +59,12 @@ jobs:
       JUMPBOX_ZONE: ${{ secrets.JUMPBOX_ZONE }}
 
     steps:
+      # See _deploy-cloud-run.yml for rationale on audit mode + sudo.
+      - name: Harden runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/_deploy-external-api.yml
+++ b/.github/workflows/_deploy-external-api.yml
@@ -1,0 +1,150 @@
+name: Deploy External API to Cloud Run (reusable)
+
+# Reusable workflow called by deploy-external-api-{dev,prd}.yml.
+
+on:
+  workflow_call:
+    inputs:
+      stage:
+        description: '"dev" or "prd" — used for cache scope and STAGE env.'
+        type: string
+        required: true
+      environment:
+        description: GitHub Actions environment name (e.g., "dev", "co-creation-dao-prod").
+        type: string
+        required: true
+      node-env:
+        description: Value to set NODE_ENV in the Cloud Run service.
+        type: string
+        required: true
+      extra-env-vars:
+        description: Additional env vars (newline-separated KEY=VAL) for the Cloud Run service.
+        type: string
+        required: false
+        default: ''
+      create-git-tag:
+        description: Whether to create + push a timestamp git tag (prd only).
+        type: boolean
+        required: false
+        default: false
+      git-tag-prefix:
+        description: Prefix prepended to the timestamp git tag (e.g. "external-api-").
+        type: string
+        required: false
+        default: ''
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    timeout-minutes: 30
+
+    permissions:
+      id-token: write
+      # contents:write は git tag push に必要 (prd only)。GHA の `permissions:` は
+      # 式で動的に切り替えできないため両 stage で write を付与する
+      # (dev でも実質 read しか使わないので影響なし)。
+      contents: write
+
+    env:
+      STAGE: ${{ inputs.stage }}
+      GCP_REGION: ${{ secrets.GCP_REGION }}
+      DB_USER: ${{ secrets.DB_USER }}
+      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+      DB_NAME: ${{ secrets.DB_NAME }}
+      CLOUD_SQL_CONNECTION_NAME: ${{ secrets.CLOUD_SQL_CONNECTION_NAME }}
+      ARTIFACT_REGISTRY: ${{ secrets.ARTIFACT_REGISTRY }}
+      EXTERNAL_API_NAME: ${{ secrets.EXTERNAL_API_NAME }}
+      JUMPBOX_INSTANCE_NAME: ${{ secrets.JUMPBOX_INSTANCE_NAME }}
+      JUMPBOX_ZONE: ${{ secrets.JUMPBOX_ZONE }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Authenticate to Google Cloud (Workload Identity Federation)
+        uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70 # v2.1.6
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+
+      - name: Set up gcloud SDK
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
+
+      - name: Open jumpbox tunnel
+        uses: ./.github/actions/jumpbox-db-tunnel
+        with:
+          jumpbox-instance-name: ${{ env.JUMPBOX_INSTANCE_NAME }}
+          jumpbox-zone: ${{ env.JUMPBOX_ZONE }}
+          db-name: ${{ env.DB_NAME }}
+
+      - name: Run prisma generate
+        env:
+          DATABASE_URL: postgresql://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
+        run: pnpm db:generate
+
+      - name: Build TypeScript output (consumed by Docker COPY)
+        run: pnpm build
+
+      - name: Configure Docker for GCP Artifact Registry
+        run: |
+          gcloud auth configure-docker "${{ env.ARTIFACT_REGISTRY }}"
+          gcloud auth configure-docker "${{ env.GCP_REGION }}-docker.pkg.dev"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
+
+      - name: Build and push External API image
+        env:
+          EXTERNAL_IMAGE: ${{ env.ARTIFACT_REGISTRY }}/${{ env.EXTERNAL_API_NAME }}:latest
+        run: |
+          docker buildx build \
+            --file Dockerfile.external \
+            --tag "$EXTERNAL_IMAGE" \
+            --cache-from "type=gha,scope=external-${{ inputs.stage }}" \
+            --cache-to "type=gha,mode=max,scope=external-${{ inputs.stage }}" \
+            --push \
+            .
+
+      - name: Deploy External API to Cloud Run
+        id: deploy
+        uses: google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522 # v2.7.6
+        with:
+          service: ${{ env.EXTERNAL_API_NAME }}
+          image: ${{ env.ARTIFACT_REGISTRY }}/${{ env.EXTERNAL_API_NAME }}:latest
+          region: ${{ env.GCP_REGION }}
+          flags: '--allow-unauthenticated --port=3000'
+          env_vars: |
+            NODE_ENV=${{ inputs.node-env }}
+            ${{ inputs.extra-env-vars }}
+
+      - name: Create Git tag
+        if: ${{ inputs.create-git-tag }}
+        run: |
+          sudo apt-get update && sudo apt-get install -y tzdata
+          sudo ln -fs /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
+          sudo dpkg-reconfigure -f noninteractive tzdata
+
+          TAG_NAME="${{ inputs.git-tag-prefix }}$(date +"%Y%m%d%H%M%S")"
+
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+
+          git tag "$TAG_NAME"
+          git push origin "$TAG_NAME"
+
+      - name: Cleanup SSH Key
+        if: always()
+        run: rm -f ~/.ssh/google_compute_engine ~/.ssh/google_compute_engine.pub

--- a/.github/workflows/_deploy-external-api.yml
+++ b/.github/workflows/_deploy-external-api.yml
@@ -61,6 +61,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || '' }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,16 @@ jobs:
       - name: Install dependencies (lockfile integrity check)
         run: pnpm install --frozen-lockfile --prefer-offline
 
-      - name: Audit (non-blocking)
-        run: pnpm audit --audit-level=high
-        continue-on-error: true
+      # Surface high/critical findings as a `::warning::` annotation visible
+      # in the PR check summary, but do not fail the job (audit results can
+      # change independently of code changes; gating CI on transitive
+      # vulnerabilities yields a flaky required check). The full audit output
+      # is preserved in the step log for triage.
+      - name: Audit (non-blocking, surfaces findings as warnings)
+        run: |
+          if ! pnpm audit --audit-level=high; then
+            echo "::warning::pnpm audit found high-severity vulnerabilities (non-blocking — see step log for details)"
+          fi
 
       - name: Apply Prisma migrations to CI database
         # TypedSQL (`--sql`) は DB 接続を必要とするため、db:generate の前に

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [master, develop]
   push:
     branches: [master]
+  # NOTE: workflow-level の `paths-ignore` は使えない。`ci` aggregator job が
+  # branch protection の required status check として登録されているため、
+  # paths-ignore で workflow ごと skip すると status が報告されず、docs-only
+  # PR が永久に merge 不能になる (admin override が必要になる)。
+  # 軽量化が必要になったら job 側で changed-files filter (dorny/paths-filter
+  # 等) を使って expensive job (build / test) を条件付き skip し、aggregator は
+  # 必ず走る形にする。
 
 permissions:
   contents: read
@@ -88,7 +95,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies (lockfile integrity check)
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Audit (non-blocking)
         run: pnpm audit --audit-level=high
@@ -107,15 +114,24 @@ jobs:
         run: pnpm gql:generate
 
       # Detect uncommitted regenerations of tracked generated files.
-      # Note: this workflow's name ("CI") will be referenced by downstream
-      # deploy workflows via `workflow_run` triggers in PR-β (not yet
-      # implemented). Renaming after PR-β lands will require updating those.
       - name: Check generated files are up to date
         run: |
           git diff --exit-code \
             src/types/graphql.ts \
             docs/schema.graphql \
             src/infrastructure/prisma/schema.prisma
+
+      # tsc incremental の `.tsbuildinfo` を branch ごとに cache。
+      # 完全一致 hit は稀でも、restore-keys 経由で前回 build の info を
+      # 復元すれば未変更ファイルの typecheck を skip できる。
+      - name: Cache TypeScript build info
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: .tsbuildinfo
+          key: tsbuildinfo-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            tsbuildinfo-${{ runner.os }}-${{ github.ref_name }}-
+            tsbuildinfo-${{ runner.os }}-
 
       - name: Build (typecheck + emit)
         run: pnpm build
@@ -196,7 +212,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies (lockfile integrity check)
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Apply Prisma migrations to CI database
         # `prisma db push` は schema.prisma のモデルのみ反映し、migration.sql を
@@ -211,6 +227,18 @@ jobs:
 
       - name: Generate GraphQL types
         run: pnpm gql:generate
+
+      # ts-jest の transform 結果 cache を matrix 単位で永続化。
+      # restore-keys で同一 matrix の最近の cache に fallback し、
+      # 変更されていない test file の transform を skip できる。
+      - name: Cache Jest transform cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: .jest-cache
+          key: jest-${{ runner.os }}-${{ matrix.name }}-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            jest-${{ runner.os }}-${{ matrix.name }}-${{ github.ref_name }}-
+            jest-${{ runner.os }}-${{ matrix.name }}-
 
       - name: Generate test JWT RSA key
         # firebase-admin の内部 JWT 署名 (RS256) 用に、test 専用の使い捨て RSA 2048

--- a/.github/workflows/deploy-external-api-dev.yml
+++ b/.github/workflows/deploy-external-api-dev.yml
@@ -4,108 +4,28 @@ on:
   push:
     branches:
       - develop
+      - 'epic/**'
+      - 'hotfix/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+# Caller permissions must be a superset of the reusable workflow's permissions
+# (`_deploy-external-api.yml`: id-token:write + contents:write). Setting them
+# explicitly here also silences CodeQL's missing-permissions warning.
+permissions:
+  id-token: write
+  contents: write
+
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    environment: dev
-    timeout-minutes: 30
-
-    permissions:
-      id-token: write
-      contents: read
-
-    env:
-      STAGE: dev
-      GCP_REGION: ${{ secrets.GCP_REGION }}
-      DB_USER: ${{ secrets.DB_USER }}
-      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-      DB_NAME: ${{ secrets.DB_NAME }}
-      CLOUD_SQL_CONNECTION_NAME: ${{ secrets.CLOUD_SQL_CONNECTION_NAME }}
-      ARTIFACT_REGISTRY: ${{ secrets.ARTIFACT_REGISTRY }}
-      EXTERNAL_API_NAME: ${{ secrets.EXTERNAL_API_NAME }}
-      JUMPBOX_INSTANCE_NAME: ${{ secrets.JUMPBOX_INSTANCE_NAME }}
-      JUMPBOX_ZONE: ${{ secrets.JUMPBOX_ZONE }}
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-    - name: Install pnpm
-      run: npm install -g pnpm
-
-    - name: Set up Node.js
-      uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
-      with:
-        node-version: '20'
-        cache: 'pnpm'
-
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile
-
-    - name: Authenticate to Google Cloud (Workload Identity Federation)
-      uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70 # v2.1.6
-      with:
-        workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
-        service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-
-    - name: Set up gcloud SDK
-      uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
-
-    - name: pnpm db:generate
-      env:
-        DATABASE_URL: postgresql://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
-      run: |
-        echo "--- Connecting to DB via jumpbox ---"
-        gcloud compute ssh ${{ env.JUMPBOX_INSTANCE_NAME }} \
-          --tunnel-through-iap \
-          --zone=${{ env.JUMPBOX_ZONE }} \
-          --quiet -- -N -L 5432:localhost:5432 &
-        SSH_PID=$!
-        sleep 60
-        for _ in {1..5}; do
-          pg_isready -h localhost -p 5432 -d ${{ env.DB_NAME }} && break
-          sleep 60
-        done
-
-        echo "--- Running prisma generate ---"
-        pnpm db:generate
-
-        echo "Killing SSH tunnel"
-        kill $SSH_PID
-
-    - name: pnpm build
-      run: pnpm build
-
-    - name: Configure Docker for GCP Artifact Registry
-      run: |
-        gcloud auth configure-docker ${{ env.ARTIFACT_REGISTRY }}
-        gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev
-
-    - name: Build External API Docker image
-      run: |
-        docker build --no-cache -t ${{ env.ARTIFACT_REGISTRY }}/${{ env.EXTERNAL_API_NAME }}:latest -f Dockerfile.external .
-
-    - name: Push External API Docker image to Artifact Registry
-      run: |
-        docker push ${{ env.ARTIFACT_REGISTRY }}/${{ env.EXTERNAL_API_NAME }}:latest
-
-    - name: Deploy External API to Cloud Run
-      id: 'deploy'
-      uses: 'google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522' # v2.7.6
-      with:
-        service: ${{ env.EXTERNAL_API_NAME }}
-        image: ${{ env.ARTIFACT_REGISTRY }}/${{ env.EXTERNAL_API_NAME }}:latest
-        region: ${{ env.GCP_REGION }}
-        flags: '--allow-unauthenticated --port=3000'
-        env_vars: |
-          NODE_ENV=development
-          ENV=dev
-
-    - name: Cleanup SSH Key
-      if: always()
-      run: rm -f ~/.ssh/google_compute_engine ~/.ssh/google_compute_engine.pub
+    uses: ./.github/workflows/_deploy-external-api.yml
+    with:
+      stage: dev
+      environment: dev
+      node-env: development
+      extra-env-vars: |
+        ENV=dev
+      create-git-tag: false
+    secrets: inherit

--- a/.github/workflows/deploy-external-api-prd.yml
+++ b/.github/workflows/deploy-external-api-prd.yml
@@ -1,124 +1,35 @@
 name: Deploy External API to Cloud Run (prd)
 
+# master への直接 push では trigger しない (本番デプロイは PR merge 経由のみ)。
+# `pull_request: closed` + `merged == true` でフィルタすることで、PR が
+# merge されずに close されたときも skip される。
 on:
-  push:
-    branches:
-      - master
+  pull_request:
+    types: [closed]
+    branches: [master]
 
+# concurrency は workflow 単位で 1 本に絞る (異なる PR が同時に master に
+# 入っても deploy を直列化)。`github.ref` 単位だと PR ごとに別キューに
+# なってしまうため意図的に外す。
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}
   cancel-in-progress: false
+
+# Caller permissions must be a superset of the reusable workflow's permissions
+# (`_deploy-external-api.yml`: id-token:write + contents:write). Setting them
+# explicitly here also silences CodeQL's missing-permissions warning.
+permissions:
+  id-token: write
+  contents: write
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    environment: co-creation-dao-prod
-    timeout-minutes: 30
-
-    permissions:
-      id-token: write
-      contents: write
-
-    env:
-      STAGE: prd
-      GCP_REGION: ${{ secrets.GCP_REGION }}
-      DB_USER: ${{ secrets.DB_USER }}
-      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-      DB_NAME: ${{ secrets.DB_NAME }}
-      CLOUD_SQL_CONNECTION_NAME: ${{ secrets.CLOUD_SQL_CONNECTION_NAME }}
-      ARTIFACT_REGISTRY: ${{ secrets.ARTIFACT_REGISTRY }}
-      EXTERNAL_API_NAME: ${{ secrets.EXTERNAL_API_NAME }}
-      JUMPBOX_INSTANCE_NAME: ${{ secrets.JUMPBOX_INSTANCE_NAME }}
-      JUMPBOX_ZONE: ${{ secrets.JUMPBOX_ZONE }}
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-    - name: Install pnpm
-      run: npm install -g pnpm
-
-    - name: Set up Node.js
-      uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
-      with:
-        node-version: '20'
-        cache: 'pnpm'
-
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile
-
-    - name: Authenticate to Google Cloud (Workload Identity Federation)
-      uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70 # v2.1.6
-      with:
-        workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
-        service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-
-    - name: Set up gcloud SDK
-      uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
-
-    - name: pnpm db:generate
-      env:
-        DATABASE_URL: postgresql://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
-      run: |
-        echo "--- Connecting to DB via jumpbox ---"
-        gcloud compute ssh ${{ env.JUMPBOX_INSTANCE_NAME }} \
-          --tunnel-through-iap \
-          --zone=${{ env.JUMPBOX_ZONE }} \
-          --quiet -- -N -L 5432:localhost:5432 &
-        SSH_PID=$!
-        sleep 60
-        for _ in {1..5}; do
-          pg_isready -h localhost -p 5432 -d ${{ env.DB_NAME }} && break
-          sleep 60
-        done
-
-        echo "--- Running prisma generate ---"
-        pnpm db:generate
-
-        echo "Killing SSH tunnel"
-        kill $SSH_PID
-
-    - name: pnpm build
-      run: pnpm build
-
-    - name: Configure Docker for GCP Artifact Registry
-      run: |
-        gcloud auth configure-docker ${{ env.ARTIFACT_REGISTRY }}
-        gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev
-
-    - name: Build External API Docker image
-      run: |
-        docker build --no-cache -t ${{ env.ARTIFACT_REGISTRY }}/${{ env.EXTERNAL_API_NAME }}:latest -f Dockerfile.external .
-
-    - name: Push External API Docker image to Artifact Registry
-      run: |
-        docker push ${{ env.ARTIFACT_REGISTRY }}/${{ env.EXTERNAL_API_NAME }}:latest
-
-    - name: Deploy External API to Cloud Run
-      id: 'deploy'
-      uses: 'google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522' # v2.7.6
-      with:
-        service: ${{ env.EXTERNAL_API_NAME }}
-        image: ${{ env.ARTIFACT_REGISTRY }}/${{ env.EXTERNAL_API_NAME }}:latest
-        region: ${{ env.GCP_REGION }}
-        flags: '--allow-unauthenticated --port=3000'
-        env_vars: |
-          NODE_ENV=production
-
-    - name: Create Git tag for External API
-      run: |
-        sudo apt-get update && sudo apt-get install -y tzdata
-        sudo ln -fs /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
-        sudo dpkg-reconfigure -f noninteractive tzdata
-        
-        TAG_NAME="external-api-$(date +"%Y%m%d%H%M%S")"
-        
-        git config user.name "github-actions"
-        git config user.email "github-actions@github.com"
-        
-        git tag "$TAG_NAME"
-        git push origin "$TAG_NAME"
-
-    - name: Cleanup SSH Key
-      if: always()
-      run: rm -f ~/.ssh/google_compute_engine ~/.ssh/google_compute_engine.pub
+    if: github.event.pull_request.merged == true
+    uses: ./.github/workflows/_deploy-external-api.yml
+    with:
+      stage: prd
+      environment: co-creation-dao-prod
+      node-env: production
+      create-git-tag: true
+      git-tag-prefix: external-api-
+    secrets: inherit

--- a/.github/workflows/deploy-richmenu.yml
+++ b/.github/workflows/deploy-richmenu.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Install pnpm
-        run: npm install -g pnpm
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Set up Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
@@ -59,7 +59,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Authenticate to Google Cloud (Workload Identity Federation)
         uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70 # v2.1.6
@@ -68,41 +68,26 @@ jobs:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
 
       - name: Set up gcloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
 
-      - name: Connect to DB via jumpbox and deploy rich menu
+      - name: Open jumpbox tunnel
+        uses: ./.github/actions/jumpbox-db-tunnel
+        with:
+          jumpbox-instance-name: ${{ env.JUMPBOX_INSTANCE_NAME }}
+          jumpbox-zone: ${{ env.JUMPBOX_ZONE }}
+          db-name: ${{ env.DB_NAME }}
+
+      - name: Generate Prisma client and deploy rich menu
         env:
           DATABASE_URL: postgresql://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
+          COMMUNITY: ${{ github.event.inputs.community }}
         run: |
-          echo "--- Connecting to DB via jumpbox ---"
-          gcloud compute ssh ${{ env.JUMPBOX_INSTANCE_NAME }} \
-            --tunnel-through-iap \
-            --zone=${{ env.JUMPBOX_ZONE }} \
-            --quiet -- -N -L 5432:localhost:5432 &
-          SSH_PID=$!
-
-          echo "--- Waiting for database connection ---"
-          for i in {1..30}; do
-            if pg_isready -h localhost -p 5432 2>/dev/null; then
-              echo "Database is ready"
-              break
-            fi
-            echo "Waiting for database connection... ($i/30)"
-            sleep 2
-          done
-
-          echo "--- Generating Prisma Client ---"
           pnpm db:generate
-
-          echo "--- Deploying Rich Menu ---"
-          if [ "${{ github.event.inputs.community }}" = "all" ]; then
+          if [ "$COMMUNITY" = "all" ]; then
             pnpm richmenu:deploy --all
           else
-            pnpm richmenu:deploy --community=${{ github.event.inputs.community }}
+            pnpm richmenu:deploy --community="$COMMUNITY"
           fi
-
-          echo "--- Killing SSH tunnel ---"
-          kill $SSH_PID || true
 
       - name: Cleanup SSH Key
         if: always()

--- a/.github/workflows/deploy-richmenu.yml
+++ b/.github/workflows/deploy-richmenu.yml
@@ -46,6 +46,12 @@ jobs:
       JUMPBOX_ZONE: ${{ secrets.JUMPBOX_ZONE }}
 
     steps:
+      # See _deploy-cloud-run.yml for rationale on audit mode.
+      - name: Harden runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/.github/workflows/deploy-to-cloud-run-dev.yml
+++ b/.github/workflows/deploy-to-cloud-run-dev.yml
@@ -1,152 +1,32 @@
-name: Deploy to Cloud Run
+name: Deploy to Cloud Run (dev)
 
 on:
   push:
     branches:
       - develop
+      - 'epic/**'
+      - 'hotfix/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+# Caller permissions must be a superset of the reusable workflow's permissions
+# (`_deploy-cloud-run.yml`: id-token:write + contents:write). Setting them
+# explicitly here also silences CodeQL's missing-permissions warning.
+permissions:
+  id-token: write
+  contents: write
+
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    environment: dev
-    timeout-minutes: 30
-
-    permissions:
-      id-token: write
-      contents: read
-
-    env:
-      # stage
-      STAGE: dev
-      # GCP settings
-      GCP_REGION: ${{ secrets.GCP_REGION }}
-      # DB credentials
-      DB_USER: ${{ secrets.DB_USER }}
-      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-      DB_NAME: ${{ secrets.DB_NAME }}
-      CLOUD_SQL_CONNECTION_NAME: ${{ secrets.CLOUD_SQL_CONNECTION_NAME }}
-      # application settings
-      ARTIFACT_REGISTRY: ${{ secrets.ARTIFACT_REGISTRY }}
-      APPLICATION_NAME: ${{ secrets.APPLICATION_NAME }}
-      # batch settings
-      BATCH_ARTIFACT_REGISTRY: ${{ secrets.BATCH_ARTIFACT_REGISTRY }}
-      BATCH_NAME: ${{ secrets.BATCH_NAME }}
-      # Jumpbox settings
-      JUMPBOX_INSTANCE_NAME: ${{ secrets.JUMPBOX_INSTANCE_NAME }}
-      JUMPBOX_ZONE: ${{ secrets.JUMPBOX_ZONE }}
-      # Apollo studio
-      APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-    - name: Install pnpm
-      run: npm install -g pnpm
-
-    - name: Set up Node.js
-      uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
-      with:
-        node-version: '20'
-        cache: 'pnpm'
-
-    - name: Install dependencies
-      run: |
-          pnpm install --frozen-lockfile
-
-    - name: Authenticate to Google Cloud (Workload Identity Federation)
-      uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70 # v2.1.6
-      with:
-        workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
-        service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-
-    - name: Set up gcloud SDK
-      uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
-
-    - name: pnpm db:generate and db:deploy
-      env:
-        DATABASE_URL: postgresql://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
-      run: |
-        echo "--- Connecting to DB via jumpbox ---"
-        gcloud compute ssh ${{ env.JUMPBOX_INSTANCE_NAME }} \
-          --tunnel-through-iap \
-          --zone=${{ env.JUMPBOX_ZONE }} \
-          --quiet -- -N -L 5432:localhost:5432 &
-        SSH_PID=$!
-        sleep 60
-        for _ in {1..5}; do
-          pg_isready -h localhost -p 5432 -d ${{ env.DB_NAME }} && break
-          sleep 60
-        done
-
-        echo "--- Running prisma generate ---"
-        pnpm db:generate
-
-        echo "--- Running prisma migrate deploy ---"
-        pnpm db:deploy
-
-        echo "Killing SSH tunnel"
-        kill $SSH_PID
-
-    - name: pnpm gql:generate
-      run: pnpm gql:generate
-
-    - name: Install and Publish via Rover CLI
-      env:
-        APOLLO_KEY: ${{ env.APOLLO_KEY }}
-      run: |
-        curl -sSL https://rover.apollo.dev/nix/latest | sh
-        export PATH="$HOME/.rover/bin:$PATH"
-        rover graph publish civicship-api-jq1988@dev --schema ./docs/schema.graphql
-
-    - name: pnpm build
-      run: pnpm build
-
-    - name: Configure Docker for GCP Artifact Registry
-      run: |
-        gcloud auth configure-docker ${{ env.ARTIFACT_REGISTRY }}
-        gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev
-
-    - name: Build Docker image
-      run: |
-        pnpm dotenvx run -- docker build --no-cache -t ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest .
-
-    - name: Push Docker image to Artifact Registry
-      run: |
-        docker push ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest
-
-    - name: Deploy Internal API to Cloud Run
-      id: 'deploy'
-      uses: 'google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522' # v2.7.6
-      with:
-        service: ${{ env.APPLICATION_NAME }}
-        image: ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest
-        region: ${{ env.GCP_REGION }}
-        env_vars: |
-          NODE_ENV=development
-          ENV=dev
-
-    - name: Build Docker image for batch job
-      run: |
-        docker build -t ${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest -f Dockerfile.batch .
-
-    - name: Push Docker image for batch job to Artifact Registry
-      run: |
-        docker push ${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest
-
-    - name: Update Cloud Run Job (batch) to new image
-      # docker push :latest alone does not roll the Cloud Run Job to the new
-      # image — Cloud Run Jobs pin the image digest at deploy time, so we
-      # need an explicit `run jobs update` to create a new revision.
-      run: |
-        gcloud run jobs update ${{ env.BATCH_NAME }} \
-          --region=${{ env.GCP_REGION }} \
-          --image=${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest
-
-    - name: Cleanup SSH Key
-      if: always()
-      run: rm -f ~/.ssh/google_compute_engine ~/.ssh/google_compute_engine.pub
+    uses: ./.github/workflows/_deploy-cloud-run.yml
+    with:
+      stage: dev
+      environment: dev
+      apollo-variant: dev
+      node-env: development
+      extra-env-vars: |
+        ENV=dev
+      create-git-tag: false
+    secrets: inherit

--- a/.github/workflows/deploy-to-cloud-run-prd.yml
+++ b/.github/workflows/deploy-to-cloud-run-prd.yml
@@ -1,169 +1,35 @@
 name: Deploy to Cloud Run （prd）
 
+# master への直接 push では trigger しない (本番デプロイは PR merge 経由のみ)。
+# `pull_request: closed` + `merged == true` でフィルタすることで、PR が
+# merge されずに close されたときも skip される。
 on:
-  push:
-    branches:
-      - master
+  pull_request:
+    types: [closed]
+    branches: [master]
 
+# concurrency は workflow 単位で 1 本に絞る (異なる PR が同時に master に
+# 入っても deploy を直列化)。`github.ref` 単位だと PR ごとに別キューに
+# なってしまうため意図的に外す。
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}
   cancel-in-progress: false
+
+# Caller permissions must be a superset of the reusable workflow's permissions
+# (`_deploy-cloud-run.yml`: id-token:write + contents:write). Setting them
+# explicitly here also silences CodeQL's missing-permissions warning.
+permissions:
+  id-token: write
+  contents: write
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    environment: co-creation-dao-prod
-    timeout-minutes: 30
-
-    permissions:
-      id-token: write
-      contents: write
-
-    env:
-      # stage
-      STAGE: prd
-      # GCP settings
-      GCP_REGION: ${{ secrets.GCP_REGION }}
-      # DB credentials
-      DB_USER: ${{ secrets.DB_USER }}
-      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-      DB_NAME: ${{ secrets.DB_NAME }}
-      CLOUD_SQL_CONNECTION_NAME: ${{ secrets.CLOUD_SQL_CONNECTION_NAME }}
-      # application settings
-      ARTIFACT_REGISTRY: ${{ secrets.ARTIFACT_REGISTRY }}
-      APPLICATION_NAME: ${{ secrets.APPLICATION_NAME }}
-      # batch settings
-      BATCH_ARTIFACT_REGISTRY: ${{ secrets.BATCH_ARTIFACT_REGISTRY }}
-      BATCH_NAME: ${{ secrets.BATCH_NAME }}
-      # Jumpbox settings
-      JUMPBOX_INSTANCE_NAME: ${{ secrets.JUMPBOX_INSTANCE_NAME }}
-      JUMPBOX_ZONE: ${{ secrets.JUMPBOX_ZONE }}
-      # Apollo studio
-      APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-    - name: Install pnpm
-      run: npm install -g pnpm
-
-    - name: Set up Node.js
-      uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
-      with:
-        node-version: '20'
-        cache: 'pnpm'
-
-    - name: Install dependencies
-      run: |
-          pnpm install --frozen-lockfile
-
-    - name: Authenticate to Google Cloud (Workload Identity Federation)
-      uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70 # v2.1.6
-      with:
-        workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
-        service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-
-    - name: Set up gcloud SDK
-      uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
-
-    - name: pnpm db:generate and db:deploy
-      env:
-        DATABASE_URL: postgresql://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
-      run: |
-        echo "--- Connecting to DB via jumpbox ---"
-        gcloud compute ssh ${{ env.JUMPBOX_INSTANCE_NAME }} \
-          --tunnel-through-iap \
-          --zone=${{ env.JUMPBOX_ZONE }} \
-          --quiet -- -N -L 5432:localhost:5432 &
-        SSH_PID=$!
-        sleep 60
-        for _ in {1..5}; do
-          pg_isready -h localhost -p 5432 -d ${{ env.DB_NAME }} && break
-          sleep 60
-        done
-
-        echo "--- Running prisma generate ---"
-        pnpm db:generate
-
-        echo "--- Running prisma migrate deploy ---"
-        pnpm db:deploy
-
-        echo "Killing SSH tunnel"
-        kill $SSH_PID
-
-    - name: pnpm gql:generate
-      run: pnpm gql:generate
-
-    - name: Install and Publish via Rover CLI
-      env:
-        APOLLO_KEY: ${{ env.APOLLO_KEY }}
-      run: |
-        curl -sSL https://rover.apollo.dev/nix/latest | sh
-        export PATH="$HOME/.rover/bin:$PATH"
-        rover graph publish civicship-api-jq1988@prod --schema ./docs/schema.graphql
-
-    - name: pnpm build
-      run: pnpm build
-
-    - name: Configure Docker for GCP Artifact Registry
-      run: |
-        gcloud auth configure-docker ${{ env.ARTIFACT_REGISTRY }}
-        gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev
-
-    - name: Build Docker image
-      run: |
-        pnpm dotenvx run -- docker build --no-cache -t ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest .
-
-    - name: Push Docker image to Artifact Registry
-      run: |
-        docker push ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest
-
-    - name: Deploy Internal API to Cloud Run
-      id: 'deploy'
-      uses: 'google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522' # v2.7.6
-      with:
-        service: ${{ env.APPLICATION_NAME }}
-        image: ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest
-        region: ${{ env.GCP_REGION }}
-        env_vars: |
-          NODE_ENV=production
-
-    - name: Build Docker image for batch job
-      run: |
-        docker build -t ${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest -f Dockerfile.batch .
-
-    - name: Push Docker image for batch job to Artifact Registry
-      run: |
-        docker push ${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest
-
-    - name: Update Cloud Run Job (batch) to new image
-      # docker push :latest alone does not roll the Cloud Run Job to the new
-      # image — Cloud Run Jobs pin the image digest at deploy time, so we
-      # need an explicit `run jobs update` to create a new revision.
-      run: |
-        gcloud run jobs update ${{ env.BATCH_NAME }} \
-          --region=${{ env.GCP_REGION }} \
-          --image=${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest
-
-    - name: Create Git tag
-      run: |
-        # Install tzdata to use Japan timezone
-        sudo apt-get update && sudo apt-get install -y tzdata
-        sudo ln -fs /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
-        sudo dpkg-reconfigure -f noninteractive tzdata
-        
-        # Generate timestamp in yyyymmddhhmmss format
-        TAG_NAME=$(date +"%Y%m%d%H%M%S")
-        
-        # Configure Git user info (required inside GitHub Actions)
-        git config user.name "github-actions"
-        git config user.email "github-actions@github.com"
-        
-        # Create and push tag
-        git tag "$TAG_NAME"
-        git push origin "$TAG_NAME"
-
-    - name: Cleanup SSH Key
-      if: always()
-      run: rm -f ~/.ssh/google_compute_engine ~/.ssh/google_compute_engine.pub
+    if: github.event.pull_request.merged == true
+    uses: ./.github/workflows/_deploy-cloud-run.yml
+    with:
+      stage: prd
+      environment: co-creation-dao-prod
+      apollo-variant: prod
+      node-env: production
+      create-git-tag: true
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ web_modules/
 # TypeScript cache
 *.tsbuildinfo
 
+# Jest cache (cacheDirectory in jest.config.cjs)
+.jest-cache/
+
 # Optional npm cache directory
 .npm
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,7 @@
+# pnpm の package import method を hardlink に固定する。
+# default の `auto` は clone (CoW) → hardlink → copy の順で fallback する
+# が、GHA runner (ubuntu-latest, ext4) は clone 非対応で必ず hardlink に
+# 落ちる。最初から hardlink 指定で probing 分のオーバーヘッドを削減。
+# (ローカル開発でも APFS / btrfs などの clone-capable な FS で挙動が
+# 揃わなくなるが、install 結果は同一なので runtime 影響なし。)
+package-import-method=hardlink

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
 FROM node:20
 WORKDIR /app
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-RUN npm install -g pnpm@10.33.0
-RUN pnpm install --frozen-lockfile
 COPY . ./
-RUN pnpm build
-CMD ["pnpm", "start"]
+CMD ["node", "-r", "tsconfig-paths/register", "dist/bootstrap/index.js"]

--- a/Dockerfile.batch
+++ b/Dockerfile.batch
@@ -1,8 +1,0 @@
-FROM node:20
-WORKDIR /tmp
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-RUN npm install -g pnpm@10.33.0
-RUN pnpm install --frozen-lockfile
-COPY . ./
-RUN pnpm build
-CMD ["node", "dist/index.js"]

--- a/Dockerfile.external
+++ b/Dockerfile.external
@@ -1,4 +1,4 @@
 FROM node:20
-WORKDIR /tmp
+WORKDIR /app
 COPY . ./
-CMD ["node", "dist/external-api.js"]
+CMD ["node", "-r", "tsconfig-paths/register", "dist/bootstrap/external-api.js"]

--- a/Dockerfile.external
+++ b/Dockerfile.external
@@ -1,8 +1,4 @@
 FROM node:20
 WORKDIR /tmp
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-RUN npm install -g pnpm@10.33.0
-RUN pnpm install --frozen-lockfile
 COPY . ./
-RUN pnpm build
 CMD ["node", "dist/external-api.js"]

--- a/docs/handbook/DEPLOYMENT.md
+++ b/docs/handbook/DEPLOYMENT.md
@@ -25,18 +25,16 @@ civicship-api supports multiple deployment configurations, separating different 
 
 ```dockerfile
 # Dockerfile
-FROM node:20-alpine
-
+FROM node:20
 WORKDIR /app
-COPY package*.json ./
-RUN pnpm install --frozen-lockfile --prod
-
-COPY .. .
-RUN pnpm build
-
-EXPOSE 3000
-CMD ["pnpm", "start"]
+COPY . ./
+CMD ["node", "-r", "tsconfig-paths/register", "dist/bootstrap/index.js"]
 ```
+
+The runner builds `dist/` via `pnpm build` before the Docker build, and
+`node_modules/` is intentionally included in the build context (see
+`.dockerignore`). The image therefore ships pre-built JS and pre-installed
+dependencies — no `pnpm install` / `pnpm build` runs inside the container.
 
 #### 2. External API (Public Wallet Operations)
 
@@ -55,18 +53,14 @@ CMD ["pnpm", "start"]
 
 ```dockerfile
 # Dockerfile.external
-FROM node:20-alpine
-
+FROM node:20
 WORKDIR /app
-COPY package*.json ./
-RUN pnpm install --frozen-lockfile --prod
-
-COPY . .
-RUN pnpm build
-
-EXPOSE 8080
-CMD ["node", "dist/external-api.js"]
+COPY . ./
+CMD ["node", "-r", "tsconfig-paths/register", "dist/bootstrap/external-api.js"]
 ```
+
+Same pattern as Internal API: `dist/` and `node_modules/` come from the
+runner-side build, so the container starts directly from the pre-built output.
 
 #### 3. Batch Processing (Background Jobs)
 

--- a/docs/handbook/DEPLOYMENT.md
+++ b/docs/handbook/DEPLOYMENT.md
@@ -71,9 +71,9 @@ CMD ["node", "dist/external-api.js"]
 #### 3. Batch Processing (Background Jobs)
 
 **Configuration:**
-- **Entry Point:** `src/batch.ts`
+- **Entry Point:** `src/index.ts` (with `PROCESS_TYPE=batch` env)
 - **Purpose:** Background job processing
-- **Dockerfile:** `Dockerfile.batch`
+- **Dockerfile:** `Dockerfile` (unified — same image as Internal API)
 - **Deployment:** Google Cloud Run Jobs
 - **Execution:** Scheduled execution
 
@@ -83,19 +83,10 @@ CMD ["node", "dist/external-api.js"]
 - Periodic cleanup
 - Notification sending
 
-```dockerfile
-# Dockerfile.batch
-FROM node:20-alpine
-
-WORKDIR /app
-COPY package*.json ./
-RUN pnpm install --frozen-lockfile --prod
-
-COPY . .
-RUN pnpm build
-
-CMD ["node", "dist/batch.js"]
-```
+The batch image is the same `Dockerfile`-built image as the Internal API.
+The Cloud Run Job overrides the entrypoint with `--command=node --args=dist/index.js`
+in the deploy workflow (`_deploy-cloud-run.yml`), and the `main()` function in
+`src/index.ts` dispatches to `batchProcess()` when `process.env.PROCESS_TYPE === "batch"`.
 
 ## Google Cloud Run Settings
 

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -6,6 +6,9 @@ module.exports = {
     verboseQuery: true,
   },
   testTimeout: 50000,
+  // ts-jest の transform 結果をプロジェクト内 .jest-cache に保存し、CI で
+  // actions/cache 経由で永続化することで test job の transform overhead を削減。
+  cacheDirectory: "<rootDir>/.jest-cache",
   setupFiles: ["<rootDir>/jest.setup.ts"],
   setupFilesAfterEnv: ["@quramy/prisma-fabbrica/scripts/jest-prisma"],
   transform: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,8 @@
     "outDir": "dist",
     "module": "es2022",
     "target": "es2022",
+    "incremental": true,
+    "tsBuildInfoFile": ".tsbuildinfo",
     "strict": true,
     "noImplicitReturns": true,
     "noImplicitAny": false,


### PR DESCRIPTION
* perf(docker): remove redundant pnpm install from Dockerfiles

`.dockerignore` (8-16 行) のコメント通り node_modules は意図的に build context に含まれており、`COPY . ./` が runner 側で pre-build した node_modules (TypedSQL 含む) を image に持ち込む。Dockerfile 内の `RUN pnpm install --frozen-lockfile` はその直後の `COPY . ./` で 上書きされるため、純粋に無駄な処理だった。

3 ファイル (Dockerfile / Dockerfile.batch / Dockerfile.external) すべてから install ステップと `COPY package.json...` を削除。
1 build あたり 1〜2 分短縮見込み。

* perf(ci): speed up deploy workflows with buildx cache and parallelism

Deploy 系 4 ワークフロー共通の高速化:

- pnpm install: `npm install -g pnpm` → `pnpm/action-setup` に統一 (ci.yml と同じ pinned version, GHA pnpm cache 活用)
- SSH トンネル待機: `sleep 60` 固定 + `sleep 60` × 5 retry (最悪 6 分の固定待ち) → `pg_isready` を 2 秒間隔で 90 秒 active wait (通常 5〜15 秒で抜ける)
- Docker build: `--no-cache` 撤去、`docker/setup-buildx-action` + `cache-from/cache-to: type=gha` で incremental build cache を有効化
- Cloud Run dev/prd: main image と batch image を `&` で並列ビルド & push (同一 source ツリーなので GHA cache layer も部分的に共有)
- `pnpm dotenvx run -- docker build` 撤去: Dockerfile に ARG が無く build 時に env が flow していなかったため no-op だった

1 デプロイあたり 8〜15 分短縮見込み。

* perf(ci): consolidate setup work into a shared job with artifacts

CI ワークフロー (`ci.yml`) で `build` + `test` matrix 4 本 = 計 5 job が それぞれ独立に `pnpm db:deploy` → `pnpm db:generate` → `pnpm gql:generate` を実行していた重複を排除する。

新しい `setup` job が:
- `pnpm install --frozen-lockfile`
- `pnpm db:deploy` (Postgres service 上)
- `pnpm db:generate` (TypedSQL を含む Prisma client 生成)
- `pnpm gql:generate` (GraphQL types 生成)
- `git diff --exit-code` で生成物の commit 漏れチェック を 1 度だけ実行し、生成物 (`node_modules/.prisma`,
`node_modules/@prisma/client`, `src/types/graphql.ts`, `docs/schema.graphql`) を `actions/upload-artifact` で配布。

`build` / `test` 各 job は `pnpm install` 後に artifact を download し、 重複生成をスキップ。test job は Postgres service 隔離が必要なため
`pnpm db:deploy` のみ各自実行 (これは ~30 秒)。

aggregator job (`ci`) の `needs:` に `setup` を追加。`required status check` として branch protection に登録されているのは `ci` のみのため、
依存 job 増加に対する設定変更は不要。

CI 全体で 3〜5 分短縮見込み。

* perf(ci): cache .tsbuildinfo + Jest transforms, skip docs-only changes

CI ワークフローの追加最適化:

- paths-ignore: `**.md` / `docs/handbook/**` / `.github/dependabot.yml` のみの変更で CI 全体を skip する。`docs/schema.graphql` (生成物) は src の schema 変更とセットで commit されるため、src 変更時の CI カバレッジは維持される。
- TypeScript incremental: `tsconfig.json` に `incremental: true` + `tsBuildInfoFile: ".tsbuildinfo"` を追加し、`actions/cache` で branch ごとに `.tsbuildinfo` を永続化。`pnpm build` の typecheck が 未変更ファイルを skip できるようになる。restore-keys で branch fallback → OS fallback の順で部分 hit を許容。
- Jest cache: `jest.config.cjs` に `cacheDirectory: <rootDir>/.jest-cache` を指定し、test matrix 名ごとに `actions/cache` で永続化。 ts-jest の transform 結果を再利用して test job を 10〜20% 程度短縮。
- pnpm install に `--prefer-offline` を追加して GHA pnpm cache hit 時の 解決を offline 優先化。
- `.gitignore` に `.jest-cache/` を追加。

* refactor(ci): extract jumpbox SSH tunnel into a composite action

5 つの deploy workflow (cloud-run dev/prd, external-api dev/prd, richmenu) で重複していた「IAP-tunnel SSH 開通 + pg_isready 待機」の ロジックを `.github/actions/jumpbox-db-tunnel` に composite action として 切り出す。

richmenu workflow を更新:
- `npm install -g pnpm` → `pnpm/action-setup`
- `pnpm install` に `--prefer-offline` を追加
- 旧 SSH tunnel ブロックを composite action 呼び出しに置き換え
- 重複していた `kill $SSH_PID` も削除 (job 終了時に runner が cleanup)

cloud-run / external-api workflow への適用は次 commit (reusable workflow 化) と同時に行う。

* refactor(ci): unify Dockerfile.batch into Dockerfile and consolidate dev/prd deploys

Dockerfile.batch を廃止して main API image (Dockerfile) と統合。`src/index.ts` は既に `process.env.PROCESS_TYPE === "batch"` で batch / server を分岐する ため、image 自体は 1 つで足りる。Cloud Run Job 側で
`--command=node --args=dist/index.js` を指定して旧 Dockerfile.batch CMD と 等価な entrypoint に上書きする。

build 側は buildx multi-tag (`--tag main:latest --tag batch:latest --push`) で 1 回のビルド + push にまとめる。並列ビルド (前 commit) で 2 つの
buildx を回していた状態から、tsc 1 回 + cache scope 1 つに削減。

dev/prd 4 workflow (cloud-run dev/prd, external-api dev/prd) を reusable workflow に集約:

- `.github/workflows/_deploy-cloud-run.yml` (new): cloud-run deploy 本体
- `.github/workflows/_deploy-external-api.yml` (new): external-api 本体
- 各 entry workflow (`deploy-{to-cloud-run,external-api}-{dev,prd}.yml`) は trigger / concurrency / inputs (stage, environment, apollo-variant, node-env, extra-env-vars, create-git-tag, git-tag-prefix) のみを 記述する薄いラッパに改修
- Dynamic permission 式 (`contents: ${{ ... }}`) は GHA non-supported なため 両 stage で `contents: write` を付与 (dev は実質 read のみ使用)
- jumpbox SSH tunnel は前 commit で抽出した composite action を使用

`docs/handbook/DEPLOYMENT.md` の batch 節を新構成に合わせて更新 (旧構成の "Dockerfile.batch" / "dist/batch.js" は実態と乖離していた)。

差分: deploy 系 ~625 行削減 / +新規 ~104 行 = -520 行。

* perf(docker,pnpm): ship pre-built dist/ from runner and pin pnpm hardlink

Docker image build をさらに高速化:

- `.dockerignore` から `dist` の除外を解除し、runner で生成済みの TypeScript 出力 (`dist/`) を `COPY . ./` 経由で image に持ち込む。
- Dockerfile / Dockerfile.external から `RUN pnpm build` を削除。 既に runner 側で `pnpm build` を実行済み (deploy workflow: Build TypeScript output ステップ) なので、container 内の tsc 再実行は冗長。1 ビルドあたり 60〜90 秒短縮見込み。
- 主 Dockerfile から `RUN npm install -g pnpm@10.33.0` を削除し、 CMD を `pnpm start` から `node -r tsconfig-paths/register dist/bootstrap/index.js` へインライン化。pnpm をランタイムから外し、 global install 分 (~20-30s) と image サイズを削減。

`.npmrc` を新規追加 (`package-import-method=hardlink`):
- default の `auto` は clone (CoW) → hardlink → copy の順で probing する。GHA runner (ubuntu-latest, ext4) は clone 非対応で必ず hardlink に落ちるため、最初から指定して probing オーバーヘッドを 削減。install 結果は同一で runtime 影響なし。

`.dockerignore` のコメントを新フローに合わせて更新
(runner-built dist/ を ship する旨を明記)。

* revert(ci): drop setup job artifact-sharing, restore per-job db:generate

Stage 4 (commit 01967d9) で setup job を新設し Prisma client + GraphQL types を artifact 経由で build / test job に配布する設計にしたが、これが TypeScript の型解決と pnpm の symlink 構造の組み合わせで壊れていた:

- pnpm は `node_modules/@prisma/client` を `node_modules/.pnpm/@prisma+client@.../node_modules/@prisma/client` への symlink として配置する
- `prisma generate --sql` は symlink の実体である `.pnpm/...` 配下に TypedSQL の型情報を書き込む
- TypeScript module resolution は realpath でこの symlink を解決するため、 `.pnpm/...` を直接参照する
- `actions/upload-artifact` は表側の `node_modules/@prisma/client` / `node_modules/.prisma` のみアップロードしており `.pnpm/...` 内の 生成物を含めない (上げると path が pnpm version 依存になり脆い)
- 結果、build / test job 側で symlink target の `.pnpm/...` には Prisma generate 未実施の状態で TS が型を見にいき、 `Module '"@prisma/client"' has no exported member 'Community'` 等で fail

撤回して、build / test job それぞれで `pnpm db:deploy` →
`pnpm db:generate` → `pnpm gql:generate` を実行する元の構造に戻す。 他の最適化 (paths-ignore / .tsbuildinfo cache / Jest cache / --prefer-offline) は維持。

aggregator job (`ci`) の `needs:` から `setup` を除外。

* fix(ci): address PR review feedback

- ci.yml: workflow-level の `paths-ignore` を撤回。`ci` aggregator job が branch protection の required status check のため、paths-ignore で workflow ごと skip すると status が報告されず docs-only PR が永続的に merge 不能になる (Devin 指摘)。軽量化が必要になったら job 側で changed-files filter を使って expensive job のみ条件 skip する形にする。
- deploy entry workflow × 4: top-level `permissions: id-token:write + contents:write` を明示。reusable workflow 側で必要な permissions の superset として設定する必要があるため、CodeQL の missing-permissions warning も解消。
- jumpbox-db-tunnel: kill 前の PID ファイル存在チェックを追加 (Gemini 指摘)。
- DEPLOYMENT.md: `src/index.ts:118-128` のような行番号参照を関数名 (`main()`) ベースに置換 (Gemini 指摘)。

`tsconfig-paths` placement (Gemini): 既に dependencies に登録済み (誤検知)。 Dockerfile CMD を `dist/index.js` に統一 (Gemini): main API は `dist/bootstrap/index.js` 経由で env banner + tracing 初期化を行うため、 挙動変更を伴うため見送り。

* feat(ci): expand dev deploy triggers and gate prd deploy on PR merge

dev deploy (cloud-run-dev / external-api-dev):
- push trigger に `epic/**`, `hotfix/**` を追加。`develop` 以外の長期作業 ブランチからも dev 環境に deploy できるようにする。
- 注意: 複数 epic/hotfix ブランチが同時 push されると後勝ちで dev 環境を 上書きする (concurrency は branch 単位で per-branch にキューされる)。

prd deploy (cloud-run-prd / external-api-prd):
- trigger を `push: master` から `pull_request: closed (merged) → master` に変更。`master` への直 push では deploy が走らなくなる。
- job に `if: github.event.pull_request.merged == true` を追加し、PR が merge されずに close されたときは skip。
- concurrency group を `${{ github.workflow }}-${{ github.ref }}` から `${{ github.workflow }}` に変更。pull_request イベントでは `github.ref` が PR ごとに異なるため、prd への複数同時 merge を直列化 するには workflow 単位でキューを共有する必要がある。

dev workflow の concurrency は per-branch のまま維持 (ブランチごとに 独立した検証環境としては扱えないが、ブランチごとにキューは独立)。

---------
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/944" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
