### PR TITLE
chore(docker): multi-stage non-root Dockerfile with HEALTHCHECK

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,48 +1,96 @@
-# Node.js dependencies
+# .dockerignore
 #
-# node_modules is intentionally NOT excluded from the build context.
+# IMPORTANT — current build flow context (do not "fix" without reading):
 #
-# The Dockerfile relies on the CI/CD runner having pre-built node_modules
-# (including Prisma TypedSQL generated types at @prisma/client/sql/*.d.ts)
-# AND the compiled output at `dist/` that are copied into the image via
-# `COPY . ./`. This is because `prisma generate --sql` requires database
-# connectivity (via jumpbox tunnel) which is not available during
-# `docker build`. The compiled `dist/` is shipped as-is from the runner so
-# the in-container `RUN pnpm build` is no longer needed.
+# CI (.github/workflows/_deploy-cloud-run.yml,
+# _deploy-external-api.yml) pre-builds the artifacts on the runner BEFORE
+# `docker buildx build` runs:
 #
-# This is intentional tech debt. A multi-stage build with CI artifact
-# injection is the proper fix - see the git log around this file and
-# the associated PR description for context. Do NOT re-enable the
-# `node_modules` / `dist` exclusion below without first resolving the build
-# flow (runner-dependent -> self-contained).
-# node_modules
-# dist  -- shipped from runner; see .dockerignore comment above
-npm-debug.log*
-yarn-debug.log*
-pnpm-debug.log*
+#   1. `pnpm install --frozen-lockfile`
+#   2. opens a jumpbox SSH tunnel to Cloud SQL
+#   3. `pnpm db:generate` (requires the live DB because
+#      `prisma generate --sql` introspects PostgreSQL — it cannot run inside
+#      `docker build` where the network is sandboxed)
+#   4. `pnpm gql:generate`
+#   5. `pnpm build`
+#
+# The Dockerfile then COPYs the pre-built `node_modules/` (with the
+# Prisma TypedSQL `.d.ts` artifacts) and `dist/` from the build context.
+# That is why `node_modules` and `dist` are intentionally NOT excluded
+# below — excluding them would break the deploy.
+#
+# The proper long-term fix is to make `prisma generate --sql` independent
+# of live DB connectivity (or persist the introspected schema) so the
+# build can be self-contained inside Docker. Tracked separately; see
+# issue #981 PR description for context.
+
+# VCS / CI metadata
+.git
+.gitignore
+.gitattributes
+.github
+.gemini
+.claude
+
+# Editor / IDE
+.vscode
+.idea
+*.swp
+*.swo
+
+# Local env files (NEVER ship secrets into images)
+.env
+.env.*
+!.env.sample
+
+# Test / coverage artifacts (not needed at runtime)
+__tests__
+**/__tests__
+*.test.ts
+*.spec.ts
+coverage
+.jest
+.nyc_output
 
 # Logs
 logs
 *.log
+npm-debug.log*
+yarn-debug.log*
+pnpm-debug.log*
 
-# Environment variables
-.env
-*.env
-
-# Git
-.git
-.gitignore
-
-# IDE settings
-.vscode
-
-# Test files and coverage
-test
-tests
-__tests__
-coverage
-.jest
-
-# Documentation
+# Documentation (not needed at runtime)
 README.md
+LICENSE
+PR_DESCRIPTION.md
 docs
+*.md
+
+# Docker / compose files (avoid recursive context inclusion)
+Dockerfile
+Dockerfile.*
+docker-compose.yaml
+docker-compose.yml
+.dockerignore
+
+# Local container scratch
+container
+
+# Build/format tooling configs not needed at runtime
+.eslintignore
+eslint.config.mjs
+babel.config.cjs
+jest.config.cjs
+jest.setup.ts
+.prettierrc
+.prisma-case-format
+.graphqlrc
+typedoc.json
+codegen.yaml
+
+# Debug & local-only scripts
+debugScripts
+
+# TypeScript incremental cache
+.tsbuildinfo
+**/.tsbuildinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,77 @@
-FROM node:20
+# syntax=docker/dockerfile:1.7
+#
+# Multi-stage build for the internal/main GraphQL API + batch job image.
+#
+# NOTE on build flow (see .dockerignore for full context):
+#   The CI runner (.github/workflows/_deploy-cloud-run.yml) pre-builds
+#   `node_modules/` (incl. Prisma TypedSQL artifacts that need a live DB
+#   tunnel) and `dist/` BEFORE invoking `docker buildx build`. The builder
+#   stage below therefore copies those pre-built artifacts from the build
+#   context and only prunes node_modules to production deps. This keeps
+#   the existing CI flow working while still giving us a small, non-root
+#   runtime stage with a HEALTHCHECK and (optional) image-digest pin.
+#
+# NOTE on digest pinning:
+#   The base image tag (`node:20-slim`) is intentionally not pinned to a
+#   sha256 digest in this initial change — `docker pull` is unavailable in
+#   the dev sandbox where this PR was authored. Digest pinning is tracked
+#   as a follow-up (apply `node:20-slim@sha256:<digest>` once a known-good
+#   digest is captured from CI / `docker buildx imagetools inspect`).
+
+# ---------------------------------------------------------------------------
+# Builder stage: take the pre-built workspace, prune dev dependencies.
+# ---------------------------------------------------------------------------
+FROM node:20-slim AS builder
+
 WORKDIR /app
