### PR TITLE
chore(ci): collect coverage from test matrix and post PR summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,18 @@ jobs:
         # 文字列そのものが pattern として解釈され 0 match になる。
         # jest の最初の positional 引数が testPathPattern として扱われる仕様を
         # 利用し、path を positional で渡す。
-        run: pnpm test -- "${{ matrix.path }}"
+        # `--coverage` で istanbul coverage を収集。matrix 単位で
+        # coverageDirectory を分け、後段の aggregator で merge して PR に
+        # 投稿する。閾値 gate は設けず、まず可視化のみ。
+        run: pnpm test -- --coverage --coverageDirectory=coverage-${{ matrix.name }} "${{ matrix.path }}"
+
+      - name: Upload coverage artifact (${{ matrix.name }})
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coverage-${{ matrix.name }}
+          path: coverage-${{ matrix.name }}/
+          retention-days: 7
+          if-no-files-found: warn
 
   # Aggregator job: branch protection の required status check として
   # `ci` を維持したまま、実体は lint / build / test の複合結果を集約する。
@@ -280,11 +291,13 @@ jobs:
   # できる。
   ci:
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
     needs: [lint, build, test]
     if: always()
     permissions:
       contents: read
+      # PR への coverage コメント投稿に必要 (marocchino/sticky-pull-request-comment)。
+      pull-requests: write
     steps:
       - name: Verify all required jobs passed
         run: |
@@ -297,3 +310,102 @@ jobs:
             exit 1
           fi
           echo "All required jobs passed"
