### PR TITLE
chore(ci): extract setup steps into composite action

### DIFF
--- a/.github/actions/setup-civicship/action.yml
+++ b/.github/actions/setup-civicship/action.yml
@@ -1,0 +1,50 @@
+name: 'Setup civicship-api dev environment'
+description: >
+  Sets up pnpm + Node.js, installs dependencies, optionally applies Prisma
+  migrations to the target database, then generates the Prisma client (with
+  TypedSQL) and the GraphQL TypeScript types. Used by both CI jobs (build /
+  test matrix) and reusable deploy workflows so the repeated bootstrap steps
+  stay in one place.
+
+inputs:
+  database-url:
+    description: DATABASE_URL used by `prisma migrate deploy` and `prisma generate --sql`.
+    required: true
+  run-migrate:
+    description: '"true" to run `pnpm db:deploy` (Prisma migrate deploy) before generating clients. Set "false" for environments where migrations are applied out-of-band (e.g. external API deploy).'
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Setup pnpm
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+    - name: Setup Node.js
+      uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+      with:
+        node-version: '20'
+        cache: 'pnpm'
+
+    - name: Install dependencies (lockfile integrity check)
+      shell: bash
+      run: pnpm install --frozen-lockfile --prefer-offline
+
+    - name: Apply Prisma migrations
+      # TypedSQL (`--sql`) は DB 接続を必要とするため、db:generate の前に
+      # migration を当ててスキーマを用意する。view / materialized view も
+      # migration.sql 経由でのみ作成される。
+      if: inputs.run-migrate == 'true'
+      shell: bash
+      env:
+        DATABASE_URL: ${{ inputs.database-url }}
+      run: pnpm db:deploy
+
+    - name: Generate Prisma client (with TypedSQL) and GraphQL types
+      shell: bash
+      env:
+        DATABASE_URL: ${{ inputs.database-url }}
+      run: |
+        pnpm db:generate
+        pnpm gql:generate

--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -78,18 +78,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha || '' }}
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-
-      - name: Set up Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
-        with:
-          node-version: '20'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --prefer-offline
-
       - name: Authenticate to Google Cloud (Workload Identity Federation)
         uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70 # v2.1.6
         with:
@@ -106,15 +94,13 @@ jobs:
           jumpbox-zone: ${{ env.JUMPBOX_ZONE }}
           db-name: ${{ env.DB_NAME }}
 
-      - name: Run prisma generate and migrate deploy
-        env:
-          DATABASE_URL: postgresql://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
-        run: |
-          pnpm db:generate
-          pnpm db:deploy
-
-      - name: Generate GraphQL types
-        run: pnpm gql:generate
+      # composite action の `pnpm db:deploy` で本番 / dev DB に対して
+      # prisma migrate deploy を実行する。jumpbox 経由 DATABASE_URL を渡す。
+      - name: Setup civicship environment (pnpm + node + deps + prisma + gql)
+        uses: ./.github/actions/setup-civicship
+        with:
+          database-url: postgresql://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
+          run-migrate: 'true'
 
       - name: Install and Publish via Rover CLI
         env:

--- a/.github/workflows/_deploy-external-api.yml
+++ b/.github/workflows/_deploy-external-api.yml
@@ -70,18 +70,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha || '' }}
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-
-      - name: Set up Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
-        with:
-          node-version: '20'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --prefer-offline
-
       - name: Authenticate to Google Cloud (Workload Identity Federation)
         uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70 # v2.1.6
         with:
@@ -98,10 +86,14 @@ jobs:
           jumpbox-zone: ${{ env.JUMPBOX_ZONE }}
           db-name: ${{ env.DB_NAME }}
 
-      - name: Run prisma generate
-        env:
-          DATABASE_URL: postgresql://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
-        run: pnpm db:generate
+      # External API は Internal API 側 deploy で migrate 済みの DB を共有するため、
+      # ここでは `prisma migrate deploy` は実行しない (`run-migrate: 'false'`)。
+      # composite action 内で db:generate (TypedSQL) と gql:generate のみ実行する。
+      - name: Setup civicship environment (pnpm + node + deps + prisma + gql)
+        uses: ./.github/actions/setup-civicship
+        with:
+          database-url: postgresql://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
+          run-migrate: 'false'
 
       - name: Build TypeScript output (consumed by Docker COPY)
         run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,17 +85,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+      - name: Setup civicship environment (pnpm + node + deps + prisma + gql)
+        uses: ./.github/actions/setup-civicship
         with:
