### PR TITLE
chore(ci): add CodeQL analysis for JS/TS

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,62 @@
+name: CodeQL
+
+# CodeQL static analysis for JavaScript/TypeScript.
+# Runs on push / PR against master / develop, plus a weekly schedule
+# (cron は UTC で 21:00 月曜 = JST 火曜 06:00)。
+# branch protection の required check には登録しない (run time が PR feedback
+# loop に乗らない / queue 競合で発見が遅れることへの許容)。
+on:
+  push:
+    branches: [master, develop]
+  pull_request:
+    branches: [master, develop]
+  schedule:
+    - cron: '0 21 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      # SARIF upload to code scanning
+      security-events: write
+      # workflow artifact / source checkout
+      contents: read
+      # required by codeql-action to read the workflow run metadata
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # JS と TS は同一の analyzer (`javascript-typescript`) で解析する。
+        # 旧 `javascript` / `typescript` 個別指定は deprecated で、統合 ID 推奨。
+        language: [javascript-typescript]
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@14c9a0cbe6373488c2a41f7e75c8dd142bb2aba8 # v3.35.3
+        with:
+          languages: ${{ matrix.language }}
+          # security-extended: 既定の security-and-quality 抜きで、より厳しめの
+          # security 系 query pack のみ有効化。FP 抑制と signal 重視のバランス。
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@14c9a0cbe6373488c2a41f7e75c8dd142bb2aba8 # v3.35.3
+        with:
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
Closes #980

## Summary
- 新規 workflow `.github/workflows/codeql.yml` を追加。GitHub CodeQL static analysis を JavaScript/TypeScript (統合 analyzer ID `javascript-typescript`) に対して有効化。
- トリガー: `push` / `pull_request` (master, develop) と weekly cron (`0 21 * * 1` UTC = JST 火曜 06:00)。
- query pack は `security-extended` (security 系のみ、quality は除外して FP 抑制)。
- supply-chain 強度は既存 workflow と同じく step-security/harden-runner + 全 action SHA pin (`# vX.Y.Z` コメント付与) で揃え、concurrency group で PR は最新 push のみ走る / branch push は直列維持。
- job permissions は `security-events: write` / `contents: read` / `actions: read` の最小 set。

## Required check
- 本 workflow は **branch protection の required check には登録しない**。
  - PR feedback loop に乗るほど短時間で終わらないこと、queue 競合で発見が遅れる可能性を許容するため。
  - schedule + push/PR トリガーで継続的に SARIF を code scanning にアップロードし、Security tab 側で triage する運用前提。

## Test plan
- [ ] PR 作成後、本 PR 自体で CodeQL workflow が起動し、`Analyze (javascript-typescript)` job が success することを確認
- [ ] Security tab → Code scanning に当 PR / develop 由来の alert が表示されることを確認
- [ ] `actionlint` (1.7.x, lint job と同等) で workflow YAML が pass することを確認 (ローカル検証済)
- [ ] 本 PR は required check 化しないため、merge は他の既存 required check (`ci`) のみで gating されることを確認

https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG)_