### PR TITLE
perf(report): use OR predicate instead of COALESCE in findDeepestChain to enable BitmapOr

### DIFF
--- a/src/application/domain/report/transactionStats/data/repository.ts
+++ b/src/application/domain/report/transactionStats/data/repository.ts
@@ -386,7 +386,8 @@ export default class ReportTransactionStatsRepository
         -- rows that survive the WHERE filter (typically <= 1 because
         -- of LIMIT 1 in the planner's reach via ORDER BY+LIMIT).
         INNER JOIN "t_transactions" t ON t."id" = e."transaction_id"
-        WHERE COALESCE(e."sender_community_id", e."recipient_community_id") = ${communityId}
+        WHERE (e."sender_community_id" = ${communityId}
+               OR e."recipient_community_id" = ${communityId})
           AND e."chain_depth" IS NOT NULL
           -- Half-open window [from JST 00:00, (to + 1 day) JST 00:00).
           -- The MV's "date" column is already JST-bucketed (@db.Date),


### PR DESCRIPTION
## Summary

#953 で gemini-code-assist が指摘した `findDeepestChain` の `COALESCE` 述語が `mv_donation_tx_edges` のコミュニティ別 index を SARGable に使えない問題への follow-up。`COALESCE(s, r) = X` を `s = X OR r = X` に書き換えて両 index が BitmapOr で結合されるようにした。

## なぜ semantic 等価か

`mv_donation_tx_edges` は view 構築時点で次の cross-community ガードを焼き込んでいる：

```sql
(sender_community_id IS NULL OR recipient_community_id IS NULL
                              OR sender_community_id = recipient_community_id)
```

これにより両側とも non-NULL なら必ず等しいので、どの行についても COALESCE 形式と OR 形式は同じ真偽値を返す：

| sender | recipient | COALESCE = X | s = X OR r = X |
|---|---|---|---|
| both non-null（≡） | | matching side = X | matching side = X ✅ |
| sender NULL | recipient = X | true | true ✅ |
| sender = X | recipient NULL | true | true ✅ |
| sender = Y | recipient = X | (cross-comm 行は MV に存在しない) | (同上) |

## Test plan

- [x] ESLint clean
- [x] `pnpm test --runInBand src/__tests__/unit/report` — 169/169 pass
- [ ] Stage で `findDeepestChain` の plan を `EXPLAIN` で確認（BitmapOr が選ばれること）

#953 が master に向かう release PR なので、こちらが develop にマージされれば次のリリース時に伝搬する。


---
_Generated by [Claude Code](https://claude.ai/code/session_019WwqfkPqfsms7j52BehBvD)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/954" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
