### PR TITLE
feat(report): JUDGE criteria + judgeScore auto-reject + coverage expansion (PR-B)

### DIFF
--- a/src/__tests__/unit/report/coverage.test.ts
+++ b/src/__tests__/unit/report/coverage.test.ts
@@ -74,4 +74,130 @@ describe("analyzeCoverage", () => {
     expect(coverage.deepest_chain_depth.value).toBeNull();
     expect(coverage.deepest_chain_depth.mentioned).toBe(false);
   });
+
+  // ---------------------------------------------------------------------------
+  // top_user_names / top_user_points (PR-B): per-user fabrication signal.
+  // names is the primary signal — the auto-reject judge prompt and the
+  // usecase warning log both look at it. points is records-only because
+  // numeric substring matches false-positive too easily.
+  // ---------------------------------------------------------------------------
+
+  const sampleTopUsers = [
+    {
+      user_id: "u-a",
+      name: "貴凛庁株式会社",
+      user_bio: null,
+      membership_bio: null,
+      headline: null,
+      role: "MEMBER",
+      joined_at: "2024-01-01",
+      days_since_joined: 100,
+      tx_count_in: 1,
+      tx_count_out: 1,
+      points_in: 21000,
+      points_out: 26000,
+      donation_out_count: 1,
+      donation_out_points: 26000,
+      received_donation_count: 1,
+      chain_root_count: 0,
+      max_chain_depth_started: null,
+      chain_depth_reached_max: null,
+      unique_counterparties_sum: 1,
+      true_unique_counterparties: 1,
+    },
+    {
+      user_id: "u-b",
+      name: "おおともやすひろ",
+      user_bio: null,
+      membership_bio: null,
+      headline: null,
+      role: "MEMBER",
+      joined_at: "2024-02-01",
+      days_since_joined: 70,
+      tx_count_in: 0,
+      tx_count_out: 0,
+      points_in: 0,
+      points_out: 0,
+      donation_out_count: 0,
+      donation_out_points: 0,
+      received_donation_count: 0,
+      chain_root_count: 0,
+      max_chain_depth_started: null,
+      chain_depth_reached_max: null,
+      unique_counterparties_sum: 0,
+      true_unique_counterparties: null,
+    },
+  ];
+
+  it("flags top_user_names that appear in the output", () => {
+    const payload = { ...basePayload, top_users: sampleTopUsers };
+    const output = "貴凛庁株式会社さんが活躍しました。おおともやすひろさんも参加。";
+    const coverage = analyzeCoverage(payload, output);
+    expect(coverage.top_user_names).toEqual([
+      { name: "貴凛庁株式会社", mentioned: true },
+      { name: "おおともやすひろ", mentioned: true },
+    ]);
+  });
+
+  it("flags top_user_names as mentioned=false when the name is missing", () => {
+    const payload = { ...basePayload, top_users: sampleTopUsers };
+    const output = "今週は静かでした。"; // neither name appears
+    const coverage = analyzeCoverage(payload, output);
+    expect(coverage.top_user_names[0].mentioned).toBe(false);
+    expect(coverage.top_user_names[1].mentioned).toBe(false);
+  });
+
+  it("returns empty top_user_names / top_user_points when top_users is empty", () => {
+    const coverage = analyzeCoverage(basePayload, "any output");
+    expect(coverage.top_user_names).toEqual([]);
+    expect(coverage.top_user_points).toEqual([]);
+  });
+
+  it("treats empty name as vacuously mentioned (presenter profile-lookup miss)", () => {
+    const payload = {
+      ...basePayload,
+      top_users: [{ ...sampleTopUsers[0], name: "" }],
+    };
+    const coverage = analyzeCoverage(payload, "irrelevant");
+    expect(coverage.top_user_names[0].mentioned).toBe(true);
+  });
+
+  it("flags top_user_points fields that match in the output", () => {
+    const payload = { ...basePayload, top_users: [sampleTopUsers[0]] };
+    const output = "貴凛庁株式会社は 21000 受け取り、26000 を贈りました。";
+    const coverage = analyzeCoverage(payload, output);
+    expect(coverage.top_user_points[0]).toEqual({
+      name: "貴凛庁株式会社",
+      points_in: true,
+      points_out: true,
+      // donation_out_points is also 26000 — same string, also matches.
+      donation_out_points: true,
+    });
+  });
+
+  it("treats zero points fields as vacuously mentioned", () => {
+    // sampleTopUsers[1] has all zero points / donations — the presenter
+    // emits zero for receiver-only or inactive users, and requiring a
+    // substring match for "0" would falsely trigger on any number
+    // containing "0" anywhere.
+    const payload = { ...basePayload, top_users: [sampleTopUsers[1]] };
+    const coverage = analyzeCoverage(payload, "no numbers at all");
+    expect(coverage.top_user_points[0]).toEqual({
+      name: "おおともやすひろ",
+      points_in: true,
+      points_out: true,
+      donation_out_points: true,
+    });
+  });
+
+  it("flags top_user_points fields as false when the non-zero value is missing", () => {
+    const payload = { ...basePayload, top_users: [sampleTopUsers[0]] };
+    const coverage = analyzeCoverage(payload, "no numbers");
+    expect(coverage.top_user_points[0]).toEqual({
+      name: "貴凛庁株式会社",
+      points_in: false,
+      points_out: false,
+      donation_out_points: false,
+    });
+  });
 });

