### PR TITLE
perf(analytics): collapse L1 dashboard fan-out to 5 bulk SQLs

### DIFF
--- a/src/__tests__/unit/analytics/community/aggregations.test.ts
+++ b/src/__tests__/unit/analytics/community/aggregations.test.ts
@@ -409,7 +409,7 @@ describe("computeDormantCount", () => {
     // Production asOf is `new Date()` with the wall-clock time
     // component preserved (e.g. 06:17:55Z). lastDonationDay is a
     // JST calendar day at UTC 00:00 (the SQL ::date cast in
-    // findMemberStats strips the time). Without truncating asOf
+    // findMemberStatsBulk strips the time). Without truncating asOf
     // to its JST date before subtracting days, a member who
     // donated on the cutoff day has lastDonationDay = cutoff-day
     // 00:00Z < cutoff-day HH:MM:SSZ → they'd be misclassified as

--- a/src/__tests__/unit/analytics/community/service.test.ts
+++ b/src/__tests__/unit/analytics/community/service.test.ts
@@ -11,11 +11,14 @@ class MockAnalyticsCommunityRepository {
   findAllCommunities = jest.fn();
   findCommunityById = jest.fn();
   findMemberStats = jest.fn();
+  findMemberStatsBulk = jest.fn();
   findMonthlyActivity = jest.fn();
   findActivitySnapshot = jest.fn();
   findNewMemberCount = jest.fn();
   findWindowActivityCounts = jest.fn();
+  findWindowActivityCountsBulk = jest.fn();
   findWindowHubMemberCount = jest.fn();
+  findWindowHubMemberCountBulk = jest.fn();
   findAllTimeTotals = jest.fn();
   findPlatformTotals = jest.fn();
   findChainDepthDistribution = jest.fn();
@@ -28,7 +31,9 @@ class MockAnalyticsCommunityRepository {
  */
 class MockReportService {
   getRetentionAggregate = jest.fn();
+  getRetentionAggregateBulk = jest.fn();
   getCohortRetention = jest.fn();
+  getCohortRetentionBulk = jest.fn();
 }
 
 describe("AnalyticsCommunityService", () => {
@@ -162,6 +167,95 @@ describe("AnalyticsCommunityService", () => {
         ...neutralMonths,
       });
       expect((await service.getAlerts(ctx, "c1", asOf)).noNewMembers).toBe(false);
+    });
+  });
+
+  // ========================================================================
+  // Bulk wrappers: pin the wiring so the L1 dashboard fan-out keeps
+  // collapsing to one SQL roundtrip per concern. Each test asserts both
+  // the underlying repository / ReportService call shape and the
+  // Map<communityId, ...> shape the usecase consumes.
+  // ========================================================================
+  describe("bulk wrappers", () => {
+    const ctx = {} as never;
+    const asOf = new Date("2026-04-30T15:00:00Z");
+
+    it("getMemberStatsBulk forwards to findMemberStatsBulk", async () => {
+      const map = new Map([["c1", []]]);
+      repo.findMemberStatsBulk.mockResolvedValueOnce(map);
+      const result = await service.getMemberStatsBulk(ctx, ["c1"], asOf);
+      expect(repo.findMemberStatsBulk).toHaveBeenCalledWith(ctx, ["c1"], asOf);
+      expect(result).toBe(map);
+    });
+
+    it("getWindowActivityBulk computes the same window bounds as the single-row variant", async () => {
+      // Pin the bounds so a regression in service-level date math
+      // breaks here before the L1 vs L2 numbers desync.
+      repo.findWindowActivityCountsBulk.mockResolvedValueOnce(new Map());
+      await service.getWindowActivityBulk(ctx, ["c1", "c2"], asOf, 28);
+      expect(repo.findWindowActivityCountsBulk).toHaveBeenCalledTimes(1);
+      const [, ids, prevLower, currLower, upper] =
+        repo.findWindowActivityCountsBulk.mock.calls[0];
+      expect(ids).toEqual(["c1", "c2"]);
+      // upper - currLower === windowDays === currLower - prevLower
+      const day = 24 * 60 * 60 * 1000;
+      expect(upper.getTime() - currLower.getTime()).toBe(28 * day);
+      expect(currLower.getTime() - prevLower.getTime()).toBe(28 * day);
+    });
+
+    it("getWindowHubMemberCountBulk extracts numeric counts and defaults missing ids to 0", async () => {
+      repo.findWindowHubMemberCountBulk.mockResolvedValueOnce(
+        new Map([
+          ["c1", { count: 5 }],
+          ["c2", { count: 0 }],
+        ]),
+      );
+      const result = await service.getWindowHubMemberCountBulk(
+        ctx,
+        ["c1", "c2", "c3-missing"],
+        asOf,
+        28,
+        3,
+      );
+      expect(result.get("c1")).toBe(5);
+      expect(result.get("c2")).toBe(0);
+      expect(result.get("c3-missing")).toBe(0);
+    });
+
+    it("getWeeklyRetentionBulk extracts retained / churned per community and zero-fills misses", async () => {
+      reportService.getRetentionAggregateBulk.mockResolvedValueOnce(
+        new Map([
+          [
+            "c1",
+            {
+              newMembers: 0,
+              retainedSenders: 7,
+              returnedSenders: 0,
+              churnedSenders: 3,
+              currentSendersCount: 0,
+              currentActiveCount: 0,
+            },
+          ],
+        ]),
+      );
+      const result = await service.getWeeklyRetentionBulk(
+        ctx,
+        ["c1", "c2-missing"],
+        asOf,
+      );
+      expect(result.get("c1")).toEqual({ retainedSenders: 7, churnedSenders: 3 });
+      expect(result.get("c2-missing")).toEqual({ retainedSenders: 0, churnedSenders: 0 });
+    });
+
+    it("getLatestCohortBulk extracts size / activeAtM1 per community and zero-fills misses", async () => {
+      reportService.getCohortRetentionBulk.mockResolvedValueOnce(
+        new Map([
+          ["c1", { cohortSize: 12, activeNextWeek: 5 }],
+        ]),
+      );
+      const result = await service.getLatestCohortBulk(ctx, ["c1", "c2-missing"], asOf);
+      expect(result.get("c1")).toEqual({ size: 12, activeAtM1: 5 });
+      expect(result.get("c2-missing")).toEqual({ size: 0, activeAtM1: 0 });
     });
   });
 });

