### PR TITLE
fix(ci/cd): address PR #944 review feedback

### DIFF
--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -64,6 +64,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || '' }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0

--- a/.github/workflows/_deploy-external-api.yml
+++ b/.github/workflows/_deploy-external-api.yml
@@ -61,6 +61,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || '' }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0

--- a/Dockerfile.external
+++ b/Dockerfile.external
@@ -1,4 +1,4 @@
 FROM node:20
 WORKDIR /tmp
 COPY . ./
-CMD ["node", "dist/external-api.js"]
+CMD ["node", "-r", "tsconfig-paths/register", "dist/external-api.js"]

--- a/Dockerfile.external
+++ b/Dockerfile.external
@@ -1,4 +1,4 @@
 FROM node:20
-WORKDIR /tmp
+WORKDIR /app
 COPY . ./
-CMD ["node", "-r", "tsconfig-paths/register", "dist/external-api.js"]
+CMD ["node", "-r", "tsconfig-paths/register", "dist/bootstrap/external-api.js"]

--- a/docs/handbook/DEPLOYMENT.md
+++ b/docs/handbook/DEPLOYMENT.md
@@ -54,9 +54,9 @@ dependencies — no `pnpm install` / `pnpm build` runs inside the container.
 ```dockerfile
 # Dockerfile.external
 FROM node:20
-WORKDIR /tmp
+WORKDIR /app
 COPY . ./
-CMD ["node", "-r", "tsconfig-paths/register", "dist/external-api.js"]
+CMD ["node", "-r", "tsconfig-paths/register", "dist/bootstrap/external-api.js"]
 ```
 
 Same pattern as Internal API: `dist/` and `node_modules/` come from the

--- a/docs/handbook/DEPLOYMENT.md
+++ b/docs/handbook/DEPLOYMENT.md
@@ -25,18 +25,16 @@ civicship-api supports multiple deployment configurations, separating different 
 
 ```dockerfile
 # Dockerfile
-FROM node:20-alpine
-
+FROM node:20
 WORKDIR /app
-COPY package*.json ./
-RUN pnpm install --frozen-lockfile --prod
-
-COPY .. .
-RUN pnpm build
-
-EXPOSE 3000
-CMD ["pnpm", "start"]
+COPY . ./
+CMD ["node", "-r", "tsconfig-paths/register", "dist/bootstrap/index.js"]
 ```
+
+The runner builds `dist/` via `pnpm build` before the Docker build, and
+`node_modules/` is intentionally included in the build context (see
+`.dockerignore`). The image therefore ships pre-built JS and pre-installed
+dependencies — no `pnpm install` / `pnpm build` runs inside the container.
 
 #### 2. External API (Public Wallet Operations)
 
@@ -55,18 +53,14 @@ CMD ["pnpm", "start"]
 
 ```dockerfile
 # Dockerfile.external
-FROM node:20-alpine
-
-WORKDIR /app
-COPY package*.json ./
-RUN pnpm install --frozen-lockfile --prod
-
-COPY . .
-RUN pnpm build
-
-EXPOSE 8080
-CMD ["node", "dist/external-api.js"]
+FROM node:20
+WORKDIR /tmp
+COPY . ./
+CMD ["node", "-r", "tsconfig-paths/register", "dist/external-api.js"]
 ```
+
+Same pattern as Internal API: `dist/` and `node_modules/` come from the
+runner-side build, so the container starts directly from the pre-built output.
 
 #### 3. Batch Processing (Background Jobs)
 


### PR DESCRIPTION
## Summary

PR #944 のレビュー指摘 4 件に対応。

- **Dockerfile.external**: `-r tsconfig-paths/register` を追加。`src/external-api.ts` が `@/` パスエイリアスを使用しているため、未指定では runtime のモジュール解決に失敗する (Gemini high)。
- **_deploy-cloud-run.yml / _deploy-external-api.yml**: `actions/checkout` に `ref: ${{ github.event.pull_request.merge_commit_sha || '' }}` を追加。prd trigger を `pull_request: closed` に変えた結果、checkout が `refs/pull/N/merge` (テストマージ commit) を取得していた。修正により実際の master merge commit を取得するため、git tag が orphan commit を指す問題と stale なコードがデプロイされる可能性を解消 (Devin high)。`push` イベント (dev workflow) では空文字フォールバックで従来通り default ref を使う。
- **docs/handbook/DEPLOYMENT.md**: Internal API / External API セクションの旧 Dockerfile 例を新フロー (runner で pre-build した `dist/` を ship する形) に合わせて更新 (Gemini medium)。

## Test plan

- [ ] CI (`ci.yml`) green
- [ ] dev deploy (cloud-run-dev / external-api-dev) で `actions/checkout` の `ref: ''` フォールバックが期待通り default ref を取得することを次回 push で確認
- [ ] external API が起動し、`@/` パスエイリアス経由の import が解決されることを dev 環境で確認
- [ ] prd deploy のテストは PR を実際に master へマージしてから確認 (`merge_commit_sha` が解決される)

https://claude.ai/code/session_019RiWDTQaL2hzVV9C3Ldioo

---
_Generated by [Claude Code](https://claude.ai/code/session_019RiWDTQaL2hzVV9C3Ldioo)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/946" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
