### PR TITLE
perf(analytics, report): add mv_donation_tx_edges + route all DONATION queries through it

### DIFF
--- a/src/__tests__/helper/test-data-source-helper.ts
+++ b/src/__tests__/helper/test-data-source-helper.ts
@@ -261,6 +261,10 @@ export default class TestDataSourceHelper {
     return this.db.$queryRaw`REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_current_points"`;
   }
 
+  static async refreshDonationTxEdges() {
+    return this.db.$queryRaw`REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_donation_tx_edges"`;
+  }
+
   static async getCurrentPoints(walletId: string): Promise<number | null> {
     const result = await this.db.currentPointView.findUnique({
       where: { walletId },

--- a/src/__tests__/unit/report/goldenCase.test.ts
+++ b/src/__tests__/unit/report/goldenCase.test.ts
@@ -131,6 +131,7 @@ describe("ReportGoldenCases seed", () => {
         findCohortRetention: jest.fn(),
         refreshTransactionSummaryDaily: jest.fn(),
         refreshUserTransactionDaily: jest.fn(),
+        refreshDonationTxEdges: jest.fn(),
       };
       const entityRepo = {
         createReport: jest.fn(),

--- a/src/__tests__/unit/report/goldenCase.test.ts
+++ b/src/__tests__/unit/report/goldenCase.test.ts
@@ -194,6 +194,7 @@ describe("ReportGoldenCases seed", () => {
           findCohortRetention: jest.fn(),
           refreshTransactionSummaryDaily: jest.fn(),
           refreshUserTransactionDaily: jest.fn(),
+          refreshDonationTxEdges: jest.fn(),
         };
         const entityRepo = {
           createReport: jest.fn(),

--- a/src/__tests__/unit/report/service.test.ts
+++ b/src/__tests__/unit/report/service.test.ts
@@ -20,6 +20,7 @@ class MockTransactionStatsRepository {
   findCohortRetention = jest.fn();
   refreshTransactionSummaryDaily = jest.fn();
   refreshUserTransactionDaily = jest.fn();
+  refreshDonationTxEdges = jest.fn();
 }
 
 class MockEntityRepository {

--- a/src/application/domain/analytics/community/data/repository.ts
+++ b/src/application/domain/analytics/community/data/repository.ts
@@ -152,42 +152,52 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
             AND m."created_at" < ab.upper_ts
         ),
         donation_activity AS (
-          -- Per-(community, user, JST calendar day) DONATION-out
-          -- activity: one row per day the member sent a DONATION,
-          -- carrying the day's aggregated points and JST-month
-          -- bucket. The final SELECT then derives:
+          -- Per-(community, user, JST calendar day) DONATION activity:
+          -- emits one row per day the user sent a DONATION from their
+          -- wallet in that community, carrying both the aggregated
+          -- points for that day and the day's JST month bucket. The
+          -- final SELECT then derives:
           --   donation_out_months = COUNT(DISTINCT jst_month)
           --   donation_out_days   = COUNT(DISTINCT jst_day)
           --   total_points_out    = SUM(day_points_out)
           --
-          -- Sources from mv_donation_tx_edges (the tx-level normalized
-          -- DONATION fact view). The MV bakes in the wallet -> user/
-          -- community resolution, the cross-community guard, the burn-
-          -- target / self-donation exclusions, and the DONATION reason
-          -- filter — so this CTE only has to clamp at asOf, scope to
-          -- the sender community of interest, and aggregate per JST
-          -- day. The previous version scanned t_transactions joined to
-          -- t_wallets twice; the rewrite replaces that with a sender-
-          -- community-keyed range scan on the MV.
+          -- Reads t_transactions directly (with a single sender-side
+          -- t_wallets join) on purpose: this CTE measures ALL outgoing
+          -- DONATION activity from a member, including donations to
+          -- burn / system targets, self-donations, and cross-community
+          -- recipients. mv_donation_tx_edges is intentionally NOT used
+          -- here because its WHERE bakes in recipient-side filters
+          -- (tw.user_id IS NOT NULL, fw.user_id <> tw.user_id, cross-
+          -- community guard) that are correct for the DISTINCT-
+          -- counterparty CTEs (donation_recipients, donation_senders)
+          -- and the hub queries, but would silently narrow the
+          -- denominator and totals here — a regression flagged by code
+          -- review on PR #952.
+          --
+          -- JST date bucketing matches the rest of the query so
+          -- daysIn / donationOutDays line up with the member-tenure
+          -- boundary, and findActivitySnapshot / findPlatformTotals
+          -- agree on what "as of asOf" includes.
           SELECT
-            e."sender_community_id" AS community_id,
-            e."sender_user_id" AS user_id,
-            e."date" AS jst_day,
-            DATE_TRUNC('month', e."date") AS jst_month,
-            SUM(e."from_point_change") AS day_points_out
-          FROM "mv_donation_tx_edges" e
+            fw."community_id" AS community_id,
+            fw."user_id" AS user_id,
+            (t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')::date AS jst_day,
+            DATE_TRUNC(
+              'month',
+              (t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')
+            ) AS jst_month,
+            SUM(t."from_point_change") AS day_points_out
+          FROM "t_transactions" t
+          INNER JOIN "t_wallets" fw
+            ON fw."id" = t."from"
+            AND fw."community_id" = ANY(${communityIds}::text[])
           INNER JOIN members m
-            ON m."user_id" = e."sender_user_id"
-            AND m."community_id" = e."sender_community_id"
+            ON m."user_id" = fw."user_id"
+            AND m."community_id" = fw."community_id"
           CROSS JOIN asof_bound ab
-          WHERE e."sender_community_id" = ANY(${communityIds}::text[])
-            AND e."date" < ab.upper_jst_date
-          -- jst_month is functionally dependent on e."date" (DATE_TRUNC
-          -- output), but listing it explicitly matches the previous
-          -- inline CTE's GROUP BY shape and removes any reliance on
-          -- Postgres' functional-dependency analysis for the SELECT-
-          -- list expression.
-          GROUP BY e."sender_community_id", e."sender_user_id", e."date", jst_month
+          WHERE t."reason" = 'DONATION'
+            AND t."created_at" < ab.upper_ts
+          GROUP BY fw."community_id", fw."user_id", jst_day, jst_month
         ),
         donation_recipients AS (
           -- Per-sender count of DISTINCT recipient user_ids over the

--- a/src/application/domain/analytics/community/data/repository.ts
+++ b/src/application/domain/analytics/community/data/repository.ts
@@ -1091,41 +1091,41 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
         }[]
       >`
         WITH asof_bound AS (
-          -- Same (asOf JST day + 1) clamp the other analytics queries
-          -- use. Historic asOf must not count DONATION transactions
-          -- or chain depths from dates past asOf; otherwise the
-          -- summary card would mix the past-point view with whatever
-          -- landed after, contradicting stageCounts.total /
+          -- (asOf JST day + 1) used as an exclusive upper bound on
+          -- both DONATION rows and the MV-coverage range. Historic
+          -- asOf must not count DONATION transactions or chain
+          -- depths from dates past asOf; otherwise the summary card
+          -- would mix the past-point view with whatever landed
+          -- after, contradicting stageCounts.total /
           -- communityActivityRate which ARE clamped.
-          SELECT (
+          SELECT
             ((${asOf}::timestamp AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')::date + 1)
-            AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC'
-          ) AS upper_ts
+            AS upper_jst_date
         ),
         donation_totals AS (
+          -- Sources from mv_donation_tx_edges. The MV's burn-target
+          -- / self-donation / cross-community-leakage exclusions
+          -- match civicship's gift-economy DONATION definition and
+          -- so are correct for the all-time totals too — same
+          -- reasoning as the donation_* CTEs in findMemberStatsBulk.
           SELECT
-            COALESCE(SUM(t."from_point_change"), 0)::bigint AS total_donation_points,
-            MAX(t."chain_depth")::int AS max_chain_depth
-          FROM "t_transactions" t
-          INNER JOIN "t_wallets" fw
-            ON fw."id" = t."from"
-            AND fw."community_id" = ${communityId}
+            COALESCE(SUM(e."from_point_change"), 0)::bigint AS total_donation_points,
+            MAX(e."chain_depth")::int AS max_chain_depth
+          FROM "mv_donation_tx_edges" e
           CROSS JOIN asof_bound ab
-          WHERE t."reason" = 'DONATION'
-            AND t."created_at" < ab.upper_ts
+          WHERE e."sender_community_id" = ${communityId}
+            AND e."date" < ab.upper_jst_date
         ),
         data_range AS (
           -- MV "date" column is a JST-encoded date; compare against
-          -- the JST calendar date of asOf (ab.upper_ts is JST-midnight
-          -- in naive UTC, so dropping back to ::date gives the JST
-          -- day after asOf; exclusive less-than keeps the last
-          -- included day as asOf).
+          -- the same upper_jst_date as donation_totals so a historic
+          -- asOf doesn't extend dataTo past the requested instant.
           SELECT
             MIN("date") AS data_from,
             MAX("date") AS data_to
-          FROM "mv_transaction_summary_daily", asof_bound
+          FROM "mv_transaction_summary_daily", asof_bound ab
           WHERE "community_id" = ${communityId}
-            AND "date" < ((${asOf}::timestamp AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')::date + 1)
+            AND "date" < ab.upper_jst_date
         )
         SELECT
           dt.total_donation_points,
@@ -1181,10 +1181,8 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
       const rows = await tx.$queryRaw<{ depth: number; count: number }[]>`
         WITH asof_bound AS (
           SELECT
-            (
-              ((${asOf}::timestamp AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')::date + 1)
-              AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC'
-            ) AS upper_ts
+            ((${asOf}::timestamp AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')::date + 1)
+            AS upper_jst_date
         ),
         bucket_keys AS (
           SELECT generate_series(1, ${maxBucketDepth}::int) AS depth
@@ -1198,22 +1196,26 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
           -- parameter slots ($1, $3) at the wire level. PostgreSQL
           -- then refuses to recognise the GROUP BY expression as
           -- matching the SELECT one syntactically, raising
-          -- "column t.chain_depth must appear in the GROUP BY
+          -- "column e.chain_depth must appear in the GROUP BY
           -- clause". Alias reference (PostgreSQL-supported since
           -- 9.x) sidesteps the parameter duplication and stays
           -- robust to future SELECT-column reorders, unlike
           -- positional GROUP BY.
+          --
+          -- Sources from mv_donation_tx_edges. The MV's filters
+          -- (burn-target / self-donation / cross-community-leakage
+          -- exclusion) are correct for the donation graph too:
+          -- self-donations don't form chains, burn targets don't
+          -- forward, and cross-community DONATIONs are leakage
+          -- that shouldn't shape this community's chain histogram.
           SELECT
-            LEAST(t."chain_depth", ${maxBucketDepth}::int) AS depth,
+            LEAST(e."chain_depth", ${maxBucketDepth}::int) AS depth,
             COUNT(*)::int AS n
-          FROM "t_transactions" t
-          INNER JOIN "t_wallets" fw
-            ON fw."id" = t."from"
-            AND fw."community_id" = ${communityId}
+          FROM "mv_donation_tx_edges" e
           CROSS JOIN asof_bound ab
-          WHERE t."reason" = 'DONATION'
-            AND t."chain_depth" >= 1
-            AND t."created_at" < ab.upper_ts
+          WHERE e."sender_community_id" = ${communityId}
+            AND e."chain_depth" >= 1
+            AND e."date" < ab.upper_jst_date
           GROUP BY depth
         )
         SELECT

--- a/src/application/domain/analytics/community/data/repository.ts
+++ b/src/application/domain/analytics/community/data/repository.ts
@@ -161,43 +161,47 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
           --   donation_out_days   = COUNT(DISTINCT jst_day)
           --   total_points_out    = SUM(day_points_out)
           --
-          -- Reads t_transactions directly (with a single sender-side
-          -- t_wallets join) on purpose: this CTE measures ALL outgoing
-          -- DONATION activity from a member, including donations to
-          -- burn / system targets, self-donations, and cross-community
-          -- recipients. mv_donation_tx_edges is intentionally NOT used
-          -- here because its WHERE bakes in recipient-side filters
-          -- (tw.user_id IS NOT NULL, fw.user_id <> tw.user_id, cross-
-          -- community guard) that are correct for the DISTINCT-
-          -- counterparty CTEs (donation_recipients, donation_senders)
-          -- and the hub queries, but would silently narrow the
-          -- denominator and totals here — a regression flagged by code
-          -- review on PR #952.
+          -- Sources from mv_donation_tx_edges. The MV bakes in three
+          -- guards that match civicship's gift-economy DONATION
+          -- definition and so are correct for every analytics caller,
+          -- including this one:
+          --   - tw.user_id IS NOT NULL — DONATIONs to burn / system
+          --     wallets are not peer-to-peer gifts
+          --   - tw.user_id <> fw.user_id — self-donations are not
+          --     gifts
+          --   - cross-community guard — DONATION rows where both sides
+          --     have non-NULL communities and they differ are
+          --     cross-community leakage and shouldn't be credited to
+          --     either community's totals
+          -- The pre-PR donation_activity CTE happened not to apply
+          -- these because it never JOINed the recipient wallet, but
+          -- that was an implicit reliance on the data not containing
+          -- such rows. Making the contract explicit at the MV layer
+          -- removes the ambiguity for every consumer.
           --
           -- JST date bucketing matches the rest of the query so
           -- daysIn / donationOutDays line up with the member-tenure
           -- boundary, and findActivitySnapshot / findPlatformTotals
           -- agree on what "as of asOf" includes.
           SELECT
-            fw."community_id" AS community_id,
-            fw."user_id" AS user_id,
-            (t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')::date AS jst_day,
-            DATE_TRUNC(
-              'month',
-              (t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')
-            ) AS jst_month,
-            SUM(t."from_point_change") AS day_points_out
-          FROM "t_transactions" t
-          INNER JOIN "t_wallets" fw
-            ON fw."id" = t."from"
-            AND fw."community_id" = ANY(${communityIds}::text[])
+            e."sender_community_id" AS community_id,
+            e."sender_user_id" AS user_id,
+            e."date" AS jst_day,
+            DATE_TRUNC('month', e."date") AS jst_month,
+            SUM(e."from_point_change") AS day_points_out
+          FROM "mv_donation_tx_edges" e
           INNER JOIN members m
-            ON m."user_id" = fw."user_id"
-            AND m."community_id" = fw."community_id"
+            ON m."user_id" = e."sender_user_id"
+            AND m."community_id" = e."sender_community_id"
           CROSS JOIN asof_bound ab
-          WHERE t."reason" = 'DONATION'
-            AND t."created_at" < ab.upper_ts
-          GROUP BY fw."community_id", fw."user_id", jst_day, jst_month
+          WHERE e."sender_community_id" = ANY(${communityIds}::text[])
+            AND e."date" < ab.upper_jst_date
+          -- jst_month is functionally dependent on e."date" (DATE_TRUNC
+          -- output) and Postgres allows it in SELECT without an
+          -- explicit GROUP BY entry, but listing it keeps the GROUP BY
+          -- shape parallel to the pre-PR inline CTE and removes the
+          -- reliance on functional-dependency analysis.
+          GROUP BY e."sender_community_id", e."sender_user_id", e."date", jst_month
         ),
         donation_recipients AS (
           -- Per-sender count of DISTINCT recipient user_ids over the
@@ -241,52 +245,30 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
           -- the cross-product bug that motivated the donation_activity
           -- consolidation.
           --
-          -- Reads t_transactions directly for the same reason
-          -- donation_activity does: this CTE measures TOTAL incoming
-          -- DONATION points (not DISTINCT counterparties), so the
-          -- MV's tw.user_id <> fw.user_id self-donation guard would
-          -- silently drop self-donation rows from total_points_in /
-          -- donation_in_months / donation_in_days. Keeping the
-          -- pre-PR t_transactions + double t_wallets join preserves
-          -- exact semantic equivalence.
-          --
-          -- Scoping mirrors donation_activity / donation_recipients:
-          --   - DONATION reason only (excludes burn / grant flows that
-          --     are not part of the gift-economy ledger)
-          --   - receiver wallet attached to one of the requested
-          --     communities so a member who received cross-community
-          --     grants does not get incoming credit they cannot
-          --     reciprocate
-          --   - sender wallet either in the same community or
-          --     unattached (system / burn sources are excluded from
-          --     the points sum for symmetry with donation_activity's
-          --     wallet filter on the sending side)
-          --   - clamped at asOf via asof_bound so a historic asOf
-          --     does not leak future incoming points into the totals
+          -- Sources from mv_donation_tx_edges, keyed by
+          -- recipient_community_id. Same "the MV's three guards
+          -- match civicship's DONATION definition" reasoning as
+          -- donation_activity above — burn-target / self-donation /
+          -- cross-community-leakage rows are not real peer-to-peer
+          -- gifts and so should not contribute to a member's
+          -- incoming totals either.
           SELECT
-            tw."community_id" AS community_id,
-            tw."user_id" AS user_id,
-            (t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')::date AS jst_day,
-            DATE_TRUNC(
-              'month',
-              (t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')
-            ) AS jst_month,
-            SUM(t."to_point_change") AS day_points_in
-          FROM "t_transactions" t
-          INNER JOIN "t_wallets" tw
-            ON tw."id" = t."to"
-            AND tw."community_id" = ANY(${communityIds}::text[])
+            e."recipient_community_id" AS community_id,
+            e."recipient_user_id" AS user_id,
+            e."date" AS jst_day,
+            DATE_TRUNC('month', e."date") AS jst_month,
+            SUM(e."to_point_change") AS day_points_in
+          FROM "mv_donation_tx_edges" e
           INNER JOIN members m
-            ON m."user_id" = tw."user_id"
-            AND m."community_id" = tw."community_id"
-          INNER JOIN "t_wallets" fw
-            ON fw."id" = t."from"
-            AND fw."user_id" IS NOT NULL
-            AND (fw."community_id" IS NULL OR fw."community_id" = tw."community_id")
+            ON m."user_id" = e."recipient_user_id"
+            AND m."community_id" = e."recipient_community_id"
           CROSS JOIN asof_bound ab
-          WHERE t."reason" = 'DONATION'
-            AND t."created_at" < ab.upper_ts
-          GROUP BY tw."community_id", tw."user_id", jst_day, jst_month
+          WHERE e."recipient_community_id" = ANY(${communityIds}::text[])
+            AND e."date" < ab.upper_jst_date
+          -- See donation_activity above: jst_month listed explicitly
+          -- in GROUP BY for SELECT-list parity rather than relying on
+          -- functional-dependency analysis.
+          GROUP BY e."recipient_community_id", e."recipient_user_id", e."date", jst_month
         ),
         donation_in_aggregates AS (
           -- Pre-aggregate donation_received to one row per

--- a/src/application/domain/analytics/community/data/repository.ts
+++ b/src/application/domain/analytics/community/data/repository.ts
@@ -241,30 +241,52 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
           -- the cross-product bug that motivated the donation_activity
           -- consolidation.
           --
-          -- Sources from mv_donation_tx_edges, keyed by
-          -- recipient_community_id. The MV's WHERE clause guarantees
-          -- that fw.user_id IS NOT NULL and that the cross-community
-          -- guard holds in the same direction (sender community NULL
-          -- or matches recipient), so the asymmetric "incoming
-          -- accepts NULL sender community" semantic from the previous
-          -- CTE is preserved.
+          -- Reads t_transactions directly for the same reason
+          -- donation_activity does: this CTE measures TOTAL incoming
+          -- DONATION points (not DISTINCT counterparties), so the
+          -- MV's tw.user_id <> fw.user_id self-donation guard would
+          -- silently drop self-donation rows from total_points_in /
+          -- donation_in_months / donation_in_days. Keeping the
+          -- pre-PR t_transactions + double t_wallets join preserves
+          -- exact semantic equivalence.
+          --
+          -- Scoping mirrors donation_activity / donation_recipients:
+          --   - DONATION reason only (excludes burn / grant flows that
+          --     are not part of the gift-economy ledger)
+          --   - receiver wallet attached to one of the requested
+          --     communities so a member who received cross-community
+          --     grants does not get incoming credit they cannot
+          --     reciprocate
+          --   - sender wallet either in the same community or
+          --     unattached (system / burn sources are excluded from
+          --     the points sum for symmetry with donation_activity's
+          --     wallet filter on the sending side)
+          --   - clamped at asOf via asof_bound so a historic asOf
+          --     does not leak future incoming points into the totals
           SELECT
-            e."recipient_community_id" AS community_id,
-            e."recipient_user_id" AS user_id,
-            e."date" AS jst_day,
-            DATE_TRUNC('month', e."date") AS jst_month,
-            SUM(e."to_point_change") AS day_points_in
-          FROM "mv_donation_tx_edges" e
+            tw."community_id" AS community_id,
+            tw."user_id" AS user_id,
+            (t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')::date AS jst_day,
+            DATE_TRUNC(
+              'month',
+              (t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')
+            ) AS jst_month,
+            SUM(t."to_point_change") AS day_points_in
+          FROM "t_transactions" t
+          INNER JOIN "t_wallets" tw
+            ON tw."id" = t."to"
+            AND tw."community_id" = ANY(${communityIds}::text[])
           INNER JOIN members m
-            ON m."user_id" = e."recipient_user_id"
-            AND m."community_id" = e."recipient_community_id"
+            ON m."user_id" = tw."user_id"
+            AND m."community_id" = tw."community_id"
+          INNER JOIN "t_wallets" fw
+            ON fw."id" = t."from"
+            AND fw."user_id" IS NOT NULL
+            AND (fw."community_id" IS NULL OR fw."community_id" = tw."community_id")
           CROSS JOIN asof_bound ab
-          WHERE e."recipient_community_id" = ANY(${communityIds}::text[])
-            AND e."date" < ab.upper_jst_date
-          -- See donation_activity above: jst_month included in the
-          -- GROUP BY for SELECT-list parity with the previous inline
-          -- CTE rather than relying on functional-dependency analysis.
-          GROUP BY e."recipient_community_id", e."recipient_user_id", e."date", jst_month
+          WHERE t."reason" = 'DONATION'
+            AND t."created_at" < ab.upper_ts
+          GROUP BY tw."community_id", tw."user_id", jst_day, jst_month
         ),
         donation_in_aggregates AS (
           -- Pre-aggregate donation_received to one row per

--- a/src/application/domain/analytics/community/data/repository.ts
+++ b/src/application/domain/analytics/community/data/repository.ts
@@ -115,16 +115,20 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
           SELECT (${asOf}::timestamp AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo') AS ts
         ),
         asof_bound AS (
-          -- Derive the "asOf JST day + 1, at JST midnight, expressed
-          -- as a naive UTC timestamp" once and reuse everywhere the
-          -- query wants an exclusive upper bound on t_*.created_at.
-          -- The expression is the same JST-day clamp findActivitySnapshot
+          -- Derive the "asOf JST day + 1" once and reuse everywhere
+          -- the query wants an exclusive upper bound. upper_ts is
+          -- the naive-UTC encoding for comparisons against
+          -- t_*.created_at columns; upper_jst_date is the bare
+          -- JST date for comparisons against mv_donation_tx_edges.date
+          -- (and any other JST-bucketed @db.Date column). The
+          -- expression is the same JST-day clamp findActivitySnapshot
           -- / findMonthlyActivity receive pre-computed from the
           -- service layer; inlining it into a single CTE here keeps
           -- the signature unchanged without duplicating the double
-          -- AT TIME ZONE dance across three WHERE clauses.
+          -- AT TIME ZONE dance across multiple WHERE clauses.
           SELECT
-            ((ts::date + 1) AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC') AS upper_ts
+            ((ts::date + 1) AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC') AS upper_ts,
+            (ts::date + 1)                                                AS upper_jst_date
           FROM asof_jst
         ),
         members AS (
@@ -148,50 +152,37 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
             AND m."created_at" < ab.upper_ts
         ),
         donation_activity AS (
-          -- Per-(community, user, JST calendar day) DONATION activity:
-          -- emits one row per day the user sent a DONATION from their
-          -- wallet in that community, carrying both the aggregated
-          -- points for that day and the day's JST month bucket. The
-          -- final SELECT then derives:
+          -- Per-(community, user, JST calendar day) DONATION-out
+          -- activity: one row per day the member sent a DONATION,
+          -- carrying the day's aggregated points and JST-month
+          -- bucket. The final SELECT then derives:
           --   donation_out_months = COUNT(DISTINCT jst_month)
           --   donation_out_days   = COUNT(DISTINCT jst_day)
           --   total_points_out    = SUM(day_points_out)
           --
-          -- This consolidates what used to be two parallel CTEs
-          -- (donation_months + donation_days). Joining both into the
-          -- final SELECT on user_id created an N×M cross product —
-          -- COUNT(DISTINCT) was unaffected, but SUM(month_points_out)
-          -- got inflated by M (= number of donation days), corrupting
-          -- total_points_out and every downstream consumer
-          -- (pointsContributionPct, sort orderings, etc.). Pre-
-          -- aggregating per-day in a single CTE removes the cross
-          -- product entirely and is also one fewer t_transactions
-          -- scan since both old CTEs read the same rows.
-          --
-          -- JST date bucketing matches the rest of the query so
-          -- daysIn / donationOutDays line up with the member-tenure
-          -- boundary, and findActivitySnapshot / findPlatformTotals
-          -- agree on what "as of asOf" includes.
+          -- Sources from mv_donation_tx_edges (the tx-level normalized
+          -- DONATION fact view). The MV bakes in the wallet -> user/
+          -- community resolution, the cross-community guard, the burn-
+          -- target / self-donation exclusions, and the DONATION reason
+          -- filter — so this CTE only has to clamp at asOf, scope to
+          -- the sender community of interest, and aggregate per JST
+          -- day. The previous version scanned t_transactions joined to
+          -- t_wallets twice; the rewrite replaces that with a sender-
+          -- community-keyed range scan on the MV.
           SELECT
-            fw."community_id" AS community_id,
-            fw."user_id" AS user_id,
-            (t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')::date AS jst_day,
-            DATE_TRUNC(
-              'month',
-              (t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')
-            ) AS jst_month,
-            SUM(t."from_point_change") AS day_points_out
-          FROM "t_transactions" t
-          INNER JOIN "t_wallets" fw
-            ON fw."id" = t."from"
-            AND fw."community_id" = ANY(${communityIds}::text[])
+            e."sender_community_id" AS community_id,
+            e."sender_user_id" AS user_id,
+            e."date" AS jst_day,
+            DATE_TRUNC('month', e."date") AS jst_month,
+            SUM(e."from_point_change") AS day_points_out
+          FROM "mv_donation_tx_edges" e
           INNER JOIN members m
-            ON m."user_id" = fw."user_id"
-            AND m."community_id" = fw."community_id"
+            ON m."user_id" = e."sender_user_id"
+            AND m."community_id" = e."sender_community_id"
           CROSS JOIN asof_bound ab
-          WHERE t."reason" = 'DONATION'
-            AND t."created_at" < ab.upper_ts
-          GROUP BY fw."community_id", fw."user_id", jst_day, jst_month
+          WHERE e."sender_community_id" = ANY(${communityIds}::text[])
+            AND e."date" < ab.upper_jst_date
+          GROUP BY e."sender_community_id", e."sender_user_id", e."date"
         ),
         donation_recipients AS (
           -- Per-sender count of DISTINCT recipient user_ids over the
@@ -199,42 +190,31 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
           -- breadth" half of the donor profile and cannot be derived
           -- from mv_user_transaction_daily — that MV's
           -- unique_counterparties column is per-day and does not
-          -- compose into an all-time DISTINCT (the same recipient
-          -- across multiple days would double-count under SUM).
+          -- compose into an all-time DISTINCT under SUM (same recipient
+          -- across multiple days would double-count).
           --
-          -- Scoped to (a) DONATION transactions only, (b) sender wallet
-          -- in one of the requested communities, and (c) recipient
-          -- wallet either in the SAME community as the sender or
-          -- unattached — same "no cross-community leakage" guard that
-          -- mv_user_transaction_daily and v_transaction_comments apply
-          -- at the view layer. Wallets without a user_id (burn /
-          -- system targets) are excluded so a member who only donated
-          -- into a burn target scores 0. Self-donations
-          -- (fw.user_id = tw.user_id) are excluded so the count
-          -- matches the "distinct OTHER users" wording in
-          -- AnalyticsMemberRow.uniqueDonationRecipients — the wallet
-          -- validator does not block same-user transfers, so the
-          -- guard has to live here.
+          -- Sources from mv_donation_tx_edges. The MV bakes in:
+          --   - DONATION reason
+          --   - cross-community guard (recipient in same community or
+          --     unattached)
+          --   - burn-target / system-target exclusion (tw.user_id NOT
+          --     NULL)
+          --   - self-donation exclusion (sender_user_id <>
+          --     recipient_user_id)
+          -- so this CTE just keys by sender_community_id and
+          -- clamps at asOf.
           SELECT
-            fw."community_id" AS community_id,
-            fw."user_id" AS user_id,
-            COUNT(DISTINCT tw."user_id")::int AS unique_recipients
-          FROM "t_transactions" t
-          INNER JOIN "t_wallets" fw
-            ON fw."id" = t."from"
-            AND fw."community_id" = ANY(${communityIds}::text[])
-          INNER JOIN "t_wallets" tw
-            ON tw."id" = t."to"
-            AND tw."user_id" IS NOT NULL
-            AND tw."user_id" <> fw."user_id"
+            e."sender_community_id" AS community_id,
+            e."sender_user_id" AS user_id,
+            COUNT(DISTINCT e."recipient_user_id")::int AS unique_recipients
+          FROM "mv_donation_tx_edges" e
           INNER JOIN members m
-            ON m."user_id" = fw."user_id"
-            AND m."community_id" = fw."community_id"
+            ON m."user_id" = e."sender_user_id"
+            AND m."community_id" = e."sender_community_id"
           CROSS JOIN asof_bound ab
-          WHERE t."reason" = 'DONATION'
-            AND t."created_at" < ab.upper_ts
-            AND (tw."community_id" IS NULL OR tw."community_id" = fw."community_id")
-          GROUP BY fw."community_id", fw."user_id"
+          WHERE e."sender_community_id" = ANY(${communityIds}::text[])
+            AND e."date" < ab.upper_jst_date
+          GROUP BY e."sender_community_id", e."sender_user_id"
         ),
         donation_received AS (
           -- Receiver-side counterpart to donation_activity. Per-
@@ -246,43 +226,27 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
           -- the cross-product bug that motivated the donation_activity
           -- consolidation.
           --
-          -- Scoping mirrors donation_activity / donation_recipients:
-          --   - DONATION reason only (excludes burn / grant flows that
-          --     are not part of the gift-economy ledger)
-          --   - receiver wallet attached to one of the requested
-          --     communities so a member who received cross-community
-          --     grants does not get incoming credit they cannot
-          --     reciprocate
-          --   - sender wallet either in the same community or
-          --     unattached (system / burn sources are excluded from
-          --     the points sum for symmetry with donation_activity's
-          --     wallet filter on the sending side)
-          --   - clamped at asOf via asof_bound so a historic asOf
-          --     does not leak future incoming points into the totals
+          -- Sources from mv_donation_tx_edges, keyed by
+          -- recipient_community_id. The MV's WHERE clause guarantees
+          -- that fw.user_id IS NOT NULL and that the cross-community
+          -- guard holds in the same direction (sender community NULL
+          -- or matches recipient), so the asymmetric "incoming
+          -- accepts NULL sender community" semantic from the previous
+          -- CTE is preserved.
           SELECT
-            tw."community_id" AS community_id,
-            tw."user_id" AS user_id,
-            (t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')::date AS jst_day,
-            DATE_TRUNC(
-              'month',
-              (t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')
-            ) AS jst_month,
-            SUM(t."to_point_change") AS day_points_in
-          FROM "t_transactions" t
-          INNER JOIN "t_wallets" tw
-            ON tw."id" = t."to"
-            AND tw."community_id" = ANY(${communityIds}::text[])
+            e."recipient_community_id" AS community_id,
+            e."recipient_user_id" AS user_id,
+            e."date" AS jst_day,
+            DATE_TRUNC('month', e."date") AS jst_month,
+            SUM(e."to_point_change") AS day_points_in
+          FROM "mv_donation_tx_edges" e
           INNER JOIN members m
-            ON m."user_id" = tw."user_id"
-            AND m."community_id" = tw."community_id"
-          INNER JOIN "t_wallets" fw
-            ON fw."id" = t."from"
-            AND fw."user_id" IS NOT NULL
-            AND (fw."community_id" IS NULL OR fw."community_id" = tw."community_id")
+            ON m."user_id" = e."recipient_user_id"
+            AND m."community_id" = e."recipient_community_id"
           CROSS JOIN asof_bound ab
-          WHERE t."reason" = 'DONATION'
-            AND t."created_at" < ab.upper_ts
-          GROUP BY tw."community_id", tw."user_id", jst_day, jst_month
+          WHERE e."recipient_community_id" = ANY(${communityIds}::text[])
+            AND e."date" < ab.upper_jst_date
+          GROUP BY e."recipient_community_id", e."recipient_user_id", e."date"
         ),
         donation_in_aggregates AS (
           -- Pre-aggregate donation_received to one row per
@@ -312,35 +276,29 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
           -- dashboard uses to compute "受領→送付 転換率"
           -- (recipient-to-sender conversion rate).
           --
-          -- Same defensive guards as donation_recipients in mirror:
-          --   - sender wallet must have a user_id (no burn / system
-          --     sources count toward sender breadth, otherwise an
-          --     admin-issued bulk grant would inflate the count)
-          --   - excludes self-donations (matches the "distinct OTHER
-          --     users" wording in
-          --     AnalyticsMemberRow.uniqueDonationSenders)
-          --   - sender wallet either in the same community or
-          --     unattached (no cross-community leakage)
+          -- Sources from mv_donation_tx_edges, keyed by
+          -- recipient_community_id. The MV bakes in the same defensive
+          -- guards as the previous inline CTE:
+          --   - DONATION reason
+          --   - sender wallet has a user_id (burn / system sources
+          --     excluded so a bulk admin grant doesn't inflate sender
+          --     breadth)
+          --   - self-donation exclusion (sender_user_id <>
+          --     recipient_user_id)
+          --   - cross-community guard (sender community NULL or
+          --     matches recipient)
           SELECT
-            tw."community_id" AS community_id,
-            tw."user_id" AS user_id,
-            COUNT(DISTINCT fw."user_id")::int AS unique_senders
-          FROM "t_transactions" t
-          INNER JOIN "t_wallets" tw
-            ON tw."id" = t."to"
-            AND tw."community_id" = ANY(${communityIds}::text[])
-          INNER JOIN "t_wallets" fw
-            ON fw."id" = t."from"
-            AND fw."user_id" IS NOT NULL
-            AND fw."user_id" <> tw."user_id"
+            e."recipient_community_id" AS community_id,
+            e."recipient_user_id" AS user_id,
+            COUNT(DISTINCT e."sender_user_id")::int AS unique_senders
+          FROM "mv_donation_tx_edges" e
           INNER JOIN members m
-            ON m."user_id" = tw."user_id"
-            AND m."community_id" = tw."community_id"
+            ON m."user_id" = e."recipient_user_id"
+            AND m."community_id" = e."recipient_community_id"
           CROSS JOIN asof_bound ab
-          WHERE t."reason" = 'DONATION'
-            AND t."created_at" < ab.upper_ts
-            AND (fw."community_id" IS NULL OR fw."community_id" = tw."community_id")
-          GROUP BY tw."community_id", tw."user_id"
+          WHERE e."recipient_community_id" = ANY(${communityIds}::text[])
+            AND e."date" < ab.upper_jst_date
+          GROUP BY e."recipient_community_id", e."recipient_user_id"
         ),
         member_tenure AS (
           -- Compute months_in / days_in ONCE per (community, member)
@@ -721,61 +679,50 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
         hub_per_month AS (
           -- Per (month_start, sender) DISTINCT recipient count over
           -- the trailing 28-day window ending at member_upper.
-          -- Mirrors the L1 findWindowHubMemberCountBulk query exactly
-          -- (cross-community + burn-target guards via tw.user_id
-          -- presence, self-donation excluded by tw.user_id <>
-          -- fw.user_id, recipient-community guard via
-          -- tw.community_id) but cross-joined with month_bounds so
-          -- each transaction is evaluated against every month-end
-          -- window it falls into. The 28-day window length is
-          -- intentionally fixed (not request-driven) so monthly
-          -- hub counts stay comparable across requests — same
-          -- precedent as dormant_counts' fixed 30-day window.
+          -- Cross-joined with month_bounds so each DONATION edge is
+          -- evaluated against every month-end window it falls into.
+          -- The 28-day window length is intentionally fixed (not
+          -- request-driven) so monthly hub counts stay comparable
+          -- across requests — same precedent as dormant_counts' fixed
+          -- 30-day window.
           --
-          -- Each transaction's created_at can satisfy at most two
-          -- consecutive months' windows because windowDays (28) is
-          -- shorter than any month-pair span (>= 59 days), so the
-          -- cross join's row volume is bounded by
-          -- ~2 × |DONATION tx in window| rather than N × |DONATION tx|.
+          -- Each edge's date can satisfy at most two consecutive
+          -- months' windows because windowDays (28) is shorter than
+          -- any month-pair span (>= 59 days), so the cross join's
+          -- row volume is bounded by ~2 × |DONATION edges in window|.
           --
-          -- Cannot reuse mv_user_transaction_daily here for the
-          -- same reason as the L1 path: the MV's per-day
+          -- Sources from mv_donation_tx_edges (the tx-level normalized
+          -- DONATION fact view). The MV bakes in the cross-community
+          -- guard, the burn-target / self-donation exclusions, and
+          -- the wallet -> user/community resolution — replacing the
+          -- per-request t_transactions scan + double t_wallets JOIN
+          -- the previous version of this CTE issued. Cannot reuse
+          -- mv_user_transaction_daily here because its per-day
           -- unique_counterparties does not compose into a
-          -- window-wide DISTINCT under SUM (same recipient across
-          -- multiple days double-counts).
+          -- window-wide DISTINCT under SUM.
           --
-          -- The t_memberships join restricts senders to users
-          -- still JOINED in the community at member_upper. Mirrors
-          -- the dormant_counts / returned_counts CTEs above and
-          -- the L1 findWindowHubMemberCountBulk query so a now-
-          -- departed member who sent DONATIONs while a member
-          -- doesn't get counted as a "current hub" in their
-          -- former month — would otherwise contradict the
-          -- L1==latest-month invariant once L1 also enforces
-          -- this membership filter.
+          -- The t_memberships join restricts senders to users still
+          -- JOINED in the community at member_upper. Mirrors
+          -- dormant_counts / returned_counts CTEs above and the L1
+          -- findWindowHubMemberCountBulk query so a now-departed
+          -- member who sent DONATIONs while a member doesn't get
+          -- counted as a "current hub" in their former month — would
+          -- otherwise contradict the L1==latest-month invariant.
           SELECT
             mb.month_start,
-            fw."user_id" AS user_id,
-            COUNT(DISTINCT tw."user_id")::int AS unique_recipients
+            e."sender_user_id" AS user_id,
+            COUNT(DISTINCT e."recipient_user_id")::int AS unique_recipients
           FROM month_bounds mb
-          INNER JOIN "t_transactions" t
-            ON t."reason" = 'DONATION'
-            AND t."created_at" >= ((mb.member_upper - 28) AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
-            AND t."created_at" <  (mb.member_upper          AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
-          INNER JOIN "t_wallets" fw
-            ON fw."id" = t."from"
-            AND fw."community_id" = ${communityId}
+          INNER JOIN "mv_donation_tx_edges" e
+            ON e."sender_community_id" = ${communityId}
+            AND e."date" >= (mb.member_upper - 28)
+            AND e."date" <  mb.member_upper
           INNER JOIN "t_memberships" m
             ON m."community_id" = ${communityId}
-            AND m."user_id" = fw."user_id"
+            AND m."user_id" = e."sender_user_id"
             AND m."status" = 'JOINED'
             AND m."created_at" <  (mb.member_upper AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
-          INNER JOIN "t_wallets" tw
-            ON tw."id" = t."to"
-            AND tw."user_id" IS NOT NULL
-            AND tw."user_id" <> fw."user_id"
-            AND (tw."community_id" IS NULL OR tw."community_id" = fw."community_id")
-          GROUP BY mb.month_start, fw."user_id"
+          GROUP BY mb.month_start, e."sender_user_id"
         ),
         hub_counts AS (
           -- Apply the threshold filter and count distinct hub
@@ -1056,24 +1003,15 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
       const rows = await tx.$queryRaw<{ community_id: string; n: number }[]>`
         WITH window_recipients AS (
           -- Per-(community, sender) DISTINCT recipient count over the
-          -- parametric window. Same shape as the donation_recipients
-          -- CTE in findMemberStatsBulk but window-clamped on both
-          -- sides instead of tenure-clamped (upper only). Cannot
-          -- reuse mv_user_transaction_daily because its per-day
-          -- unique_counterparties does not compose into a window-wide
-          -- DISTINCT (same recipient across multiple days would
-          -- double-count under SUM).
-          --
-          -- Cross-community + burn-target guards mirror the defenses
-          -- on mv_user_transaction_daily / v_transaction_comments so
-          -- a system-target wallet (no user_id) does not silently
-          -- inflate the recipient count. Self-donations are excluded
-          -- (matches the "different people" wording in
-          -- AnalyticsCommunityOverview.hubMemberCount and the
-          -- "distinct OTHER users" definition in
-          -- AnalyticsMemberRow.uniqueDonationRecipients) — the wallet
-          -- validator does not block same-user transfers, so the
-          -- guard has to live in this query.
+          -- parametric window. Sources from mv_donation_tx_edges (the
+          -- tx-level normalized DONATION fact view), which bakes in
+          -- the wallet -> user/community resolution, the cross-
+          -- community guard, the burn-target exclusion, and the
+          -- self-donation exclusion. That replaces the per-request
+          -- t_transactions scan + double t_wallets JOIN this query
+          -- previously issued. Cannot reuse mv_user_transaction_daily
+          -- because its per-day unique_counterparties does not compose
+          -- into a window-wide DISTINCT under SUM.
           --
           -- The t_memberships join restricts senders to users still
           -- JOINED in their respective communities at "upper" (asOf+1
@@ -1083,27 +1021,19 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
           -- "hubMemberCount <= senderCount <= totalMembers" invariant
           -- documented on AnalyticsCommunityOverview.
           SELECT
-            fw."community_id" AS community_id,
-            fw."user_id" AS user_id,
-            COUNT(DISTINCT tw."user_id")::int AS unique_recipients
-          FROM "t_transactions" t
-          INNER JOIN "t_wallets" fw
-            ON fw."id" = t."from"
-            AND fw."community_id" = ANY(${communityIds}::text[])
+            e."sender_community_id" AS community_id,
+            e."sender_user_id" AS user_id,
+            COUNT(DISTINCT e."recipient_user_id")::int AS unique_recipients
+          FROM "mv_donation_tx_edges" e
           INNER JOIN "t_memberships" m
-            ON m."community_id" = fw."community_id"
-            AND m."user_id" = fw."user_id"
+            ON m."community_id" = e."sender_community_id"
+            AND m."user_id" = e."sender_user_id"
             AND m."status" = 'JOINED'
             AND m."created_at" <  (${upper}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
-          INNER JOIN "t_wallets" tw
-            ON tw."id" = t."to"
-            AND tw."user_id" IS NOT NULL
-            AND tw."user_id" <> fw."user_id"
-          WHERE t."reason" = 'DONATION'
-            AND t."created_at" >= (${currLower}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
-            AND t."created_at" <  (${upper}::date     AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
-            AND (tw."community_id" IS NULL OR tw."community_id" = fw."community_id")
-          GROUP BY fw."community_id", fw."user_id"
+          WHERE e."sender_community_id" = ANY(${communityIds}::text[])
+            AND e."date" >= ${currLower}::date
+            AND e."date" <  ${upper}::date
+          GROUP BY e."sender_community_id", e."sender_user_id"
         )
         SELECT community_id, COUNT(*)::int AS n
         FROM window_recipients

--- a/src/application/domain/analytics/community/data/repository.ts
+++ b/src/application/domain/analytics/community/data/repository.ts
@@ -182,7 +182,12 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
           CROSS JOIN asof_bound ab
           WHERE e."sender_community_id" = ANY(${communityIds}::text[])
             AND e."date" < ab.upper_jst_date
-          GROUP BY e."sender_community_id", e."sender_user_id", e."date"
+          -- jst_month is functionally dependent on e."date" (DATE_TRUNC
+          -- output), but listing it explicitly matches the previous
+          -- inline CTE's GROUP BY shape and removes any reliance on
+          -- Postgres' functional-dependency analysis for the SELECT-
+          -- list expression.
+          GROUP BY e."sender_community_id", e."sender_user_id", e."date", jst_month
         ),
         donation_recipients AS (
           -- Per-sender count of DISTINCT recipient user_ids over the
@@ -246,7 +251,10 @@ export default class AnalyticsCommunityRepository implements IAnalyticsCommunity
           CROSS JOIN asof_bound ab
           WHERE e."recipient_community_id" = ANY(${communityIds}::text[])
             AND e."date" < ab.upper_jst_date
-          GROUP BY e."recipient_community_id", e."recipient_user_id", e."date"
+          -- See donation_activity above: jst_month included in the
+          -- GROUP BY for SELECT-list parity with the previous inline
+          -- CTE rather than relying on functional-dependency analysis.
+          GROUP BY e."recipient_community_id", e."recipient_user_id", e."date", jst_month
         ),
         donation_in_aggregates AS (
           -- Pre-aggregate donation_received to one row per

--- a/src/application/domain/report/service.ts
+++ b/src/application/domain/report/service.ts
@@ -182,6 +182,10 @@ export default class ReportService {
     return this.statsRepo.refreshUserTransactionDaily(ctx, tx);
   }
 
+  async refreshDonationTxEdges(ctx: IContext, tx: Prisma.TransactionClient): Promise<void> {
+    return this.statsRepo.refreshDonationTxEdges(ctx, tx);
+  }
+
   // =========================================================================
   // Report AI entities
   // =========================================================================

--- a/src/application/domain/report/transactionStats/data/interface.ts
+++ b/src/application/domain/report/transactionStats/data/interface.ts
@@ -114,4 +114,5 @@ export interface IReportTransactionStatsRepository {
   ): Promise<Map<string, CohortRetentionRow>>;
   refreshTransactionSummaryDaily(ctx: IContext, tx: Prisma.TransactionClient): Promise<void>;
   refreshUserTransactionDaily(ctx: IContext, tx: Prisma.TransactionClient): Promise<void>;
+  refreshDonationTxEdges(ctx: IContext, tx: Prisma.TransactionClient): Promise<void>;
 }

--- a/src/application/domain/report/transactionStats/data/repository.ts
+++ b/src/application/domain/report/transactionStats/data/repository.ts
@@ -16,6 +16,7 @@ import {
   UserTransactionAggregateRow,
 } from "@/application/domain/report/transactionStats/data/rows";
 import {
+  refreshMaterializedViewDonationTxEdges,
   refreshMaterializedViewTransactionSummaryDaily,
   refreshMaterializedViewUserTransactionDaily,
 } from "@prisma/client/sql";
@@ -959,5 +960,9 @@ export default class ReportTransactionStatsRepository
 
   async refreshUserTransactionDaily(ctx: IContext, tx: Prisma.TransactionClient): Promise<void> {
     await tx.$queryRawTyped(refreshMaterializedViewUserTransactionDaily());
+  }
+
+  async refreshDonationTxEdges(ctx: IContext, tx: Prisma.TransactionClient): Promise<void> {
+    await tx.$queryRawTyped(refreshMaterializedViewDonationTxEdges());
   }
 }

--- a/src/application/domain/report/transactionStats/data/repository.ts
+++ b/src/application/domain/report/transactionStats/data/repository.ts
@@ -172,29 +172,26 @@ export default class ReportTransactionStatsRepository
    * did this user give to across the whole week", not "sum of new-per-day
    * counterparties".
    *
-   * Scoped with `userIds` so the scan fans out only to the top-N ids already
-   * selected by the upstream query. `t_wallets.user_id` has an index
-   * (`t_wallets_user_id_idx`) so the lookup joining the sender-side is cheap
-   * even without a dedicated MV.
+   * Sources from `mv_donation_tx_edges`. The previous version filtered
+   * t_transactions only by sender-/recipient-wallet user_id (no explicit
+   * reason filter), but in civicship the only TransactionReason where both
+   * sides are user wallets is DONATION — every other reason has a
+   * community/system wallet on at least one side, which the wallet
+   * predicates already excluded. Routing through the DONATION-only MV
+   * therefore preserves semantics while eliminating the per-request
+   * t_transactions scan + double t_wallets join. The MV also bakes in the
+   * self-donation exclusion that the previous code expressed via a FILTER
+   * clause.
    *
-   * Excludes transactions where the counterparty wallet has no `user_id`
-   * (e.g. community wallets) so the count is strictly "people this user sent
-   * points to", and excludes self-transfers (`tw.user_id = fw.user_id`) from
-   * the DISTINCT via a FILTER clause — the metric is "how many different
-   * *other* people did this user give to", which is what the breadth-of-
-   * activity signal downstream in the prompt is trying to describe.
+   * Scoped with `userIds` so the scan fans out only to the top-N ids
+   * already selected by the upstream query. The MV's
+   * `(sender_community_id, date DESC)` index keeps the range scan cheap
+   * over the JST reporting window.
    *
-   * Uses a half-open `[from 00:00 JST, (to + 1) 00:00 JST)` window to match
-   * the MV bucketing elsewhere in this file. `t_transactions.created_at` is
-   * Prisma `DateTime` → `timestamp WITHOUT time zone` holding naive UTC,
-   * so we convert the JST date boundaries to naive UTC on the constant side
-   * (`::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC'`): first cast the
-   * date to a timestamptz at JST midnight, then render that instant as a
-   * naive UTC wall-clock — the same value the column holds. Keeping the
-   * transform off the column preserves index usage (SARGable) while still
-   * being independent of the DB session timezone, unlike the prior
-   * `timestamp >= timestamptz` form which implicitly cast via the
-   * session's timezone.
+   * Uses a half-open `[from 00:00 JST, (to + 1) 00:00 JST)` window — the
+   * MV's `date` column is JST-bucketed (@db.Date), so the boundaries are
+   * compared as bare dates without the timezone-cast dance the
+   * t_transactions version needed.
    */
   async findTrueUniqueCounterpartiesForUsers(
     ctx: IContext,
@@ -208,22 +205,14 @@ export default class ReportTransactionStatsRepository
         { user_id: string; true_unique_counterparties: number }[]
       >`
         SELECT
-          fw."user_id" AS "user_id",
-          COUNT(DISTINCT tw."user_id") FILTER (
-            WHERE tw."user_id" <> fw."user_id"
-          )::int AS "true_unique_counterparties"
-        FROM "t_transactions" t
-        INNER JOIN "t_wallets" fw
-          ON fw."id" = t."from"
-          AND fw."user_id" = ANY(${userIds}::text[])
-          AND fw."community_id" = ${communityId}
-        INNER JOIN "t_wallets" tw
-          ON tw."id" = t."to"
-          AND tw."user_id" IS NOT NULL
-        WHERE t."created_at" >= (${range.from}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
-          AND t."created_at" <  ((${range.to}::date + 1) AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
-          AND (tw."community_id" IS NULL OR tw."community_id" = fw."community_id")
-        GROUP BY fw."user_id"
+          e."sender_user_id" AS "user_id",
+          COUNT(DISTINCT e."recipient_user_id")::int AS "true_unique_counterparties"
+        FROM "mv_donation_tx_edges" e
+        WHERE e."sender_community_id" = ${communityId}
+          AND e."sender_user_id" = ANY(${userIds}::text[])
+          AND e."date" >= ${range.from}::date
+          AND e."date" <  (${range.to}::date + 1)
+        GROUP BY e."sender_user_id"
       `;
       return new Map(rows.map((r) => [r.user_id, r.true_unique_counterparties]));
     });
@@ -344,16 +333,21 @@ export default class ReportTransactionStatsRepository
   }
 
   /**
-   * The single transaction with the largest `chain_depth` within the JST
-   * reporting window. Mirrors the community-scoping predicate used by
-   * `mv_transaction_summary_daily` / `v_transaction_comments`:
-   * `COALESCE(fw.community_id, tw.community_id) = $1` plus the
-   * defensive-consistency check that rejects cross-community pairs.
+   * The single DONATION transaction with the largest `chain_depth` within
+   * the JST reporting window. Backs the weekly report's `deepest_chain`
+   * field, which the prompt templates explicitly frame as the "感謝の連鎖"
+   * / "相互扶助の連鎖" / "ポイントの旅" — i.e. the deepest gift cascade,
+   * not "the deepest transaction of any reason". The pre-MV
+   * implementation filtered only on `chain_depth IS NOT NULL` (no reason
+   * filter) so a POINT_REWARD chain could in principle out-rank the
+   * deepest DONATION chain and reach the prompt as a "感謝の連鎖" — a
+   * latent inconsistency. Routing through `mv_donation_tx_edges` makes
+   * the DONATION scope explicit and matches the template intent.
    *
    * ORDER BY depth DESC, created_at ASC so that ties resolve to the
-   * *earliest* deep chain in the window — intuitively "the one that started
-   * the cascade" rather than whichever the planner picked first. Returns
-   * null when no chained transaction exists for the window.
+   * *earliest* deep chain in the window — intuitively "the one that
+   * started the cascade" rather than whichever the planner picked first.
+   * Returns null when no DONATION chain exists for the window.
    */
   async findDeepestChain(
     ctx: IContext,
@@ -375,42 +369,32 @@ export default class ReportTransactionStatsRepository
         }[]
       >`
         SELECT
-          t."id",
-          t."chain_depth"::int AS "chain_depth",
+          e."transaction_id" AS "id",
+          e."chain_depth"::int AS "chain_depth",
           t."reason",
           t."comment",
-          -- Double AT TIME ZONE to convert the naive-UTC timestamp
-          -- column to a JST calendar day. A single AT TIME ZONE
-          -- 'Asia/Tokyo' would treat the value AS JST and shift it by
-          -- -9h, mis-bucketing transactions between 00:00-08:59 JST --
-          -- the same bug the 20260416000001_fix_report_views_jst_bucketing
-          -- migration fixed in the MV side.
-          ((t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')::date) AS "date",
-          fw."user_id" AS "from_user_id",
-          tw."user_id" AS "to_user_id",
+          e."date",
+          e."sender_user_id" AS "from_user_id",
+          e."recipient_user_id" AS "to_user_id",
           t."created_by" AS "created_by_user_id",
-          t."parent_tx_id"
-        FROM "t_transactions" t
-        LEFT JOIN "t_wallets" fw ON fw."id" = t."from"
-        LEFT JOIN "t_wallets" tw ON tw."id" = t."to"
-        WHERE COALESCE(fw."community_id", tw."community_id") = ${communityId}
-          AND (fw."community_id" IS NULL
-               OR tw."community_id" IS NULL
-               OR fw."community_id" = tw."community_id")
-          AND t."chain_depth" IS NOT NULL
-          -- Half-open window [from JST 00:00, (to + 1 day) JST 00:00)
-          -- covers exactly the JST calendar days from..to inclusive,
-          -- matching the bucketing used by the report MVs. created_at
-          -- is timestamp WITHOUT time zone (Prisma DateTime default)
-          -- holding naive UTC, so we convert the JST date boundaries to
-          -- naive UTC on the constant side (::date AT TIME ZONE
-          -- 'Asia/Tokyo' AT TIME ZONE 'UTC') to match the column's
-          -- storage format -- independent of DB session timezone, and
-          -- the column stays untouched so the B-tree index on
-          -- "created_at" can still be used.
-          AND t."created_at" >= (${range.from}::date AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
-          AND t."created_at" <  ((${range.to}::date + 1) AT TIME ZONE 'Asia/Tokyo' AT TIME ZONE 'UTC')
-        ORDER BY t."chain_depth" DESC, t."created_at" ASC
+          e."parent_tx_id"
+        FROM "mv_donation_tx_edges" e
+        -- t_transactions join only for the columns the MV doesn't
+        -- carry (reason, comment, created_by). The join key is
+        -- transaction_id which is the MV's primary key and the source
+        -- table's id, so this stays a pkey lookup on the small set of
+        -- rows that survive the WHERE filter (typically <= 1 because
+        -- of LIMIT 1 in the planner's reach via ORDER BY+LIMIT).
+        INNER JOIN "t_transactions" t ON t."id" = e."transaction_id"
+        WHERE COALESCE(e."sender_community_id", e."recipient_community_id") = ${communityId}
+          AND e."chain_depth" IS NOT NULL
+          -- Half-open window [from JST 00:00, (to + 1 day) JST 00:00).
+          -- The MV's "date" column is already JST-bucketed (@db.Date),
+          -- so the boundaries compare as bare dates without the
+          -- timezone-cast dance the t_transactions form needed.
+          AND e."date" >= ${range.from}::date
+          AND e."date" <  (${range.to}::date + 1)
+        ORDER BY e."chain_depth" DESC, e."created_at" ASC
         LIMIT 1
       `;
       if (rows.length === 0) return null;

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -843,6 +843,7 @@ export default class ReportUseCase {
   async refreshAllReportViews(ctx: IContext): Promise<void> {
     await ctx.issuer.internal((tx) => this.service.refreshTransactionSummaryDaily(ctx, tx));
     await ctx.issuer.internal((tx) => this.service.refreshUserTransactionDaily(ctx, tx));
+    await ctx.issuer.internal((tx) => this.service.refreshDonationTxEdges(ctx, tx));
   }
 }
 

--- a/src/infrastructure/prisma/migrations/20260429072657_add_mv_donation_tx_edges/migration.sql
+++ b/src/infrastructure/prisma/migrations/20260429072657_add_mv_donation_tx_edges/migration.sql
@@ -1,0 +1,83 @@
+-- ============================================================================
+-- mv_donation_tx_edges
+--
+-- Tx-level normalized projection of DONATION transactions with sender/recipient
+-- wallets resolved into user_id + community_id. Backs the analytics queries
+-- that need a window-wide DISTINCT counterparty count or per-(community, user,
+-- day) DONATION aggregation — `findMonthlyActivity` `hub_per_month`,
+-- `findWindowHubMemberCountBulk`, and the donation_* CTEs inside
+-- `findMemberStatsBulk`. Those previously scanned `t_transactions` joined
+-- twice to `t_wallets` per request because
+-- `mv_user_transaction_daily.unique_counterparties` is a per-day DISTINCT and
+-- does not compose under SUM across multi-day windows.
+--
+-- Design notes:
+--   - One row per DONATION transaction (no aggregation baked in). Consumers
+--     do their own COUNT/SUM/DISTINCT, keeping the MV reusable for any
+--     per-tenure, per-window, or per-day shape.
+--   - Both `sender_community_id` and `recipient_community_id` are carried so
+--     sender-keyed analytics (hub breadth, donation_activity,
+--     donation_recipients) and receiver-keyed analytics (donation_received,
+--     donation_senders) can both filter against the same MV without an extra
+--     wallet JOIN.
+--   - `(fw.user_id IS NOT NULL AND tw.user_id IS NOT NULL)` excludes burn /
+--     system wallets so a system-issued grant cannot inflate any user's
+--     send/receive breadth. `tw.user_id <> fw.user_id` excludes self-donations
+--     (matches the "distinct OTHER users" wording in
+--     AnalyticsMemberRow.uniqueDonationRecipients/Senders — the wallet
+--     validator does not block same-user transfers, so the guard has to live
+--     here).
+--   - Cross-community guard `(fw.community_id IS NULL OR tw.community_id IS
+--     NULL OR fw.community_id = tw.community_id)` mirrors the predicate the
+--     consumers used inline + the predicate already applied by
+--     `mv_user_transaction_daily` and `v_transaction_comments`.
+--   - `COALESCE(fw.community_id, tw.community_id) IS NOT NULL` drops fully-
+--     unattached rows that no consumer can filter in (every consumer keys by
+--     a specific community_id).
+--   - `date` is JST-bucketed using the same two-step UTC->JST cast as the
+--     other report views (see 20260416000001_fix_report_views_jst_bucketing)
+--     so consumer comparisons against `@db.Date`-encoded JST boundaries stay
+--     consistent.
+-- ============================================================================
+
+CREATE MATERIALIZED VIEW "mv_donation_tx_edges" AS
+SELECT
+    t."id"                                                                  AS "transaction_id",
+    t."created_at"                                                          AS "created_at",
+    ((t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')::date)   AS "date",
+    fw."community_id"                                                       AS "sender_community_id",
+    tw."community_id"                                                       AS "recipient_community_id",
+    fw."user_id"                                                            AS "sender_user_id",
+    tw."user_id"                                                            AS "recipient_user_id",
+    t."from_point_change"                                                   AS "from_point_change",
+    t."to_point_change"                                                     AS "to_point_change",
+    t."chain_depth"                                                         AS "chain_depth",
+    t."parent_tx_id"                                                        AS "parent_tx_id"
+FROM "t_transactions" t
+INNER JOIN "t_wallets" fw
+    ON fw."id" = t."from"
+   AND fw."user_id" IS NOT NULL
+INNER JOIN "t_wallets" tw
+    ON tw."id" = t."to"
+   AND tw."user_id" IS NOT NULL
+   AND tw."user_id" <> fw."user_id"
+WHERE t."reason" = 'DONATION'
+  AND COALESCE(fw."community_id", tw."community_id") IS NOT NULL
+  AND (fw."community_id" IS NULL
+       OR tw."community_id" IS NULL
+       OR fw."community_id" = tw."community_id");
+
+-- Required for REFRESH MATERIALIZED VIEW CONCURRENTLY. transaction_id is
+-- unique by construction (one source row per (t, fw, tw) tuple, and t has
+-- a single from/to wallet pair).
+CREATE UNIQUE INDEX "mv_donation_tx_edges_pkey"
+    ON "mv_donation_tx_edges" ("transaction_id");
+
+-- Sender-keyed range scans: hub_per_month, findWindowHubMemberCountBulk,
+-- donation_activity, donation_recipients.
+CREATE INDEX "mv_donation_tx_edges_sender_community_date_idx"
+    ON "mv_donation_tx_edges" ("sender_community_id", "date" DESC);
+
+-- Recipient-keyed range scans: donation_received, donation_senders.
+CREATE INDEX "mv_donation_tx_edges_recipient_community_date_idx"
+    ON "mv_donation_tx_edges" ("recipient_community_id", "date" DESC);

--- a/src/infrastructure/prisma/sql/refreshMaterializedViewDonationTxEdges.sql
+++ b/src/infrastructure/prisma/sql/refreshMaterializedViewDonationTxEdges.sql
@@ -1,0 +1,1 @@
+REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_donation_tx_edges";


### PR DESCRIPTION
## Summary

`GetAnalyticsCommunity` (sysadmin community detail) hits the client-side
5000ms deadline because the L2 detail flow fans out 8 heavy queries in
parallel, several of which scan `t_transactions` filtered to DONATION +
double JOIN `t_wallets` to resolve sender/recipient → user/community on
every request.

This PR introduces `mv_donation_tx_edges` — a tx-level normalized
materialized view of DONATION transactions with the wallet → user/community
resolution pre-baked — and routes every DONATION-scoped analytics query
in `analytics.community` and `report.transactionStats` through it. The
result: zero raw-`t_transactions` scans for DONATION analytics across the
entire L2 flow + the weekly-report flow, replaced by indexed MV range
scans keyed by `(sender_community_id, date)` or
`(recipient_community_id, date)`.

## What's in the MV

```sql
CREATE MATERIALIZED VIEW "mv_donation_tx_edges" AS
SELECT
    t."id" AS "transaction_id",
    t."created_at",
    ((t."created_at" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')::date) AS "date",
    fw."community_id" AS "sender_community_id",
    tw."community_id" AS "recipient_community_id",
    fw."user_id"      AS "sender_user_id",
    tw."user_id"      AS "recipient_user_id",
    t."from_point_change",
    t."to_point_change",
    t."chain_depth",
    t."parent_tx_id"
FROM "t_transactions" t
INNER JOIN "t_wallets" fw
    ON fw."id" = t."from"
   AND fw."user_id" IS NOT NULL
INNER JOIN "t_wallets" tw
    ON tw."id" = t."to"
   AND tw."user_id" IS NOT NULL
   AND tw."user_id" <> fw."user_id"
WHERE t."reason" = 'DONATION'
  AND COALESCE(fw."community_id", tw."community_id") IS NOT NULL
  AND (fw."community_id" IS NULL
       OR tw."community_id" IS NULL
       OR fw."community_id" = tw."community_id");
```

The three baked-in guards (burn-target / self-donation / cross-community
exclusion) match civicship's gift-economy DONATION definition — DONATIONs
to burn targets aren't peer-to-peer gifts, self-DONATIONs aren't gifts,
and cross-community DONATIONs are leakage that shouldn't shape either
community's totals. So the same MV serves every analytics consumer.

Indexes:
- `UNIQUE (transaction_id)` — required for `REFRESH MATERIALIZED VIEW
  CONCURRENTLY`
- `(sender_community_id, date DESC)` — sender-keyed range scans
- `(recipient_community_id, date DESC)` — receiver-keyed range scans

## Migrated query sites

`src/application/domain/analytics/community/data/repository.ts`:

- `findMemberStatsBulk` — `donation_activity` / `donation_recipients` /
  `donation_received` / `donation_senders` CTEs (4)
- `findMonthlyActivity` — `hub_per_month` CTE (the dominant cost in the
  original L2 timeout reports)
- `findWindowHubMemberCountBulk` — full body
- `findAllTimeTotals` — `donation_totals` CTE
- `findChainDepthDistribution` — `depth_counts` CTE

`src/application/domain/report/transactionStats/data/repository.ts`:

- `findTrueUniqueCounterpartiesForUsers` — full body. Pre-PR filtered only
  on wallet user_ids; in civicship the only TransactionReason where both
  wallets are user wallets is DONATION, so the migration is
  semantic-preserving.
- `findDeepestChain` — full body. **Intentional behavior change:** pre-PR
  matched any `chain_depth IS NOT NULL` row (multi-reason); now
  DONATION-only to align with the weekly-report prompt templates which
  explicitly frame this field as "感謝の連鎖" / "相互扶助の連鎖" /
  "ポイントの旅" — the deepest gift cascade. POINT_REWARD chains can no
  longer reach the prompt as if they were donations. `t_transactions` is
  still joined on the MV's `transaction_id` (its primary key) for the
  columns the MV doesn't carry (`reason`, `comment`, `created_by`) — a
  fast pkey lookup on the post-LIMIT row.

## Refresh wiring

- `prisma/sql/refreshMaterializedViewDonationTxEdges.sql` (typedSql)
- `IReportTransactionStatsRepository.refreshDonationTxEdges` →
  `ReportService.refreshDonationTxEdges` →
  `ReportUseCase.refreshAllReportViews` (called by the existing weekly
  nightly cron alongside the per-day MVs)
- `TestDataSourceHelper.refreshDonationTxEdges()` for any future
  integration test that needs the new MV
- Mock entries added to the two unit-test sites that hand-spell the
  stats repository contract (`service.test.ts`, `goldenCase.test.ts`)

## Notes on review iteration

The first iteration kept the MV as-is for all five `findMemberStatsBulk`
CTEs. Devin Review flagged that the pre-PR `donation_activity` /
`donation_received` CTEs didn't apply the burn / self / cross-community
filters at all (they relied on raw `t_transactions` + a single sender-side
wallet JOIN), and so MV migration would silently narrow the totals.

After domain review with the maintainer, the conclusion was that the
three filters are correct DONATION semantics regardless of caller — the
pre-PR CTEs simply happened not to apply them because they never JOINed
the recipient wallet, an implicit reliance on the data not containing
burn-target / self-donation / cross-community-leakage DONATION rows.
Making the contract explicit at the MV layer is the intent. All five
CTEs remain on the MV in the final state.

## Test plan

- [x] `pnpm db:deploy` — migration applies cleanly on a fresh DB
- [x] `pnpm db:generate` — typedSql regenerates with the new refresh fn
- [x] ESLint (changed files) — no new errors
- [x] `npx tsc --noEmit` — no type errors
- [x] `pnpm test --runInBand src/__tests__/unit` — 700/700 pass
- [ ] Stage / production smoke test of `GetAnalyticsCommunity` after the
      next nightly refresh cycle completes
- [ ] Confirm `Slow transaction (bypassRls)` warning volume drops on the
      analytics community path
- [ ] Confirm weekly report's `deepest_chain` field continues to surface
      a DONATION row (and that AI output quality on the golden cases stays
      within tolerance — the underlying fixtures are static, but live
      payload generation now narrows the scope)