--- a/src/__tests__/unit/analytics/community/service.test.ts
+++ b/src/__tests__/unit/analytics/community/service.test.ts
@@ -10,14 +10,11 @@ import AnalyticsCommunityService from "@/application/domain/analytics/community/
 class MockAnalyticsCommunityRepository {
   findAllCommunities = jest.fn();
   findCommunityById = jest.fn();
-  findMemberStats = jest.fn();
   findMemberStatsBulk = jest.fn();
   findMonthlyActivity = jest.fn();
   findActivitySnapshot = jest.fn();
   findNewMemberCount = jest.fn();
-  findWindowActivityCounts = jest.fn();
   findWindowActivityCountsBulk = jest.fn();
-  findWindowHubMemberCount = jest.fn();
   findWindowHubMemberCountBulk = jest.fn();
   findAllTimeTotals = jest.fn();
   findPlatformTotals = jest.fn();

--- a/src/application/domain/analytics/community/aggregations.ts
+++ b/src/application/domain/analytics/community/aggregations.ts
@@ -287,7 +287,7 @@ export function computeTenureDistribution(
     else if (m.daysIn < 365) m3to12Months++;
     else gte12Months++;
     // Members with daysIn < 0 (data anomaly — shouldn't occur
-    // because findMemberStats clamps daysIn to >= 1) are
+    // because findMemberStatsBulk clamps daysIn to >= 1) are
     // already counted in lt1Month above (daysIn < 0 < 30), so
     // they also flow into histogram bucket 0 via the
     // Math.max(0, ...) clamp below. Without that clamp,
@@ -341,7 +341,7 @@ export function computeDormantCount(
  *   habitual      — classifyMember(...) === "habitual"
  *
  * activatedD30 / repeated / habitual are JOINED-at-asOf scoped
- * because `members` is itself JOINED-at-asOf (findMemberStats
+ * because `members` is itself JOINED-at-asOf (findMemberStatsBulk
  * applies the membership filter).
  */
 export function computeCohortFunnel(
@@ -377,7 +377,7 @@ export function computeCohortFunnel(
     if (!bucket) continue;
     bucket.acquired++;
     // Both sides are JST-day grain: firstDonationDay is already
-    // a JST date encoded at UTC midnight (see findMemberStats),
+    // a JST date encoded at UTC midnight (see findMemberStatsBulk),
     // and joinedAt is truncated to its JST date here so the
     // "30 days within join" comparison is symmetric. Without
     // truncation the joinedAt time-of-day component skewed the

--- a/src/application/domain/analytics/community/bounds.ts
+++ b/src/application/domain/analytics/community/bounds.ts
@@ -4,7 +4,7 @@ import { addDays, truncateToJstDate } from "@/application/domain/report/util";
  * Clamp helper for queries whose upper bound should never land in the
  * future relative to an `asOf` timestamp.
  *
- * Four places across the sysadmin domain need the same calculation:
+ * Four places across the analytics domain need the same calculation:
  *   - usecase.getDashboard  (findPlatformTotals upper)
  *   - service.getMonthActivityWithPrev (current-month snapshot)
  *   - service.getRetentionTrend (per-week denominator)

--- a/src/application/domain/analytics/community/data/converter.ts
+++ b/src/application/domain/analytics/community/data/converter.ts
@@ -1,5 +1,5 @@
 /**
- * Wire-format → internal form for the sysadmin domain. Pure GraphQL
+ * Wire-format → internal form for the analytics domain. Pure GraphQL
  * input-side transforms only. The matching internal → GraphQL
  * output direction (e.g. encoding the next-page cursor) lives in
  * the presenter to keep each layer's transform direction clean.

--- a/src/application/domain/analytics/community/data/interface.ts
+++ b/src/application/domain/analytics/community/data/interface.ts
@@ -12,7 +12,7 @@ import {
 } from "@/application/domain/analytics/community/data/type";
 
 /**
- * Repository contract for the sysadmin analytics surface.
+ * Repository contract for the analytics community surface.
  *
  * All queries read through `ctx.issuer.public` (MVs bypass RLS anyway,
  * and the t_memberships / t_transactions reads here are gated at the

--- a/src/application/domain/analytics/community/data/interface.ts
+++ b/src/application/domain/analytics/community/data/interface.ts
@@ -44,6 +44,20 @@ export interface IAnalyticsCommunityRepository {
   ): Promise<AnalyticsMemberStatsRow[]>;
 
   /**
+   * Bulk variant of `findMemberStats`. Computes per-member counters for
+   * every community in `communityIds` in a single SQL roundtrip,
+   * returning a `Map<communityId, rows[]>` pre-seeded with empty arrays.
+   * Cross-community leakage guards and same-user JOIN keys are tightened
+   * to `(user_id, community_id)` so a user who is a member of multiple
+   * communities is correctly bucketed.
+   */
+  findMemberStatsBulk(
+    ctx: IContext,
+    communityIds: string[],
+    asOf: Date,
+  ): Promise<Map<string, AnalyticsMemberStatsRow[]>>;
+
+  /**
    * Monthly activity series for `windowMonths` trailing JST months
    * ending at `asOf`. One row per month with data; months with zero
    * senders and zero new members are still emitted (with zero

--- a/src/application/domain/analytics/community/data/interface.ts
+++ b/src/application/domain/analytics/community/data/interface.ts
@@ -115,6 +115,20 @@ export interface IAnalyticsCommunityRepository {
   ): Promise<AnalyticsHubMemberCountRow>;
 
   /**
+   * Bulk variant of `findWindowHubMemberCount`. Computes the hub-member
+   * count for every community in `communityIds` in a single SQL pass.
+   * Returns one entry per requested community (count=0 for communities
+   * with no hub members in the window).
+   */
+  findWindowHubMemberCountBulk(
+    ctx: IContext,
+    communityIds: string[],
+    currLower: Date,
+    upper: Date,
+    hubBreadthThreshold: number,
+  ): Promise<Map<string, AnalyticsHubMemberCountRow>>;
+
+  /**
    * All five raw counts the L1 `AnalyticsWindowActivity` payload needs
    * for the parametric window pair driven by `windowDays`. Issues a
    * single SQL with two scans (one over `mv_user_transaction_daily`
@@ -131,6 +145,21 @@ export interface IAnalyticsCommunityRepository {
     currLower: Date,
     upper: Date,
   ): Promise<AnalyticsWindowActivityCountsRow>;
+
+  /**
+   * Bulk variant of `findWindowActivityCounts`. Aggregates the same five
+   * counts for every community in `communityIds` in a single SQL pass.
+   * Returns one entry per requested community (zero-row defaults for
+   * communities with no activity in the window). Used by the L1
+   * dashboard fan-out to collapse N roundtrips to one.
+   */
+  findWindowActivityCountsBulk(
+    ctx: IContext,
+    communityIds: string[],
+    prevLower: Date,
+    currLower: Date,
+    upper: Date,
+  ): Promise<Map<string, AnalyticsWindowActivityCountsRow>>;
 
   /** All-time DONATION totals + MV data window for the summary card,
    * clamped at `asOf` for historic-asOf consistency with the rest of

--- a/src/application/domain/analytics/community/data/interface.ts
+++ b/src/application/domain/analytics/community/data/interface.ts
@@ -33,21 +33,11 @@ export interface IAnalyticsCommunityRepository {
   ): Promise<AnalyticsCommunityRow | null>;
 
   /**
-   * Per-member LTV-variable counters at `asOf` for one community.
-   * Scoped to `status='JOINED'`. A member with zero DONATION-outs is
-   * still present (donationOutMonths=0, userSendRate=0, latent stage).
-   */
-  findMemberStats(
-    ctx: IContext,
-    communityId: string,
-    asOf: Date,
-  ): Promise<AnalyticsMemberStatsRow[]>;
-
-  /**
-   * Bulk variant of `findMemberStats`. Computes per-member counters for
-   * every community in `communityIds` in a single SQL roundtrip,
-   * returning a `Map<communityId, rows[]>` pre-seeded with empty arrays.
-   * Cross-community leakage guards and same-user JOIN keys are tightened
+   * Per-member LTV-variable counters at `asOf` for every community in
+   * `communityIds`, returned as `Map<communityId, rows[]>` pre-seeded
+   * with empty arrays. Scoped to `status='JOINED'`. A member with zero
+   * DONATION-outs is still present (donationOutMonths=0,
+   * userSendRate=0, latent stage). Same-user JOIN keys are tightened
    * to `(user_id, community_id)` so a user who is a member of multiple
    * communities is correctly bucketed.
    */
@@ -67,7 +57,7 @@ export interface IAnalyticsCommunityRepository {
    * a sender is counted as a hub for month N if they sent DONATION
    * to >= hubBreadthThreshold distinct recipients during the trailing
    * 28-day window ending at month N's end. Same threshold semantic
-   * as `findWindowHubMemberCount`, evaluated at each month-end.
+   * as `findWindowHubMemberCountBulk`, evaluated at each month-end.
    */
   findMonthlyActivity(
     ctx: IContext,
@@ -100,39 +90,24 @@ export interface IAnalyticsCommunityRepository {
   ): Promise<AnalyticsNewMemberCountRow>;
 
   /**
-   * Per-community count of members whose distinct DONATION
-   * recipient count within `[currLower, upper)` reaches
-   * `hubBreadthThreshold`. Backs
+   * Per-community count of members whose distinct DONATION recipient
+   * count within `[currLower, upper)` reaches `hubBreadthThreshold`,
+   * computed for every community in `communityIds` in one SQL pass and
+   * returned as `Map<communityId, {count}>` pre-seeded with count=0 for
+   * every requested community. Backs
    * `AnalyticsCommunityOverview.hubMemberCount`.
    *
-   * The recipient count is computed against `t_transactions`
-   * directly (not `mv_user_transaction_daily`) because the MV's
-   * per-day `unique_counterparties` does not compose into a
-   * window-wide DISTINCT — the same recipient across multiple days
-   * would double-count under SUM. Same reasoning as the
-   * `donation_recipients` CTE in `findMemberStats`, restricted to
-   * the parametric window instead of the full tenure.
+   * The recipient count is computed against `t_transactions` directly
+   * (not `mv_user_transaction_daily`) because the MV's per-day
+   * `unique_counterparties` does not compose into a window-wide
+   * DISTINCT — the same recipient across multiple days would
+   * double-count under SUM.
    *
-   * Senders are restricted to users still JOINED in this community
-   * at `upper` (membership filter mirrors `findActivitySnapshot`
-   * /`findMemberStats`), so a now-departed member who donated
-   * while a member is excluded. Without that filter, the L1
-   * invariant `hubMemberCount <= senderCount <= totalMembers`
-   * would not hold.
-   */
-  findWindowHubMemberCount(
-    ctx: IContext,
-    communityId: string,
-    currLower: Date,
-    upper: Date,
-    hubBreadthThreshold: number,
-  ): Promise<AnalyticsHubMemberCountRow>;
-
-  /**
-   * Bulk variant of `findWindowHubMemberCount`. Computes the hub-member
-   * count for every community in `communityIds` in a single SQL pass.
-   * Returns one entry per requested community (count=0 for communities
-   * with no hub members in the window).
+   * Senders are restricted to users still JOINED in this community at
+   * `upper` (membership filter mirrors `findActivitySnapshot`), so a
+   * now-departed member who donated while a member is excluded.
+   * Without that filter, the L1 invariant
+   * `hubMemberCount <= senderCount <= totalMembers` would not hold.
    */
   findWindowHubMemberCountBulk(
     ctx: IContext,
@@ -144,28 +119,14 @@ export interface IAnalyticsCommunityRepository {
 
   /**
    * All five raw counts the L1 `AnalyticsWindowActivity` payload needs
-   * for the parametric window pair driven by `windowDays`. Issues a
-   * single SQL with two scans (one over `mv_user_transaction_daily`
-   * and one over `t_memberships`), each spanning `[prevLower, upper)`.
+   * for the parametric window pair driven by `windowDays`, computed for
+   * every community in `communityIds` in one SQL pass and returned as
+   * `Map<communityId, counts>` pre-seeded with zero-row defaults.
    *
-   * Replaces three separate `findActivitySnapshot` / intersection
-   * calls and two `findNewMemberCount` calls; the previous design
-   * scanned the same MV three times for overlapping windows.
-   */
-  findWindowActivityCounts(
-    ctx: IContext,
-    communityId: string,
-    prevLower: Date,
-    currLower: Date,
-    upper: Date,
-  ): Promise<AnalyticsWindowActivityCountsRow>;
-
-  /**
-   * Bulk variant of `findWindowActivityCounts`. Aggregates the same five
-   * counts for every community in `communityIds` in a single SQL pass.
-   * Returns one entry per requested community (zero-row defaults for
-   * communities with no activity in the window). Used by the L1
-   * dashboard fan-out to collapse N roundtrips to one.
+   * The SQL issues two scans: one over `mv_user_transaction_daily`
+   * spanning `[prevLower, upper)` collapsed by FILTER clauses into
+   * curr / prev / intersection counts, and one over `t_memberships`
+   * over the same span split into curr / prev new-member counts.
    */
   findWindowActivityCountsBulk(
     ctx: IContext,

--- a/src/application/domain/analytics/community/data/repository.ts
+++ b/src/application/domain/analytics/community/data/repository.ts
@@ -59,40 +59,24 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
   }
 
   /**
-   * One row per JOINED member with tenure + donation-out counters at
-   * `asOf`. `months_in` is the JST-calendar-month difference (floor,
-   * minimum 1) so a member who joined today and a member who joined
-   * earlier this month both get `months_in = 1` — the spec defines
-   * tenure in completed-month units, not days.
+   * Per-member LTV-variable counters at `asOf` for every community in
+   * `communityIds`, returned as `Map<communityId, rows[]>` pre-seeded
+   * with empty arrays so the caller can iterate `communityIds` without
+   * null-checking.
    *
-   * `donation_out_months` counts DISTINCT JST calendar months with at
-   * least one DONATION-out originating from a wallet owned by this
-   * member in this community. `total_points_out` sums the Int
-   * `from_point_change` column; the `::bigint` upcast protects against
-   * overflow once SUM aggregates enough rows.
+   * Scoped to `status='JOINED'`. A member with zero DONATION-outs is
+   * still present (donationOutMonths=0, userSendRate=0, latent stage).
+   * `months_in` is the JST-calendar-month difference (floor, minimum
+   * 1) so a member who joined today and a member who joined earlier
+   * this month both get `months_in = 1` — tenure is in completed-month
+   * units, not days. `user_send_rate` is emitted already-rounded to
+   * 3dp so the presenter stays a pure shape-mapper.
    *
-   * `user_send_rate` is emitted already-rounded to 3dp so the presenter
-   * stays a pure shape-mapper.
-   *
-   * The `t.created_at <= asOf` comparison is a naive-UTC vs naive-UTC
-   * compare — both sides hold the same storage format, no timezone
-   * dance required.
-   */
-  /**
-   * Bulk variant of `findMemberStats`. Computes the same per-member
-   * counters for every community in `communityIds` in one SQL roundtrip
-   * by widening every CTE's community filter to `= ANY(...)` and
-   * carrying `community_id` through the JOIN keys / final GROUP BY.
-   *
-   * Every CTE that previously joined on `user_id` alone now joins on
-   * `(user_id, community_id)` so a user who is a member of multiple
-   * communities is bucketed into the right community. Cross-community
-   * leakage guards (`tw.community_id IS NULL OR tw.community_id =
-   * fw.community_id`) are unchanged because they reference the sender
-   * wallet's community, which is already correctly scoped per row.
-   *
-   * Returns a `Map<communityId, rows[]>` pre-seeded with empty arrays
-   * so the caller can iterate `communityIds` without null-checking.
+   * Every CTE joins on `(user_id, community_id)` so a user who is a
+   * member of multiple communities is bucketed into the right one.
+   * Cross-community leakage guards (`tw.community_id IS NULL OR
+   * tw.community_id = fw.community_id`) reference the sender wallet's
+   * community, which is correctly scoped per row.
    */
   async findMemberStatsBulk(
     ctx: IContext,
@@ -338,374 +322,6 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
     });
   }
 
-  async findMemberStats(
-    ctx: IContext,
-    communityId: string,
-    asOf: Date,
-  ): Promise<AnalyticsMemberStatsRow[]> {
-    return ctx.issuer.public(ctx, async (tx) => {
-      const rows = await tx.$queryRaw<
-        {
-          user_id: string;
-          name: string | null;
-          months_in: number;
-          days_in: number;
-          donation_out_months: number;
-          donation_out_days: number;
-          total_points_out: bigint;
-          user_send_rate: number;
-          unique_donation_recipients: number;
-          donation_in_months: number;
-          donation_in_days: number;
-          total_points_in: bigint;
-          unique_donation_senders: number;
-          last_donation_day: Date | null;
-          first_donation_day: Date | null;
-          joined_at: Date;
-        }[]
-      >`
-        WITH asof_jst AS (
-          -- The asOf instant expressed in JST, computed once so every
-          -- downstream CTE can reuse the same naive JST timestamp
-          -- (for year/month extraction and day-boundary derivation).
-          SELECT (${asOf}::timestamp AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo') AS ts
-        ),
-        asof_bound AS (
-          -- Derive the "asOf JST day + 1, at JST midnight, expressed
-          -- as a naive UTC timestamp" once and reuse everywhere the
-          -- query wants an exclusive upper bound on t_*.created_at.
-          -- The expression is the same JST-day clamp findActivitySnapshot
-          -- / findMonthlyActivity receive pre-computed from the
-          -- service layer; inlining it into a single CTE here keeps
-          -- findMemberStats' signature unchanged without duplicating
-          -- the double-AT TIME ZONE dance across three WHERE clauses.
-          SELECT
-            ((ts::date + 1) AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC') AS upper_ts
-          FROM asof_jst
-        ),
-        members AS (
-          -- Filter to members whose membership existed at asOf.
-          -- Without this, a historic asOf would include members who
-          -- joined after that point, inflating stageCounts.total,
-          -- polluting stage classification, and leaking future members
-          -- into the paginated list. findActivitySnapshot already scopes
-          -- total_members this way; mirroring it keeps the activity
-          -- rate denominator consistent with stageCounts.total.
-          SELECT
-            m."user_id",
-            m."created_at"
-          FROM "t_memberships" m, asof_bound ab
-          WHERE m."community_id" = ${communityId}
-            AND m."status" = 'JOINED'
-            AND m."created_at" < ab.upper_ts
-        ),
-        donation_activity AS (
-          -- Per-(user, JST calendar day) DONATION activity: emits one
-          -- row per day the user sent a DONATION, carrying both the
-          -- aggregated points for that day and the day's JST month
-          -- bucket. The final SELECT then derives:
-          --   donation_out_months = COUNT(DISTINCT jst_month)
-          --   donation_out_days   = COUNT(DISTINCT jst_day)
-          --   total_points_out    = SUM(day_points_out)
-          --
-          -- This consolidates what used to be two parallel CTEs
-          -- (donation_months + donation_days). Joining both into the
-          -- final SELECT on user_id created an N×M cross product —
-          -- COUNT(DISTINCT) was unaffected, but SUM(month_points_out)
-          -- got inflated by M (= number of donation days), corrupting
-          -- total_points_out and every downstream consumer
-          -- (pointsContributionPct, sort orderings, etc.). Pre-
-          -- aggregating per-day in a single CTE removes the cross
-          -- product entirely and is also one fewer t_transactions
-          -- scan since both old CTEs read the same rows.
-          --
-          -- JST date bucketing matches the rest of the query so
-          -- daysIn / donationOutDays line up with the member-tenure
-          -- boundary, and findActivitySnapshot / findPlatformTotals
-          -- agree on what "as of asOf" includes.
-          SELECT
-            fw."user_id" AS user_id,
-            (t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')::date AS jst_day,
-            DATE_TRUNC(
-              'month',
-              (t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')
-            ) AS jst_month,
-            SUM(t."from_point_change") AS day_points_out
-          FROM "t_transactions" t
-          INNER JOIN "t_wallets" fw
-            ON fw."id" = t."from"
-            AND fw."community_id" = ${communityId}
-          INNER JOIN members m ON m."user_id" = fw."user_id"
-          CROSS JOIN asof_bound ab
-          WHERE t."reason" = 'DONATION'
-            AND t."created_at" < ab.upper_ts
-          GROUP BY fw."user_id", jst_day, jst_month
-        ),
-        donation_recipients AS (
-          -- Per-sender count of DISTINCT recipient user_ids over the
-          -- whole tenure (clamped at asOf). This is the "network
-          -- breadth" half of the donor profile and cannot be derived
-          -- from mv_user_transaction_daily — that MV's
-          -- unique_counterparties column is per-day and does not
-          -- compose into an all-time DISTINCT (the same recipient
-          -- across multiple days would double-count under SUM).
-          --
-          -- Scoped to (a) DONATION transactions only, (b) sender wallet
-          -- in this community, and (c) recipient wallet either
-          -- in-community or unattached — same "no cross-community
-          -- leakage" guard that mv_user_transaction_daily and
-          -- v_transaction_comments apply at the view layer. Wallets
-          -- without a user_id (burn / system targets) are excluded so
-          -- a member who only donated into a burn target scores 0.
-          -- Self-donations (fw.user_id = tw.user_id) are excluded so
-          -- the count matches the "distinct OTHER users" wording in
-          -- AnalyticsMemberRow.uniqueDonationRecipients — the wallet
-          -- validator does not block same-user transfers, so the
-          -- guard has to live here.
-          SELECT
-            fw."user_id" AS user_id,
-            COUNT(DISTINCT tw."user_id")::int AS unique_recipients
-          FROM "t_transactions" t
-          INNER JOIN "t_wallets" fw
-            ON fw."id" = t."from"
-            AND fw."community_id" = ${communityId}
-          INNER JOIN "t_wallets" tw
-            ON tw."id" = t."to"
-            AND tw."user_id" IS NOT NULL
-            AND tw."user_id" <> fw."user_id"
-          INNER JOIN members m ON m."user_id" = fw."user_id"
-          CROSS JOIN asof_bound ab
-          WHERE t."reason" = 'DONATION'
-            AND t."created_at" < ab.upper_ts
-            AND (tw."community_id" IS NULL OR tw."community_id" = fw."community_id")
-          GROUP BY fw."user_id"
-        ),
-        donation_received AS (
-          -- Receiver-side counterpart to donation_activity. Per-(user,
-          -- JST calendar day) DONATION-IN activity for each member of
-          -- this community, with the day's points-in and the JST
-          -- month bucket. Same single-CTE shape so the final SELECT
-          -- can derive donation_in_months / donation_in_days /
-          -- total_points_in without re-introducing the cross-product
-          -- bug that motivated the donation_activity consolidation.
-          --
-          -- Scoping mirrors donation_activity / donation_recipients:
-          --   - DONATION reason only (excludes burn / grant flows that
-          --     are not part of the gift-economy ledger)
-          --   - receiver wallet attached to this community so a member
-          --     who received cross-community grants does not get
-          --     incoming credit they cannot reciprocate
-          --   - sender wallet either in this community or unattached
-          --     (system / burn sources are excluded from the points
-          --     sum for symmetry with donation_activity's wallet
-          --     filter on the sending side)
-          --   - clamped at asOf via asof_bound so a historic asOf
-          --     does not leak future incoming points into the totals
-          SELECT
-            tw."user_id" AS user_id,
-            (t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')::date AS jst_day,
-            DATE_TRUNC(
-              'month',
-              (t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')
-            ) AS jst_month,
-            SUM(t."to_point_change") AS day_points_in
-          FROM "t_transactions" t
-          INNER JOIN "t_wallets" tw
-            ON tw."id" = t."to"
-            AND tw."community_id" = ${communityId}
-          INNER JOIN members m ON m."user_id" = tw."user_id"
-          INNER JOIN "t_wallets" fw
-            ON fw."id" = t."from"
-            AND fw."user_id" IS NOT NULL
-            AND (fw."community_id" IS NULL OR fw."community_id" = tw."community_id")
-          CROSS JOIN asof_bound ab
-          WHERE t."reason" = 'DONATION'
-            AND t."created_at" < ab.upper_ts
-          GROUP BY tw."user_id", jst_day, jst_month
-        ),
-        donation_in_aggregates AS (
-          -- Pre-aggregate donation_received to one row per user so the
-          -- final SELECT can LEFT JOIN both donation_activity and
-          -- this CTE without re-introducing the multi-row × multi-row
-          -- cross product that the donation_activity consolidation
-          -- comment warns about. donation_activity stays per-day
-          -- because the final SELECT still uses
-          -- COUNT(DISTINCT da.jst_month / da.jst_day) — those are
-          -- cheap and unaffected by row multiplicity. The incoming
-          -- side has no equivalent need; one row per user is all the
-          -- final SELECT consumes.
-          SELECT
-            user_id,
-            COUNT(DISTINCT jst_month)::int AS donation_in_months,
-            COUNT(DISTINCT jst_day)::int AS donation_in_days,
-            COALESCE(SUM(day_points_in), 0)::bigint AS total_points_in
-          FROM donation_received
-          GROUP BY user_id
-        ),
-        donation_senders AS (
-          -- Receiver-side counterpart to donation_recipients. Per-
-          -- recipient count of DISTINCT sender user_ids over the
-          -- whole tenure (clamped at asOf). Backs
-          -- AnalyticsMemberRow.uniqueDonationSenders, which the L2
-          -- dashboard uses to compute "受領→送付 転換率"
-          -- (recipient-to-sender conversion rate).
-          --
-          -- Same defensive guards as donation_recipients in mirror:
-          --   - sender wallet must have a user_id (no burn / system
-          --     sources count toward sender breadth, otherwise an
-          --     admin-issued bulk grant would inflate the count)
-          --   - excludes self-donations (matches the "distinct OTHER
-          --     users" wording in
-          --     AnalyticsMemberRow.uniqueDonationSenders)
-          --   - sender wallet either in this community or unattached
-          --     (no cross-community leakage)
-          SELECT
-            tw."user_id" AS user_id,
-            COUNT(DISTINCT fw."user_id")::int AS unique_senders
-          FROM "t_transactions" t
-          INNER JOIN "t_wallets" tw
-            ON tw."id" = t."to"
-            AND tw."community_id" = ${communityId}
-          INNER JOIN "t_wallets" fw
-            ON fw."id" = t."from"
-            AND fw."user_id" IS NOT NULL
-            AND fw."user_id" <> tw."user_id"
-          INNER JOIN members m ON m."user_id" = tw."user_id"
-          CROSS JOIN asof_bound ab
-          WHERE t."reason" = 'DONATION'
-            AND t."created_at" < ab.upper_ts
-            AND (fw."community_id" IS NULL OR fw."community_id" = tw."community_id")
-          GROUP BY tw."user_id"
-        ),
-        member_tenure AS (
-          -- Compute months_in / days_in ONCE per member so the
-          -- final SELECT can reuse them as both raw fields and as
-          -- the denominators of monthly / daily activity rates.
-          --
-          -- months_in: "distinct JST calendar months the member
-          -- has been present in (join-month through asOf-month
-          -- inclusive)" — the +1 turns the month-number diff into
-          -- a span count, matching how donation_out_months
-          -- (COUNT DISTINCT jst_month) counts.
-          --
-          -- days_in: "distinct JST calendar days the member has
-          -- been present in" — same +1 inclusivity, matching how
-          -- donation_out_days (COUNT DISTINCT jst_day) counts.
-          --
-          -- GREATEST(1, ...) defends against any future clock
-          -- skew on both. Pulling the asOf-side conversion from
-          -- asof_jst avoids re-running the double AT TIME ZONE
-          -- cast once per row.
-          SELECT
-            m."user_id",
-            GREATEST(
-              1,
-              (
-                (
-                  EXTRACT(YEAR FROM aj.ts)::int
-                  - EXTRACT(YEAR FROM (m."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo'))::int
-                ) * 12
-                + (
-                  EXTRACT(MONTH FROM aj.ts)::int
-                  - EXTRACT(MONTH FROM (m."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo'))::int
-                )
-                + 1
-              )
-            )::int AS months_in,
-            GREATEST(
-              1,
-              (
-                (aj.ts::date - (m."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')::date) + 1
-              )
-            )::int AS days_in
-          FROM members m, asof_jst aj
-        )
-        SELECT
-          m."user_id",
-          u."name" AS "name",
-          mt.months_in,
-          mt.days_in,
-          COALESCE(COUNT(DISTINCT da.jst_month), 0)::int AS donation_out_months,
-          COALESCE(COUNT(DISTINCT da.jst_day), 0)::int AS donation_out_days,
-          -- SUM is over per-day rows (one row per user per donation
-          -- day in donation_activity). No cross product with another
-          -- per-user-multi-row CTE, so each day's points are summed
-          -- exactly once.
-          COALESCE(SUM(da.day_points_out), 0)::bigint AS total_points_out,
-          -- GREATEST(1, ...) inside member_tenure guarantees the
-          -- divisor is >= 1; no zero branch needed around ROUND.
-          ROUND(
-            COALESCE(COUNT(DISTINCT da.jst_month), 0)::numeric
-              / mt.months_in::numeric,
-            3
-          )::double precision AS user_send_rate,
-          -- donation_recipients is pre-grouped by user_id, so each
-          -- sender appears at most once on the right side of the
-          -- LEFT JOIN. MAX() (rather than adding the column to GROUP
-          -- BY) propagates that single value through the per-user
-          -- grouping cleanly and matches the COALESCE/MAX pattern
-          -- used elsewhere when joining a pre-aggregated CTE.
-          COALESCE(MAX(dr.unique_recipients), 0)::int AS unique_donation_recipients,
-          -- donation_in_aggregates is pre-grouped by user_id (one row
-          -- per user), so each value comes through the per-user
-          -- GROUP BY unchanged. MAX is structurally a no-op here and
-          -- mirrors the COALESCE/MAX pattern used for donation_recipients
-          -- and donation_senders below. Default 0 when the receiver
-          -- has never received a DONATION (LEFT JOIN miss).
-          COALESCE(MAX(dia.donation_in_months), 0)::int AS donation_in_months,
-          COALESCE(MAX(dia.donation_in_days), 0)::int AS donation_in_days,
-          COALESCE(MAX(dia.total_points_in), 0)::bigint AS total_points_in,
-          COALESCE(MAX(ds.unique_senders), 0)::int AS unique_donation_senders,
-          -- MAX over the per-(user, jst_day) rows in donation_activity
-          -- gives the most recent JST day this user sent a DONATION.
-          -- NULL when the LEFT JOIN found no donation_activity rows
-          -- (= the member never donated, the latent case). The service
-          -- layer derives dormantCount from this without re-scanning
-          -- t_transactions.
-          MAX(da.jst_day) AS last_donation_day,
-          -- MIN over the same per-day rows is the FIRST DONATION day,
-          -- powering the cohort funnel's activatedD30 stage in the
-          -- service layer (member is "activated within 30 days" iff
-          -- first_donation_day - joined_at < 30 days). Same NULL
-          -- semantic as last_donation_day for never-donated members.
-          MIN(da.jst_day) AS first_donation_day,
-          -- t_memberships.created_at exposed verbatim so the cohort
-          -- funnel can bucket members by their join month
-          -- (DATE_TRUNC at the JST timezone in service-side TS).
-          -- GROUP BY m."created_at" added below so the aggregate
-          -- doesn't collapse it.
-          m."created_at" AS joined_at
-        FROM members m
-        INNER JOIN member_tenure mt ON mt."user_id" = m."user_id"
-        LEFT JOIN donation_activity da ON da.user_id = m."user_id"
-        LEFT JOIN donation_recipients dr ON dr.user_id = m."user_id"
-        LEFT JOIN donation_in_aggregates dia ON dia.user_id = m."user_id"
-        LEFT JOIN donation_senders ds ON ds.user_id = m."user_id"
-        LEFT JOIN "t_users" u ON u."id" = m."user_id"
-        GROUP BY m."user_id", m."created_at", mt.months_in, mt.days_in, u."name"
-        ORDER BY m."user_id"
-      `;
-      return rows.map((r) => ({
-        userId: r.user_id,
-        name: r.name,
-        monthsIn: r.months_in,
-        daysIn: r.days_in,
-        donationOutMonths: r.donation_out_months,
-        donationOutDays: r.donation_out_days,
-        totalPointsOut: r.total_points_out,
-        userSendRate: r.user_send_rate,
-        uniqueDonationRecipients: r.unique_donation_recipients,
-        donationInMonths: r.donation_in_months,
-        donationInDays: r.donation_in_days,
-        totalPointsIn: r.total_points_in,
-        uniqueDonationSenders: r.unique_donation_senders,
-        lastDonationDay: r.last_donation_day,
-        firstDonationDay: r.first_donation_day,
-        joinedAt: r.joined_at,
-      }));
-    });
-  }
-
   /**
    * `windowMonths` trailing JST months (inclusive of the asOf month).
    * Sources everything off MVs except the member counts, which come
@@ -761,7 +377,7 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
             -- so the most recent month doesn't count members who
             -- joined after asOf. For past months the LEAST collapses
             -- to next_month_start, so behaviour is unchanged. Mirrors
-            -- the clamp findMemberStats / findActivitySnapshot already
+            -- the clamp findMemberStatsBulk / findActivitySnapshot already
             -- apply, so totalMembersEndOfMonth on the trend lines up
             -- with stageCounts.total and the summary-card rate.
             LEAST(
@@ -938,7 +554,7 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
         hub_per_month AS (
           -- Per (month_start, sender) DISTINCT recipient count over
           -- the trailing 28-day window ending at member_upper.
-          -- Mirrors the L1 findWindowHubMemberCount query exactly
+          -- Mirrors the L1 findWindowHubMemberCountBulk query exactly
           -- (cross-community + burn-target guards via tw.user_id
           -- presence, self-donation excluded by tw.user_id <>
           -- fw.user_id, recipient-community guard via
@@ -964,7 +580,7 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
           -- The t_memberships join restricts senders to users
           -- still JOINED in the community at member_upper. Mirrors
           -- the dormant_counts / returned_counts CTEs above and
-          -- the L1 findWindowHubMemberCount query so a now-
+          -- the L1 findWindowHubMemberCountBulk query so a now-
           -- departed member who sent DONATIONs while a member
           -- doesn't get counted as a "current hub" in their
           -- former month — would otherwise contradict the
@@ -1107,12 +723,16 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
   }
 
   /**
-   * Bulk version of `findWindowActivityCounts` for the L1 dashboard
-   * fan-out. One SQL roundtrip covers every community in `communityIds`;
-   * the returned Map yields a zero-row entry for any community that has
-   * no activity in the window, so the caller can iterate `communityIds`
-   * without null-checking. Same date-window contract as the
-   * single-community method.
+   * All five raw counts the L1 `AnalyticsWindowActivity` payload needs
+   * for the parametric window pair driven by `windowDays`, computed for
+   * every community in `communityIds` in one SQL roundtrip. Returns
+   * `Map<communityId, counts>` pre-seeded with zero-row defaults so the
+   * caller can iterate `communityIds` without null-checking.
+   *
+   * The SQL issues two scans: one over `mv_user_transaction_daily`
+   * spanning `[prevLower, upper)` collapsed by FILTER clauses into
+   * curr/prev/intersection counts, and one over `t_memberships` over
+   * the same span split into curr/prev new-member counts.
    */
   async findWindowActivityCountsBulk(
     ctx: IContext,
@@ -1214,110 +834,20 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
     });
   }
 
-  async findWindowActivityCounts(
-    ctx: IContext,
-    communityId: string,
-    prevLower: Date,
-    currLower: Date,
-    upper: Date,
-  ): Promise<AnalyticsWindowActivityCountsRow> {
-    return ctx.issuer.public(ctx, async (tx) => {
-      const rows = await tx.$queryRaw<
-        {
-          curr_sender_count: number;
-          prev_sender_count: number;
-          retained_count: number;
-          curr_new_member_count: number;
-          prev_new_member_count: number;
-        }[]
-      >`
-        WITH window_senders AS (
-          -- One MV scan over [prevLower, upper). Per-user aggregation
-          -- collapses each user's daily rows into two booleans
-          -- recording whether they sent a DONATION in the current /
-          -- previous window. The outer FILTER clauses then count
-          -- senders, prev-senders, and the intersection (retained)
-          -- without rescanning the MV.
-          --
-          -- The INNER JOIN against t_memberships restricts the
-          -- senders to users still JOINED in this community at
-          -- "upper" (asOf+1 JST). Without this, a user who had a
-          -- community wallet during the window but later left
-          -- (status != 'JOINED' at asOf) would still be counted —
-          -- the dashboard would surface a "former member" as a
-          -- live sender, which contradicts the L1 invariant
-          -- "senderCount <= totalMembers" (totalMembers already
-          -- enforces JOINED-at-asOf via findActivitySnapshot). The
-          -- t_memberships scan is cheap because the
-          -- (community_id, user_id, status) index narrows it to
-          -- the same row count as t_wallets for the community.
-          SELECT
-            mv."user_id",
-            bool_or(mv."date" >= ${currLower}::date AND mv."date" <  ${upper}::date) AS in_curr,
-            bool_or(mv."date" >= ${prevLower}::date AND mv."date" <  ${currLower}::date) AS in_prev
-          FROM "mv_user_transaction_daily" mv
-          INNER JOIN "t_memberships" m
-            ON m."community_id" = ${communityId}
-            AND m."user_id" = mv."user_id"
-            AND m."status" = 'JOINED'
-            AND m."created_at" <  (${upper}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
-          WHERE mv."community_id" = ${communityId}
-            AND mv."donation_out_count" > 0
-            AND mv."date" >= ${prevLower}::date
-            AND mv."date" <  ${upper}::date
-          GROUP BY mv."user_id"
-        ),
-        sender_aggregates AS (
-          SELECT
-            COUNT(*) FILTER (WHERE in_curr)::int                AS curr_sender_count,
-            COUNT(*) FILTER (WHERE in_prev)::int                AS prev_sender_count,
-            COUNT(*) FILTER (WHERE in_curr AND in_prev)::int    AS retained_count
-          FROM window_senders
-        ),
-        new_members AS (
-          -- One t_memberships scan over [prevLower, upper).
-          -- Same FILTER pattern: split current vs previous in one pass.
-          SELECT
-            COUNT(*) FILTER (
-              WHERE "created_at" >= (${currLower}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
-                AND "created_at" <  (${upper}::date     AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
-            )::int AS curr_new_member_count,
-            COUNT(*) FILTER (
-              WHERE "created_at" >= (${prevLower}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
-                AND "created_at" <  (${currLower}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
-            )::int AS prev_new_member_count
-          FROM "t_memberships"
-          WHERE "community_id" = ${communityId}
-            AND "status" = 'JOINED'
-            AND "created_at" >= (${prevLower}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
-            AND "created_at" <  (${upper}::date     AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
-        )
-        SELECT
-          COALESCE(s.curr_sender_count, 0)     AS curr_sender_count,
-          COALESCE(s.prev_sender_count, 0)     AS prev_sender_count,
-          COALESCE(s.retained_count, 0)        AS retained_count,
-          COALESCE(n.curr_new_member_count, 0) AS curr_new_member_count,
-          COALESCE(n.prev_new_member_count, 0) AS prev_new_member_count
-        FROM sender_aggregates s
-        CROSS JOIN new_members n
-      `;
-      const r = rows[0];
-      return {
-        senderCount: r?.curr_sender_count ?? 0,
-        senderCountPrev: r?.prev_sender_count ?? 0,
-        retainedSenders: r?.retained_count ?? 0,
-        newMemberCount: r?.curr_new_member_count ?? 0,
-        newMemberCountPrev: r?.prev_new_member_count ?? 0,
-      };
-    });
-  }
-
   /**
-   * Bulk variant of `findWindowHubMemberCount`. Computes the hub-member
-   * count for every community in `communityIds` in a single SQL pass,
-   * keeping the same DISTINCT-recipient semantics. Communities with no
-   * hub members are returned with count=0 so the caller can iterate
-   * `communityIds` without null-checking.
+   * Per-community count of members whose distinct DONATION recipient
+   * count within `[currLower, upper)` reaches `hubBreadthThreshold`,
+   * returned as `Map<communityId, {count}>` pre-seeded with count=0 for
+   * every requested community. Backs
+   * `AnalyticsCommunityOverview.hubMemberCount`.
+   *
+   * The recipient count is computed against `t_transactions` directly
+   * (not `mv_user_transaction_daily`) because the MV's per-day
+   * `unique_counterparties` does not compose into a window-wide
+   * DISTINCT — the same recipient across multiple days would
+   * double-count under SUM. Senders are restricted to users still
+   * JOINED in this community at `upper` so the L1 invariant
+   * `hubMemberCount <= senderCount <= totalMembers` holds.
    */
   async findWindowHubMemberCountBulk(
     ctx: IContext,
@@ -1364,73 +894,6 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
         out.set(r.community_id, { count: r.n ?? 0 });
       }
       return out;
-    });
-  }
-
-  async findWindowHubMemberCount(
-    ctx: IContext,
-    communityId: string,
-    currLower: Date,
-    upper: Date,
-    hubBreadthThreshold: number,
-  ): Promise<AnalyticsHubMemberCountRow> {
-    return ctx.issuer.public(ctx, async (tx) => {
-      const rows = await tx.$queryRaw<{ n: number }[]>`
-        WITH window_recipients AS (
-          -- Per-sender DISTINCT recipient count over the parametric
-          -- window. Same shape as the donation_recipients CTE in
-          -- findMemberStats but window-clamped on both sides instead
-          -- of tenure-clamped (upper only). Cannot reuse
-          -- mv_user_transaction_daily because its per-day
-          -- unique_counterparties does not compose into a window-wide
-          -- DISTINCT (same recipient across multiple days would
-          -- double-count under SUM).
-          --
-          -- Cross-community + burn-target guards mirror the defenses
-          -- on mv_user_transaction_daily / v_transaction_comments so
-          -- a system-target wallet (no user_id) does not silently
-          -- inflate the recipient count. Self-donations are excluded
-          -- (matches the "different people" wording in
-          -- AnalyticsCommunityOverview.hubMemberCount and the
-          -- "distinct OTHER users" definition in
-          -- AnalyticsMemberRow.uniqueDonationRecipients) — the wallet
-          -- validator does not block same-user transfers, so the
-          -- guard has to live in this query.
-          --
-          -- The t_memberships join restricts senders to users
-          -- still JOINED in this community at "upper" (asOf+1
-          -- JST). Without it, a now-departed member who sent
-          -- DONATIONs while a member would still get counted as
-          -- a "current hub", contradicting the
-          -- "hubMemberCount <= senderCount <= totalMembers"
-          -- invariant documented on AnalyticsCommunityOverview.
-          SELECT
-            fw."user_id" AS user_id,
-            COUNT(DISTINCT tw."user_id")::int AS unique_recipients
-          FROM "t_transactions" t
-          INNER JOIN "t_wallets" fw
-            ON fw."id" = t."from"
-            AND fw."community_id" = ${communityId}
-          INNER JOIN "t_memberships" m
-            ON m."community_id" = ${communityId}
-            AND m."user_id" = fw."user_id"
-            AND m."status" = 'JOINED'
-            AND m."created_at" <  (${upper}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
-          INNER JOIN "t_wallets" tw
-            ON tw."id" = t."to"
-            AND tw."user_id" IS NOT NULL
-            AND tw."user_id" <> fw."user_id"
-          WHERE t."reason" = 'DONATION'
-            AND t."created_at" >= (${currLower}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
-            AND t."created_at" <  (${upper}::date     AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
-            AND (tw."community_id" IS NULL OR tw."community_id" = fw."community_id")
-          GROUP BY fw."user_id"
-        )
-        SELECT COUNT(*)::int AS n
-        FROM window_recipients
-        WHERE unique_recipients >= ${hubBreadthThreshold}
-      `;
-      return { count: rows[0]?.n ?? 0 };
     });
   }
 
@@ -1523,7 +986,7 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
       // the per-tx aggregation collapses chain_depth >=
       // maxBucketDepth into the final bucket via LEAST.
       //
-      // Sender-side guards mirror findWindowHubMemberCount:
+      // Sender-side guards mirror findWindowHubMemberCountBulk:
       // sender wallet must be in this community, and we filter to
       // reason='DONATION'. No recipient-side or membership filter
       // is applied because chainDepthDistribution describes the
@@ -1536,7 +999,7 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
       // The asof_bound CTE clamps t.created_at at the JST-day-end
       // following asOf (= asOf JST day + 1 at JST midnight,
       // expressed as naive UTC). Mirrors the upper-bound pattern
-      // used by findMemberStats / findAllTimeTotals so
+      // used by findMemberStatsBulk / findAllTimeTotals so
       // maxChainDepthAllTime (read from findAllTimeTotals) and
       // chainDepthDistribution agree on which transactions are
       // "all-time as of asOf" — without this clamp a transaction

--- a/src/application/domain/analytics/community/data/repository.ts
+++ b/src/application/domain/analytics/community/data/repository.ts
@@ -846,6 +846,114 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
     });
   }
 
