### PR TITLE
chore(ci): gate PRs on ESLint and Prettier check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,28 @@ jobs:
         # Image: rhysd/actionlint:1.7.7 (Docker Hub, multi-arch index digest)
         # shellcheck / pyflakes are bundled in the image.
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies (lockfile integrity check)
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      # ESLint (no --fix) と Prettier --check で source の lint / format 違反を検出する。
+      # 現状 src/ には既存違反 (ESLint 841 errors / Prettier 265 files) が残存している
+      # ため、暫定的に failure を `::warning::` に降格し job は green を維持する。
+      # 既存違反の解消後 (separate PR) に `|| echo` を外して required check 化する。
+      - name: Lint (ESLint + Prettier check, non-blocking)
+        run: |
+          if ! pnpm lint:check; then
+            echo "::warning::existing lint failures (ESLint / Prettier) — see step log; failures are non-blocking until backlog is fixed (issue #978)"
+          fi
+
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dev:https:prd": "tsx scripts/confirmPrd.ts 'dev:https:prd' && dotenvx run -f .env.prd --env='NODE_HTTPS=true' --env='LOCAL_DEV=true' -- tsx watch src/bootstrap/index.ts",
     "dev:external": "dotenvx run -f .env --env='NODE_HTTPS=false' --env='LOCAL_DEV=true' -- tsx watch src/bootstrap/external-api.ts",
     "lint": "eslint --fix src/ && prettier --write src/",
+    "lint:check": "eslint src/ && prettier --check src/",
     "test": "jest --runInBand",
     "test:coverage": "jest --coverage --runInBand",
     "db:pull": "prisma db pull --schema src/infrastructure/prisma/schema.prisma",


### PR DESCRIPTION
## Summary
- Add `lint:check` script (`eslint src/ && prettier --check src/`) to `package.json`. The existing `lint` script applies `--fix`/`--write` and mutates the worktree, so it cannot be used as a CI gate; `lint:check` is the read-only variant.
- Wire the new script into the CI `lint` job. The job now installs deps via `pnpm/action-setup` + `actions/setup-node` (cache: pnpm) + `pnpm install --frozen-lockfile --prefer-offline`, mirroring the SHA-pinned action versions used by the existing `build` job.

## Existing violations (non-blocking rollout)
Local run of `pnpm lint:check` against `origin/develop` HEAD reports:

- **ESLint**: 841 errors, 0 warnings (mostly `@typescript-eslint/no-explicit-any`)
- **Prettier**: 265 files need re-formatting

To avoid making the `lint` job (a required check via the `ci` aggregator) immediately red, the step demotes failures to a `::warning::` annotation:

```sh
if ! pnpm lint:check; then
  echo "::warning::existing lint failures (ESLint / Prettier) - see step log; failures are non-blocking until backlog is fixed (issue #978)"
fi
```

Once the backlog is cleared in a follow-up PR, dropping the `if !` / `|| echo` wrapper makes the step blocking. `--max-warnings=0` is intentionally not added until baseline is clean.

## Test plan
- [x] `pnpm install --frozen-lockfile` succeeds locally
- [x] `pnpm lint:check` runs end-to-end (currently fails with the counts above - expected)
- [x] `actionlint` (1.7.12, local binary) reports no issues for the modified workflow
- [ ] CI `lint` job completes green with a `::warning::` annotation

Closes #978

https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG)_