### PR TITLE
chore(ci): add post-deploy smoke check to Cloud Run deploys

### DIFF
--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -164,6 +164,26 @@ jobs:
             NODE_ENV=${{ inputs.node-env }}
             ${{ inputs.extra-env-vars }}
 
+      # Cloud Run の deploy アクションは revision の作成成功までしか保証しない。
+      # 実際にコンテナが起動失敗した (例: 起動時 import error / DB 接続失敗) ケースでも
+      # workflow は green になってしまうため、deploy 直後に health endpoint を叩いて
+      # 失敗時はジョブを fail させ、Cloud Run のエラーログを step summary に残す。
+      - name: Smoke check
+        env:
+          SERVICE: ${{ env.APPLICATION_NAME }}
+          REGION: ${{ env.GCP_REGION }}
+        run: |
+          URL=$(gcloud run services describe "$SERVICE" --region="$REGION" --format='value(status.url)')
+          echo "Smoking $URL/health"
+          if ! curl --fail --silent --show-error --retry 6 --retry-delay 10 --max-time 10 "$URL/health"; then
+            echo "::error::Smoke check failed for $SERVICE"
+            gcloud logging read \
+              "resource.type=cloud_run_revision AND resource.labels.service_name=$SERVICE AND severity>=ERROR" \
+              --limit=50 --format='value(timestamp,textPayload,jsonPayload.message)' \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
       - name: Update Cloud Run Job (batch) to new image
         # docker push :latest alone does not roll the Cloud Run Job to the new
         # image — Cloud Run Jobs pin the image digest at deploy time, so we

--- a/.github/workflows/_deploy-external-api.yml
+++ b/.github/workflows/_deploy-external-api.yml
@@ -138,6 +138,26 @@ jobs:
             NODE_ENV=${{ inputs.node-env }}
             ${{ inputs.extra-env-vars }}
 
+      # Cloud Run の deploy アクションは revision の作成成功までしか保証しない。
+      # 実際にコンテナが起動失敗した (例: 起動時 import error / DB 接続失敗) ケースでも
+      # workflow は green になってしまうため、deploy 直後に health endpoint を叩いて
+      # 失敗時はジョブを fail させ、Cloud Run のエラーログを step summary に残す。
+      - name: Smoke check
+        env:
+          SERVICE: ${{ env.EXTERNAL_API_NAME }}
+          REGION: ${{ env.GCP_REGION }}
+        run: |
+          URL=$(gcloud run services describe "$SERVICE" --region="$REGION" --format='value(status.url)')
+          echo "Smoking $URL/health"
+          if ! curl --fail --silent --show-error --retry 6 --retry-delay 10 --max-time 10 "$URL/health"; then
+            echo "::error::Smoke check failed for $SERVICE"
+            gcloud logging read \
+              "resource.type=cloud_run_revision AND resource.labels.service_name=$SERVICE AND severity>=ERROR" \
+              --limit=50 --format='value(timestamp,textPayload,jsonPayload.message)' \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
       - name: Create Git tag
         if: ${{ inputs.create-git-tag }}
         run: |


### PR DESCRIPTION
## Summary
- Cloud Run の `deploy-cloudrun` アクションは revision 作成までしか保証しないため、起動失敗 (import error / DB 接続失敗等) が起きても workflow が green になっていた問題を修正。
- Internal API (`_deploy-cloud-run.yml`) と External API (`_deploy-external-api.yml`) の両方で deploy step 直後に smoke check step を追加。`gcloud run services describe` で URL を取得し、`/health` を curl で叩く (`--retry 6 --retry-delay 10 --max-time 10`)。失敗時は Cloud Run のエラーログ最大 50 件を `$GITHUB_STEP_SUMMARY` に追記して `exit 1`。
- 既存の health endpoint (`src/index.ts:79` および `src/external-api.ts:35` でそれぞれ `app.get("/health")` として実装済み、200 + `{ status: "healthy" }` を返す) を流用。Issue では `/healthz` が例として挙げられていたが、リポジトリは `/health` を採用しているのでそちらに合わせている。

## Validation
- `actionlint v1.7.12` を 2 ファイルおよび `.github/workflows/` 全体に対して実行 — エラーなし。

## Test plan
- [ ] dev 環境への merge 後、`Deploy Internal API to Cloud Run` job で `Smoke check` step が green になり `Smoking https://.../health` がログに出ること
- [ ] 同じく External API の deploy job で `Smoke check` step が green になること
- [ ] (任意, 別 PR で検証) わざと起動失敗するイメージを deploy し、`Smoke check` step が fail し step summary に Cloud Run の error ログが記録されること

Closes #975

https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG)_