### PR TITLE
chore(ci): tag Cloud Run images with commit SHA for rollback

### DIFF
--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -139,15 +139,22 @@ jobs:
       # main / batch の両 registry に同じ image を multi-tag push する。
       # batch (Cloud Run Job) 側は entrypoint を `--command/--args` で
       # `node dist/index.js` に上書きする (旧 Dockerfile.batch CMD と等価)。
+      # `:sha-${{ github.sha }}` を `:latest` と並列で push することで、
+      # Cloud Run の各 revision を commit SHA 単位で identifyable にし、
+      # 過去 image にロールバックできるようにする (DEPLOYMENT.md 参照)。
       - name: Build unified image and push to main + batch registries
         env:
           MAIN_IMAGE: ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest
+          MAIN_IMAGE_SHA: ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:sha-${{ github.sha }}
           BATCH_IMAGE: ${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest
+          BATCH_IMAGE_SHA: ${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:sha-${{ github.sha }}
         run: |
           docker buildx build \
             --file Dockerfile \
             --tag "$MAIN_IMAGE" \
+            --tag "$MAIN_IMAGE_SHA" \
             --tag "$BATCH_IMAGE" \
+            --tag "$BATCH_IMAGE_SHA" \
             --cache-from "type=gha,scope=cloud-run-${{ inputs.stage }}" \
             --cache-to "type=gha,mode=max,scope=cloud-run-${{ inputs.stage }}" \
             --push \
@@ -158,7 +165,7 @@ jobs:
         uses: google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522 # v2.7.6
         with:
           service: ${{ env.APPLICATION_NAME }}
-          image: ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest
+          image: ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:sha-${{ github.sha }}
           region: ${{ env.GCP_REGION }}
           env_vars: |
             NODE_ENV=${{ inputs.node-env }}
@@ -177,7 +184,7 @@ jobs:
         run: |
           gcloud run jobs update "${{ env.BATCH_NAME }}" \
             --region="${{ env.GCP_REGION }}" \
-            --image="${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest" \
+            --image="${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:sha-${{ github.sha }}" \
             --command=node \
             --args=-r,tsconfig-paths/register,dist/bootstrap/batch.js
 

--- a/.github/workflows/_deploy-external-api.yml
+++ b/.github/workflows/_deploy-external-api.yml
@@ -114,13 +114,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
 
+      # `:sha-${{ github.sha }}` を `:latest` と並列で push することで、
+      # Cloud Run の各 revision を commit SHA 単位で identifyable にし、
+      # 過去 image にロールバックできるようにする (DEPLOYMENT.md 参照)。
       - name: Build and push External API image
         env:
           EXTERNAL_IMAGE: ${{ env.ARTIFACT_REGISTRY }}/${{ env.EXTERNAL_API_NAME }}:latest
+          EXTERNAL_IMAGE_SHA: ${{ env.ARTIFACT_REGISTRY }}/${{ env.EXTERNAL_API_NAME }}:sha-${{ github.sha }}
         run: |
           docker buildx build \
             --file Dockerfile.external \
             --tag "$EXTERNAL_IMAGE" \
+            --tag "$EXTERNAL_IMAGE_SHA" \
             --cache-from "type=gha,scope=external-${{ inputs.stage }}" \
             --cache-to "type=gha,mode=max,scope=external-${{ inputs.stage }}" \
             --push \
@@ -131,7 +136,7 @@ jobs:
         uses: google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522 # v2.7.6
         with:
           service: ${{ env.EXTERNAL_API_NAME }}
-          image: ${{ env.ARTIFACT_REGISTRY }}/${{ env.EXTERNAL_API_NAME }}:latest
+          image: ${{ env.ARTIFACT_REGISTRY }}/${{ env.EXTERNAL_API_NAME }}:sha-${{ github.sha }}
           region: ${{ env.GCP_REGION }}
           flags: '--allow-unauthenticated --port=3000'
           env_vars: |

--- a/docs/handbook/DEPLOYMENT.md
+++ b/docs/handbook/DEPLOYMENT.md
@@ -404,6 +404,58 @@ run.googleapis.com/vpc-access-connector: projects/PROJECT_ID/locations/REGION/co
 run.googleapis.com/vpc-access-egress: private-ranges-only
 ```
 
+## Rollback
+
+### Image SHA Tagging
+
+Every deploy pushes the built image with two tags in parallel:
+
+- `:latest` — moving tag, always points at the most recent successful build
+- `:sha-<commit-sha>` — immutable tag pinned to the commit that triggered the
+  build (`github.sha`)
+
+Cloud Run services / Jobs are deployed with the `:sha-<commit-sha>` tag (not
+`:latest`) so that each revision is identifyable by the source commit and a
+specific past build can be re-deployed at any time.
+
+### Rolling back to a previous image
+
+To roll a Cloud Run **service** back to an older build, look up the commit SHA
+of the target build (e.g. from the GitHub Actions run, `git log`, or
+`gcloud artifacts docker tags list`) and run:
+
+```bash
+# Internal API
+gcloud run services update "$APPLICATION_NAME" \
+  --image="${ARTIFACT_REGISTRY}/${APPLICATION_NAME}:sha-${TARGET_SHA}" \
+  --region="$GCP_REGION"
+
+# External API
+gcloud run services update "$EXTERNAL_API_NAME" \
+  --image="${ARTIFACT_REGISTRY}/${EXTERNAL_API_NAME}:sha-${TARGET_SHA}" \
+  --region="$GCP_REGION"
+```
+
+For the **batch Cloud Run Job**, use `run jobs update` instead:
+
+```bash
+gcloud run jobs update "$BATCH_NAME" \
+  --image="${BATCH_ARTIFACT_REGISTRY}/${BATCH_NAME}:sha-${TARGET_SHA}" \
+  --region="$GCP_REGION"
+```
+
+Alternatively, for services you can shift traffic back to a previously
+deployed revision without re-deploying the image:
+
+```bash
+gcloud run services update-traffic "$APPLICATION_NAME" \
+  --to-revisions="<previous-revision-name>=100" \
+  --region="$GCP_REGION"
+```
+
+Use `gcloud run revisions list --service="$APPLICATION_NAME" --region="$GCP_REGION"`
+to find the revision name.
+
 ## Troubleshooting
 
 ### Deployment issues


### PR DESCRIPTION
## Summary
- Push each Cloud Run image with both `:latest` and `:sha-${github.sha}` tags so revisions are identifyable per commit.
- Deploy Internal API / External API / batch Job from the immutable SHA tag, and document the rollback procedure (`gcloud run services update --image=...:sha-XXXX`) in `docs/handbook/DEPLOYMENT.md`.

Closes #974

## Test plan
- [ ] Merge to `develop` and verify the dev deploy workflow pushes both `:latest` and `:sha-<sha>` tags to Artifact Registry.
- [ ] Confirm the new Cloud Run revision references `:sha-<sha>` (not `:latest`) via `gcloud run services describe`.
- [ ] Verify the batch Cloud Run Job is updated to the SHA-tagged image (`gcloud run jobs describe`).
- [ ] Dry-run the documented rollback command against a non-prod service to ensure the syntax is valid.

https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG)_