### PR TITLE
chore(ci): scan Cloud Run images with Trivy on deploy

### DIFF
--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -45,6 +45,9 @@ jobs:
       # 式で動的に切り替えできないため、両 stage で write を付与する
       # (dev でも実質 read しか使わないので影響なし)。
       contents: write
+      # security-events:write は Trivy scan 結果 (sarif) を Security タブに
+      # upload するために必要 (codeql-action/upload-sarif)。
+      security-events: write
 
     env:
       STAGE: ${{ inputs.stage }}
@@ -60,6 +63,12 @@ jobs:
       JUMPBOX_INSTANCE_NAME: ${{ secrets.JUMPBOX_INSTANCE_NAME }}
       JUMPBOX_ZONE: ${{ secrets.JUMPBOX_ZONE }}
       APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
+      # MAIN_IMAGE を job-level env に出すことで、build/push と Trivy scan の
+      # 両 step から同じ参照 (`${{ env.MAIN_IMAGE }}`) で扱えるようにする。
+      # #974 で sha tag が入った後は MAIN_IMAGE_SHA を別途設定し、Trivy 側は
+      # `MAIN_IMAGE_SHA || MAIN_IMAGE` の fallback で動く想定。
+      MAIN_IMAGE: ${{ secrets.ARTIFACT_REGISTRY }}/${{ secrets.APPLICATION_NAME }}:latest
+      BATCH_IMAGE: ${{ secrets.BATCH_ARTIFACT_REGISTRY }}/${{ secrets.BATCH_NAME }}:latest
 
     steps:
       # `audit` mode: log egress (GCP / npm registry / GitHub) without blocking.
@@ -140,9 +149,6 @@ jobs:
       # batch (Cloud Run Job) 側は entrypoint を `--command/--args` で
       # `node dist/index.js` に上書きする (旧 Dockerfile.batch CMD と等価)。
       - name: Build unified image and push to main + batch registries
