### PR TITLE
fix(probe): align default window with generateWeeklyReports JST calendar

### DIFF
--- a/scripts/probe-reports.ts
+++ b/scripts/probe-reports.ts
@@ -6,6 +6,7 @@ import { ReportTemplateKind, ReportTemplateScope } from "@prisma/client";
 import { container } from "tsyringe";
 import { GqlReportVariant } from "@/types/graphql";
 import ReportUseCase from "@/application/domain/report/usecase";
+import { addDays, truncateToJstDate } from "@/application/domain/report/util";
 import { prismaClient } from "@/infrastructure/prisma/client";
 import type { IContext } from "@/types/server";
 
@@ -117,18 +118,15 @@ function parseArgs(): CliArgs {
       periodTo: new Date(`${toArg}T00:00:00Z`),
     };
   }
-  // Default window: yesterday back 6 days (the same 7-day inclusive
-  // window the live weekly batch uses). Operating in UTC at this layer
-  // is fine because `generateReport` itself runs the values through
-  // `truncateToJstDate` before persisting.
-  const today = new Date();
-  const todayUtc = new Date(
-    Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()),
-  );
-  const periodTo = new Date(todayUtc);
-  periodTo.setUTCDate(periodTo.getUTCDate() - 1);
-  const periodFrom = new Date(periodTo);
-  periodFrom.setUTCDate(periodFrom.getUTCDate() - 6);
+  // Default window: yesterday back 6 days, computed against the JST
+  // calendar via the same `truncateToJstDate` helper the live weekly
+  // batch uses (`generateWeeklyReports.ts:24-25`). The earlier UTC-only
+  // computation drifted by a day during the JST 00:00–09:00 window
+  // (= UTC 15:00–24:00 of the prior day) because `getUTCDate()` would
+  // already have rolled to "today" while JST was still on "yesterday",
+  // landing the probe one day off from what the batch would have run.
+  const periodTo = addDays(truncateToJstDate(new Date()), -1);
+  const periodFrom = addDays(periodTo, -6);
   return { communityIds, periodFrom, periodTo };
 }
 

--- a/scripts/probe-reports.ts
+++ b/scripts/probe-reports.ts
@@ -123,7 +123,7 @@ function parseArgs(): CliArgs {
   // batch uses (`generateWeeklyReports.ts:24-25`). The earlier UTC-only
   // computation drifted by a day during the JST 00:00–09:00 window
   // (= UTC 15:00–24:00 of the prior day) because `getUTCDate()` would
-  // already have rolled to "today" while JST was still on "yesterday",
+  // still be on "yesterday" while JST had already rolled to "today",
   // landing the probe one day off from what the batch would have run.
   const periodTo = addDays(truncateToJstDate(new Date()), -1);
   const periodFrom = addDays(periodTo, -6);


### PR DESCRIPTION
## Summary

PR #970 マージ後の Gemini 指摘 #2 への対応。probe スクリプトのデフォルト window 計算が live バッチと **JST 早朝で 1 日ずれる** バグを修正。

## 何が起きていたか

| 場所 | 計算式 |
|---|---|
| `generateWeeklyReports.ts:24` (live バッチ) | `addDays(truncateToJstDate(new Date()), -1)` |
| `scripts/probe-reports.ts` (probe) | `Date.UTC(today.getUTCFullYear(), ...)` ベースの自前計算 |

JST 00:00〜09:00（= UTC 前日 15:00〜24:00）の時間帯に probe を叩くと、`getUTCDate()` は既に「今日」にロールしているのに JST はまだ「昨日」のまま → probe の "yesterday" がバッチの想定 "yesterday" より 1 日ずれる。

## 修正

```diff
+import { addDays, truncateToJstDate } from "@/application/domain/report/util";

-const today = new Date();
-const todayUtc = new Date(
-  Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()),
-);
-const periodTo = new Date(todayUtc);
-periodTo.setUTCDate(periodTo.getUTCDate() - 1);
-const periodFrom = new Date(periodTo);
-periodFrom.setUTCDate(periodFrom.getUTCDate() - 6);
+const periodTo = addDays(truncateToJstDate(new Date()), -1);
+const periodFrom = addDays(periodTo, -6);
```

`truncateToJstDate` / `addDays` は既に `src/application/domain/report/util.ts` にあったヘルパー。最初からこっちを import すべきだった（PR #970 時点での自分のミス）。

## Test plan

- [x] `npx tsc --noEmit` → エラーゼロ
- 挙動的影響: JST 日中（9:00〜23:59）に叩く分には diff ゼロ。JST 早朝に叩いた時のみ window が 1 日後ろにスライドする（= バッチと一致するようになる）

## 関連

PR #970 への Gemini Code Assist の review コメント 3 件のうち：

- **#1 ERD.md 重複行** — prisma generator の出力なので touch しない
- **#2 日付計算の不整合** — 本 PR で修正
- **#3 makeProbeContext の loaders/communityId 欠落** — `as any` キャストで型を欺いているが、`issuer.*` の実装そのものを passthrough に置き換えているので実行時参照は発生しない。実害ゼロかつ `scripts/ci/run-golden-cases.ts` も同パターンなので touch しない

https://claude.ai/code/session_017UyUGJLdMnK1MnLZ9L8LTG

---
_Generated by [Claude Code](https://claude.ai/code/session_017UyUGJLdMnK1MnLZ9L8LTG)_