+  /**
+   * Bulk version of `findWindowActivityCounts` for the L1 dashboard
+   * fan-out. One SQL roundtrip covers every community in `communityIds`;
+   * the returned Map yields a zero-row entry for any community that has
+   * no activity in the window, so the caller can iterate `communityIds`
+   * without null-checking. Same date-window contract as the
+   * single-community method.
+   */
+  async findWindowActivityCountsBulk(
+    ctx: IContext,
+    communityIds: string[],
+    prevLower: Date,
+    currLower: Date,
+    upper: Date,
+  ): Promise<Map<string, AnalyticsWindowActivityCountsRow>> {
+    const empty = (): AnalyticsWindowActivityCountsRow => ({
+      senderCount: 0,
+      senderCountPrev: 0,
+      retainedSenders: 0,
+      newMemberCount: 0,
+      newMemberCountPrev: 0,
+    });
+    const out = new Map<string, AnalyticsWindowActivityCountsRow>();
+    for (const id of communityIds) out.set(id, empty());
+    if (communityIds.length === 0) return out;
+    return ctx.issuer.public(ctx, async (tx) => {
+      const rows = await tx.$queryRaw<
+        {
+          community_id: string;
+          curr_sender_count: number;
+          prev_sender_count: number;
+          retained_count: number;
+          curr_new_member_count: number;
+          prev_new_member_count: number;
+        }[]
+      >`
+        WITH window_senders AS (
+          SELECT
+            mv."community_id",
+            mv."user_id",
+            bool_or(mv."date" >= ${currLower}::date AND mv."date" <  ${upper}::date) AS in_curr,
+            bool_or(mv."date" >= ${prevLower}::date AND mv."date" <  ${currLower}::date) AS in_prev
+          FROM "mv_user_transaction_daily" mv
+          INNER JOIN "t_memberships" m
+            ON m."community_id" = mv."community_id"
+            AND m."user_id" = mv."user_id"
+            AND m."status" = 'JOINED'
+            AND m."created_at" <  (${upper}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+          WHERE mv."community_id" = ANY(${communityIds}::text[])
+            AND mv."donation_out_count" > 0
+            AND mv."date" >= ${prevLower}::date
+            AND mv."date" <  ${upper}::date
+          GROUP BY mv."community_id", mv."user_id"
+        ),
+        sender_aggregates AS (
+          SELECT
+            "community_id",
+            COUNT(*) FILTER (WHERE in_curr)::int                AS curr_sender_count,
+            COUNT(*) FILTER (WHERE in_prev)::int                AS prev_sender_count,
+            COUNT(*) FILTER (WHERE in_curr AND in_prev)::int    AS retained_count
+          FROM window_senders
+          GROUP BY "community_id"
+        ),
+        new_members AS (
+          SELECT
+            "community_id",
+            COUNT(*) FILTER (
+              WHERE "created_at" >= (${currLower}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+                AND "created_at" <  (${upper}::date     AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+            )::int AS curr_new_member_count,
+            COUNT(*) FILTER (
+              WHERE "created_at" >= (${prevLower}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+                AND "created_at" <  (${currLower}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+            )::int AS prev_new_member_count
+          FROM "t_memberships"
+          WHERE "community_id" = ANY(${communityIds}::text[])
+            AND "status" = 'JOINED'
+            AND "created_at" >= (${prevLower}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+            AND "created_at" <  (${upper}::date     AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+          GROUP BY "community_id"
+        ),
+        community_keys AS (
+          SELECT unnest(${communityIds}::text[]) AS community_id
+        )
+        SELECT
+          ck."community_id"                       AS community_id,
+          COALESCE(s.curr_sender_count, 0)        AS curr_sender_count,
+          COALESCE(s.prev_sender_count, 0)        AS prev_sender_count,
+          COALESCE(s.retained_count, 0)           AS retained_count,
+          COALESCE(n.curr_new_member_count, 0)    AS curr_new_member_count,
+          COALESCE(n.prev_new_member_count, 0)    AS prev_new_member_count
+        FROM community_keys ck
+        LEFT JOIN sender_aggregates s ON s."community_id" = ck."community_id"
+        LEFT JOIN new_members n      ON n."community_id" = ck."community_id"
+      `;
+      for (const r of rows) {
+        out.set(r.community_id, {
+          senderCount: r.curr_sender_count ?? 0,
+          senderCountPrev: r.prev_sender_count ?? 0,
+          retainedSenders: r.retained_count ?? 0,
+          newMemberCount: r.curr_new_member_count ?? 0,
+          newMemberCountPrev: r.prev_new_member_count ?? 0,
+        });
+      }
+      return out;
+    });
+  }
+
   async findWindowActivityCounts(
     ctx: IContext,
     communityId: string,
@@ -941,6 +1049,61 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
         newMemberCount: r?.curr_new_member_count ?? 0,
         newMemberCountPrev: r?.prev_new_member_count ?? 0,
       };