--- a/src/__tests__/unit/report/service.test.ts
+++ b/src/__tests__/unit/report/service.test.ts
@@ -68,6 +68,12 @@ describe("ReportService", () => {
       [ReportStatus.APPROVED, ReportStatus.REJECTED],
       [ReportStatus.APPROVED, ReportStatus.SUPERSEDED],
       [ReportStatus.PUBLISHED, ReportStatus.SUPERSEDED],
+      // PR-B: regenerating from a REJECTED parent (auto-rejected by the
+      // judge or manually rejected by an admin) routes through
+      // supersedeParentIfRegenerating, which calls
+      // assertStatusTransition(REJECTED, SUPERSEDED). Without this entry
+      // the regenerate path would throw on every attempt.
+      [ReportStatus.REJECTED, ReportStatus.SUPERSEDED],
       // Force-regenerating from a SKIPPED parent needs this transition so
       // the shared supersedeParentIfRegenerating helper can mark the prior
       // row obsolete before the fresh run is persisted.

--- a/src/__tests__/unit/report/usecase.test.ts
+++ b/src/__tests__/unit/report/usecase.test.ts
@@ -369,6 +369,200 @@ describe("ReportUseCase.generateReport", () => {
       expect(result.report.outputMarkdown).toBe(llmResult.text);
     }
   });
+
+  // ---------------------------------------------------------------------------
+  // PR-B auto-reject: judge score below the threshold (60) flips the row to
+  // REJECTED in the same transaction as the judge save. The threshold is
+  // tuned so that fabrication detections (which the judge prompt scores at
+  // ≤ 40) reliably land below it, while quality-only failures (60–89) stay
+  // DRAFT for human review.
+  // ---------------------------------------------------------------------------
+  describe("judge auto-reject (PR-B)", () => {
+    const activePayload: WeeklyReportPayload = {
+      ...zeroActivityPayload,
+      community_context: {
+        ...zeroActivityPayload.community_context!,
+        active_users_in_window: 26,
+        active_rate: 0.046,
+      },
+      daily_summaries: [
+        {
+          date: "2026-04-14",
+          reason: "DONATION",
+          tx_count: 8,
+          points_sum: 125830,
+          chain_root_count: 0,
+          chain_descendant_count: 8,
+          max_chain_depth: 19,
+          avg_chain_depth: 5,
+          issuance_count: 0,
+          burn_count: 0,
+        },
+      ],
+    };
+    const llmResult: LlmCompleteResult = {
+      text: "## レポート本文 ...",
+      model: "claude-sonnet-4-6",
+      usage: {
+        inputTokens: 10000,
+        outputTokens: 3000,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      },
+      stopReason: "end_turn",
+    };
+    const judgeTemplate = {
+      id: "judge-tpl-1",
+      variant: GqlReportVariant.WeeklySummary,
+      kind: "JUDGE",
+      systemPrompt: "judge system",
+      userPromptTemplate: "${judge_criteria}/${input_payload}/${output_markdown}",
+      model: "claude-haiku-4-5-20251001",
+      maxTokens: 1000,
+      temperature: 0,
+      stopSequences: [],
+      isEnabled: true,
+      isActive: true,
+    };
+
+    beforeEach(() => {
+      service.evaluateSkipReason.mockReturnValue(null);
+      jest.spyOn(usecase, "buildReportPayload").mockResolvedValue(activePayload);
+      llmClient.complete.mockResolvedValue(llmResult);
+      judgeService.selectJudgeTemplate.mockResolvedValue(judgeTemplate);
+
+      // Default: updateReportStatus echoes back a REJECTED-shaped row so
+      // the auto-reject test can assert on its return without contorting
+      // the type-narrow happy-path mock.
+      service.updateReportStatus.mockImplementation(async (_ctx, id, status) => {
+        const lastCreate = service.createReport.mock.results.at(-1);
+        const created = lastCreate ? await lastCreate.value : null;
+        return { ...(created ?? { id }), status };
+      });
+    });
+
+    it("flips DRAFT to REJECTED in the same tx when judgeScore is below the threshold", async () => {
+      // Score 35 puts the row firmly inside the "fabrication detected"
+      // band (≤ 40 by the prompt's scoring rule), well below the
+      // auto-reject threshold of 60.
+      judgeService.executeJudge.mockResolvedValue({
+        score: 35,
+        breakdown: {
+          fabrication: { top_user_names: false, top_user_points: true, chain_depth: true },
+          quality: { actionable_insights: true },
+        },
+        issues: ["架空のユーザー名が含まれていました"],
+        strengths: [],
+      });
+
+      const result = await usecase.generateReport(
+        {
+          input: {
+            communityId,
+            variant: GqlReportVariant.WeeklySummary,
+            periodFrom: new Date("2026-04-11"),
+            periodTo: new Date("2026-04-17"),
+          },
+          permission: { communityId },
+        },
+        fakeCtx,
+      );
+
+      expect(judgeService.executeJudge).toHaveBeenCalledTimes(1);
+      // criteria must be threaded through for WEEKLY_SUMMARY — JSON.stringify(undefined ?? {})
+      // would emit "{}" and the rubric never reaches the judge prompt.
+      const judgeCallArg = judgeService.executeJudge.mock.calls[0][2];
+      expect(judgeCallArg.judgeCriteria).toBeDefined();
+      expect(judgeCallArg.judgeCriteria.fabrication_check).toBeDefined();
+
+      expect(service.saveJudgeResult).toHaveBeenCalledTimes(1);
+      const saveArgs = service.saveJudgeResult.mock.calls[0];
+      expect(saveArgs[2].judgeScore).toBe(35);
+
+      // Auto-reject: assertStatusTransition + updateReportStatus must
+      // both fire on the same tx as the judge save.
+      expect(service.assertStatusTransition).toHaveBeenCalledWith(
+        ReportStatus.DRAFT,
+        ReportStatus.REJECTED,
+      );
+      expect(service.updateReportStatus).toHaveBeenCalledTimes(1);
+      const updateArgs = service.updateReportStatus.mock.calls[0];
+      expect(updateArgs[2]).toBe(ReportStatus.REJECTED);
+
+      expect(result.__typename).toBe("GenerateReportSuccess");
+      if (result.__typename === "GenerateReportSuccess") {
+        expect(result.report.status).toBe(ReportStatus.REJECTED);
+      }
+    });
+
+    it("leaves the row as DRAFT when judgeScore meets the threshold (no auto-reject)", async () => {
+      // 75 lands in the "quality-only failures" band (60–89). Quality
+      // issues are real but not fabrication — the row stays DRAFT for a
+      // human reviewer.
+      judgeService.executeJudge.mockResolvedValue({
+        score: 75,
+        breakdown: {
+          fabrication: { top_user_names: true, top_user_points: true, chain_depth: true },
+          quality: { actionable_insights: false },
+        },
+        issues: ["来週への具体的アクションが不足"],
+        strengths: ["数値の引用は正確"],
+      });
+
+      const result = await usecase.generateReport(
+        {
+          input: {
+            communityId,
+            variant: GqlReportVariant.WeeklySummary,
+            periodFrom: new Date("2026-04-11"),
+            periodTo: new Date("2026-04-17"),
+          },
+          permission: { communityId },
+        },
+        fakeCtx,
+      );
+
+      expect(service.saveJudgeResult).toHaveBeenCalledTimes(1);
+      // Critical regression guard: at-or-above the threshold must NOT
+      // trigger the reject path. Without these assertions, a future
+      // off-by-one in the comparison (`<` vs `<=`) would silently land.
+      expect(service.assertStatusTransition).not.toHaveBeenCalled();
+      expect(service.updateReportStatus).not.toHaveBeenCalled();
+
+      expect(result.__typename).toBe("GenerateReportSuccess");
+      if (result.__typename === "GenerateReportSuccess") {
+        expect(result.report.status).toBe(ReportStatus.DRAFT);
+      }
+    });
+
+    it("does not auto-reject when judgeScore equals the threshold exactly (60)", async () => {
+      // Boundary check: the comparison is `<` not `<=`, so 60 stays
+      // DRAFT. Pinning this lets a future "make it stricter" change be
+      // an obvious code edit rather than a silent threshold shift.
+      judgeService.executeJudge.mockResolvedValue({
+        score: 60,
+        breakdown: {},
+        issues: [],
+        strengths: [],
+      });
+
+      await usecase.generateReport(
+        {
+          input: {
+            communityId,
+            variant: GqlReportVariant.WeeklySummary,
+            periodFrom: new Date("2026-04-11"),
+            periodTo: new Date("2026-04-17"),
+          },
+          permission: { communityId },
+        },
+        fakeCtx,
+      );
+
+      expect(service.assertStatusTransition).not.toHaveBeenCalled();
+      expect(service.updateReportStatus).not.toHaveBeenCalled();
+    });
+  });
 });
 
 describe("ReportUseCase.buildReportPayload retention window", () => {

--- a/src/application/domain/report/service.ts
+++ b/src/application/domain/report/service.ts
@@ -431,7 +431,13 @@ export default class ReportService {
         ReportStatus.SUPERSEDED,
       ],
       [ReportStatus.PUBLISHED]: [ReportStatus.SUPERSEDED],
-      [ReportStatus.REJECTED]: [],
+      // PR-B: REJECTED → SUPERSEDED is permitted so a manual or batch
+      // regenerate of an auto-rejected row (judgeScore < threshold) can
+      // mark the prior row obsolete via `supersedeParentIfRegenerating`.
+      // Without this transition `generateReport(parentRunId=<rejected>)`
+      // would fail at the assertStatusTransition guard. SUPERSEDED is
+      // the only legal target — there is no "un-reject" mutation.
+      [ReportStatus.REJECTED]: [ReportStatus.SUPERSEDED],
       [ReportStatus.SUPERSEDED]: [],
       // SKIPPED is a creation-time state: rows are born SKIPPED when the
       // zero-activity guard elides the LLM call. They do NOT progress into

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -2,6 +2,7 @@ import { Prisma, ReportStatus, ReportTemplateKind } from "@prisma/client";
 import { inject, injectable } from "tsyringe";
 import { IContext } from "@/types/server";
 import { ValidationError } from "@/errors/graphql";
+import logger from "@/infrastructure/logging";
 import ReportService from "@/application/domain/report/service";
 import ReportJudgeService, { JudgeParseError } from "@/application/domain/report/template/judgeService";
 import ReportTemplateSelector from "@/application/domain/report/template/selector";
@@ -21,6 +22,7 @@ import {
   GqlReportsConnection,
   GqlReport,
   GqlReportTemplate,
+  GqlReportVariant,
   GqlUpdateReportTemplatePayload,
   GqlApproveReportPayload,
   GqlPublishReportPayload,
@@ -49,6 +51,61 @@ const DEFAULT_COMMENT_LIMIT = 200;
 const MAX_WINDOW_DAYS = 90;
 const MAX_TOP_N = 100;
 const MAX_COMMENT_LIMIT = 1000;
+
+/**
+ * Score below which the judge auto-rejects the report (DRAFT → REJECTED in
+ * the same transaction as the judge save). Paired with the JUDGE prompt's
+ * scoring rule "fabrication 検知時は score ≤ 40", the threshold of 60 means
+ * "auto-reject only when fabrication is detected" — quality-only failures
+ * land in 60–89 and stay DRAFT for human review.
+ */
+const JUDGE_AUTO_REJECT_THRESHOLD = 60;
+
+/**
+ * Variant-specific rubric handed to the JUDGE prompt via the
+ * `${judge_criteria}` placeholder in `userPromptTemplate`. Splits the
+ * checks into `fabrication_check` (factual fidelity — must all be true to
+ * avoid auto-reject) and `quality_check` (narrative qualities — false
+ * here lowers score but does not trigger auto-reject by itself).
+ *
+ * Other variants pass `judgeCriteria: undefined` to `executeJudge` and
+ * receive a JSON.stringify of `{}` in the prompt. JUDGE templates do not
+ * exist for non-WEEKLY_SUMMARY variants today, so the judge step is
+ * skipped upstream and the empty-criteria branch is unreachable in
+ * practice; it stays for forward compatibility with future variants.
+ */
+const WEEKLY_SUMMARY_JUDGE_CRITERIA = {
+  fabrication_check: {
+    top_user_names:
+      "レポートに登場する人名は payload の top_users[*].name のいずれかと一致しているか。" +
+      "存在しない名前が書かれていたら false。top_users が空なら true。",
+    top_user_points:
+      "レポートに登場するポイント数値は payload の top_users[*].points_in / points_out / donation_out_points の値と一致しているか。" +
+      "数値が変形・概算されていたら false。top_users が空なら true。",
+    chain_depth:
+      "deepest_chain.chain_depth の値がレポートに正確に記載されているか。" +
+      "deepest_chain が null なら true。",
+    active_users:
+      "community_context.active_users_in_window の値がレポートに正確に記載されているか。",
+    total_members:
+      "community_context.total_members の値がレポートに正確に記載されているか。",
+    no_phantom_comparison:
+      "previous_period が null のとき、前週比・先週比・増加・減少等の比較表現がレポートに含まれていないか。" +
+      "previous_period が non-null なら true。",
+  },
+  quality_check: {
+    deepest_chain_mentioned:
+      "deepest_chain が non-null のとき、そのエピソードがレポートに言及されているか。" +
+      "deepest_chain が null なら true。",
+    actionable_insights:
+      "来週に向けた具体的なアクション（「〇〇をする」形式）が含まれているか。",
+    reason_distinction:
+      "活動認定と感謝の贈り合いが正確に区別されているか。" +
+      "活動認定をメンバー間の感謝として誤記していたら false。",
+    no_enum_names:
+      "DONATION / GRANT / ONBOARDING 等の内部キー名がそのまま出力されていないか。",
+  },
+} as const;
 
 @injectable()
 export default class ReportUseCase {
@@ -450,6 +507,24 @@ export default class ReportUseCase {
     // coverage signal recorded.
     const coverage = analyzeCoverage(payload, outputMarkdown);
 
+    // Coverage observability: surface top_user_names that the LLM
+    // failed to copy verbatim. Numeric fields (top_user_points etc.)
+    // are intentionally NOT logged here because their substring
+    // matches false-positive too easily (e.g. "21000" appearing as a
+    // fragment of "210000") to be a useful signal — the raw counters
+    // still flow into `coverageJson` for offline analysis.
+    const missedNames = coverage.top_user_names
+      .filter((u) => !u.mentioned)
+      .map((u) => u.name);
+    if (missedNames.length > 0) {
+      logger.warn("report.coverage.top_user_names_missed", {
+        event: "report.coverage.top_user_names_missed",
+        reportId: report.id,
+        variant: report.variant,
+        names: missedNames,
+      });
+    }
+
     let judgeTemplate;
     try {
       judgeTemplate = await this.judgeService.selectJudgeTemplate(ctx, report.variant);
@@ -483,11 +558,21 @@ export default class ReportUseCase {
       });
     }
 
+    // Variant-specific rubric. WEEKLY_SUMMARY has the only criteria
+    // defined today; other variants currently have no JUDGE template
+    // either, so this branch is unreachable in practice but keeps the
+    // call contract honest for future variants.
+    const judgeCriteria =
+      report.variant === GqlReportVariant.WeeklySummary
+        ? WEEKLY_SUMMARY_JUDGE_CRITERIA
+        : undefined;
+
     let judgeResult;
     try {
       judgeResult = await this.judgeService.executeJudge(ctx, judgeTemplate, {
         outputMarkdown,
         inputPayload: payload,
+        judgeCriteria,
       });
     } catch (e) {
       const isParseError = e instanceof JudgeParseError;
@@ -514,11 +599,12 @@ export default class ReportUseCase {
       });
     }
 
-    return this.persistJudgeOutcome(ctx, report.id, {
+    return this.persistJudgeOutcomeWithAutoReject(ctx, report.id, {
       judgeScore: judgeResult.score,
       judgeBreakdown: judgeResult as unknown as Prisma.InputJsonValue,
       judgeTemplateId: judgeTemplate.id,
       coverageJson: coverage as unknown as Prisma.InputJsonValue,
+      reportVariant: report.variant,
     });
   }
 
@@ -542,6 +628,60 @@ export default class ReportUseCase {
     return ctx.issuer.onlyBelongingCommunity(ctx, (tx) =>
       this.service.saveJudgeResult(ctx, reportId, data, tx),
     );
+  }
+
+  /**
+   * Success-path counterpart to `persistJudgeOutcome`: saves the judge
+   * outcome AND, if `judgeScore < JUDGE_AUTO_REJECT_THRESHOLD`, flips
+   * the row to REJECTED **inside the same transaction**. The combined
+   * write closes the observable window where a fabricating row would
+   * otherwise be visible as DRAFT with a low judgeScore until the
+   * follow-up status update lands.
+   *
+   * Failure paths (judge template missing, parse error, LLM 5xx) keep
+   * using `persistJudgeOutcome` directly — `judgeScore` is null on
+   * those paths and the threshold comparison is not meaningful, so the
+   * row stays DRAFT for human review rather than being auto-rejected
+   * on insufficient evidence.
+   */
+  private async persistJudgeOutcomeWithAutoReject(
+    ctx: IContext,
+    reportId: string,
+    data: {
+      judgeScore: number;
+      judgeBreakdown: Prisma.InputJsonValue;
+      judgeTemplateId: string;
+      coverageJson: Prisma.InputJsonValue;
+      reportVariant: string;
+    },
+  ) {
+    const { reportVariant, ...judgeData } = data;
+    return ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
+      const updated = await this.service.saveJudgeResult(ctx, reportId, judgeData, tx);
+      if (data.judgeScore >= JUDGE_AUTO_REJECT_THRESHOLD) {
+        return updated;
+      }
+      // Auto-reject path: assertStatusTransition throws on illegal
+      // moves so a future workflow change that disallows DRAFT → REJECTED
+      // surfaces here as a hard error rather than a silently-skipped
+      // transition.
+      this.service.assertStatusTransition(updated.status, ReportStatus.REJECTED);
+      const rejected = await this.service.updateReportStatus(
+        ctx,
+        reportId,
+        ReportStatus.REJECTED,
+        undefined,
+        tx,
+      );
+      logger.warn("report.judge.auto_rejected", {
+        event: "report.judge.auto_rejected",
+        reportId,
+        variant: reportVariant,
+        judgeScore: data.judgeScore,
+        threshold: JUDGE_AUTO_REJECT_THRESHOLD,
+      });
+      return rejected;
+    });
   }
 
   /**

--- a/src/application/domain/report/util/coverage.ts
+++ b/src/application/domain/report/util/coverage.ts
@@ -24,6 +24,18 @@ export interface CoverageField {
  * here is a strong "fabrication or omission" signal. Empty `name`
  * values (rare; profile lookup miss in the presenter) carry
  * `mentioned: true` so they don't poison the warning aggregation.
+ *
+ * Same shipability-vs-fidelity tradeoff as `CoverageField`: substring
+ * matching has no concept of word boundaries (especially in Japanese,
+ * where there isn't a reliable boundary character), so a payload name
+ * of "田中" matches an unrelated "田中太郎" in the output and gets
+ * flagged `mentioned: true`. The reverse failure (payload "田中" vs.
+ * output "田中さん") is the exact case we want to catch, and
+ * disambiguating is impossible from the substring alone. The
+ * authoritative fidelity check lives in the JUDGE prompt's
+ * `fabrication_check.top_user_names` rubric, which reads the surrounding
+ * context; this coverage signal is a cheap pre-judge tripwire and is
+ * intentionally permissive.
  */
 export interface TopUserNameCoverage {
   name: string;

--- a/src/application/domain/report/util/coverage.ts
+++ b/src/application/domain/report/util/coverage.ts
@@ -17,17 +17,68 @@ export interface CoverageField {
   mentioned: boolean;
 }
 
+/**
+ * Per-top-user name check. `mentioned` is true when the user's `name`
+ * appears as a substring in the generated markdown — the LLM is
+ * required to copy `top_users[*].name` verbatim, so a missing match
+ * here is a strong "fabrication or omission" signal. Empty `name`
+ * values (rare; profile lookup miss in the presenter) carry
+ * `mentioned: true` so they don't poison the warning aggregation.
+ */
+export interface TopUserNameCoverage {
+  name: string;
+  mentioned: boolean;
+}
+
+/**
+ * Per-top-user numeric coverage. Each field is true when the
+ * corresponding payload value appears as a substring in the markdown,
+ * OR when the value is zero / null (no payload value to mention →
+ * vacuously satisfied). Numeric substring matches false-positive far
+ * more easily than name matches (a "21000" prefix can match "210000"),
+ * so the usecase deliberately does NOT log warnings off these fields —
+ * they are recorded for offline analysis only.
+ */
+export interface TopUserPointsCoverage {
+  name: string;
+  points_in: boolean;
+  points_out: boolean;
+  donation_out_points: boolean;
+}
+
 export interface CoverageJson {
   active_users: CoverageField;
   total_members: CoverageField;
   deepest_chain_depth: CoverageField;
+  /**
+   * Per-top-user name coverage. Empty when `payload.top_users` is
+   * empty (no users to check). Each entry's `mentioned` is the
+   * substring lookup against `outputMarkdown` and is the primary
+   * signal driving the auto-reject judge prompt.
+   */
+  top_user_names: TopUserNameCoverage[];
+  /**
+   * Per-top-user numeric coverage. Same length as `top_user_names`
+   * (one entry per `top_users[i]`). Records-only: no warning
+   * aggregation lives off these because numeric substring matches
+   * carry too much false-positive noise.
+   */
+  top_user_points: TopUserPointsCoverage[];
 }
 
 /**
- * Substring-mention check for headline numeric fields. `null` `value`s
- * (e.g. no community_context, no deepest_chain) carry `mentioned: false`
- * by convention so the downstream summariser can show "n/a" without
- * special-casing nulls itself.
+ * Substring-mention check for headline numeric fields and the top-N
+ * users (names + per-user numeric fields).
+ *
+ * `null` / zero values carry `mentioned: true` by convention — there
+ * is no payload string to "mention" in those cases, so flagging them
+ * as missed would generate noise. Empty `top_users` collapses
+ * `top_user_names` / `top_user_points` to empty arrays for the same
+ * reason.
+ *
+ * Pure function: no logging, no exceptions, no I/O. The caller
+ * (judgeAndPersist) decides which misses are worth a warning log
+ * based on signal-to-noise; this layer only computes the booleans.
  */
 export function analyzeCoverage(
   payload: WeeklyReportPayload,
@@ -36,6 +87,27 @@ export function analyzeCoverage(
   const activeUsers = payload.community_context?.active_users_in_window ?? null;
   const totalMembers = payload.community_context?.total_members ?? null;
   const chainDepth = payload.deepest_chain?.chain_depth ?? null;
+
+  const top_user_names: TopUserNameCoverage[] = payload.top_users.map((u) => ({
+    name: u.name,
+    // Empty name → presenter could not resolve a profile row; treat
+    // as vacuously satisfied so it doesn't show up in the warning log.
+    mentioned: u.name === "" ? true : output.includes(u.name),
+  }));
+
+  const top_user_points: TopUserPointsCoverage[] = payload.top_users.map((u) => ({
+    name: u.name,
+    // Zero is treated as "nothing to mention" — a user with
+    // `points_in: 0` has no incoming-points number that should appear
+    // in the markdown, so requiring its substring match would
+    // perpetually flag receiver-only / sender-only users.
+    points_in: u.points_in === 0 ? true : output.includes(String(u.points_in)),
+    points_out: u.points_out === 0 ? true : output.includes(String(u.points_out)),
+    donation_out_points:
+      u.donation_out_points === 0
+        ? true
+        : output.includes(String(u.donation_out_points)),
+  }));
 
   return {
     active_users: {
@@ -50,5 +122,7 @@ export function analyzeCoverage(
       value: chainDepth,
       mentioned: chainDepth !== null && output.includes(String(chainDepth)),
     },
+    top_user_names,
+    top_user_points,
   };
 }

--- a/src/infrastructure/prisma/seeds/reportTemplates.ts
+++ b/src/infrastructure/prisma/seeds/reportTemplates.ts
@@ -394,32 +394,52 @@ ${COMMON_RULES}`,
     maxTokens: 1000,
     temperature: 0,
     notes:
-      "WEEKLY_SUMMARY 生成結果を評価する LLM-as-Judge プロンプト。SYSTEM scope 固定。",
-    systemPrompt: `あなたはコミュニティレポートの品質評価者です。
-以下の基準で生成されたレポートを 0-100 点で評価してください。
-必ず JSON 形式のみで回答してください。前後に解説や Markdown フェンスを付けないでください。`,
-    userPromptTemplate: `# 評価対象レポート
-\${output_markdown}
+      "WEEKLY_SUMMARY 生成結果を評価する LLM-as-Judge プロンプト。SYSTEM scope 固定。" +
+      "PR-B: fabrication / quality を分離した breakdown と「fabrication 検知時のみ score ≤ 40」のスコア設計で、" +
+      "auto-reject 閾値 60 と組み合わせて「捏造があれば自動却下」を担保する。",
+    systemPrompt: `あなたはコミュニティレポートの品質審査員です。
+元データ（payload）と生成されたレポートを照合し、指定された審査基準に従って審査してください。
 
-# 元データ（payload）
-\${input_payload}
+出力は必ず以下の JSON 形式のみとすること。JSON 以外のテキスト・Markdown フェンス・前後の解説は出力しない。
 
-# 評価基準（このリストの観点で減点・加点を判断）
-\${judge_criteria}
-
-# 出力形式（JSON のみ。前後のテキスト不要）
 {
-  "score": <0-100>,
+  "score": 0から100の整数,
   "breakdown": {
-    "data_accuracy": <0-100>,
-    "narrative_quality": <0-100>,
-    "deepest_chain_mentioned": <true|false>,
-    "actionable_insights": <0-100>,
-    "no_fabrication": <true|false>
+    "fabrication": {
+      "top_user_names": true または false,
+      "top_user_points": true または false,
+      "chain_depth": true または false,
+      "active_users": true または false,
+      "total_members": true または false,
+      "no_phantom_comparison": true または false
+    },
+    "quality": {
+      "deepest_chain_mentioned": true または false,
+      "actionable_insights": true または false,
+      "reason_distinction": true または false,
+      "no_enum_names": true または false
+    }
   },
   "issues": ["問題点1", "問題点2"],
   "strengths": ["良い点1"]
-}`,
+}
+
+スコア計算ルール：
+- fabrication の各項目のいずれかが false → score は 40 以下にする
+- fabrication がすべて true かつ quality がすべて true → score: 90〜100
+- fabrication がすべて true かつ quality に false あり → score: 60〜89`,
+    userPromptTemplate: `以下の審査基準に従って審査してください。
+
+## 審査基準
+\${judge_criteria}
+
+## 元データ（payload）
+\${input_payload}
+
+## 生成されたレポート
+\${output_markdown}
+
+上記の形式の JSON のみを出力してください。`,
   },
   {
     variant: GqlReportVariant.MemberNewsletter,


### PR DESCRIPTION
## Summary

PR-A はプロンプト構造で「正しいものを書かせる」力を上げた。PR-B は「正しくない出力を検知して止める」仕組みを入れる。これで初めてハルシネーション検知が運用に効く状態になる。

### 1. JUDGE プロンプトの再構成

`fabrication_check` / `quality_check` を分離した breakdown と、スコア計算ルールを明文化：

- fabrication いずれか false → score ≤ 40
- fabrication 全て true + quality 全て true → 90〜100
- fabrication 全て true + quality に false あり → 60〜89

これにより閾値 60 = **「fabrication 検知時のみ自動 REJECT」** と同義になる。

`${judge_criteria}` は `userPromptTemplate` に置く（`renderPromptTemplate` は systemPrompt を substitution しない仕様。systemPrompt に置くと silent failure になる）。

### 2. `WEEKLY_SUMMARY_JUDGE_CRITERIA` 定数 + variant 経路

`usecase.ts` に定数を定義し、`report.variant === GqlReportVariant.WeeklySummary` のときだけ criteria を `executeJudge` に渡す。他 variant は `undefined`（JUDGE テンプレも seed されてないので unreachable だが forward-compat 用）。

### 3. 同 tx 内の auto-reject

`persistJudgeOutcomeWithAutoReject` を新設して、judge 保存と REJECTED 遷移を **1 つの `onlyBelongingCommunity` ブロックで実行**。これで「fabricate 内容が DRAFT として一瞬 observable」な window を閉じる。失敗パス（template 無し / parse error / LLM 5xx）は judgeScore が null なので閾値判定は無意味 → 既存の `persistJudgeOutcome` をそのまま使い続ける。

### 4. `REJECTED → SUPERSEDED` 遷移の追加

`service.ts` の `assertStatusTransition` で `REJECTED → SUPERSEDED` を許可。これがないと `generateReport(parentRunId=<auto-rejected>)` が落ちる。逆遷移（REJECTED → DRAFT 等の「un-reject」）は意図的に追加しない — regen は新しい row を作る方針。

### 5. `coverage.ts` 拡張

`top_user_names` を追加（人名は LLM が verbatim 引用すべき強いシグナル）、`top_user_points` も記録するが warn ログは出さない（数値の substring 一致は false positive が起きやすい："21000" が "210000" の一部に一致）。`coverage.ts` は **pure 関数のまま**、`top_user_names_missed` の warn は usecase 層で出す。

## Test plan

- [x] `npx tsc --noEmit` → エラーゼロ
- [x] `pnpm test --runInBand src/__tests__/unit/report/` → 14 suites / **191 tests pass**（PR-A の 180 + 新規 11）
  - coverage.test.ts: top_user_names / top_user_points の通常・null・空配列・部分マッチ・欠落の各ケース（+8 tests）
  - service.test.ts: REJECTED → SUPERSEDED の許可（既存 validTransitions 配列に追加）
  - usecase.test.ts: judge auto-reject の 3 ケース（score 35 → REJECT / score 75 → DRAFT / score 60 ちょうどは DRAFT）
- [x] 完了確認 grep 7 件すべて期待通り
  - `judge_criteria` は userPromptTemplate のみ（systemPrompt にはない）
  - `JUDGE_AUTO_REJECT_THRESHOLD` / `WEEKLY_SUMMARY_JUDGE_CRITERIA` 定義済み
  - `report.variant` 経由（`input.variant` ではない）
  - `REJECTED → SUPERSEDED` が allowedTransitions に追加
  - `top_user_names` / `top_user_points` が coverage に追加
  - coverage.ts に logger / throw / console は無し（pure 関数）
  - `http://`（自動リンク）残留ゼロ

## 設計判断

- **閾値 60 ハードコード**: 運用見ながら必要なら別 PR で env 化。spec 通り。
- **`summary` フィールド**: JUDGE 出力 JSON から削除（parseJudgeResponse で消費されないため。issues / strengths が既に観測フィールドとしてある）。
- **points の warn ログ**: 出さない（substring false positive リスク）。coverageJson に記録するだけ。
- **既存 fixture の更新**: optional ではなく明示的に必須フィールドとして追加して既存テストを直す（型不整合を optional で誤魔化す方が後々の負債）。

https://claude.ai/code/session_017UyUGJLdMnK1MnLZ9L8LTG

---
_Generated by [Claude Code](https://claude.ai/code/session_017UyUGJLdMnK1MnLZ9L8LTG)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hopin-inc/civicship-api/pull/964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