-        env:
-          MAIN_IMAGE: ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest
-          BATCH_IMAGE: ${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest
         run: |
           docker buildx build \
             --file Dockerfile \
@@ -152,6 +158,47 @@ jobs:
             --cache-to "type=gha,mode=max,scope=cloud-run-${{ inputs.stage }}" \
             --push \
             .
+
+      # Trivy scan は docker push 直後 / Cloud Run deploy 前に走らせる。
+      # CRITICAL は exit-code 1 で deploy を block。HIGH は exit-code 0 で
+      # warning 扱いとし、両 severity の sarif を Security タブに upload する。
+      # `ignore-unfixed: true` で fix が出ていない CVE は雑音になるので除外。
+      # MAIN_IMAGE_SHA (#974) が定義された環境ではそちらを優先し、未定義の
+      # 場合は :latest tag (MAIN_IMAGE) を scan する。
+      - name: Scan image (Trivy CRITICAL — blocking)
+        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
+        with:
+          image-ref: ${{ env.MAIN_IMAGE_SHA || env.MAIN_IMAGE }}
+          severity: CRITICAL
+          exit-code: '1'
+          ignore-unfixed: true
+          format: sarif
+          output: trivy-critical.sarif
+
+      - name: Scan image (Trivy HIGH — warning)
+        if: always()
+        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
+        with:
+          image-ref: ${{ env.MAIN_IMAGE_SHA || env.MAIN_IMAGE }}
+          severity: HIGH
+          exit-code: '0'
+          ignore-unfixed: true
+          format: sarif
+          output: trivy-high.sarif
+
+      - name: Upload Trivy CRITICAL results to Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@4f3212b61783c3c68e8309a0f18a699764811cda # v3.27.1
+        with:
+          sarif_file: trivy-critical.sarif
+          category: trivy-critical
+
+      - name: Upload Trivy HIGH results to Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@4f3212b61783c3c68e8309a0f18a699764811cda # v3.27.1
+        with:
+          sarif_file: trivy-high.sarif
+          category: trivy-high
 
       - name: Deploy Internal API to Cloud Run
         id: deploy

--- a/.github/workflows/_deploy-external-api.yml
+++ b/.github/workflows/_deploy-external-api.yml
@@ -45,6 +45,9 @@ jobs:
       # 式で動的に切り替えできないため両 stage で write を付与する
       # (dev でも実質 read しか使わないので影響なし)。
       contents: write
+      # security-events:write は Trivy scan 結果 (sarif) を Security タブに
+      # upload するために必要 (codeql-action/upload-sarif)。
+      security-events: write
 
     env:
       STAGE: ${{ inputs.stage }}
@@ -57,6 +60,9 @@ jobs:
       EXTERNAL_API_NAME: ${{ secrets.EXTERNAL_API_NAME }}
       JUMPBOX_INSTANCE_NAME: ${{ secrets.JUMPBOX_INSTANCE_NAME }}
       JUMPBOX_ZONE: ${{ secrets.JUMPBOX_ZONE }}
+      # MAIN_IMAGE を job-level env に出すことで build/push と Trivy scan の
+      # 両 step から同じ参照で扱えるようにする (cloud-run 側と命名を合わせる)。
+      MAIN_IMAGE: ${{ secrets.ARTIFACT_REGISTRY }}/${{ secrets.EXTERNAL_API_NAME }}:latest
 
     steps:
       # See _deploy-cloud-run.yml for rationale on audit mode + sudo.
@@ -115,16 +121,53 @@ jobs:
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
 
       - name: Build and push External API image
-        env:
-          EXTERNAL_IMAGE: ${{ env.ARTIFACT_REGISTRY }}/${{ env.EXTERNAL_API_NAME }}:latest
         run: |
           docker buildx build \
             --file Dockerfile.external \
-            --tag "$EXTERNAL_IMAGE" \
+            --tag "$MAIN_IMAGE" \
             --cache-from "type=gha,scope=external-${{ inputs.stage }}" \
             --cache-to "type=gha,mode=max,scope=external-${{ inputs.stage }}" \
             --push \
             .
+
+      # Trivy scan は docker push 直後 / Cloud Run deploy 前に走らせる。
+      # CRITICAL は exit-code 1 で deploy を block。HIGH は exit-code 0 で
+      # warning 扱いとし、両 severity の sarif を Security タブに upload する。
+      # 詳細な rationale は _deploy-cloud-run.yml の同名 step を参照。
+      - name: Scan image (Trivy CRITICAL — blocking)
+        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
+        with:
+          image-ref: ${{ env.MAIN_IMAGE_SHA || env.MAIN_IMAGE }}
+          severity: CRITICAL
+          exit-code: '1'
+          ignore-unfixed: true
+          format: sarif
+          output: trivy-critical.sarif
+
+      - name: Scan image (Trivy HIGH — warning)
+        if: always()
+        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
+        with:
+          image-ref: ${{ env.MAIN_IMAGE_SHA || env.MAIN_IMAGE }}
+          severity: HIGH
+          exit-code: '0'
+          ignore-unfixed: true
+          format: sarif
+          output: trivy-high.sarif
+
+      - name: Upload Trivy CRITICAL results to Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@4f3212b61783c3c68e8309a0f18a699764811cda # v3.27.1
+        with:
+          sarif_file: trivy-critical.sarif
+          category: trivy-external-critical
+
+      - name: Upload Trivy HIGH results to Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@4f3212b61783c3c68e8309a0f18a699764811cda # v3.27.1
+        with:
+          sarif_file: trivy-high.sarif
+          category: trivy-external-high
 
       - name: Deploy External API to Cloud Run
         id: deploy

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,11 @@
+# .trivyignore — Trivy が CVE を無視するためのリスト。
+#
+# 運用ルール:
+#   1. 1 行 1 CVE。形式は `CVE-YYYY-NNNNN`。`#` から行末はコメント。
+#   2. 追加するときは必ず以下を併記したコメントを直前に置く:
+#        - 影響範囲 (どの image / どのライブラリ経由か)
+#        - 暫定 ignore する理由 (例: upstream fix 待ち / 不到達 path)
+#        - 期限 (`expires: YYYY-MM-DD` 目安) と再評価担当
+#   3. 期限切れの ignore を月次で棚卸しし、不要になったら削除する。
+#
+# 詳細は docs/handbook/SECURITY.md の "Container Image Scanning (Trivy)" を参照。

--- a/docs/handbook/SECURITY.md
+++ b/docs/handbook/SECURITY.md
@@ -395,6 +395,65 @@ app.post('/admin/users', adminController.createUser);
 - Auditing Administrator Actions
 - Recording Security Violations
 
+## Container Image Scanning (Trivy)
+
+Cloud Run にデプロイされる image は、`docker push` 直後 / `gcloud run deploy` 前に
+[Trivy](https://github.com/aquasecurity/trivy-action) で vulnerability scan を行う。
+対象 workflow は以下:
+
+- `.github/workflows/_deploy-cloud-run.yml` (internal API + batch)
+- `.github/workflows/_deploy-external-api.yml` (external API)
+
+### Severity Policy
+
+| Severity | exit-code | 振る舞い                                   |
+| -------- | --------- | ------------------------------------------ |
+| CRITICAL | `1`       | deploy を **block** (job が fail)          |
+| HIGH     | `0`       | warning。job は通り、結果は Security タブで確認 |
+| その他   | -         | scan 対象外 (MEDIUM 以下は雑音になりやすい)   |
+
+両 severity の結果は SARIF として GitHub の **Security → Code scanning alerts**
+タブに upload される (`github/codeql-action/upload-sarif`)。`category` を
+`trivy-critical` / `trivy-high` (external API は `trivy-external-*`) で
+分けることで、severity 別に alert を追える。
+
+`ignore-unfixed: true` を付けているため、upstream で fix が未公開の CVE は
+対象外となる。
+
+### `.trivyignore`
+
+リポジトリ root の [.trivyignore](../../.trivyignore) で、誤検知や対応保留の
+CVE を一時的に除外できる。**追加時は必ず以下を併記**:
+
+1. 1 行 1 CVE (`CVE-YYYY-NNNNN`)。`#` から行末はコメント。
+2. 直前のコメントで影響範囲・ignore 理由・再評価期限 (`expires: YYYY-MM-DD`)
+   を明示する。
+3. 月次で棚卸しし、期限切れまたは不要になったエントリは削除する。
+
+### Local 検証
+
+PR を出す前に手元で同じ scan を回したい場合:
+
+```bash
+# CRITICAL のみ blocking で確認
+trivy image --severity CRITICAL --exit-code 1 --ignore-unfixed \
+  asia-northeast1-docker.pkg.dev/<project>/<repo>/<image>:latest
+
+# HIGH の一覧を確認 (block しない)
+trivy image --severity HIGH --exit-code 0 --ignore-unfixed \
+  asia-northeast1-docker.pkg.dev/<project>/<repo>/<image>:latest
+```
+
+### Block 時の対処
+
+deploy が CRITICAL で fail したら、まず scan log で CVE と該当パッケージを
+特定し、以下の優先順で対応する:
+
+1. **Base image / dependency の bump** で fix 済み version に上げる (推奨)。
+2. **multi-stage build (`Dockerfile`) で当該パッケージを最終ステージから外す**。
+3. 上記が現実的でない場合のみ、`.trivyignore` に追記して暫定回避し、
+   別 issue で恒久対応をトラックする。
+
 ## Related Documentation
 
 - [Architecture Guide](./ARCHITECTURE.md) - System Design Overview


### PR DESCRIPTION
Closes #982

## Summary

Run [Trivy](https://github.com/aquasecurity/trivy-action) against the freshly pushed image right after `docker push` and **before** `gcloud run deploy` in both reusable deploy workflows:

- `.github/workflows/_deploy-cloud-run.yml` (internal API + batch)
- `.github/workflows/_deploy-external-api.yml` (external API)

### Severity policy

| Severity | exit-code | behaviour |
| --- | --- | --- |
| `CRITICAL` | `1` | **blocks** deploy (job fails) |
| `HIGH`     | `0` | warning only; result still uploaded |

Both severities upload SARIF to the GitHub **Security → Code scanning alerts** tab via `github/codeql-action/upload-sarif`, split into separate categories (`trivy-critical` / `trivy-high`, plus `trivy-external-*` for the external API job) so the alerts stay disambiguated.

`ignore-unfixed: true` keeps unactionable noise (no upstream fix yet) out of the report.

### Other changes

- Promote `MAIN_IMAGE` (and `BATCH_IMAGE` for the cloud-run workflow) to **job-level `env:`** so the build/push and Trivy scan steps share one canonical reference instead of redefining it per step.
- The Trivy `image-ref` uses `${{ env.MAIN_IMAGE_SHA || env.MAIN_IMAGE }}`, so the workflow **falls back to `:latest`** today and will automatically prefer the immutable sha tag once #974 lands.
- Add `security-events: write` to the deploy job permissions (required by `upload-sarif`).
- Drop a template `.trivyignore` at the repo root with the operational rules baked into the comments.
- Document the severity policy, `.trivyignore` workflow, local verification recipe, and CRITICAL-block playbook in `docs/handbook/SECURITY.md`.

## Dependencies / Assumptions

This PR is written assuming the following are merged first (or shortly after); it works without them, but is more useful with them:

- #974 — sha-tagged image push (gives Trivy an immutable digest via `MAIN_IMAGE_SHA`).
- #981 — multi-stage Dockerfile (smaller surface for Trivy to scan).

If `MAIN_IMAGE_SHA` is not yet defined in the env, the scan still runs against `:latest` (`MAIN_IMAGE`) and behaves identically.

## Test plan

- [ ] Confirm `actionlint` passes against both workflows (verified locally — clean).
- [ ] On first dev deploy after merge, verify the Trivy steps appear in the job log and complete.
- [ ] Verify SARIF results show up under **Security → Code scanning alerts** with categories `trivy-critical` / `trivy-high` (and `trivy-external-*` for external-api).
- [ ] Manually inject a known CRITICAL CVE (e.g. an outdated base image) on a throwaway branch and confirm the deploy job fails at the Trivy CRITICAL step before `gcloud run deploy` runs.
- [ ] Confirm a HIGH-only finding does not fail the job, and that the SARIF still uploads.
- [ ] After merge, audit `.trivyignore` is empty and that `docs/handbook/SECURITY.md` renders correctly on the docs site.

https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG)_