+    });
+  }
+
+  /**
+   * Bulk variant of `findWindowHubMemberCount`. Computes the hub-member
+   * count for every community in `communityIds` in a single SQL pass,
+   * keeping the same DISTINCT-recipient semantics. Communities with no
+   * hub members are returned with count=0 so the caller can iterate
+   * `communityIds` without null-checking.
+   */
+  async findWindowHubMemberCountBulk(
+    ctx: IContext,
+    communityIds: string[],
+    currLower: Date,
+    upper: Date,
+    hubBreadthThreshold: number,
+  ): Promise<Map<string, AnalyticsHubMemberCountRow>> {
+    const out = new Map<string, AnalyticsHubMemberCountRow>();
+    for (const id of communityIds) out.set(id, { count: 0 });
+    if (communityIds.length === 0) return out;
+    return ctx.issuer.public(ctx, async (tx) => {
+      const rows = await tx.$queryRaw<{ community_id: string; n: number }[]>`
+        WITH window_recipients AS (
+          SELECT
+            fw."community_id" AS community_id,
+            fw."user_id" AS user_id,
+            COUNT(DISTINCT tw."user_id")::int AS unique_recipients
+          FROM "t_transactions" t
+          INNER JOIN "t_wallets" fw
+            ON fw."id" = t."from"
+            AND fw."community_id" = ANY(${communityIds}::text[])
+          INNER JOIN "t_memberships" m
+            ON m."community_id" = fw."community_id"
+            AND m."user_id" = fw."user_id"
+            AND m."status" = 'JOINED'
+            AND m."created_at" <  (${upper}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+          INNER JOIN "t_wallets" tw
+            ON tw."id" = t."to"
+            AND tw."user_id" IS NOT NULL
+            AND tw."user_id" <> fw."user_id"
+          WHERE t."reason" = 'DONATION'
+            AND t."created_at" >= (${currLower}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+            AND t."created_at" <  (${upper}::date     AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+            AND (tw."community_id" IS NULL OR tw."community_id" = fw."community_id")
+          GROUP BY fw."community_id", fw."user_id"
+        )
+        SELECT community_id, COUNT(*)::int AS n
+        FROM window_recipients
+        WHERE unique_recipients >= ${hubBreadthThreshold}
+        GROUP BY community_id
+      `;
+      for (const r of rows) {
+        out.set(r.community_id, { count: r.n ?? 0 });
+      }
+      return out;
     });
   }
 

