### PR TITLE
perf(analytics): parallelize getAlerts in analyticsCommunity usecase

### DIFF
--- a/src/application/domain/analytics/community/usecase.ts
+++ b/src/application/domain/analytics/community/usecase.ts
@@ -70,6 +70,7 @@ export default class AnalyticsCommunityUseCase {
       retentionTrend,
       cohortRetention,
       chainDepthDistribution,
+      alerts,
     ] = await Promise.all([
       this.service.getMemberStats(ctx, community.communityId, asOf),
       this.service.getMonthlyActivity(
@@ -84,14 +85,13 @@ export default class AnalyticsCommunityUseCase {
       this.service.getRetentionTrend(ctx, community.communityId, asOf, windowMonths),
       this.service.getCohortRetention(ctx, community.communityId, asOf, windowMonths),
       this.service.getChainDepthDistribution(ctx, community.communityId, asOf),
+      this.service.getAlerts(ctx, community.communityId, asOf),
     ]);
 
     const stageCounts = computeStageCounts(members, thresholds);
     const stageBreakdown = computeStageBreakdown(members, thresholds);
     const dormantCount = computeDormantCount(members, asOf, dormantThresholdDays);
     const cohortFunnel = computeCohortFunnel(members, asOf, windowMonths, thresholds);
-
-    const alerts = await this.service.getAlerts(ctx, community.communityId, asOf);
 
     const memberList = paginateMembers(members, {
       minSendRate: input.userFilter?.minSendRate ?? 0.7,


### PR DESCRIPTION
## サマリ

PR #947 のレビュー指摘 (Gemini Code Assist) への対応。`AnalyticsCommunityUseCase.getCommunity` で `getAlerts` の呼び出しが先行する `Promise.all` の外で逐次実行されていた。他の 7 メソッドと依存関係がないため、同じ `Promise.all` 内に含めて並列化することで `analyticsCommunity` query のレスポンスタイムを短縮。

## 変更内容

**`src/application/domain/analytics/community/usecase.ts`**:

```diff
     const [
       members,
       monthlyActivity,
       allTimeTotals,
       currentMonthActivity,
       retentionTrend,
       cohortRetention,
       chainDepthDistribution,
+      alerts,
     ] = await Promise.all([
       this.service.getMemberStats(ctx, community.communityId, asOf),
       this.service.getMonthlyActivity(...),
       this.service.getAllTimeTotals(ctx, community.communityId, asOf),
       this.service.getMonthActivityWithPrev(ctx, community.communityId, asOf),
       this.service.getRetentionTrend(ctx, community.communityId, asOf, windowMonths),
       this.service.getCohortRetention(ctx, community.communityId, asOf, windowMonths),
       this.service.getChainDepthDistribution(ctx, community.communityId, asOf),
+      this.service.getAlerts(ctx, community.communityId, asOf),
     ]);

     const stageCounts = computeStageCounts(members, thresholds);
     const stageBreakdown = computeStageBreakdown(members, thresholds);
     const dormantCount = computeDormantCount(members, asOf, dormantThresholdDays);
     const cohortFunnel = computeCohortFunnel(members, asOf, windowMonths, thresholds);
-
-    const alerts = await this.service.getAlerts(ctx, community.communityId, asOf);
```

7 メソッドの中で最も遅いものに律速されていた処理時間が、8 メソッド全体の最大時間に変わるだけ — `getAlerts` の wall-clock がボトルネックでない限り体感差は小さいが、retention/cohort 系で fan-out が走るコミュニティでは最大 1 ラウンドトリップ分の改善。

## レビュー対応

PR #947 で Gemini bot から指摘された 2 件のうち、本 PR は **getAlerts 並列化のみ対応**。もう 1 件 (N+1) は設計議論で、コード内 docstring で既に「~20 community 超えで GROUP BY 切替」と documented 済みなのでスコープ外。

## Test plan

- [x] `pnpm typecheck` — エラーなし
- [x] `pnpm test src/__tests__/unit/analytics/` — **91/91 pass**
- [x] 動作変更ゼロ (出力 payload は完全互換、実行順序のみ並列化)
- [ ] CI で全 unit / integration / e2e suite pass

https://claude.ai/code/session_01UW6ubb47XcbTNreZj9PWNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01UW6ubb47XcbTNreZj9PWNU)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/950" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
