### PR TITLE
chore(ci): skip build/test on docs-only PRs while keeping aggregator required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,10 @@ on:
   # branch protection の required status check として登録されているため、
   # paths-ignore で workflow ごと skip すると status が報告されず、docs-only
   # PR が永久に merge 不能になる (admin override が必要になる)。
-  # 軽量化が必要になったら job 側で changed-files filter (dorny/paths-filter
-  # 等) を使って expensive job (build / test) を条件付き skip し、aggregator は
-  # 必ず走る形にする。
+  # 代わりに job 側で changed-files filter (`filter` job + dorny/paths-filter)
+  # を使って expensive job (build / test) を条件付き skip し、aggregator (`ci`)
+  # は always() で必ず走らせる。aggregator 側では skipped を success と同等に
+  # 扱うことで required status check を緑に保つ。
 
 permissions:
   contents: read
@@ -21,6 +22,43 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Detect whether the PR touches code that affects build / test outputs.
+  # docs-only PR (README, handbook, schema doc 等) では expensive な build / test を
+  # skip して PR feedback loop を高速化する。aggregator job (`ci`) は always() で
+  # 走り、skipped を success と同等に扱うことで required status check を緑に保つ。
+  # workflow lint (lint job) は filter に依存させない: workflow 自体の文法 / 安全性
+  # チェックは docs-only PR でも常に必要。
+  filter:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    outputs:
+      code: ${{ steps.changes.outputs.code }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Detect code-affecting changes
+        id: changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            code:
+              - 'src/**'
+              - 'pnpm-lock.yaml'
+              - 'package.json'
+              - 'tsconfig*.json'
+              - '.github/workflows/**'
+              - '.github/actions/**'
+              - 'Dockerfile*'
+              - 'scripts/**'
+
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -49,6 +87,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: [filter]
+    if: needs.filter.outputs.code == 'true'
     permissions:
       contents: read
 
@@ -146,6 +186,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: [filter]
+    if: needs.filter.outputs.code == 'true'
     permissions:
       contents: read
     strategy:
@@ -287,13 +329,19 @@ jobs:
       contents: read
     steps:
       - name: Verify all required jobs passed
+        # docs-only PR では filter job が build / test を skip させるため、
+        # `skipped` も success と同等に扱う必要がある (skipped を fail 扱い
+        # すると aggregator が永久に赤くなり required check が通らない)。
+        # 一方 `cancelled` / `failure` 等の異常終了は明示的に fail させる。
         run: |
           lint='${{ needs.lint.result }}'
           build='${{ needs.build.result }}'
           test='${{ needs.test.result }}'
           echo "lint=$lint build=$build test=$test"
-          if [ "$lint" != "success" ] || [ "$build" != "success" ] || [ "$test" != "success" ]; then
-            echo "::error::One or more required jobs failed"
-            exit 1
-          fi
-          echo "All required jobs passed"
+          for j in "$lint" "$build" "$test"; do
+            case "$j" in
+              success|skipped) ;;
+              *) echo "::error::job failed: $j"; exit 1 ;;
+            esac
+          done
+          echo "All required jobs passed (skipped treated as success)"


### PR DESCRIPTION
Closes #984

## Summary

docs-only PR で expensive な `build` / `test` job を skip しつつ、branch protection の required status check (`ci` aggregator) は常に緑で報告されるようにした。

### Changes (`.github/workflows/ci.yml`)

- 新 job `filter` を追加 (`dorny/paths-filter@v3.0.2` SHA-pin)。
  code-affecting paths (`src/**`, `pnpm-lock.yaml`, `package.json`, `tsconfig*.json`, `.github/workflows/**`, `.github/actions/**`, `Dockerfile*`, `scripts/**`) の変更有無を `outputs.code` で公開する。
- `build` / `test` job に `needs: [filter]` + `if: needs.filter.outputs.code == 'true'` を追加し、docs-only PR では skip されるようにした。
- `lint` (workflow lint = actionlint) は filter に依存させない。docs 変更でも workflow 自体の文法 / 安全性チェックは常に必要なため。
- `ci` aggregator job の verify script を `for` + `case` に書き直し、`success` と `skipped` の双方を許容する形にした。`cancelled` / `failure` 等の異常終了は引き続き明示的に fail させる。
- 既存コメント (`ci.yml:8-15`) を新方針 (job-level filter + aggregator は always) に整合する内容へ更新。

### Why

workflow-level の `paths-ignore` は使えない (aggregator が required check 登録されているため、workflow ごと skip すると status が報告されず docs-only PR が永久に merge 不能になる)。job-level の skip + aggregator で skipped を success と同等扱いすることで、required check を緑に保ったまま CI 時間を短縮する。

## Test plan

- [ ] PR を開いた時点で `filter` / `lint` job が必ず走り、`build` / `test` は本 PR が `.github/workflows/**` を変更しているため `code=true` で実行される (この PR 自体で job が skip される条件にはならない確認)。
- [ ] `ci` aggregator job が `success` で完了する。
- [ ] follow-up: docs-only PR (例: `docs/handbook/*.md` のみ変更) を別途用意した際、`build` / `test` が `skipped` になり、`ci` aggregator は `success` のままになることを確認する。

https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG)_