-          node-version: '20'
-          cache: 'pnpm'
-
-      - name: Install dependencies (lockfile integrity check)
-        run: pnpm install --frozen-lockfile --prefer-offline
+          database-url: ${{ env.DATABASE_URL }}
 
       # Surface high/critical findings as a `::warning::` annotation visible
       # in the PR check summary, but do not fail the job (audit results can
@@ -107,18 +100,6 @@ jobs:
           if ! pnpm audit --audit-level=high; then
             echo "::warning::pnpm audit found high-severity vulnerabilities (non-blocking — see step log for details)"
           fi
-
-      - name: Apply Prisma migrations to CI database
-        # TypedSQL (`--sql`) は DB 接続を必要とするため、db:generate の前に
-        # migration を当ててスキーマを用意する。view / materialized view も
-        # migration.sql 経由でのみ作成される。
-        run: pnpm db:deploy
-
-      - name: Generate Prisma client (with TypedSQL)
-        run: pnpm db:generate
-
-      - name: Generate GraphQL types
-        run: pnpm gql:generate
 
       # Detect uncommitted regenerations of tracked generated files.
       - name: Check generated files are up to date
@@ -209,31 +190,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+      # `prisma db push` は schema.prisma のモデルのみ反映し、migration.sql を
+      # 実行しない。view (10 個) / materialized view (4 個) は migration.sql のみで
+      # 定義されているため、db push だと view/mv が作られず、それらに依存する test
+      # が構造的に fail する。composite action 内の `pnpm db:deploy`
+      # (= prisma migrate deploy) で migration を順次適用し、view/mv 含めた全スキーマを
+      # CI DB に反映する。
+      - name: Setup civicship environment (pnpm + node + deps + prisma + gql)
+        uses: ./.github/actions/setup-civicship
         with:
-          node-version: '20'
-          cache: 'pnpm'
-
-      - name: Install dependencies (lockfile integrity check)
-        run: pnpm install --frozen-lockfile --prefer-offline
-
-      - name: Apply Prisma migrations to CI database
-        # `prisma db push` は schema.prisma のモデルのみ反映し、migration.sql を
-        # 実行しない。view (10 個) / materialized view (4 個) は migration.sql のみで
-        # 定義されているため、db push だと view/mv が作られず、それらに依存する test
-        # が構造的に fail する。`pnpm db:deploy` (= prisma migrate deploy) で migration
-        # を順次適用し、view/mv 含めた全スキーマを CI DB に反映する。
-        run: pnpm db:deploy
-
-      - name: Generate Prisma client (with TypedSQL)
-        run: pnpm db:generate
-
-      - name: Generate GraphQL types
-        run: pnpm gql:generate
+          database-url: ${{ env.DATABASE_URL }}
 
       # ts-jest の transform 結果 cache を matrix 単位で永続化。
       # restore-keys で同一 matrix の最近の cache に fallback し、


### PR DESCRIPTION
Closes #985

## Summary
- Add new composite action `.github/actions/setup-civicship` that bundles the repeated bootstrap steps: `pnpm install` + (optional) `db:deploy` + `db:generate` (TypedSQL) + `gql:generate`. Inputs are `database-url` (required) and `run-migrate` (default `'true'`).
- Replace the duplicated 4-step bootstrap block in `ci.yml` (build / test×4) and the deploy reusable workflows (`_deploy-cloud-run.yml`, `_deploy-external-api.yml`) with a single `uses: ./.github/actions/setup-civicship` step.
- `_deploy-cloud-run.yml` keeps `run-migrate: 'true'` (Internal API deploy is the source of truth for migrations); `_deploy-external-api.yml` sets `run-migrate: 'false'` because External API deploys share the already-migrated DB.
- Action SHAs (`pnpm/action-setup`, `actions/setup-node`) are pinned to match the existing repo convention; node 20 + `cache: 'pnpm'` ordering preserved so install benefits from the cache.

## Test plan
- [ ] CI on this PR: `lint`, `build`, `test (unit / integration / e2e / auth)` all green via composite action.
- [ ] After merge, dev `_deploy-cloud-run.yml` run completes (`pnpm db:deploy` against jumpbox-tunneled DB still applies migrations + view/MV).
- [ ] After merge, dev `_deploy-external-api.yml` run completes without re-running migrate (only `db:generate` / `gql:generate`).
- [ ] `actionlint` clean (verified locally with v1.7.7).

## Notes
- Likely to conflict with other in-flight CI PRs at `.github/workflows/ci.yml`; expect to rebase before merge.

https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG)_