-COPY . ./
+
+# corepack provides the `pnpm` shim so `pnpm prune` works without a global
+# install. Pin the version to match `packageManager` in package.json.
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+
+# Copy lockfile + manifests first (small, rarely-changing layer).
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+
+# Pre-built artifacts copied from the CI runner build context.
+# (See file header comment for why these are pre-built rather than built
+#  in-stage.)
+COPY node_modules ./node_modules
+COPY dist ./dist
+
+# Drop devDependencies from node_modules so the runtime stage only carries
+# what's needed at runtime. `--prod` keeps dependencies in the
+# `dependencies` field; devDependencies are removed.
+RUN pnpm prune --prod
+
+# ---------------------------------------------------------------------------
+# Runtime stage: minimal, non-root, HEALTHCHECK enabled.
+# ---------------------------------------------------------------------------
+FROM node:20-slim AS runtime
+
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    PORT=3000
+
+# `node:20-slim` ships a `node` user (uid/gid 1000) created for exactly
+# this purpose. Run the app as that user instead of root.
+USER node
+
+# Copy only what's needed at runtime, owned by the non-root user.
+COPY --from=builder --chown=node:node /app/node_modules ./node_modules
+COPY --from=builder --chown=node:node /app/dist ./dist
+COPY --from=builder --chown=node:node /app/package.json ./package.json
+COPY --chown=node:node tsconfig.json ./tsconfig.json
+
+EXPOSE 3000
+
+# HEALTHCHECK is ignored by Cloud Run (which uses its own startup/liveness
+# probes), but it's useful for local debugging via `docker run` /
+# docker-compose / any orchestrator that honours OCI HEALTHCHECK.
+# Node 20 ships a global `fetch`, so no extra runtime dep is required.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+    CMD node -e "fetch('http://127.0.0.1:' + (process.env.PORT || 3000) + '/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
+
+# `-r tsconfig-paths/register` is required because the compiled output keeps
+# `@/` path aliases (resolved via tsconfig paths at runtime).
 CMD ["node", "-r", "tsconfig-paths/register", "dist/bootstrap/index.js"]

--- a/Dockerfile.external
+++ b/Dockerfile.external
@@ -1,4 +1,49 @@
-FROM node:20
+# syntax=docker/dockerfile:1.7
+#
+# Multi-stage build for the External API service.
+#
+# Mirrors `Dockerfile` (internal/main API). See that file's header comment
+# for context on why the builder stage copies pre-built `node_modules` /
+# `dist` from the CI build context instead of running `pnpm install` +
+# `pnpm build` itself.
+
+# ---------------------------------------------------------------------------
+# Builder stage: take the pre-built workspace, prune dev dependencies.
+# ---------------------------------------------------------------------------
+FROM node:20-slim AS builder
+
 WORKDIR /app
-COPY . ./
+
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+
+COPY node_modules ./node_modules
+COPY dist ./dist
+
+RUN pnpm prune --prod
+
+# ---------------------------------------------------------------------------
+# Runtime stage: minimal, non-root, HEALTHCHECK enabled.
+# ---------------------------------------------------------------------------
+FROM node:20-slim AS runtime
+
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    PORT=3000
+
+USER node
+
+COPY --from=builder --chown=node:node /app/node_modules ./node_modules
+COPY --from=builder --chown=node:node /app/dist ./dist
+COPY --from=builder --chown=node:node /app/package.json ./package.json
+COPY --chown=node:node tsconfig.json ./tsconfig.json
+
+EXPOSE 3000
+
+# Same /health endpoint exists in src/external-api.ts.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+    CMD node -e "fetch('http://127.0.0.1:' + (process.env.PORT || 3000) + '/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
+
 CMD ["node", "-r", "tsconfig-paths/register", "dist/bootstrap/external-api.js"]


### PR DESCRIPTION
Closes #981

## Summary

Rewrite `Dockerfile` and `Dockerfile.external` as multi-stage, non-root images with an OCI `HEALTHCHECK`, and tighten `.dockerignore`.

### Changes

**`Dockerfile` / `Dockerfile.external`** — both files now follow the same multi-stage pattern:

- `# syntax=docker/dockerfile:1.7` for modern BuildKit features (cache mounts, `--chown`).
- **Builder stage** (`node:20-slim AS builder`):
  - `corepack enable && corepack prepare pnpm@10.33.0 --activate` (matches `packageManager` in `package.json`).
  - Copies pre-built `node_modules` and `dist` from the build context (see "Notes" below).
  - `pnpm prune --prod` drops devDependencies from `node_modules`.
- **Runtime stage** (`node:20-slim AS runtime`):
  - `ENV NODE_ENV=production PORT=3000`
  - `USER node` — non-root execution (`node:20-slim` ships a `node` user at uid 1000).
  - `COPY --from=builder --chown=node:node` for `node_modules`, `dist`, `package.json`; `tsconfig.json` from the context.
  - `EXPOSE 3000`.
  - `HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3` calling `GET /health` via Node 20's global `fetch` (no extra dep).
  - `CMD ["node", "-r", "tsconfig-paths/register", "dist/bootstrap/index.js"]` for the main image; `dist/bootstrap/external-api.js` for the external API.

**`.dockerignore`** — restructured into commented sections:
- Excludes: `.git`, `.github`, `.gemini`, `.claude`, `.vscode`, `.idea`, `.env*` (with `!.env.sample`), `__tests__`, `*.test.ts`, `*.spec.ts`, `coverage`, `.jest`, `.nyc_output`, logs, `README.md`, `LICENSE`, `PR_DESCRIPTION.md`, `docs/`, `*.md`, `Dockerfile*`, `docker-compose*.yml`, `container/`, lint/format/test configs, `debugScripts/`, `.tsbuildinfo`.
- Intentionally **does not** exclude `node_modules` and `dist` (rationale documented in the file header — see "Notes" below).

## Notes / caveats

### Why `node_modules` and `dist` are NOT excluded by `.dockerignore` (and why the builder stage doesn't run `pnpm install` + `pnpm build`)

CI (`.github/workflows/_deploy-cloud-run.yml` and `_deploy-external-api.yml`) pre-builds the workspace on the runner BEFORE invoking `docker buildx build`:

1. `pnpm install --frozen-lockfile`
2. opens an SSH tunnel to Cloud SQL via the jumpbox
3. `pnpm db:generate` — required because `prisma generate --sql` introspects the live PostgreSQL DB to emit TypedSQL `.d.ts` artifacts; this cannot run inside `docker build` where the network is sandboxed.
4. `pnpm gql:generate`
5. `pnpm build`

The Dockerfile builder stage therefore copies the pre-built `node_modules/` (incl. Prisma TypedSQL types) and `dist/` from the build context, then prunes dev deps. Switching the in-Docker `pnpm install` + `pnpm build` flow that issue #981 sketches as the example would break the deploy until `prisma generate --sql` is decoupled from live DB connectivity (separate tracking item).

### Digest pinning deferred

The issue suggests pinning the base image to `node:20-slim@sha256:<digest>`. This change leaves the tag unpinned for now — the dev sandbox where this PR was authored has no network access to `docker pull` / `docker buildx imagetools inspect` to capture a known-good digest. **Follow-up:** capture the digest from a successful CI build and apply `node:20-slim@sha256:<digest>` to both Dockerfiles.

### `HEALTHCHECK` and Cloud Run

Cloud Run ignores OCI `HEALTHCHECK` (it runs its own startup/liveness probes against the container port). The `HEALTHCHECK` here is for `docker run` / `docker-compose` / any local debugging / non-Cloud-Run orchestrator that honours it.

### Image size before/after

`docker build` could not be executed in the dev sandbox (Docker daemon not reachable: `unix:///var/run/docker.sock` not present), so concrete before/after MB numbers are not included in this PR. The CI build will produce the new image; expected reductions come from:
- `pnpm prune --prod` removing devDependencies from `node_modules` (the previous `FROM node:20` + `COPY . ./` shipped the entire dev tree).
- `node:20-slim` instead of `node:20` (~200 MB → ~60 MB base).
- Tighter `.dockerignore` removing tests, docs, configs, VCS metadata.

Recommended local validation once a Docker daemon is available:

```bash
docker build -t civicship-api:after .
docker images civicship-api:after --format '{{.Size}}'
docker run --rm civicship-api:after node -e "console.log('ok')"
```

## Test plan

- [ ] CI `_deploy-cloud-run.yml` builds and pushes the new image successfully.
- [ ] CI `_deploy-external-api.yml` builds and pushes the new external image successfully.
- [ ] Cloud Run revision starts and the `/health` endpoint returns 200 (Cloud Run's own probes will validate this; the in-image `HEALTHCHECK` is for local use).
- [ ] Compare `docker images` size before/after locally and append numbers to this PR.
- [ ] Capture a `node:20-slim` digest from a successful CI run and open a follow-up to pin it.

https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG)_