### PR TITLE
fix(ci/cd): batch tracing, deploy harden-runner, audit annotations

### DIFF
--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -62,6 +62,17 @@ jobs:
       APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
 
     steps:
+      # `audit` mode: log egress (GCP / npm registry / GitHub) without blocking.
+      # `block` mode would require maintaining an allowlist for every gcloud
+      # endpoint and is fragile across SDK updates. `disable-sudo` is left
+      # enabled (default) because the "Create Git tag" step installs tzdata
+      # via apt-get on prd. Audit logs surface in the job summary and let us
+      # detect unexpected egress (e.g. credential exfiltration) post-hoc.
+      - name: Harden runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -157,13 +168,18 @@ jobs:
         # docker push :latest alone does not roll the Cloud Run Job to the new
         # image — Cloud Run Jobs pin the image digest at deploy time, so we
         # need an explicit `run jobs update` to create a new revision.
-        # `--command=node --args=dist/index.js` で旧 Dockerfile.batch の CMD を再現。
+        # `dist/bootstrap/batch.js` 経由で起動することで OpenTelemetry tracing 初期化
+        # (`tracingReady` await) を batch ジョブでも有効にする。`@/` パスエイリアスが
+        # bootstrap 層で使われるため `-r tsconfig-paths/register` も必須。
+        # PROCESS_TYPE=batch は Cloud Run Job 側の env で別途設定されている前提
+        # (bootstrap/batch.ts は ../index に dispatch するだけで、batch 分岐自体は
+        # src/index.ts:main() が PROCESS_TYPE で判定する)。
         run: |
           gcloud run jobs update "${{ env.BATCH_NAME }}" \
             --region="${{ env.GCP_REGION }}" \
             --image="${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest" \
             --command=node \
-            --args=dist/index.js
+            --args=-r,tsconfig-paths/register,dist/bootstrap/batch.js
 
       - name: Create Git tag
         if: ${{ inputs.create-git-tag }}

--- a/.github/workflows/_deploy-external-api.yml
+++ b/.github/workflows/_deploy-external-api.yml
@@ -59,6 +59,12 @@ jobs:
       JUMPBOX_ZONE: ${{ secrets.JUMPBOX_ZONE }}
 
     steps:
+      # See _deploy-cloud-run.yml for rationale on audit mode + sudo.
+      - name: Harden runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,16 @@ jobs:
       - name: Install dependencies (lockfile integrity check)
         run: pnpm install --frozen-lockfile --prefer-offline
 
-      - name: Audit (non-blocking)
-        run: pnpm audit --audit-level=high
-        continue-on-error: true
+      # Surface high/critical findings as a `::warning::` annotation visible
+      # in the PR check summary, but do not fail the job (audit results can
+      # change independently of code changes; gating CI on transitive
+      # vulnerabilities yields a flaky required check). The full audit output
+      # is preserved in the step log for triage.
+      - name: Audit (non-blocking, surfaces findings as warnings)
+        run: |
+          if ! pnpm audit --audit-level=high; then
+            echo "::warning::pnpm audit found high-severity vulnerabilities (non-blocking — see step log for details)"
+          fi
 
       - name: Apply Prisma migrations to CI database
         # TypedSQL (`--sql`) は DB 接続を必要とするため、db:generate の前に

--- a/.github/workflows/deploy-richmenu.yml
+++ b/.github/workflows/deploy-richmenu.yml
@@ -46,6 +46,12 @@ jobs:
       JUMPBOX_ZONE: ${{ secrets.JUMPBOX_ZONE }}
 
     steps:
+      # See _deploy-cloud-run.yml for rationale on audit mode.
+      - name: Harden runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 


### PR DESCRIPTION
## Summary

PR #944 / #946 のフォローアップ。CI/CD ワークフロー全体を再点検した結果見つかった 3 件を一括対応。

### 1. 🔴 Batch Cloud Run Job の OpenTelemetry tracing 復旧
`_deploy-cloud-run.yml`: batch Job override を `dist/index.js` 直起動から `dist/bootstrap/batch.js` 経由に変更。`bootstrap/batch.ts` は `tracingReady` await → `../index` を import するため、これを通さないと **本番 batch ジョブで OTel instrumentation が初期化されない** 状態だった (Devin 指摘)。`@/` パスエイリアスが bootstrap 層で使われるため `-r tsconfig-paths/register` も追加。`PROCESS_TYPE=batch` の env は Cloud Run Job 側で別途設定されている前提を維持。

### 2. 🟡 Deploy workflow に `step-security/harden-runner` 追加
`_deploy-cloud-run.yml` / `_deploy-external-api.yml` / `deploy-richmenu.yml`: WIF 認証・DB credential・jumpbox SSH key を扱う deploy 系こそ egress audit が必要だが、これまで `ci.yml` にしか入っていなかった。`audit` mode (block ではない) で導入 — gcloud SDK の egress surface が広く allowlist 維持が脆いため。`disable-sudo` は付けない (prd の git tag step で `apt-get install tzdata` を sudo 実行)。

### 3. 🟡 `pnpm audit` を annotation 化
`ci.yml`: 高深刻度脆弱性検出時に `::warning::` を出して PR check summary に可視化。CI 自体は引き続き non-blocking (transitive 脆弱性は code change と独立に変動するため required check に gating すると flaky)。`continue-on-error: true` で完全に隠していた状態を改善。

### 検証済まず確認したこと

- 4 つの deploy entry workflow (`deploy-{to-cloud-run,external-api}-{dev,prd}.yml`) は薄いラッパなので変更不要
- harden-runner は `ci.yml` で実績あり、audit mode は失敗時も non-blocking
- batch CMD の `--args=-r,tsconfig-paths/register,dist/bootstrap/batch.js` は gcloud の comma-separated list 仕様に合致

## Test plan

- [ ] `ci.yml` のすべての required check が green
- [ ] 次回 dev deploy 後、Cloud Run Job (batch) のリビジョン update を gcloud で確認 (`gcloud run jobs describe <BATCH_NAME> --region=<REGION>` で `command: node`, `args: [-r, tsconfig-paths/register, dist/bootstrap/batch.js]` を確認)
- [ ] dev 環境の batch ジョブ実行後、OTel trace が collector に届くこと
- [ ] deploy job の Actions UI に `harden-runner` の egress summary が出ること

https://claude.ai/code/session_019RiWDTQaL2hzVV9C3Ldioo

---
_Generated by [Claude Code](https://claude.ai/code/session_019RiWDTQaL2hzVV9C3Ldioo)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