--- a/src/application/domain/analytics/community/data/repository.ts
+++ b/src/application/domain/analytics/community/data/repository.ts
@@ -109,14 +109,35 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
         }[]
       >`
         WITH asof_jst AS (
+          -- The asOf instant expressed in JST, computed once so every
+          -- downstream CTE can reuse the same naive JST timestamp
+          -- (for year/month extraction and day-boundary derivation).
           SELECT (${asOf}::timestamp AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo') AS ts
         ),
         asof_bound AS (
+          -- Derive the "asOf JST day + 1, at JST midnight, expressed
+          -- as a naive UTC timestamp" once and reuse everywhere the
+          -- query wants an exclusive upper bound on t_*.created_at.
+          -- The expression is the same JST-day clamp findActivitySnapshot
+          -- / findMonthlyActivity receive pre-computed from the
+          -- service layer; inlining it into a single CTE here keeps
+          -- the signature unchanged without duplicating the double
+          -- AT TIME ZONE dance across three WHERE clauses.
           SELECT
             ((ts::date + 1) AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC') AS upper_ts
           FROM asof_jst
         ),
         members AS (
+          -- Filter to members whose membership existed at asOf, in any
+          -- of the requested communities. Without this, a historic
+          -- asOf would include members who joined after that point,
+          -- inflating stageCounts.total, polluting stage classification,
+          -- and leaking future members into the paginated list.
+          -- findActivitySnapshot already scopes total_members this way;
+          -- mirroring it keeps the activity rate denominator consistent
+          -- with stageCounts.total. community_id is carried through
+          -- so the per-user JOIN keys downstream stay correctly bucketed
+          -- when a single user is a member of multiple communities.
           SELECT
             m."community_id",
             m."user_id",
@@ -127,6 +148,30 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
             AND m."created_at" < ab.upper_ts
         ),
         donation_activity AS (
+          -- Per-(community, user, JST calendar day) DONATION activity:
+          -- emits one row per day the user sent a DONATION from their
+          -- wallet in that community, carrying both the aggregated
+          -- points for that day and the day's JST month bucket. The
+          -- final SELECT then derives:
+          --   donation_out_months = COUNT(DISTINCT jst_month)
+          --   donation_out_days   = COUNT(DISTINCT jst_day)
+          --   total_points_out    = SUM(day_points_out)
+          --
+          -- This consolidates what used to be two parallel CTEs
+          -- (donation_months + donation_days). Joining both into the
+          -- final SELECT on user_id created an N×M cross product —
+          -- COUNT(DISTINCT) was unaffected, but SUM(month_points_out)
+          -- got inflated by M (= number of donation days), corrupting
+          -- total_points_out and every downstream consumer
+          -- (pointsContributionPct, sort orderings, etc.). Pre-
+          -- aggregating per-day in a single CTE removes the cross
+          -- product entirely and is also one fewer t_transactions
+          -- scan since both old CTEs read the same rows.
+          --
+          -- JST date bucketing matches the rest of the query so
+          -- daysIn / donationOutDays line up with the member-tenure
+          -- boundary, and findActivitySnapshot / findPlatformTotals
+          -- agree on what "as of asOf" includes.
           SELECT
             fw."community_id" AS community_id,
             fw."user_id" AS user_id,
@@ -149,6 +194,27 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
           GROUP BY fw."community_id", fw."user_id", jst_day, jst_month
         ),
         donation_recipients AS (
+          -- Per-sender count of DISTINCT recipient user_ids over the
+          -- whole tenure (clamped at asOf). This is the "network
+          -- breadth" half of the donor profile and cannot be derived
+          -- from mv_user_transaction_daily — that MV's
+          -- unique_counterparties column is per-day and does not
+          -- compose into an all-time DISTINCT (the same recipient
+          -- across multiple days would double-count under SUM).
+          --
+          -- Scoped to (a) DONATION transactions only, (b) sender wallet
+          -- in one of the requested communities, and (c) recipient
+          -- wallet either in the SAME community as the sender or
+          -- unattached — same "no cross-community leakage" guard that
+          -- mv_user_transaction_daily and v_transaction_comments apply
+          -- at the view layer. Wallets without a user_id (burn /
+          -- system targets) are excluded so a member who only donated
+          -- into a burn target scores 0. Self-donations
+          -- (fw.user_id = tw.user_id) are excluded so the count
+          -- matches the "distinct OTHER users" wording in
+          -- AnalyticsMemberRow.uniqueDonationRecipients — the wallet
+          -- validator does not block same-user transfers, so the
+          -- guard has to live here.
           SELECT
             fw."community_id" AS community_id,
             fw."user_id" AS user_id,
@@ -171,6 +237,28 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
           GROUP BY fw."community_id", fw."user_id"
         ),
         donation_received AS (
+          -- Receiver-side counterpart to donation_activity. Per-
+          -- (community, user, JST calendar day) DONATION-IN activity
+          -- for each member of the requested communities, with the
+          -- day's points-in and the JST month bucket. Same single-CTE
+          -- shape so the final SELECT can derive donation_in_months /
+          -- donation_in_days / total_points_in without re-introducing
+          -- the cross-product bug that motivated the donation_activity
+          -- consolidation.
+          --
+          -- Scoping mirrors donation_activity / donation_recipients:
+          --   - DONATION reason only (excludes burn / grant flows that
+          --     are not part of the gift-economy ledger)
+          --   - receiver wallet attached to one of the requested
+          --     communities so a member who received cross-community
+          --     grants does not get incoming credit they cannot
+          --     reciprocate
+          --   - sender wallet either in the same community or
+          --     unattached (system / burn sources are excluded from
+          --     the points sum for symmetry with donation_activity's
+          --     wallet filter on the sending side)
+          --   - clamped at asOf via asof_bound so a historic asOf
+          --     does not leak future incoming points into the totals
           SELECT
             tw."community_id" AS community_id,
             tw."user_id" AS user_id,
@@ -197,6 +285,16 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
           GROUP BY tw."community_id", tw."user_id", jst_day, jst_month
         ),
         donation_in_aggregates AS (
+          -- Pre-aggregate donation_received to one row per
+          -- (community, user) so the final SELECT can LEFT JOIN both
+          -- donation_activity and this CTE without re-introducing the
+          -- multi-row × multi-row cross product that the
+          -- donation_activity consolidation comment warns about.
+          -- donation_activity stays per-day because the final SELECT
+          -- still uses COUNT(DISTINCT da.jst_month / da.jst_day) —
+          -- those are cheap and unaffected by row multiplicity. The
+          -- incoming side has no equivalent need; one row per
+          -- (community, user) is all the final SELECT consumes.
           SELECT
             community_id,
             user_id,
@@ -207,6 +305,22 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
           GROUP BY community_id, user_id
         ),
         donation_senders AS (
+          -- Receiver-side counterpart to donation_recipients. Per-
+          -- recipient count of DISTINCT sender user_ids over the
+          -- whole tenure (clamped at asOf). Backs
+          -- AnalyticsMemberRow.uniqueDonationSenders, which the L2
+          -- dashboard uses to compute "受領→送付 転換率"
+          -- (recipient-to-sender conversion rate).
+          --
+          -- Same defensive guards as donation_recipients in mirror:
+          --   - sender wallet must have a user_id (no burn / system
+          --     sources count toward sender breadth, otherwise an
+          --     admin-issued bulk grant would inflate the count)
+          --   - excludes self-donations (matches the "distinct OTHER
+          --     users" wording in
+          --     AnalyticsMemberRow.uniqueDonationSenders)
+          --   - sender wallet either in the same community or
+          --     unattached (no cross-community leakage)
           SELECT
             tw."community_id" AS community_id,
             tw."user_id" AS user_id,
@@ -229,6 +343,24 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
           GROUP BY tw."community_id", tw."user_id"
         ),
         member_tenure AS (
+          -- Compute months_in / days_in ONCE per (community, member)
+          -- so the final SELECT can reuse them as both raw fields and
+          -- as the denominators of monthly / daily activity rates.
+          --
+          -- months_in: "distinct JST calendar months the member has
+          -- been present in (join-month through asOf-month
+          -- inclusive)" — the +1 turns the month-number diff into a
+          -- span count, matching how donation_out_months
+          -- (COUNT DISTINCT jst_month) counts.
+          --
+          -- days_in: "distinct JST calendar days the member has been
+          -- present in" — same +1 inclusivity, matching how
+          -- donation_out_days (COUNT DISTINCT jst_day) counts.
+          --
+          -- GREATEST(1, ...) defends against any future clock skew on
+          -- both. Pulling the asOf-side conversion from asof_jst
+          -- avoids re-running the double AT TIME ZONE cast once per
+          -- row.
           SELECT
             m."community_id",
             m."user_id",
@@ -262,19 +394,54 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
           mt.days_in,
           COALESCE(COUNT(DISTINCT da.jst_month), 0)::int AS donation_out_months,
           COALESCE(COUNT(DISTINCT da.jst_day), 0)::int AS donation_out_days,
+          -- SUM is over per-day rows (one row per (community, user)
+          -- per donation day in donation_activity). No cross product
+          -- with another per-user-multi-row CTE, so each day's points
+          -- are summed exactly once.
           COALESCE(SUM(da.day_points_out), 0)::bigint AS total_points_out,
+          -- GREATEST(1, ...) inside member_tenure guarantees the
+          -- divisor is >= 1; no zero branch needed around ROUND.
           ROUND(
             COALESCE(COUNT(DISTINCT da.jst_month), 0)::numeric
               / mt.months_in::numeric,
             3
           )::double precision AS user_send_rate,
+          -- donation_recipients is pre-grouped by (community, user),
+          -- so each sender appears at most once on the right side of
+          -- the LEFT JOIN. MAX() (rather than adding the column to
+          -- GROUP BY) propagates that single value through the
+          -- per-user grouping cleanly and matches the COALESCE/MAX
+          -- pattern used elsewhere when joining a pre-aggregated CTE.
           COALESCE(MAX(dr.unique_recipients), 0)::int AS unique_donation_recipients,
+          -- donation_in_aggregates is pre-grouped by (community,
+          -- user) (one row per pair), so each value comes through
+          -- the per-user GROUP BY unchanged. MAX is structurally a
+          -- no-op here and mirrors the COALESCE/MAX pattern used for
+          -- donation_recipients and donation_senders below. Default
+          -- 0 when the receiver has never received a DONATION (LEFT
+          -- JOIN miss).
           COALESCE(MAX(dia.donation_in_months), 0)::int AS donation_in_months,
           COALESCE(MAX(dia.donation_in_days), 0)::int AS donation_in_days,
           COALESCE(MAX(dia.total_points_in), 0)::bigint AS total_points_in,
           COALESCE(MAX(ds.unique_senders), 0)::int AS unique_donation_senders,
+          -- MAX over the per-(community, user, jst_day) rows in
+          -- donation_activity gives the most recent JST day this user
+          -- sent a DONATION. NULL when the LEFT JOIN found no
+          -- donation_activity rows (= the member never donated, the
+          -- latent case). The service layer derives dormantCount
+          -- from this without re-scanning t_transactions.
           MAX(da.jst_day) AS last_donation_day,
+          -- MIN over the same per-day rows is the FIRST DONATION day,
+          -- powering the cohort funnel's activatedD30 stage in the
+          -- service layer (member is "activated within 30 days" iff
+          -- first_donation_day - joined_at < 30 days). Same NULL
+          -- semantic as last_donation_day for never-donated members.
           MIN(da.jst_day) AS first_donation_day,
+          -- t_memberships.created_at exposed verbatim so the cohort
+          -- funnel can bucket members by their join month
+          -- (DATE_TRUNC at the JST timezone in service-side TS).
+          -- GROUP BY m."created_at" added below so the aggregate
+          -- doesn't collapse it.
           m."created_at" AS joined_at
         FROM members m
         INNER JOIN member_tenure mt
@@ -763,6 +930,25 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
         }[]
       >`
         WITH window_senders AS (
+          -- One MV scan over [prevLower, upper). Per-(community, user)
+          -- aggregation collapses each user's daily rows into two
+          -- booleans recording whether they sent a DONATION in the
+          -- current / previous window. The outer FILTER clauses then
+          -- count senders, prev-senders, and the intersection
+          -- (retained) without rescanning the MV.
+          --
+          -- The INNER JOIN against t_memberships restricts the
+          -- senders to users still JOINED in their respective
+          -- communities at "upper" (asOf+1 JST). Without this, a user
+          -- who had a community wallet during the window but later
+          -- left (status != 'JOINED' at asOf) would still be counted —
+          -- the dashboard would surface a "former member" as a live
+          -- sender, which contradicts the L1 invariant
+          -- "senderCount <= totalMembers" (totalMembers already
+          -- enforces JOINED-at-asOf via findActivitySnapshot). The
+          -- t_memberships scan is cheap because the
+          -- (community_id, user_id, status) index narrows it to the
+          -- same row count as t_wallets for each community.
           SELECT
             mv."community_id",
             mv."user_id",
@@ -790,6 +976,9 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
           GROUP BY "community_id"
         ),
         new_members AS (
+          -- One t_memberships scan over [prevLower, upper). Same
+          -- FILTER pattern: split current vs previous in one pass,
+          -- grouped by community.
           SELECT
             "community_id",
             COUNT(*) FILTER (
@@ -808,6 +997,10 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
           GROUP BY "community_id"
         ),
         community_keys AS (
+          -- Materialise the input id list so the final LEFT JOIN
+          -- emits one row per requested community, even those with no
+          -- senders / no new members in the window. Without this, the
+          -- caller would have to null-check every Map.get(id) lookup.
           SELECT unnest(${communityIds}::text[]) AS community_id
         )
         SELECT
@@ -862,6 +1055,33 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
     return ctx.issuer.public(ctx, async (tx) => {
       const rows = await tx.$queryRaw<{ community_id: string; n: number }[]>`
         WITH window_recipients AS (
+          -- Per-(community, sender) DISTINCT recipient count over the
+          -- parametric window. Same shape as the donation_recipients
+          -- CTE in findMemberStatsBulk but window-clamped on both
+          -- sides instead of tenure-clamped (upper only). Cannot
+          -- reuse mv_user_transaction_daily because its per-day
+          -- unique_counterparties does not compose into a window-wide
+          -- DISTINCT (same recipient across multiple days would
+          -- double-count under SUM).
+          --
+          -- Cross-community + burn-target guards mirror the defenses
+          -- on mv_user_transaction_daily / v_transaction_comments so
+          -- a system-target wallet (no user_id) does not silently
+          -- inflate the recipient count. Self-donations are excluded
+          -- (matches the "different people" wording in
+          -- AnalyticsCommunityOverview.hubMemberCount and the
+          -- "distinct OTHER users" definition in
+          -- AnalyticsMemberRow.uniqueDonationRecipients) — the wallet
+          -- validator does not block same-user transfers, so the
+          -- guard has to live in this query.
+          --
+          -- The t_memberships join restricts senders to users still
+          -- JOINED in their respective communities at "upper" (asOf+1
+          -- JST). Without it, a now-departed member who sent
+          -- DONATIONs while a member would still get counted as a
+          -- "current hub", contradicting the
+          -- "hubMemberCount <= senderCount <= totalMembers" invariant
+          -- documented on AnalyticsCommunityOverview.
           SELECT
             fw."community_id" AS community_id,
             fw."user_id" AS user_id,

--- a/src/application/domain/analytics/community/data/repository.ts
+++ b/src/application/domain/analytics/community/data/repository.ts
@@ -78,6 +78,266 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
    * compare — both sides hold the same storage format, no timezone
    * dance required.
    */
+  /**
+   * Bulk variant of `findMemberStats`. Computes the same per-member
+   * counters for every community in `communityIds` in one SQL roundtrip
+   * by widening every CTE's community filter to `= ANY(...)` and
+   * carrying `community_id` through the JOIN keys / final GROUP BY.
+   *
+   * Every CTE that previously joined on `user_id` alone now joins on
+   * `(user_id, community_id)` so a user who is a member of multiple
+   * communities is bucketed into the right community. Cross-community
+   * leakage guards (`tw.community_id IS NULL OR tw.community_id =
+   * fw.community_id`) are unchanged because they reference the sender
+   * wallet's community, which is already correctly scoped per row.
+   *
+   * Returns a `Map<communityId, rows[]>` pre-seeded with empty arrays
+   * so the caller can iterate `communityIds` without null-checking.
+   */
+  async findMemberStatsBulk(
+    ctx: IContext,
+    communityIds: string[],
+    asOf: Date,
+  ): Promise<Map<string, AnalyticsMemberStatsRow[]>> {
+    const out = new Map<string, AnalyticsMemberStatsRow[]>();
+    for (const id of communityIds) out.set(id, []);
+    if (communityIds.length === 0) return out;
+    return ctx.issuer.public(ctx, async (tx) => {
+      const rows = await tx.$queryRaw<
+        {
+          community_id: string;
+          user_id: string;
+          name: string | null;
+          months_in: number;
+          days_in: number;
+          donation_out_months: number;
+          donation_out_days: number;
+          total_points_out: bigint;
+          user_send_rate: number;
+          unique_donation_recipients: number;
+          donation_in_months: number;
+          donation_in_days: number;
+          total_points_in: bigint;
+          unique_donation_senders: number;
+          last_donation_day: Date | null;
+          first_donation_day: Date | null;
+          joined_at: Date;
+        }[]
+      >`
+        WITH asof_jst AS (
+          SELECT (${asOf}::timestamp AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo') AS ts
+        ),
+        asof_bound AS (
+          SELECT
+            ((ts::date + 1) AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC') AS upper_ts
+          FROM asof_jst
+        ),
+        members AS (
+          SELECT
+            m."community_id",
+            m."user_id",
+            m."created_at"
+          FROM "t_memberships" m, asof_bound ab
+          WHERE m."community_id" = ANY(${communityIds}::text[])
+            AND m."status" = 'JOINED'
+            AND m."created_at" < ab.upper_ts
+        ),
+        donation_activity AS (
+          SELECT
+            fw."community_id" AS community_id,
+            fw."user_id" AS user_id,
+            (t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')::date AS jst_day,
+            DATE_TRUNC(
+              'month',
+              (t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')
+            ) AS jst_month,
+            SUM(t."from_point_change") AS day_points_out
+          FROM "t_transactions" t
+          INNER JOIN "t_wallets" fw
+            ON fw."id" = t."from"
+            AND fw."community_id" = ANY(${communityIds}::text[])
+          INNER JOIN members m
+            ON m."user_id" = fw."user_id"
+            AND m."community_id" = fw."community_id"
+          CROSS JOIN asof_bound ab
+          WHERE t."reason" = 'DONATION'
+            AND t."created_at" < ab.upper_ts
+          GROUP BY fw."community_id", fw."user_id", jst_day, jst_month
+        ),
+        donation_recipients AS (
+          SELECT
+            fw."community_id" AS community_id,
+            fw."user_id" AS user_id,
+            COUNT(DISTINCT tw."user_id")::int AS unique_recipients
+          FROM "t_transactions" t
+          INNER JOIN "t_wallets" fw
+            ON fw."id" = t."from"
+            AND fw."community_id" = ANY(${communityIds}::text[])
+          INNER JOIN "t_wallets" tw
+            ON tw."id" = t."to"
+            AND tw."user_id" IS NOT NULL
+            AND tw."user_id" <> fw."user_id"
+          INNER JOIN members m
+            ON m."user_id" = fw."user_id"
+            AND m."community_id" = fw."community_id"
+          CROSS JOIN asof_bound ab
+          WHERE t."reason" = 'DONATION'
+            AND t."created_at" < ab.upper_ts
+            AND (tw."community_id" IS NULL OR tw."community_id" = fw."community_id")
+          GROUP BY fw."community_id", fw."user_id"
+        ),
+        donation_received AS (
+          SELECT
+            tw."community_id" AS community_id,
+            tw."user_id" AS user_id,
+            (t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')::date AS jst_day,
+            DATE_TRUNC(
+              'month',
+              (t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')
+            ) AS jst_month,
+            SUM(t."to_point_change") AS day_points_in
+          FROM "t_transactions" t
+          INNER JOIN "t_wallets" tw
+            ON tw."id" = t."to"
+            AND tw."community_id" = ANY(${communityIds}::text[])
+          INNER JOIN members m
+            ON m."user_id" = tw."user_id"
+            AND m."community_id" = tw."community_id"
+          INNER JOIN "t_wallets" fw
+            ON fw."id" = t."from"
+            AND fw."user_id" IS NOT NULL
+            AND (fw."community_id" IS NULL OR fw."community_id" = tw."community_id")
+          CROSS JOIN asof_bound ab
+          WHERE t."reason" = 'DONATION'
+            AND t."created_at" < ab.upper_ts
+          GROUP BY tw."community_id", tw."user_id", jst_day, jst_month
+        ),
+        donation_in_aggregates AS (
+          SELECT
+            community_id,
+            user_id,
+            COUNT(DISTINCT jst_month)::int AS donation_in_months,
+            COUNT(DISTINCT jst_day)::int AS donation_in_days,
+            COALESCE(SUM(day_points_in), 0)::bigint AS total_points_in
+          FROM donation_received
+          GROUP BY community_id, user_id
+        ),
+        donation_senders AS (
+          SELECT
+            tw."community_id" AS community_id,
+            tw."user_id" AS user_id,
+            COUNT(DISTINCT fw."user_id")::int AS unique_senders
+          FROM "t_transactions" t
+          INNER JOIN "t_wallets" tw
+            ON tw."id" = t."to"
+            AND tw."community_id" = ANY(${communityIds}::text[])
+          INNER JOIN "t_wallets" fw
+            ON fw."id" = t."from"
+            AND fw."user_id" IS NOT NULL
+            AND fw."user_id" <> tw."user_id"
+          INNER JOIN members m
+            ON m."user_id" = tw."user_id"
+            AND m."community_id" = tw."community_id"
+          CROSS JOIN asof_bound ab
+          WHERE t."reason" = 'DONATION'
+            AND t."created_at" < ab.upper_ts
+            AND (fw."community_id" IS NULL OR fw."community_id" = tw."community_id")
+          GROUP BY tw."community_id", tw."user_id"
+        ),
+        member_tenure AS (
+          SELECT
+            m."community_id",
+            m."user_id",
+            GREATEST(
+              1,
+              (
+                (
+                  EXTRACT(YEAR FROM aj.ts)::int
+                  - EXTRACT(YEAR FROM (m."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo'))::int
+                ) * 12
+                + (
+                  EXTRACT(MONTH FROM aj.ts)::int
+                  - EXTRACT(MONTH FROM (m."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo'))::int
+                )
+                + 1
+              )
+            )::int AS months_in,
+            GREATEST(
+              1,
+              (
+                (aj.ts::date - (m."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')::date) + 1
+              )
+            )::int AS days_in
+          FROM members m, asof_jst aj
+        )
+        SELECT
+          m."community_id" AS community_id,
+          m."user_id",
+          u."name" AS "name",
+          mt.months_in,
+          mt.days_in,
+          COALESCE(COUNT(DISTINCT da.jst_month), 0)::int AS donation_out_months,
+          COALESCE(COUNT(DISTINCT da.jst_day), 0)::int AS donation_out_days,
+          COALESCE(SUM(da.day_points_out), 0)::bigint AS total_points_out,
+          ROUND(
+            COALESCE(COUNT(DISTINCT da.jst_month), 0)::numeric
+              / mt.months_in::numeric,
+            3
+          )::double precision AS user_send_rate,
+          COALESCE(MAX(dr.unique_recipients), 0)::int AS unique_donation_recipients,
+          COALESCE(MAX(dia.donation_in_months), 0)::int AS donation_in_months,
+          COALESCE(MAX(dia.donation_in_days), 0)::int AS donation_in_days,
+          COALESCE(MAX(dia.total_points_in), 0)::bigint AS total_points_in,
+          COALESCE(MAX(ds.unique_senders), 0)::int AS unique_donation_senders,
+          MAX(da.jst_day) AS last_donation_day,
+          MIN(da.jst_day) AS first_donation_day,
+          m."created_at" AS joined_at
+        FROM members m
+        INNER JOIN member_tenure mt
+          ON mt."user_id" = m."user_id"
+          AND mt."community_id" = m."community_id"
+        LEFT JOIN donation_activity da
+          ON da.user_id = m."user_id"
+          AND da.community_id = m."community_id"
+        LEFT JOIN donation_recipients dr
+          ON dr.user_id = m."user_id"
+          AND dr.community_id = m."community_id"
+        LEFT JOIN donation_in_aggregates dia
+          ON dia.user_id = m."user_id"
+          AND dia.community_id = m."community_id"
+        LEFT JOIN donation_senders ds
+          ON ds.user_id = m."user_id"
+          AND ds.community_id = m."community_id"
+        LEFT JOIN "t_users" u ON u."id" = m."user_id"
+        GROUP BY m."community_id", m."user_id", m."created_at", mt.months_in, mt.days_in, u."name"
+        ORDER BY m."community_id", m."user_id"
+      `;
+      for (const r of rows) {
+        const bucket = out.get(r.community_id);
+        if (!bucket) continue;
+        bucket.push({
+          userId: r.user_id,
+          name: r.name,
+          monthsIn: r.months_in,
+          daysIn: r.days_in,
+          donationOutMonths: r.donation_out_months,
+          donationOutDays: r.donation_out_days,
+          totalPointsOut: r.total_points_out,
+          userSendRate: r.user_send_rate,
+          uniqueDonationRecipients: r.unique_donation_recipients,
+          donationInMonths: r.donation_in_months,
+          donationInDays: r.donation_in_days,
+          totalPointsIn: r.total_points_in,
+          uniqueDonationSenders: r.unique_donation_senders,
+          lastDonationDay: r.last_donation_day,
+          firstDonationDay: r.first_donation_day,
+          joinedAt: r.joined_at,
+        });
+      }
+      return out;
+    });
+  }
+
   async findMemberStats(
     ctx: IContext,
     communityId: string,

--- a/src/application/domain/analytics/community/data/repository.ts
+++ b/src/application/domain/analytics/community/data/repository.ts
@@ -14,7 +14,7 @@ import {
 import { IAnalyticsCommunityRepository } from "@/application/domain/analytics/community/data/interface";
 
 /**
- * SQL helpers for the sysadmin analytics surface.
+ * SQL helpers for the analytics community surface.
  *
  * Conventions inherited from the report repository:
  *   - Every read goes through `ctx.issuer.public`; MVs are RLS-less and
@@ -1139,7 +1139,7 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
         }[]
       >`
         WITH asof_bound AS (
-          -- Same (asOf JST day + 1) clamp the other sysadmin queries
+          -- Same (asOf JST day + 1) clamp the other analytics queries
           -- use. Historic asOf must not count DONATION transactions
           -- or chain depths from dates past asOf; otherwise the
           -- summary card would mix the past-point view with whatever

--- a/src/application/domain/analytics/community/data/type.ts
+++ b/src/application/domain/analytics/community/data/type.ts
@@ -47,7 +47,7 @@ export type AnalyticsMemberStatsRow = {
   /**
    * The most recent JST calendar day the member sent a DONATION
    * (UTC-encoded date at JST midnight, same convention as the rest
-   * of the sysadmin domain). null when the member has never
+   * of the analytics domain). null when the member has never
    * donated. Internal raw signal; not exposed in GraphQL today —
    * `dormantCount` is derived from it in the service layer.
    */

--- a/src/application/domain/analytics/community/presenter.ts
+++ b/src/application/domain/analytics/community/presenter.ts
@@ -227,7 +227,7 @@ export default class AnalyticsCommunityPresenter {
       donationInDays: row.donationInDays,
       uniqueDonationSenders: row.uniqueDonationSenders,
       // lastDonationDay is already a JST-midnight Date on the row
-      // (see findMemberStats); rename to the public-facing
+      // (see findMemberStatsBulk); rename to the public-facing
       // `lastDonationAt` here. null pass-through for never-donated
       // members.
       lastDonationAt: row.lastDonationDay,

--- a/src/application/domain/analytics/community/schema/query.graphql
+++ b/src/application/domain/analytics/community/schema/query.graphql
@@ -2,7 +2,7 @@
 # Analytics Community Query Definitions
 #
 # Per-community analytics view (member stats, stage distribution,
-# trailing-window trends, cohort retention, alerts) for sysadmin
+# trailing-window trends, cohort retention, alerts) for admin
 # operators. Bypasses per-community RLS under the hood
 # (ctx.issuer.public) because admins legitimately need to see across
 # every community at once.

--- a/src/application/domain/analytics/community/service.ts
+++ b/src/application/domain/analytics/community/service.ts
@@ -188,8 +188,15 @@ export default class AnalyticsCommunityService {
     return this.repository.findCommunityById(ctx, communityId);
   }
 
+  /**
+   * Per-member counters for one community at `asOf`, returned as a flat
+   * array. Thin wrapper over the bulk SQL — the L2 community-detail
+   * path is the only single-community caller, so we share the bulk
+   * primitive instead of maintaining a duplicate 1300-line CTE.
+   */
   async getMemberStats(ctx: IContext, communityId: string, asOf: Date) {
-    return this.repository.findMemberStats(ctx, communityId, asOf);
+    const map = await this.repository.findMemberStatsBulk(ctx, [communityId], asOf);
+    return map.get(communityId) ?? [];
   }
 
   /**
@@ -451,45 +458,22 @@ export default class AnalyticsCommunityService {
   /**
    * Rolling-window DONATION activity for the L1 overview. Returns the
    * raw sender / new-member counts for both the current window and the
-   * immediately preceding window of equal length. The client divides
-   * by `totalMembers` for rates and computes growth as
-   * `(currRate - prevRate) / prevRate` with a null guard.
+   * immediately preceding window of equal length, keyed by community.
+   * The client divides by `totalMembers` for rates and computes growth
+   * as `(currRate - prevRate) / prevRate` with a null guard.
    *
    *   current  = [asOf - windowDays JST日, asOf + 1 JST日)
    *   previous = [asOf - 2 * windowDays, asOf - windowDays)
    *
    * All five counts come from a single repository call
-   * (`findWindowActivityCounts`) which scans `mv_user_transaction_daily`
-   * once over `[prevLower, upper)` and `t_memberships` once over the
-   * same span — collapsing what used to be five overlapping scans
-   * (curr senders + prev senders + intersection + curr new members +
-   * prev new members) into two. The service's only job here is the
-   * date-window arithmetic.
-   */
-  async getWindowActivity(
-    ctx: IContext,
-    communityId: string,
-    asOf: Date,
-    windowDays: number,
-  ): Promise<WindowActivityCounts> {
-    const upper = asOfBounds(asOf).asOfJstDayPlusOne;
-    const currLower = addDays(upper, -windowDays);
-    const prevLower = addDays(upper, -windowDays * 2);
-
-    return this.repository.findWindowActivityCounts(
-      ctx,
-      communityId,
-      prevLower,
-      currLower,
-      upper,
-    );
-  }
-
-  /**
-   * Bulk variant of `getWindowActivity` for the L1 dashboard fan-out.
-   * The same window arithmetic applies uniformly to every community —
-   * `windowDays` is a dashboard-level scalar — so the date math runs
-   * once and the repository takes care of the per-community split.
+   * (`findWindowActivityCountsBulk`) which scans
+   * `mv_user_transaction_daily` once over `[prevLower, upper)` and
+   * `t_memberships` once over the same span — collapsing what used to
+   * be five overlapping scans (curr senders + prev senders +
+   * intersection + curr new members + prev new members) into two. The
+   * service's only job here is the date-window arithmetic; the same
+   * window applies uniformly to every community because `windowDays`
+   * is a dashboard-level scalar.
    */
   async getWindowActivityBulk(
     ctx: IContext,
@@ -511,43 +495,20 @@ export default class AnalyticsCommunityService {
   }
 
   /**
-   * Count of members classified as hubs within the parametric
-   * window: those who sent DONATION to at least
-   * `hubBreadthThreshold` DISTINCT counterparties during
-   * `[asOf - windowDays, asOf + 1 JST日)`.
+   * Count of members classified as hubs within the parametric window:
+   * those who sent DONATION to at least `hubBreadthThreshold` DISTINCT
+   * counterparties during `[asOf - windowDays, asOf + 1 JST日)`,
+   * computed for every community in `communityIds` and returned as
+   * `Map<communityId, count>` (zero for communities with no hub
+   * members in the window).
    *
-   * Single-axis classification (breadth only) — reaching the
-   * threshold inherently requires that many transactions, so a
-   * separate frequency floor would be redundant. The service's
-   * only job is the date arithmetic; the count itself comes from a
-   * dedicated repository SQL because it needs DISTINCT recipient
-   * aggregation against `t_transactions` (which the per-day MV
-   * cannot compose into a window-wide DISTINCT).
-   */
-  async getWindowHubMemberCount(
-    ctx: IContext,
-    communityId: string,
-    asOf: Date,
-    windowDays: number,
-    hubBreadthThreshold: number,
-  ): Promise<number> {
-    const upper = asOfBounds(asOf).asOfJstDayPlusOne;
-    const currLower = addDays(upper, -windowDays);
-
-    const row = await this.repository.findWindowHubMemberCount(
-      ctx,
-      communityId,
-      currLower,
-      upper,
-      hubBreadthThreshold,
-    );
-    return row.count;
-  }
-
-  /**
-   * Bulk variant of `getWindowHubMemberCount`. Returns one count per
-   * community (defaulting to 0 for communities with no hub members in
-   * the window).
+   * Single-axis classification (breadth only) — reaching the threshold
+   * inherently requires that many transactions, so a separate
+   * frequency floor would be redundant. The service's only job is the
+   * date arithmetic; the count itself comes from a dedicated
+   * repository SQL because it needs DISTINCT recipient aggregation
+   * against `t_transactions` (which the per-day MV cannot compose into
+   * a window-wide DISTINCT).
    */
   async getWindowHubMemberCountBulk(
     ctx: IContext,

--- a/src/application/domain/analytics/community/service.ts
+++ b/src/application/domain/analytics/community/service.ts
@@ -192,6 +192,15 @@ export default class AnalyticsCommunityService {
     return this.repository.findMemberStats(ctx, communityId, asOf);
   }
 
+  /**
+   * Bulk variant of `getMemberStats` for the L1 dashboard fan-out.
+   * Replaces N per-community SQL roundtrips with one. The returned Map
+   * is pre-seeded with empty arrays for every requested community.
+   */
+  async getMemberStatsBulk(ctx: IContext, communityIds: string[], asOf: Date) {
+    return this.repository.findMemberStatsBulk(ctx, communityIds, asOf);
+  }
+
   async getChainDepthDistribution(ctx: IContext, communityId: string, asOf: Date) {
     return this.repository.findChainDepthDistribution(
       ctx,
@@ -477,6 +486,31 @@ export default class AnalyticsCommunityService {
   }
 
   /**
+   * Bulk variant of `getWindowActivity` for the L1 dashboard fan-out.
+   * The same window arithmetic applies uniformly to every community —
+   * `windowDays` is a dashboard-level scalar — so the date math runs
+   * once and the repository takes care of the per-community split.
+   */
+  async getWindowActivityBulk(
+    ctx: IContext,
+    communityIds: string[],
+    asOf: Date,
+    windowDays: number,
+  ): Promise<Map<string, WindowActivityCounts>> {
+    const upper = asOfBounds(asOf).asOfJstDayPlusOne;
+    const currLower = addDays(upper, -windowDays);
+    const prevLower = addDays(upper, -windowDays * 2);
+
+    return this.repository.findWindowActivityCountsBulk(
+      ctx,
+      communityIds,
+      prevLower,
+      currLower,
+      upper,
+    );
+  }
+
+  /**
    * Count of members classified as hubs within the parametric
    * window: those who sent DONATION to at least
    * `hubBreadthThreshold` DISTINCT counterparties during
@@ -511,6 +545,35 @@ export default class AnalyticsCommunityService {
   }
 
   /**
+   * Bulk variant of `getWindowHubMemberCount`. Returns one count per
+   * community (defaulting to 0 for communities with no hub members in
+   * the window).
+   */
+  async getWindowHubMemberCountBulk(
+    ctx: IContext,
+    communityIds: string[],
+    asOf: Date,
+    windowDays: number,
+    hubBreadthThreshold: number,
+  ): Promise<Map<string, number>> {
+    const upper = asOfBounds(asOf).asOfJstDayPlusOne;
+    const currLower = addDays(upper, -windowDays);
+
+    const rowsByCommunity = await this.repository.findWindowHubMemberCountBulk(
+      ctx,
+      communityIds,
+      currLower,
+      upper,
+      hubBreadthThreshold,
+    );
+    const out = new Map<string, number>();
+    for (const id of communityIds) {
+      out.set(id, rowsByCommunity.get(id)?.count ?? 0);
+    }
+    return out;
+  }
+
+  /**
    * DONATION sender retention against the most recently completed ISO
    * week. The asOf-containing week is in progress, so the "latest
    * completed" week is the one starting `latestWeekStart - 7d`. The
@@ -539,6 +602,42 @@ export default class AnalyticsCommunityService {
       retainedSenders: retention.retainedSenders,
       churnedSenders: retention.churnedSenders,
     };
+  }
+
+  /**
+   * Bulk variant of `getWeeklyRetention`. The week-arithmetic is a
+   * dashboard-level scalar (asOf only), so the bounds run once and the
+   * single bulk repository call returns one entry per community.
+   */
+  async getWeeklyRetentionBulk(
+    ctx: IContext,
+    communityIds: string[],
+    asOf: Date,
+  ): Promise<Map<string, WeeklyRetentionCounts>> {
+    const latestWeekStart = isoWeekStartJst(asOf);
+    const prevWeekStart = addDays(latestWeekStart, -7);
+    const prevPrevWeekStart = addDays(prevWeekStart, -7);
+    const twelveWeeksAgo = addDays(prevWeekStart, -7 * 12);
+
+    const aggByCommunity = await this.reportService.getRetentionAggregateBulk(
+      ctx,
+      communityIds,
+      {
+        currentWeekStart: prevWeekStart,
+        nextWeekStart: latestWeekStart,
+        prevWeekStart: prevPrevWeekStart,
+        twelveWeeksAgo,
+      },
+    );
+    const out = new Map<string, WeeklyRetentionCounts>();
+    for (const id of communityIds) {
+      const agg = aggByCommunity.get(id);
+      out.set(id, {
+        retainedSenders: agg?.retainedSenders ?? 0,
+        churnedSenders: agg?.churnedSenders ?? 0,
+      });
+    }
+    return out;
   }
 
   /**
@@ -571,6 +670,39 @@ export default class AnalyticsCommunityService {
       size: row.cohortSize,
       activeAtM1: row.activeNextWeek,
     };
+  }
+
+  /**
+   * Bulk variant of `getLatestCohort`. The cohort-month math depends
+   * only on `asOf`, so the same window applies uniformly across
+   * `communityIds` and the bulk repository call returns one entry per
+   * community.
+   */
+  async getLatestCohortBulk(
+    ctx: IContext,
+    communityIds: string[],
+    asOf: Date,
+  ): Promise<Map<string, LatestCohortCounts>> {
+    const monthStart = jstMonthStart(asOf);
+    const cohortStart = jstMonthStartOffset(monthStart, -2);
+    const cohortEnd = jstMonthStartOffset(monthStart, -1);
+    const activeStart = cohortEnd;
+    const activeEnd = monthStart;
+    const rowsByCommunity = await this.reportService.getCohortRetentionBulk(
+      ctx,
+      communityIds,
+      { cohortStart, cohortEnd },
+      { activeStart, activeEnd },
+    );
+    const out = new Map<string, LatestCohortCounts>();
+    for (const id of communityIds) {
+      const row = rowsByCommunity.get(id);
+      out.set(id, {
+        size: row?.cohortSize ?? 0,
+        activeAtM1: row?.activeNextWeek ?? 0,
+      });
+    }
+    return out;
   }
 
   /**

--- a/src/application/domain/analytics/community/service.ts
+++ b/src/application/domain/analytics/community/service.ts
@@ -162,7 +162,7 @@ export default class AnalyticsCommunityService {
     // domain's service-layer entry point), not the report repository.
     // CLAUDE.md restricts services to "Call other domain services
     // (read operations only)" — going straight to the repository
-    // would couple sysadmin to the report domain's data layer.
+    // would couple analytics to the report domain's data layer.
     @inject("ReportService") private readonly reportService: ReportService,
   ) {}
 

--- a/src/application/domain/analytics/schema/query.graphql
+++ b/src/application/domain/analytics/schema/query.graphql
@@ -1,7 +1,7 @@
 # ------------------------------
 # Analytics Dashboard Query
 #
-# L1 overview surface for sysadmin operators: platform totals plus
+# L1 overview surface for admin operators: platform totals plus
 # one row per community. Bypasses per-community RLS under the hood
 # (ctx.issuer.public) because admins legitimately need to see across
 # every community at once.

--- a/src/application/domain/analytics/usecase.ts
+++ b/src/application/domain/analytics/usecase.ts
@@ -64,39 +64,67 @@ export default class AnalyticsUseCase {
       this.communityService.getAllCommunities(ctx),
     ]);
 
-    const rows = await Promise.all(
-      communities.map(async (c): Promise<GqlAnalyticsCommunityOverview> => {
-        const [members, windowActivity, weeklyRetention, latestCohort, hubMemberCount] =
-          await Promise.all([
-            this.communityService.getMemberStats(ctx, c.communityId, asOf),
-            this.communityService.getWindowActivity(ctx, c.communityId, asOf, windowDays),
-            this.communityService.getWeeklyRetention(ctx, c.communityId, asOf),
-            this.communityService.getLatestCohort(ctx, c.communityId, asOf),
-            this.communityService.getWindowHubMemberCount(
-              ctx,
-              c.communityId,
-              asOf,
-              windowDays,
-              hubBreadthThreshold,
-            ),
-          ]);
-        const stageCounts = computeStageCounts(members, thresholds);
-        const tenureDistribution = computeTenureDistribution(members);
-        const dormantCount = computeDormantCount(members, asOf, dormantThresholdDays);
-        return AnalyticsPresenter.overviewRow({
-          communityId: c.communityId,
-          communityName: c.communityName,
-          totalMembers: stageCounts.total,
-          stageCounts,
-          windowActivity,
-          weeklyRetention,
-          latestCohort,
-          hubMemberCount,
-          tenureDistribution,
-          dormantCount,
-        });
-      }),
-    );
+    // Single fan-out: each bulk* method issues one SQL covering every
+    // community, replacing the previous N×5 per-community roundtrips
+    // with 5 total. Per-community computations (stage classification,
+    // dormant count, etc.) stay in memory and operate on the
+    // already-bucketed rows below.
+    const communityIds = communities.map((c) => c.communityId);
+    const [
+      memberStatsByCommunity,
+      windowActivityByCommunity,
+      weeklyRetentionByCommunity,
+      latestCohortByCommunity,
+      hubMemberCountByCommunity,
+    ] = await Promise.all([
+      this.communityService.getMemberStatsBulk(ctx, communityIds, asOf),
+      this.communityService.getWindowActivityBulk(ctx, communityIds, asOf, windowDays),
+      this.communityService.getWeeklyRetentionBulk(ctx, communityIds, asOf),
+      this.communityService.getLatestCohortBulk(ctx, communityIds, asOf),
+      this.communityService.getWindowHubMemberCountBulk(
+        ctx,
+        communityIds,
+        asOf,
+        windowDays,
+        hubBreadthThreshold,
+      ),
+    ]);
+
+    const rows: GqlAnalyticsCommunityOverview[] = communities.map((c) => {
+      const members = memberStatsByCommunity.get(c.communityId) ?? [];
+      const windowActivity = windowActivityByCommunity.get(c.communityId) ?? {
+        senderCount: 0,
+        senderCountPrev: 0,
+        retainedSenders: 0,
+        newMemberCount: 0,
+        newMemberCountPrev: 0,
+      };
+      const weeklyRetention = weeklyRetentionByCommunity.get(c.communityId) ?? {
+        retainedSenders: 0,
+        churnedSenders: 0,
+      };
+      const latestCohort = latestCohortByCommunity.get(c.communityId) ?? {
+        size: 0,
+        activeAtM1: 0,
+      };
+      const hubMemberCount = hubMemberCountByCommunity.get(c.communityId) ?? 0;
+
+      const stageCounts = computeStageCounts(members, thresholds);
+      const tenureDistribution = computeTenureDistribution(members);
+      const dormantCount = computeDormantCount(members, asOf, dormantThresholdDays);
+      return AnalyticsPresenter.overviewRow({
+        communityId: c.communityId,
+        communityName: c.communityName,
+        totalMembers: stageCounts.total,
+        stageCounts,
+        windowActivity,
+        weeklyRetention,
+        latestCohort,
+        hubMemberCount,
+        tenureDistribution,
+        dormantCount,
+      });
+    });
 
     return AnalyticsPresenter.dashboard({
       asOf,

--- a/src/application/domain/report/README.md
+++ b/src/application/domain/report/README.md
@@ -1,6 +1,6 @@
 # report ドメイン — 計算ロジック解説
 
-このドキュメントは、`report` および `report` を再利用する `sysadmin` ドメインで使われる
+このドキュメントは、`report` および `report` を再利用する `analytics` ドメインで使われる
 **集計・分析クエリの計算ロジック**を日本語でまとめたものです。
 新しい分析メソッドを追加する際は、本ドキュメントを参照して既存パターンと整合させてください。
 
@@ -82,7 +82,7 @@ AND m."created_at" < (${jstUpper}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE '
 - 「ある週」 → `[weekStart, weekStart + 7日)`
 
 `<= asOf::timestamp` のような閉区間と JST 日単位の `< (...)::date` を
-混在させると `findMemberStats` と `findActivitySnapshot` で精度がズレるので統一する。
+混在させると `findMemberStatsBulk` と `findActivitySnapshot` で精度がズレるので統一する。
 
 ---
 
@@ -263,7 +263,7 @@ const upperExclusive = addDays(asOfJstDay, 1);            // 翌日 0:00 JST
 
 ---
 
-## 5. ステージ分類（sysadmin）
+## 5. ステージ分類（analytics）
 
 `userSendRate` の閾値で 4 段階に分類:
 
@@ -315,11 +315,14 @@ L1 dashboard の表示用には累積、L2 詳細の構成比表示には disjoi
 
 ### 7.1. fan-out 戦略
 
-- 現状（コミュニティ数 〜6）：N ループを許容（`Promise.all`）
-- 〜20 を超えたら：`GROUP BY community_id` のバルク取得メソッドを検討
-- 週次 retention のループ（〜43 週）も同様。MV のインデックス
-  `(community_id, date)` が効くので並列小クエリで十分速い
-  （`scripts/sysadmin_bench.ts` の計測：bulk 化は 364x 遅化したので revert）
+- L1 dashboard (community 軸 fan-out)：`*Bulk` メソッドで `GROUP BY
+  community_id` の単一 SQL 化済み (`AnalyticsCommunityRepository.findMemberStatsBulk` 等、
+  `ReportRepository.findRetentionAggregateBulk` 等)。コミュニティ数に
+  依らず 1 ラウンドトリップ
+- 週次 retention / 月次 cohort のループ（〜43 週 / 〜36 ヶ月）は per-time-window
+  ループのまま。MV のインデックス `(community_id, date)` が効くので並列小
+  クエリで十分速い（`scripts/sysadmin_bench.ts` の計測：時間軸 bulk 化は
+  364x 遅化したので revert）
 
 ### 7.2. `windowMonths` の上限
 
@@ -348,8 +351,8 @@ input に上限を設ける（`MAX_WINDOW_MONTHS = 36`）。
 | パス | 内容 |
 |---|---|
 | `src/application/domain/report/util.ts` | JST 日付ヘルパー、`bigintToSafeNumber`、`percentChange` |
-| `src/application/domain/report/data/repository.ts` | retention / cohort / period aggregates の中核実装 |
-| `src/application/domain/sysadmin/data/repository.ts` | `findMemberStats` / `findMonthlyActivity` などの sysadmin 固有クエリ |
-| `src/application/domain/sysadmin/service.ts` | アラート判定・ステージ分類・トレンド orchestrator |
-| `scripts/sysadmin_bench.ts` | 週次 retention のローカル計測スクリプト |
+| `src/application/domain/report/transactionStats/data/repository.ts` | retention / cohort / period aggregates の中核実装（`findRetentionAggregate` / `findRetentionAggregateBulk` 等） |
+| `src/application/domain/analytics/community/data/repository.ts` | `findMemberStatsBulk` / `findMonthlyActivity` / `findWindowActivityCountsBulk` などの analytics 固有クエリ |
+| `src/application/domain/analytics/community/service.ts` | アラート判定・ステージ分類・トレンド orchestrator |
+| `scripts/sysadmin_bench.ts` | 週次 retention のローカル計測スクリプト（旧 sysadmin 命名のまま） |
 | `src/infrastructure/prisma/migrations/20260416000001_fix_report_views_jst_bucketing/` | JST バケツバグの修正履歴 |

--- a/src/application/domain/report/service.ts
+++ b/src/application/domain/report/service.ts
@@ -136,6 +136,23 @@ export default class ReportService {
     return this.statsRepo.findRetentionAggregate(ctx, communityId, range);
   }
 
+  /**
+   * Bulk variant of `getRetentionAggregate` for the L1 dashboard
+   * fan-out. Delegates straight through to the repository's bulk SQL.
+   */
+  async getRetentionAggregateBulk(
+    ctx: IContext,
+    communityIds: string[],
+    range: {
+      currentWeekStart: Date;
+      nextWeekStart: Date;
+      prevWeekStart: Date;
+      twelveWeeksAgo: Date;
+    },
+  ): Promise<Map<string, RetentionAggregateRow>> {
+    return this.statsRepo.findRetentionAggregateBulk(ctx, communityIds, range);
+  }
+
   async getCohortRetention(
     ctx: IContext,
     communityId: string,
@@ -143,6 +160,18 @@ export default class ReportService {
     active: { activeStart: Date; activeEnd: Date },
   ): Promise<CohortRetentionRow> {
     return this.statsRepo.findCohortRetention(ctx, communityId, cohort, active);
+  }
+
+  /**
+   * Bulk variant of `getCohortRetention` for the L1 dashboard fan-out.
+   */
+  async getCohortRetentionBulk(
+    ctx: IContext,
+    communityIds: string[],
+    cohort: { cohortStart: Date; cohortEnd: Date },
+    active: { activeStart: Date; activeEnd: Date },
+  ): Promise<Map<string, CohortRetentionRow>> {
+    return this.statsRepo.findCohortRetentionBulk(ctx, communityIds, cohort, active);
   }
 
   async refreshTransactionSummaryDaily(ctx: IContext, tx: Prisma.TransactionClient): Promise<void> {

--- a/src/application/domain/report/transactionStats/data/interface.ts
+++ b/src/application/domain/report/transactionStats/data/interface.ts
@@ -80,12 +80,38 @@ export interface IReportTransactionStatsRepository {
       twelveWeeksAgo: Date;
     },
   ): Promise<RetentionAggregateRow>;
+  /**
+   * Bulk variant of `findRetentionAggregate`. Computes the same six
+   * counters for every community in `communityIds` in a single SQL
+   * roundtrip; returns one entry per requested community
+   * (zero-row defaults for communities with no rows in the window).
+   */
+  findRetentionAggregateBulk(
+    ctx: IContext,
+    communityIds: string[],
+    range: {
+      currentWeekStart: Date;
+      nextWeekStart: Date;
+      prevWeekStart: Date;
+      twelveWeeksAgo: Date;
+    },
+  ): Promise<Map<string, RetentionAggregateRow>>;
   findCohortRetention(
     ctx: IContext,
     communityId: string,
     cohort: { cohortStart: Date; cohortEnd: Date },
     active: { activeStart: Date; activeEnd: Date },
   ): Promise<CohortRetentionRow>;
+  /**
+   * Bulk variant of `findCohortRetention`. Computes cohort-size and
+   * active-next-week per community in a single SQL roundtrip.
+   */
+  findCohortRetentionBulk(
+    ctx: IContext,
+    communityIds: string[],
+    cohort: { cohortStart: Date; cohortEnd: Date },
+    active: { activeStart: Date; activeEnd: Date },
+  ): Promise<Map<string, CohortRetentionRow>>;
   refreshTransactionSummaryDaily(ctx: IContext, tx: Prisma.TransactionClient): Promise<void>;
   refreshUserTransactionDaily(ctx: IContext, tx: Prisma.TransactionClient): Promise<void>;
 }

--- a/src/application/domain/report/transactionStats/data/interface.ts
+++ b/src/application/domain/report/transactionStats/data/interface.ts
@@ -17,7 +17,7 @@ import {
 /**
  * Transaction-statistics repository contract for the report domain.
  * Aggregations + materialized-view refreshes are scoped here so callers
- * (ReportService.weeklyPayload, sysadmin retention/cohort orchestrators)
+ * (ReportService.weeklyPayload, analytics retention/cohort orchestrators)
  * can ask for a single concern without dragging the entity / template
  * surface around.
  */

--- a/src/application/domain/report/transactionStats/data/repository.ts
+++ b/src/application/domain/report/transactionStats/data/repository.ts
@@ -536,6 +536,154 @@ export default class ReportTransactionStatsRepository
    * communities; the trade-off is documented in the design notes —
    * 13+-week comebacks land in no bucket.
    */
+  /**
+   * Bulk variant of `findRetentionAggregate`. Same six counters per
+   * community, computed in one SQL roundtrip across `communityIds`.
+   * Communities with no rows in the window are returned with all counts
+   * set to zero so the caller can iterate `communityIds` without
+   * null-checking.
+   */
+  async findRetentionAggregateBulk(
+    ctx: IContext,
+    communityIds: string[],
+    range: {
+      currentWeekStart: Date;
+      nextWeekStart: Date;
+      prevWeekStart: Date;
+      twelveWeeksAgo: Date;
+    },
+  ): Promise<Map<string, RetentionAggregateRow>> {
+    const empty = (): RetentionAggregateRow => ({
+      newMembers: 0,
+      retainedSenders: 0,
+      returnedSenders: 0,
+      churnedSenders: 0,
+      currentSendersCount: 0,
+      currentActiveCount: 0,
+    });
+    const out = new Map<string, RetentionAggregateRow>();
+    for (const id of communityIds) out.set(id, empty());
+    if (communityIds.length === 0) return out;
+    return ctx.issuer.public(ctx, async (tx) => {
+      const rows = await tx.$queryRaw<
+        {
+          community_id: string;
+          new_members: number;
+          retained_senders: number;
+          returned_senders: number;
+          churned_senders: number;
+          current_senders_count: number;
+          current_active_count: number;
+        }[]
+      >`
+        WITH current_week AS (
+          SELECT
+            "community_id",
+            "user_id",
+            BOOL_OR("donation_out_count" > 0) AS is_sender,
+            BOOL_OR("received_donation_count" > 0) AS is_receiver
+          FROM "mv_user_transaction_daily"
+          WHERE "community_id" = ANY(${communityIds}::text[])
+            AND "date" >= ${range.currentWeekStart}::date
+            AND "date" <  ${range.nextWeekStart}::date
+          GROUP BY "community_id", "user_id"
+        ),
+        prev_week AS (
+          SELECT
+            "community_id",
+            "user_id",
+            BOOL_OR("donation_out_count" > 0) AS is_sender
+          FROM "mv_user_transaction_daily"
+          WHERE "community_id" = ANY(${communityIds}::text[])
+            AND "date" >= ${range.prevWeekStart}::date
+            AND "date" <  ${range.currentWeekStart}::date
+          GROUP BY "community_id", "user_id"
+        ),
+        ever_before AS (
+          SELECT DISTINCT "community_id", "user_id"
+          FROM "mv_user_transaction_daily"
+          WHERE "community_id" = ANY(${communityIds}::text[])
+            AND "date" >= ${range.twelveWeeksAgo}::date
+            AND "date" <  ${range.prevWeekStart}::date
+            AND "donation_out_count" > 0
+        ),
+        new_this_week AS (
+          SELECT "community_id", COUNT(*)::int AS n
+          FROM "t_memberships"
+          WHERE "community_id" = ANY(${communityIds}::text[])
+            AND "status" = 'JOINED'
+            AND "created_at" >= (${range.currentWeekStart}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+            AND "created_at" <  (${range.nextWeekStart}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+          GROUP BY "community_id"
+        ),
+        joined AS (
+          SELECT
+            COALESCE(cw."community_id", pw."community_id") AS community_id,
+            cw."user_id" AS cw_user,
+            pw."user_id" AS pw_user,
+            cw.is_sender AS cw_is_sender,
+            cw.is_receiver AS cw_is_receiver,
+            pw.is_sender AS pw_is_sender,
+            eb."user_id" AS eb_user
+          FROM current_week cw
+          FULL OUTER JOIN prev_week pw
+            ON cw."community_id" = pw."community_id"
+            AND cw."user_id" = pw."user_id"
+          LEFT JOIN ever_before eb
+            ON eb."community_id" = COALESCE(cw."community_id", pw."community_id")
+            AND eb."user_id" = COALESCE(cw."user_id", pw."user_id")
+        ),
+        joined_aggregates AS (
+          SELECT
+            community_id,
+            COUNT(*) FILTER (
+              WHERE cw_is_sender = true AND pw_is_sender = true
+            )::int AS retained_senders,
+            COUNT(*) FILTER (
+              WHERE cw_is_sender = true
+                AND (pw_is_sender IS NULL OR pw_is_sender = false)
+                AND eb_user IS NOT NULL
+            )::int AS returned_senders,
+            COUNT(*) FILTER (
+              WHERE pw_is_sender = true
+                AND (cw_is_sender IS NULL OR cw_is_sender = false)
+            )::int AS churned_senders,
+            COUNT(*) FILTER (WHERE cw_is_sender = true)::int AS current_senders_count,
+            COUNT(*) FILTER (
+              WHERE cw_is_sender = true OR cw_is_receiver = true
+            )::int AS current_active_count
+          FROM joined
+          GROUP BY community_id
+        ),
+        community_keys AS (
+          SELECT unnest(${communityIds}::text[]) AS community_id
+        )
+        SELECT
+          ck."community_id"                          AS community_id,
+          COALESCE(nw.n, 0)                          AS new_members,
+          COALESCE(ja.retained_senders, 0)           AS retained_senders,
+          COALESCE(ja.returned_senders, 0)           AS returned_senders,
+          COALESCE(ja.churned_senders, 0)            AS churned_senders,
+          COALESCE(ja.current_senders_count, 0)      AS current_senders_count,
+          COALESCE(ja.current_active_count, 0)       AS current_active_count
+        FROM community_keys ck
+        LEFT JOIN new_this_week nw       ON nw."community_id" = ck."community_id"
+        LEFT JOIN joined_aggregates ja   ON ja."community_id" = ck."community_id"
+      `;
+      for (const r of rows) {
+        out.set(r.community_id, {
+          newMembers: r.new_members,
+          retainedSenders: r.retained_senders,
+          returnedSenders: r.returned_senders,
+          churnedSenders: r.churned_senders,
+          currentSendersCount: r.current_senders_count,
+          currentActiveCount: r.current_active_count,
+        });
+      }
+      return out;
+    });
+  }
+
   async findRetentionAggregate(
     ctx: IContext,
     communityId: string,
@@ -656,6 +804,70 @@ export default class ReportTransactionStatsRepository
    * `findRetentionAggregate` so week1/week4 retention and the weekly
    * retention counters are apples-to-apples.
    */
+  /**
+   * Bulk variant of `findCohortRetention`. Same numerator / denominator
+   * per community, computed in one SQL roundtrip across `communityIds`.
+   * Communities with no cohort members in the window get
+   * {cohortSize: 0, activeNextWeek: 0}.
+   */
+  async findCohortRetentionBulk(
+    ctx: IContext,
+    communityIds: string[],
+    cohort: { cohortStart: Date; cohortEnd: Date },
+    active: { activeStart: Date; activeEnd: Date },
+  ): Promise<Map<string, CohortRetentionRow>> {
+    const out = new Map<string, CohortRetentionRow>();
+    for (const id of communityIds) out.set(id, { cohortSize: 0, activeNextWeek: 0 });
+    if (communityIds.length === 0) return out;
+    return ctx.issuer.public(ctx, async (tx) => {
+      const rows = await tx.$queryRaw<
+        {
+          community_id: string;
+          cohort_size: number;
+          active_next_week: number;
+        }[]
+      >`
+        WITH cohort AS (
+          SELECT "community_id", "user_id"
+          FROM "t_memberships"
+          WHERE "community_id" = ANY(${communityIds}::text[])
+            AND "status" = 'JOINED'
+            AND "created_at" >= (${cohort.cohortStart}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+            AND "created_at" <  (${cohort.cohortEnd}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
+        ),
+        active_members AS (
+          SELECT DISTINCT "community_id", "user_id"
+          FROM "mv_user_transaction_daily"
+          WHERE "community_id" = ANY(${communityIds}::text[])
+            AND "date" >= ${active.activeStart}::date
+            AND "date" <  ${active.activeEnd}::date
+            AND "donation_out_count" > 0
+        ),
+        community_keys AS (
+          SELECT unnest(${communityIds}::text[]) AS community_id
+        )
+        SELECT
+          ck."community_id" AS community_id,
+          COUNT(DISTINCT c."user_id")::int AS "cohort_size",
+          COUNT(DISTINCT a."user_id")::int AS "active_next_week"
+        FROM community_keys ck
+        LEFT JOIN cohort c
+          ON c."community_id" = ck."community_id"
+        LEFT JOIN active_members a
+          ON a."community_id" = c."community_id"
+          AND a."user_id" = c."user_id"
+        GROUP BY ck."community_id"
+      `;
+      for (const r of rows) {
+        out.set(r.community_id, {
+          cohortSize: r.cohort_size,
+          activeNextWeek: r.active_next_week,
+        });
+      }
+      return out;
+    });
+  }
+
   async findCohortRetention(
     ctx: IContext,
     communityId: string,

--- a/src/application/domain/report/transactionStats/data/repository.ts
+++ b/src/application/domain/report/transactionStats/data/repository.ts
@@ -510,38 +510,40 @@ export default class ReportTransactionStatsRepository
   }
 
   /**
-   * Retention signals for one week. Computed via FULL OUTER JOIN on the
-   * week-aggregated sender sets for [currentWeekStart, nextWeekStart) and
-   * [prevWeekStart, currentWeekStart) so each user contributes one row
-   * regardless of which weeks they appear in — a naive two-pass COUNT
-   * would double-count people active in both weeks.
+   * Retention signals for one week, computed for every community in
+   * `communityIds` in one SQL roundtrip. Same six counters per
+   * community as the single-row variant; `Map<communityId, counts>` is
+   * pre-seeded with zero-row defaults so the caller can iterate
+   * `communityIds` without null-checking.
+   *
+   * Computed via FULL OUTER JOIN on the week-aggregated sender sets
+   * for [currentWeekStart, nextWeekStart) and [prevWeekStart,
+   * currentWeekStart) so each (community, user) pair contributes one
+   * row regardless of which weeks they appear in — a naive two-pass
+   * COUNT would double-count people active in both weeks.
    *
    * `is_sender` is gated on `donation_out_count > 0` (not
    * `tx_count_out > 0`) so the definition stays consistent with
    * `returned_senders` which scans the same MV column. This matters:
    * ONBOARDING / GRANT transactions increment `tx_count_out` for the
-   * admin wallet but not `donation_out_count`, and we want retention to
-   * track peer-to-peer DONATION behaviour specifically.
+   * admin wallet but not `donation_out_count`, and we want retention
+   * to track peer-to-peer DONATION behaviour specifically.
    *
-   * `is_receiver` is gated symmetrically on `received_donation_count > 0`
-   * (DONATION-only) rather than `tx_count_in > 0`. The same ONBOARDING /
-   * GRANT noise that we filter out of the sender frame also shows up on
-   * the receiver side (admin-issued grants land as incoming transactions
-   * on every recipient's wallet); including those in `is_receiver` would
+   * `is_receiver` is gated symmetrically on
+   * `received_donation_count > 0` (DONATION-only) rather than
+   * `tx_count_in > 0`. The same ONBOARDING / GRANT noise that we
+   * filter out of the sender frame also shows up on the receiver side
+   * (admin-issued grants land as incoming transactions on every
+   * recipient's wallet); including those in `is_receiver` would
    * inflate `current_active_count` and the `active_rate_any` the
    * presenter divides out of it, overstating peer-to-peer engagement.
    *
    * The `ever_before` CTE is bounded to a 12-week lookback to keep the
-   * returning-users scan from fanning out to years of history on mature
-   * communities; the trade-off is documented in the design notes —
-   * 13+-week comebacks land in no bucket.
-   */
-  /**
-   * Bulk variant of `findRetentionAggregate`. Same six counters per
-   * community, computed in one SQL roundtrip across `communityIds`.
-   * Communities with no rows in the window are returned with all counts
-   * set to zero so the caller can iterate `communityIds` without
-   * null-checking.
+   * returning-users scan from fanning out to years of history on
+   * mature communities; the trade-off is documented in the design
+   * notes — 13+-week comebacks land in no bucket. The lookback widens
+   * by `community_id` for the bulk version so each community gets its
+   * own per-user "ever-before" set.
    */
   async findRetentionAggregateBulk(
     ctx: IContext,
@@ -608,6 +610,11 @@ export default class ReportTransactionStatsRepository
             AND "donation_out_count" > 0
         ),
         new_this_week AS (
+          -- created_at is naive-UTC timestamp -- see the boundary
+          -- conversion rationale in findDeepestChain. The
+          -- ::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC' dance
+          -- pins the window to JST midnight regardless of the DB
+          -- session timezone.
           SELECT "community_id", COUNT(*)::int AS n
           FROM "t_memberships"
           WHERE "community_id" = ANY(${communityIds}::text[])
@@ -617,6 +624,13 @@ export default class ReportTransactionStatsRepository
           GROUP BY "community_id"
         ),
         joined AS (
+          -- FULL OUTER JOIN on (community_id, user_id) so each user
+          -- contributes one row per community regardless of which
+          -- weeks they appear in — a naive two-pass COUNT would
+          -- double-count people active in both weeks. ever_before is
+          -- LEFT JOINed on the union key so a user who appears in
+          -- only one of the two weeks still gets their returning-
+          -- user signal looked up.
           SELECT
             COALESCE(cw."community_id", pw."community_id") AS community_id,
             cw."user_id" AS cw_user,
@@ -656,6 +670,11 @@ export default class ReportTransactionStatsRepository
           GROUP BY community_id
         ),
         community_keys AS (
+          -- Materialise the input id list so the final LEFT JOIN
+          -- emits one row per requested community, even those with
+          -- no senders / no new members in the window. Without this,
+          -- the caller would have to null-check every Map.get(id)
+          -- lookup.
           SELECT unnest(${communityIds}::text[]) AS community_id
         )
         SELECT
@@ -684,6 +703,14 @@ export default class ReportTransactionStatsRepository
     });
   }
 
+  /**
+   * Single-community variant of `findRetentionAggregateBulk`. Same
+   * SQL semantics applied to one community at a time — kept because
+   * `getRetentionTrend` and the per-month cohort fan-out call this
+   * once per time window, where the bulk-by-community axis doesn't
+   * help. See the bulk variant's docblock for `is_sender` / `is_receiver`
+   * gating and `ever_before` 12-week lookback rationale.
+   */
   async findRetentionAggregate(
     ctx: IContext,
     communityId: string,
@@ -794,21 +821,20 @@ export default class ReportTransactionStatsRepository
   }
 
   /**
-   * Week-N retention lookup: how many members of the cohort that joined
-   * during `[cohortStart, cohortEnd)` were senders during
-   * `[activeStart, activeEnd)`. Returns raw numerator / denominator so
-   * an empty cohort surfaces as `cohortSize = 0` and the presenter
-   * converts that to `null` rather than `0 / 0`.
+   * Week-N retention lookup, computed for every community in
+   * `communityIds` in one SQL roundtrip: how many members of the
+   * cohort that joined during `[cohortStart, cohortEnd)` were senders
+   * during `[activeStart, activeEnd)`. Returns
+   * `Map<communityId, {cohortSize, activeNextWeek}>` pre-seeded with
+   * zeros for every requested community.
+   *
+   * Returns raw numerator / denominator so an empty cohort surfaces
+   * as `cohortSize = 0` and the presenter converts that to `null`
+   * rather than `0 / 0`.
    *
    * `is_sender` uses the same `donation_out_count > 0` frame as
-   * `findRetentionAggregate` so week1/week4 retention and the weekly
-   * retention counters are apples-to-apples.
-   */
-  /**
-   * Bulk variant of `findCohortRetention`. Same numerator / denominator
-   * per community, computed in one SQL roundtrip across `communityIds`.
-   * Communities with no cohort members in the window get
-   * {cohortSize: 0, activeNextWeek: 0}.
+   * `findRetentionAggregateBulk` so week1/week4 retention and the
+   * weekly retention counters are apples-to-apples.
    */
   async findCohortRetentionBulk(
     ctx: IContext,
@@ -828,6 +854,9 @@ export default class ReportTransactionStatsRepository
         }[]
       >`
         WITH cohort AS (
+          -- Naive-UTC timestamp column vs JST-midnight boundary:
+          -- see the findDeepestChain comment for the full
+          -- explanation of the double AT TIME ZONE dance.
           SELECT "community_id", "user_id"
           FROM "t_memberships"
           WHERE "community_id" = ANY(${communityIds}::text[])
@@ -836,6 +865,10 @@ export default class ReportTransactionStatsRepository
             AND "created_at" <  (${cohort.cohortEnd}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
         ),
         active_members AS (
+          -- donation_out_count > 0 keeps the active-side definition
+          -- aligned with findRetentionAggregateBulk is_sender frame:
+          -- week1/week4 retention and the weekly retention counters
+          -- land on the same definition of "active".
           SELECT DISTINCT "community_id", "user_id"
           FROM "mv_user_transaction_daily"
           WHERE "community_id" = ANY(${communityIds}::text[])
@@ -844,6 +877,10 @@ export default class ReportTransactionStatsRepository
             AND "donation_out_count" > 0
         ),
         community_keys AS (
+          -- Materialise the input id list so the final LEFT JOIN
+          -- emits one row per requested community, even those with
+          -- empty cohorts. Without this, the caller would have to
+          -- null-check every Map.get(id) lookup.
           SELECT unnest(${communityIds}::text[]) AS community_id
         )
         SELECT
@@ -868,6 +905,14 @@ export default class ReportTransactionStatsRepository
     });
   }
 
+  /**
+   * Single-community variant of `findCohortRetentionBulk`. Same SQL
+   * semantics applied to one community at a time — kept because the
+   * per-month cohort fan-out (`AnalyticsCommunityService.getCohortRetention`)
+   * issues 4 calls per cohort window, where the bulk-by-community
+   * axis doesn't help. See the bulk variant's docblock for the
+   * `is_sender` gating rationale.
+   */
   async findCohortRetention(
     ctx: IContext,
     communityId: string,

--- a/src/application/domain/report/util.ts
+++ b/src/application/domain/report/util.ts
@@ -111,10 +111,11 @@ export function percentChange(current: number, previous: number): number | null 
 // start" is a Date whose UTC components encode the first day of the JST
 // calendar month at UTC 00:00. Round-trips through Prisma `@db.Date`
 // filters and the `::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC'`
-// SQL pattern the report / sysadmin repositories use.
+// SQL pattern the report / analytics repositories use.
 //
-// Lived under sysadmin/util.ts originally; moved here so every analytics
-// domain imports from the same place as the day/week helpers above.
+// Lived under sysadmin/util.ts originally (pre-rename); moved to
+// report/util.ts so every analytics domain imports from the same place
+// as the day/week helpers above.
 // ============================================================================
 
 /**


### PR DESCRIPTION
## Summary

L1 dashboard (`analyticsDashboard`) のクエリを **N×5 → 5** に削減。 PR #949 の Gemini レビューで指摘された N+1 パターンの解消。

### Before / After

| | Before | After |
|---|---|---|
| dashboard 1 リクエストあたりの SQL 数 | `5 × communities.length` | `5` |
| `findMemberStats` SQL の重複 | 2 (single + bulk) | 1 (bulk のみ) |
| 維持された single 系メソッド | `findMemberStats` / `findWindowActivityCounts` / `findWindowHubMemberCount` | (削除) |

### 実装概要

1. **bulk SQL を 5 メソッド追加** (`*Bulk` suffix)
   - `analytics/community/data/repository.ts`: `findMemberStatsBulk` / `findWindowActivityCountsBulk` / `findWindowHubMemberCountBulk`
   - `report/transactionStats/data/repository.ts`: `findRetentionAggregateBulk` / `findCohortRetentionBulk`
   - 各 CTE は `community_id = ANY(...)` に拡張、JOIN keys を `(user_id, community_id)` にタイトン化
   - 戻り値は `Map<communityId, T>` で全 input id を pre-seed (caller の null-check 不要)

2. **service 層 bulk wrapper を追加**
   - `AnalyticsCommunityService`: `getMemberStatsBulk` / `getWindowActivityBulk` / `getWindowHubMemberCountBulk` / `getWeeklyRetentionBulk` / `getLatestCohortBulk`
   - `ReportService`: `getRetentionAggregateBulk` / `getCohortRetentionBulk`

3. **`AnalyticsUseCase.getDashboard` を bulk 呼び出しに書き換え**
   - 旧: `Promise.all(communities.map(async c => Promise.all([5 SQLs])))`
   - 新: `Promise.all([5 bulk SQLs])` → 各 community 単位の純粋計算は in-memory で実行

4. **per-community single メソッドを削除** (重複解消、618 行削除)
   - repository: `findMemberStats` / `findWindowActivityCounts` / `findWindowHubMemberCount` 削除
   - service: `getWindowActivity` / `getWindowHubMemberCount` 削除 (L1 専用だった)
   - `getMemberStats` は L2 detail 用に bulk のシン wrapper として残存 (`Map.get(id) ?? []`)
   - **意図的に残した**: `findRetentionAggregate` / `findCohortRetention` — 時間窓ループ (`getRetentionTrend` / per-month cohort fan-out) で N=「時間窓数」軸の primitive として必要

### Commits

| # | commit | 規模 |
|---|---|---|
| 1 | `34a3421` perf(analytics): add bulk variants for window activity / hub-member counts | S |
| 2 | `5b7c719` perf(analytics): add findMemberStatsBulk for L1 dashboard fan-out | L |
| 3 | `f416e8b` perf(report): add bulk variants for retention / cohort aggregates | M |
| 4 | `6049d9a` perf(analytics): use bulk SQLs in L1 dashboard fan-out | M |
| 5 | `614e136` test(analytics): pin bulk wrapper wiring in service unit tests | S |
| 6 | `9cc4708` refactor(analytics): drop per-community singles superseded by bulk variants | M |

### Verification

- [x] `pnpm tsc --noEmit` clean (既存の `refreshMaterializedView*` エラーは pre-existing)
- [x] `pnpm jest --testPathPattern="(unit/analytics|unit/report)"` — **265 tests pass**
  - うち bulk wrapper の wiring を pin する unit test を 5 本追加
- [ ] 手動 smoke (preview env): `analyticsDashboard` で同等の payload が返ることを確認 (frontend 切替不要、内部 SQL 形だけ変わる)

### 互換性

- **GraphQL surface 変更なし** — `Query.analyticsDashboard` の payload 形は完全互換
- frontend の同期リリース不要

## Test plan

- [ ] preview env で `analyticsDashboard` を実行し、payload が develop と同一であることを確認
- [ ] preview env で `analyticsCommunity` (L2 detail) も従来通り動作することを確認 (`getMemberStats` が bulk wrapper 経由になったため)
- [ ] CI: `pnpm test` / `pnpm lint` / `pnpm typecheck` green

https://claude.ai/code/session_01UW6ubb47XcbTNreZj9PWNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01UW6ubb47XcbTNreZj9PWNU)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/951" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
