### PR TITLE
chore(ci): lint Dockerfiles with hadolint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,21 @@ jobs:
         # Image: rhysd/actionlint:1.7.7 (Docker Hub, multi-arch index digest)
         # shellcheck / pyflakes are bundled in the image.
 
+      - name: Lint Dockerfiles (hadolint v2.12.0-alpine)
+        # Pin to tag for now; follow-up will swap to immutable @sha256 digest
+        # (mirrors actionlint pattern above) once the digest is captured from
+        # `docker pull hadolint/hadolint:v2.12.0-alpine`.
+        # `continue-on-error: true` keeps this advisory while the existing
+        # Dockerfile / Dockerfile.external are brought into compliance in a
+        # follow-up PR — see PR description for the violation breakdown.
+        continue-on-error: true
+        run: |
+          docker run --rm -i \
+            -v "${{ github.workspace }}:/repo:ro" \
+            hadolint/hadolint:v2.12.0-alpine \
+            hadolint --config /repo/.hadolint.yaml \
+              /repo/Dockerfile /repo/Dockerfile.external
+
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,9 @@
+# Hadolint configuration for civicship-api Dockerfiles.
+#
+# Reference: https://github.com/hadolint/hadolint#configure
+#
+# `ignored` lists rule IDs that should be skipped repo-wide. Keep this list
+# minimal and document why each rule is suppressed; prefer fixing the
+# Dockerfile to ignoring the rule. Rules can also be ignored inline with
+# `# hadolint ignore=DLxxxx` immediately above the offending instruction.
+ignored: []


### PR DESCRIPTION
## Summary
- Adds a Docker-ized hadolint step to the `ci.yml:lint` job (alongside actionlint) so `Dockerfile` and `Dockerfile.external` are linted on every PR.
- Ships a minimal repo-level `.hadolint.yaml` (empty `ignored:` list, with guidance comments) so future rule suppressions land in one auditable place.
- Runs as **advisory** (`continue-on-error: true`) so the new check does not block merges while existing Dockerfiles are brought into compliance — see *Follow-ups* below.

Closes #983

## Implementation notes
- Follows the same Docker-image-with-mounted-repo pattern as the existing actionlint step.
- Uses the `hadolint/hadolint:v2.12.0-alpine` tag for now. The local sandbox has no Docker daemon available, so the immutable `@sha256:<digest>` could not be captured during this PR. A follow-up will pin the digest to match the actionlint pattern (`rhysd/actionlint@sha256:...`).
- `--config /repo/.hadolint.yaml` is passed explicitly because the working directory inside the container is not the mounted repo root.

## Expected violations on existing Dockerfiles
Both `Dockerfile` and `Dockerfile.external` are 4-line minimal images of the form:
```dockerfile
FROM node:20
WORKDIR /app
COPY . ./
CMD ["node", "-r", "tsconfig-paths/register", "dist/.../index.js"]
```
Likely hadolint findings (could not be confirmed locally — Docker daemon unavailable in the sandbox):
- **DL3007** *Using latest is prone to errors if the image will ever update.* — `node:20` is a floating major-version tag; pinning to `node:20.x.y` (or `node:20-slim@sha256:...`) is recommended.
- **DL3006** *Always tag the version of an image explicitly.* — only triggered if `:20` is treated as too loose; usually fine but worth confirming from the actual CI run.
- Possibly **DL3025** (use JSON form for `CMD`) — `CMD` already uses JSON form, so DL3025 should pass.

The CI run on this PR will produce the authoritative list. Because the step is `continue-on-error: true`, the findings will surface as a non-blocking warning in the lint job log; a follow-up PR will either fix the Dockerfiles, ignore specific rules in `.hadolint.yaml`, and then flip the step to blocking.

## Follow-ups
1. Pin `hadolint/hadolint:v2.12.0-alpine` to an immutable `@sha256:<digest>` (mirrors the actionlint pin).
2. Address the violations reported by the first CI run on this PR — either by fixing the Dockerfiles or by adding the rule IDs to `.hadolint.yaml` `ignored:` with a justification comment.
3. Remove `continue-on-error: true` from the hadolint step so it becomes a blocking check.

## Test plan
- [ ] `lint` job runs the new "Lint Dockerfiles (hadolint v2.12.0-alpine)" step and prints hadolint output for both Dockerfiles.
- [ ] The step does not fail the `lint` job even if hadolint reports findings (`continue-on-error: true`).
- [ ] `actionlint` step still passes against the modified `ci.yml`.
- [ ] `ci` aggregator job still reports `success` (lint result is `success` because hadolint failures are swallowed).
- [ ] Capture the actual hadolint findings from the CI log and open the follow-up PR described above.

https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG)_