### PR TITLE
chore(ci): publish schema after deploy and drop tzdata install

### DIFF
--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -32,6 +32,11 @@ on:
         type: boolean
         required: false
         default: false
+      git-tag-prefix:
+        description: Prefix prepended to the timestamp git tag (e.g. "internal-api-").
+        type: string
+        required: false
+        default: ''
 
 jobs:
   deploy:
@@ -64,14 +69,16 @@ jobs:
     steps:
       # `audit` mode: log egress (GCP / npm registry / GitHub) without blocking.
       # `block` mode would require maintaining an allowlist for every gcloud
-      # endpoint and is fragile across SDK updates. `disable-sudo` is left
-      # enabled (default) because the "Create Git tag" step installs tzdata
-      # via apt-get on prd. Audit logs surface in the job summary and let us
-      # detect unexpected egress (e.g. credential exfiltration) post-hoc.
+      # endpoint and is fragile across SDK updates. Audit logs surface in the
+      # job summary and let us detect unexpected egress (e.g. credential
+      # exfiltration) post-hoc. `disable-sudo: true` matches ci.yml — no step
+      # in this workflow needs sudo (the "Create Git tag" step uses
+      # `TZ=Asia/Tokyo date` instead of installing tzdata).
       - name: Harden runner
         uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
+          disable-sudo: true
 
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -115,14 +122,6 @@ jobs:
 
       - name: Generate GraphQL types
         run: pnpm gql:generate
-
-      - name: Install and Publish via Rover CLI
-        env:
-          APOLLO_KEY: ${{ env.APOLLO_KEY }}
-        run: |
-          curl -sSL https://rover.apollo.dev/nix/latest | sh
-          export PATH="$HOME/.rover/bin:$PATH"
-          rover graph publish "civicship-api-jq1988@${{ inputs.apollo-variant }}" --schema ./docs/schema.graphql
 
       - name: Build TypeScript output (consumed by Docker COPY)
         run: pnpm build
@@ -181,18 +180,26 @@ jobs:
             --command=node \
             --args=-r,tsconfig-paths/register,dist/bootstrap/batch.js
 
+      # Publish the schema to Apollo Studio only after the Cloud Run service
+      # (and batch job) has been updated successfully. Publishing earlier risks
+      # advertising a schema that the running service does not yet implement
+      # if the deploy fails for any reason.
+      - name: Install and Publish via Rover CLI
+        env:
+          APOLLO_KEY: ${{ env.APOLLO_KEY }}
+        run: |
+          curl -sSL https://rover.apollo.dev/nix/latest | sh
+          export PATH="$HOME/.rover/bin:$PATH"
+          rover graph publish "civicship-api-jq1988@${{ inputs.apollo-variant }}" --schema ./docs/schema.graphql
+
       - name: Create Git tag
         if: ${{ inputs.create-git-tag }}
+        env:
+          TZ: Asia/Tokyo
         run: |
-          sudo apt-get update && sudo apt-get install -y tzdata
-          sudo ln -fs /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
-          sudo dpkg-reconfigure -f noninteractive tzdata
-
-          TAG_NAME=$(date +"%Y%m%d%H%M%S")
-
+          TAG_NAME="${{ inputs.git-tag-prefix }}$(date +'%Y%m%d%H%M%S')"
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-
           git tag "$TAG_NAME"
           git push origin "$TAG_NAME"
 

--- a/.github/workflows/_deploy-external-api.yml
+++ b/.github/workflows/_deploy-external-api.yml
@@ -59,11 +59,14 @@ jobs:
       JUMPBOX_ZONE: ${{ secrets.JUMPBOX_ZONE }}
 
     steps:
-      # See _deploy-cloud-run.yml for rationale on audit mode + sudo.
+      # See _deploy-cloud-run.yml for rationale on audit mode. `disable-sudo:
+      # true` matches ci.yml — the "Create Git tag" step uses
+      # `TZ=Asia/Tokyo date` instead of installing tzdata via apt-get.
       - name: Harden runner
         uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
+          disable-sudo: true
 
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -140,16 +143,12 @@ jobs:
 
       - name: Create Git tag
         if: ${{ inputs.create-git-tag }}
+        env:
+          TZ: Asia/Tokyo
         run: |
-          sudo apt-get update && sudo apt-get install -y tzdata
-          sudo ln -fs /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
-          sudo dpkg-reconfigure -f noninteractive tzdata
-
-          TAG_NAME="${{ inputs.git-tag-prefix }}$(date +"%Y%m%d%H%M%S")"
-
+          TAG_NAME="${{ inputs.git-tag-prefix }}$(date +'%Y%m%d%H%M%S')"
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-
           git tag "$TAG_NAME"
           git push origin "$TAG_NAME"
 


### PR DESCRIPTION
Closes #986

## Summary
2 つの軽微な CI fix:

1. **Apollo schema publish 順序を deploy 後に移動** (`_deploy-cloud-run.yml`)
   - `Install and Publish via Rover CLI` step を `Deploy Internal API to Cloud Run` + `Update Cloud Run Job (batch)` の **後** に移動。
   - deploy が失敗した場合に「実装されていない schema を Apollo Studio に公開してしまう」リスクを回避。

2. **tzdata install を廃止** (`_deploy-cloud-run.yml`, `_deploy-external-api.yml`)
   - `Create Git tag` step で毎回 `sudo apt-get install tzdata` していたのを `env: TZ: Asia/Tokyo` + `date +'%Y%m%d%H%M%S'` に置換。
   - 同じ結果が得られ、apt 実行 (~10s) と sudo 権限が不要に。
   - sudo 不要になったので `harden-runner` の `disable-sudo: true` を両 workflow に追加 (ci.yml と整合)。
   - `_deploy-cloud-run.yml` には `git-tag-prefix` input が無かったので default `''` で追加 (`_deploy-external-api.yml` には既に存在)。

## Validation
- `actionlint` を両 workflow に実行 → エラーなし。
- 動作変更は CI workflow のみで、production code には触れていない。

## Follow-up
- #975 (smoke check) / #976 (canary) が merge されたら、Apollo schema publish step は smoke / canary の **後ろ** にさらに移動する必要あり (現状は deploy 直後)。本 PR は smoke 未追加前提なので deploy 直後で OK。

https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG)_