+
+      # 以下、coverage 集約 step。閾値 gate は設けない:
+      # coverage の生成や merge が失敗しても aggregator 自体は success を維持し、
+      # PR の merge 可能性に影響を与えない (issue #979 方針)。
+      - name: Download all coverage artifacts
+        if: github.event_name == 'pull_request'
+        id: download-coverage
+        continue-on-error: true
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          path: coverage-artifacts
+          pattern: coverage-*
+          merge-multiple: false
+
+      - name: Merge coverage and generate lcov
+        if: github.event_name == 'pull_request' && steps.download-coverage.outcome == 'success'
+        id: merge-coverage
+        continue-on-error: true
+        run: |
+          set -eu
+          mkdir -p coverage-merged coverage-final
+          # download-artifact は各 artifact を `coverage-artifacts/<artifact-name>/`
+          # 配下に展開する。upload 時の path には `coverage-${name}/` を指定しており、
+          # 結果として coverage-final.json は
+          # `coverage-artifacts/coverage-<name>/coverage-<name>/coverage-final.json`
+          # に置かれる。階層深さに依存しない `find` で全て収集し、matrix 名を
+          # ファイル名に埋め込んで coverage-merged/ に集約。nyc merge は input
+          # ディレクトリ配下の *.json を全て merge する。
+          found=0
+          while IFS= read -r -d '' file; do
+            # /coverage-<name>/ に含まれる name を抽出して unique なファイル名にする。
+            rel="${file#coverage-artifacts/}"
+            top="${rel%%/*}"
+            cp "$file" "coverage-merged/${top}.json"
+            found=$((found + 1))
+          done < <(find coverage-artifacts -type f -name 'coverage-final.json' -print0)
+          if [ "$found" -eq 0 ]; then
+            echo "::warning::no coverage files found to merge"
+            echo "has_coverage=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # nyc merge: 複数 coverage-final.json を 1 つに統合。
+          # nyc report: lcov / text-summary を生成。
+          pnpm dlx nyc@17.1.0 merge coverage-merged coverage-final/coverage-final.json
+          pnpm dlx nyc@17.1.0 report \
+            --temp-dir coverage-merged \
+            --report-dir coverage-final \
+            --reporter=lcov \
+            --reporter=text-summary \
+            --reporter=json-summary \
+            > coverage-final/text-summary.txt
+          echo "has_coverage=true" >> "$GITHUB_OUTPUT"
+
+      - name: Build PR coverage comment
+        if: github.event_name == 'pull_request' && steps.merge-coverage.outputs.has_coverage == 'true'
+        id: build-comment
+        continue-on-error: true
+        run: |
+          set -eu
+          summary_json="coverage-final/coverage-summary.json"
+          if [ ! -f "$summary_json" ]; then
+            echo "::warning::coverage-summary.json not found; skipping comment"
+            exit 0
+          fi
+          # jq で total の lines / branches / functions / statements を抽出。
+          lines_pct=$(jq -r '.total.lines.pct' "$summary_json")
+          branches_pct=$(jq -r '.total.branches.pct' "$summary_json")
+          functions_pct=$(jq -r '.total.functions.pct' "$summary_json")
+          statements_pct=$(jq -r '.total.statements.pct' "$summary_json")
+          lines_cov=$(jq -r '.total.lines.covered' "$summary_json")
+          lines_tot=$(jq -r '.total.lines.total' "$summary_json")
+          branches_cov=$(jq -r '.total.branches.covered' "$summary_json")
+          branches_tot=$(jq -r '.total.branches.total' "$summary_json")
+          functions_cov=$(jq -r '.total.functions.covered' "$summary_json")
+          functions_tot=$(jq -r '.total.functions.total' "$summary_json")
+          statements_cov=$(jq -r '.total.statements.covered' "$summary_json")
+          statements_tot=$(jq -r '.total.statements.total' "$summary_json")
+          {
+            echo 'body<<COVERAGE_EOF'
+            echo '## Coverage Report'
+            echo ''
+            echo '| Metric | Coverage | Covered / Total |'
+            echo '| --- | ---: | ---: |'
+            echo "| Lines | ${lines_pct}% | ${lines_cov} / ${lines_tot} |"
+            echo "| Branches | ${branches_pct}% | ${branches_cov} / ${branches_tot} |"
+            echo "| Functions | ${functions_pct}% | ${functions_cov} / ${functions_tot} |"
+            echo "| Statements | ${statements_pct}% | ${statements_cov} / ${statements_tot} |"
+            echo ''
+            echo '> Aggregated across all test matrix jobs (unit / integration / e2e / auth). Visualization only — no threshold gate.'
+            echo 'COVERAGE_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post coverage comment to PR
+        if: github.event_name == 'pull_request' && steps.build-comment.outputs.body != ''
+        continue-on-error: true
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: ci-coverage
+          message: ${{ steps.build-comment.outputs.body }}


### PR DESCRIPTION
Closes #979

## Summary

Wires Jest coverage collection into the existing `test` matrix and aggregates the per-matrix results into a single PR sticky comment. Visualization-only — no threshold gate, so CI status remains determined entirely by lint / build / test.

## Changes (`.github/workflows/ci.yml`)

- **`test` matrix**: `Run tests` step now passes `--coverage --coverageDirectory=coverage-${{ matrix.name }}` to jest so each matrix entry (`unit` / `integration` / `e2e` / `auth`) writes its own istanbul coverage tree.
- **Upload step**: each matrix uploads `coverage-<name>/` via `actions/upload-artifact@v4.6.2` (pinned by SHA) with `retention-days: 7`.
- **`ci` aggregator** (`needs: [lint, build, test]`):
  - Adds `pull-requests: write` permission for the sticky-comment action.
  - Downloads all `coverage-*` artifacts via `actions/download-artifact@v4.2.1` (PR events only).
  - Merges per-matrix `coverage-final.json` with `pnpm dlx nyc@17.1.0 merge`, then renders `lcov`, `text-summary`, and `json-summary`.
  - Builds a markdown table of lines / branches / functions / statements totals (with covered/total counts) from `coverage-summary.json` via `jq`.
  - Posts/updates a sticky comment via `marocchino/sticky-pull-request-comment@v3.0.4` (pinned by SHA) using `header: ci-coverage`.
- **No-block guarantee**: every coverage step runs with `continue-on-error: true` and is gated `if: github.event_name == 'pull_request'`. The `Verify all required jobs passed` step (which is what determines aggregator success) is unchanged, so coverage failures cannot block merges.
- `ci` job timeout bumped from 2 → 5 min to accommodate the merge / report steps.

## Pinning notes

All third-party actions follow the repo's existing pattern: full commit SHA + `# vX.Y.Z` comment.

- `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2`
- `actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1`
- `marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4`

## Test plan

- [ ] `actionlint -color .github/workflows/ci.yml` passes (verified locally with v1.7.7).
- [ ] After merge, open a follow-up PR and confirm:
  - [ ] Each matrix job uploads its `coverage-<name>` artifact.
  - [ ] `ci` job downloads all artifacts and posts a single sticky `Coverage Report` comment.
  - [ ] Re-running CI updates the existing comment in place (sticky behaviour) instead of appending duplicates.
  - [ ] Failing or missing coverage data leaves `ci` green (no merge block).

https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG)_