### PR TITLE
chore(ci): warn on destructive Prisma migrations in PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,13 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # Destructive-migration scan (`pnpm db:migrate-diff`) diffs new
+          # migration .sql files against the PR base branch. The default
+          # shallow checkout (fetch-depth=1) doesn't include the base ref, so
+          # `git merge-base origin/<base>` would fail and the scan would
+          # silently no-op. fetch-depth=0 ensures `origin/<base>` is reachable.
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
@@ -107,6 +114,18 @@ jobs:
           if ! pnpm audit --audit-level=high; then
             echo "::warning::pnpm audit found high-severity vulnerabilities (non-blocking — see step log for details)"
           fi
+
+      # Surface destructive Prisma migration DDL (DROP TABLE / DROP COLUMN /
+      # ALTER COLUMN ... TYPE / RENAME / non-CONCURRENTLY DROP INDEX / ...)
+      # added by this PR as `::warning::` annotations on the PR check summary.
+      # Non-blocking by design: reviewers decide whether the migration is
+      # safe (2-step migration, backfill, view-based replacement). See
+      # docs/handbook/DB_MIGRATION.md for the safe-migration playbook.
+      - name: Detect destructive Prisma migration DDL (non-blocking)
+        if: github.event_name == 'pull_request'
+        env:
+          MIGRATE_DIFF_BASE_REF: origin/${{ github.base_ref }}
+        run: pnpm db:migrate-diff
 
       - name: Apply Prisma migrations to CI database
         # TypedSQL (`--sql`) は DB 接続を必要とするため、db:generate の前に

--- a/docs/handbook/DB_MIGRATION.md
+++ b/docs/handbook/DB_MIGRATION.md
@@ -1,0 +1,153 @@
+# Database Migration Operations Guide
+
+This document describes the operational playbook for safely landing Prisma
+schema migrations in civicship-api, with particular focus on **destructive
+DDL** that can corrupt data, drop tables/columns still in use, or block
+readers/writers under load.
+
+## Why This Matters
+
+Cloud Run runs **multiple revisions concurrently** during a deploy: the new
+revision starts taking traffic before the old revision finishes draining. If
+a migration removes a column that the still-live old revision is reading,
+those requests will fail with a `column "x" does not exist` error mid-flight.
+Similarly, an `ALTER COLUMN ... TYPE` rewrites the entire table while
+holding `ACCESS EXCLUSIVE`, blocking every reader and writer until done.
+
+The CI workflow runs `pnpm db:migrate-diff` on every PR. It scans newly
+added or modified migration `.sql` files for destructive patterns and
+surfaces them as `::warning::` annotations in the PR check summary. The
+check is **non-blocking by design** — reviewers decide whether the
+migration is safe to land. Use this guide to make that decision.
+
+## Destructive DDL Patterns Detected by CI
+
+| Pattern | Why it's dangerous |
+| --- | --- |
+| `DROP TABLE` | Permanent data loss; breaks any code still referencing the table. |
+| `DROP COLUMN` | Permanent data loss; breaks live readers/writers on the old revision. |
+| `ALTER TABLE ... DROP ...` | Same as above (constraint / column / index drops). |
+| `ALTER COLUMN ... TYPE ...` | Full table rewrite under `ACCESS EXCLUSIVE`; can block production for minutes on large tables; cast may fail mid-rewrite. |
+| `RENAME TABLE / COLUMN / TO` | Old revision continues to read the old name during deploy → 100% error rate on that path until rollout completes. |
+| `DROP VIEW` / `DROP MATERIALIZED VIEW` | Breaks consumers; also affects materialized point views (`mv_current_points`, `mv_accumulated_points`). |
+| `DROP INDEX` (without `CONCURRENTLY`) | Holds `ACCESS EXCLUSIVE` on the table for the duration of the drop; blocks reads and writes. |
+| `TRUNCATE` | Permanent data loss. |
+
+If CI flags any of these, **do not merge the PR until you have either**:
+
+1. Restructured the change as a multi-step (expand → migrate → contract)
+   migration, or
+2. Reviewed and explicitly accepted the risk in the PR description, with an
+   approving review from a maintainer aware of the operational impact.
+
+## Safe-Migration Playbook
+
+### Pattern 1: Two-Step Migration (Expand / Contract)
+
+Use this for any column rename, type change, or column drop where the column
+is currently read or written by application code.
+
+**Step 1 — Expand (PR #1):**
+- Add the new column / table / shape alongside the old one. **Do not drop
+  the old one yet.**
+- Update application code to **dual-write** to both old and new.
+- Optionally: backfill historical rows from old → new (see Pattern 2).
+- Deploy. Both revisions are now stable: old revision reads/writes old, new
+  revision reads/writes both.
+
+**Step 2 — Migrate readers (PR #2):**
+- Switch all reads to the new column.
+- Stop writing to the old column.
+- Deploy. Verify in production that the old column is no longer read.
+
+**Step 3 — Contract (PR #3):**
+- Drop the old column / table.
+- Deploy. By construction no live code references the old shape, so the
+  destructive DDL is safe.
+
+**Why three PRs?** Each deploy must complete (old revision fully drained)
+before the next destructive change goes out. Combining steps risks
+overlapping the drop with the still-live old revision.
+
+### Pattern 2: Backfill via Migration Script
+
+When you need to populate a new column from existing data:
+
+- Add the new column as nullable in the migration.
+- Run the backfill in a **separate** migration (or as application code) in
+  bounded batches (e.g. `UPDATE ... WHERE id IN (SELECT id FROM ... LIMIT
+  1000)` in a loop).
+- Once backfill is verified complete, add a `NOT NULL` constraint in a
+  follow-up migration.
+
+Avoid `UPDATE table SET col = ...` without `LIMIT` or batching on large
+tables — it holds row locks for the entire table and can saturate WAL.
+
+### Pattern 3: View-Based Replacement
+
+When changing the shape of data exposed to read paths (e.g. splitting a
+table, renaming derived columns):
+
+- Create a database `VIEW` that exposes the **old** shape on top of the
+  **new** underlying tables.
+- Point the application at the view (transparent to readers).
+- Migrate the underlying schema freely.
+- Once readers are migrated to the new shape directly, drop the view.
+
+This is the same idea as Pattern 1 but at the storage layer instead of the
+column layer.
+
+### Pattern 4: `DROP INDEX CONCURRENTLY` for Index Removal
+
+Plain `DROP INDEX` takes `ACCESS EXCLUSIVE` on the table — every read and
+write blocks until the drop completes. On large tables this can be
+seconds-to-minutes of full unavailability.
+
+`DROP INDEX CONCURRENTLY` waits for in-flight transactions and only locks
+briefly:
+
+```sql
+DROP INDEX CONCURRENTLY IF EXISTS idx_old_thing;
+```
+
+Caveats:
+- Cannot run inside a transaction. Prisma migrations wrap each `.sql` file
+  in a transaction by default; you must split the `DROP INDEX
+  CONCURRENTLY` into its own migration **and** add the `-- prisma+deploy`
+  marker (or split the file) so it runs outside a transaction. See the
+  Prisma docs for the current escape hatch.
+
+The same applies to `CREATE INDEX CONCURRENTLY` for adding indexes on
+large tables.
+
+## Local Workflow Reminder
+
+The same script (`scripts/prisma/migrate-diff.sh`, exposed as
+`pnpm db:migrate-diff`) has two modes:
+
+- **Developer mode** — `pnpm db:migrate-diff <name>`: scaffolds a new
+  `migrations/<timestamp>_<name>/migration.sql` from the current
+  `schema.prisma`. Used locally when authoring a migration.
+- **CI scan mode** — `pnpm db:migrate-diff` (no args): scans `.sql`
+  migrations added vs `origin/develop` (or `MIGRATE_DIFF_BASE_REF`) for
+  destructive DDL and emits GitHub Actions `::warning::` annotations.
+  Always exits 0 — informational only.
+
+Running `pnpm db:migrate-diff` locally before pushing surfaces the same
+warnings you'll see on the PR.
+
+## Reviewer Checklist
+
+When reviewing a PR with `::warning::` destructive-migration annotations:
+
+- [ ] Is this a multi-step migration where the destructive step is the
+      *contract* phase, with the *expand* phase already deployed and the
+      old shape verified unused?
+- [ ] If `ALTER COLUMN ... TYPE`: how large is the table? Will the rewrite
+      fit within an acceptable maintenance window?
+- [ ] If `DROP INDEX`: can it be `DROP INDEX CONCURRENTLY` instead?
+- [ ] If `RENAME`: is there application code reading the old name in the
+      currently-deployed revision?
+- [ ] Is there a rollback plan that doesn't require restoring from backup?
+
+If any answer is "no" or "unknown", request changes and link this document.

--- a/docs/handbook/DEPLOYMENT.md
+++ b/docs/handbook/DEPLOYMENT.md
@@ -436,4 +436,5 @@ gcloud alpha monitoring policies create --policy-from-file=alerting-policy.yaml
 - [Security Guide](./SECURITY.md) - Security Architecture
 - [Performance Guide](./PERFORMANCE.md) - Optimization Strategies
 - [Environment Variable Guide](./ENVIRONMENT.md) - Environment Settings
+- [Database Migration Guide](./DB_MIGRATION.md) - Safe-migration playbook for destructive DDL
 - [Troubleshooting](./TROUBLESHOOTING.md) - Problem Resolution Guide

--- a/scripts/prisma/migrate-diff.sh
+++ b/scripts/prisma/migrate-diff.sh
@@ -1,41 +1,194 @@
 #!/bin/bash
 
-# 第一引数を取得
-NAME=$1
+# scripts/prisma/migrate-diff.sh
+#
+# Two modes:
+#
+# 1. Developer mode (positional NAME argument):
+#      pnpm db:migrate-diff <migration_name>
+#    Generates a new migration directory by diffing schema.prisma against
+#    itself (datasource → datamodel). Used locally to scaffold a migration.
+#
+# 2. CI scan mode (no arguments, or `--ci` / CI=true):
+#      pnpm db:migrate-diff
+#    Scans Prisma migration .sql files added vs the base branch (default
+#    `origin/develop`) for destructive DDL patterns (DROP TABLE, DROP COLUMN,
+#    ALTER COLUMN ... TYPE, RENAME, non-CONCURRENTLY DROP INDEX, ...).
+#    Detected hits are emitted as `::warning::` GitHub Actions annotations on
+#    stdout. Exit code is always 0 — this check informs reviewers, it does
+#    not block merge.
+#
+# The two modes are mutually exclusive. If the first argument is `--ci` or no
+# argument is supplied, CI mode runs; otherwise developer mode runs.
 
-# 引数チェック: 名前が空（未指定）の場合はエラーを表示して終了
-if [ -z "$NAME" ]; then
-  echo "❌ Error: マイグレーション名が指定されていません。"
-  echo "Usage: pnpm db:migrate-diff <migration_name>"
-  echo "Example: pnpm db:migrate-diff add_user_table"
-  exit 1
-fi
+set -uo pipefail
 
-TIMESTAMP=$(date +%Y%m%d%H%M%S)
-DIR_NAME="${TIMESTAMP}_${NAME}"
-SCHEMA_PATH="src/infrastructure/prisma/schema.prisma"
-MIGRATIONS_DIR="src/infrastructure/prisma/migrations/${DIR_NAME}"
+MODE="${1:-}"
 
-echo "🚀 Creating migration: ${DIR_NAME}..."
+run_developer_mode() {
+  local NAME="$1"
 
-# フォルダ作成
-mkdir -p "$MIGRATIONS_DIR"
+  if [ -z "$NAME" ]; then
+    echo "❌ Error: マイグレーション名が指定されていません。"
+    echo "Usage: pnpm db:migrate-diff <migration_name>"
+    echo "Example: pnpm db:migrate-diff add_user_table"
+    exit 1
+  fi
 
-# diffの実行と保存
-npx prisma migrate diff \
-  --from-schema-datasource "$SCHEMA_PATH" \
-  --to-schema-datamodel "$SCHEMA_PATH" \
-  --script > "$MIGRATIONS_DIR/migration.sql"
+  local TIMESTAMP DIR_NAME SCHEMA_PATH MIGRATIONS_DIR
+  TIMESTAMP=$(date +%Y%m%d%H%M%S)
+  DIR_NAME="${TIMESTAMP}_${NAME}"
+  SCHEMA_PATH="src/infrastructure/prisma/schema.prisma"
+  MIGRATIONS_DIR="src/infrastructure/prisma/migrations/${DIR_NAME}"
 
-# 実行結果の確認
-if [ $? -eq 0 ]; then
-  echo "✅ Success! Migration file created at: $MIGRATIONS_DIR/migration.sql"
-  echo "---------------------------------------------------"
-  echo "Next steps:"
-  echo "1. SQLの内容を確認してください。"
-  echo "2. npx prisma db push --schema $SCHEMA_PATH でDBに反映します。"
-  echo "3. npx prisma migrate resolve --applied ${DIR_NAME} --schema ${SCHEMA_PATH} で履歴を同期します。"
+  echo "🚀 Creating migration: ${DIR_NAME}..."
+
+  mkdir -p "$MIGRATIONS_DIR"
+
+  npx prisma migrate diff \
+    --from-schema-datasource "$SCHEMA_PATH" \
+    --to-schema-datamodel "$SCHEMA_PATH" \
+    --script > "$MIGRATIONS_DIR/migration.sql"
+
+  if [ $? -eq 0 ]; then
+    echo "✅ Success! Migration file created at: $MIGRATIONS_DIR/migration.sql"
+    echo "---------------------------------------------------"
+    echo "Next steps:"
+    echo "1. SQLの内容を確認してください。"
+    echo "2. npx prisma db push --schema $SCHEMA_PATH でDBに反映します。"
+    echo "3. npx prisma migrate resolve --applied ${DIR_NAME} --schema ${SCHEMA_PATH} で履歴を同期します。"
+  else
+    echo "❌ Error: SQLの生成に失敗しました。スキーマファイルの設定を確認してください。"
+    exit 1
+  fi
+}
+
+run_ci_mode() {
+  local BASE_REF="${MIGRATE_DIFF_BASE_REF:-origin/develop}"
+  local MIGRATIONS_PATH="src/infrastructure/prisma/migrations"
+
+  echo "🔍 Scanning Prisma migrations added vs ${BASE_REF} for destructive DDL..."
+
+  # Resolve the merge-base so we look only at commits introduced by this PR.
+  # If BASE_REF is unavailable (e.g. shallow clone without develop fetched),
+  # fall back to comparing the working tree against HEAD's parent.
+  local MERGE_BASE=""
+  if git rev-parse --verify --quiet "$BASE_REF" >/dev/null; then
+    MERGE_BASE=$(git merge-base "$BASE_REF" HEAD 2>/dev/null || true)
+  fi
+
+  if [ -z "$MERGE_BASE" ]; then
+    echo "::warning::base ref '${BASE_REF}' not found locally; skipping destructive-migration scan"
+    exit 0
+  fi
+
+  # Collect added migration .sql files (status=A) plus modified ones (M),
+  # since edits to historical migrations are themselves suspicious.
+  local CHANGED_FILES
+  CHANGED_FILES=$(git diff --name-only --diff-filter=AM "$MERGE_BASE"...HEAD -- \
+    "${MIGRATIONS_PATH}/*/migration.sql" 2>/dev/null || true)
+
+  if [ -z "$CHANGED_FILES" ]; then
+    echo "✅ No new or modified Prisma migration .sql files in this PR."
+    exit 0
+  fi
+
+  echo "Found migration file(s) to inspect:"
+  while IFS= read -r f; do
+    [ -n "$f" ] && echo "  - $f"
+  done <<< "$CHANGED_FILES"
+
+  # Destructive DDL patterns. Each entry: <regex>:::<label>.
+  # Patterns are POSIX ERE (grep -E), case-insensitive. The `:::` separator
+  # is used (instead of `|`) because some regexes themselves contain `|`
+  # for alternation (e.g. RENAME (TABLE|COLUMN|TO)), which would otherwise
+  # be split mid-regex by the `${entry%%|*}` parameter expansion.
+  local PATTERNS=(
+    'DROP[[:space:]]+TABLE:::DROP TABLE (data loss)'
+    'DROP[[:space:]]+COLUMN:::DROP COLUMN (data loss)'
+    'ALTER[[:space:]]+COLUMN[[:space:]]+[^;]*[[:space:]]+TYPE[[:space:]]:::ALTER COLUMN ... TYPE (rewrite + potential cast failure)'
+    'ALTER[[:space:]]+TABLE[[:space:]]+[^;]*[[:space:]]+DROP[[:space:]]+:::ALTER TABLE ... DROP (data loss)'
+    'RENAME[[:space:]]+(TABLE|COLUMN|TO):::RENAME (breaks live readers)'
+    'DROP[[:space:]]+(MATERIALIZED[[:space:]]+)?VIEW:::DROP VIEW / MATERIALIZED VIEW'
+    'TRUNCATE[[:space:]]:::TRUNCATE (data loss)'
+  )
+
+  # DROP INDEX is destructive only when not CONCURRENTLY (production-safe form).
+  # Match "DROP INDEX" *not* immediately followed by CONCURRENTLY.
+  local DROP_INDEX_PATTERN='DROP[[:space:]]+INDEX(?![[:space:]]+CONCURRENTLY)'
+
+  local TOTAL_HITS=0
+
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    [ ! -f "$file" ] && continue
+
+    local file_hits=0
+
+    for entry in "${PATTERNS[@]}"; do
+      local regex="${entry%%:::*}"
+      local label="${entry#*:::}"
+
+      # grep -n: line numbers; -E: ERE; -i: case-insensitive.
+      # || true so that "no match" (exit 1) doesn't kill the script under set -e.
+      local matches
+      matches=$(grep -nEi "$regex" "$file" 2>/dev/null || true)
+      if [ -n "$matches" ]; then
+        while IFS= read -r match_line; do
+          [ -z "$match_line" ] && continue
+          local lineno
+          lineno=$(echo "$match_line" | cut -d: -f1)
+          local content
+          content=$(echo "$match_line" | cut -d: -f2-)
+          # Trim leading whitespace from content for the annotation.
+          content=$(echo "$content" | sed 's/^[[:space:]]*//')
+          echo "::warning file=${file},line=${lineno}::Destructive DDL detected (${label}): ${content}"
+          file_hits=$((file_hits + 1))
+        done <<< "$matches"
+      fi
+    done
+
+    # DROP INDEX without CONCURRENTLY (PCRE via grep -P; fall back to ERE
+    # heuristic if -P isn't available, e.g. on BusyBox grep).
+    local drop_index_matches=""
+    if echo "" | grep -P "" >/dev/null 2>&1; then
+      drop_index_matches=$(grep -nPi "$DROP_INDEX_PATTERN" "$file" 2>/dev/null || true)
+    else
+      drop_index_matches=$(grep -nEi 'DROP[[:space:]]+INDEX' "$file" 2>/dev/null \
+        | grep -viE 'DROP[[:space:]]+INDEX[[:space:]]+CONCURRENTLY' || true)
+    fi
+    if [ -n "$drop_index_matches" ]; then
+      while IFS= read -r match_line; do
+        [ -z "$match_line" ] && continue
+        local lineno
+        lineno=$(echo "$match_line" | cut -d: -f1)
+        local content
+        content=$(echo "$match_line" | cut -d: -f2-)
+        content=$(echo "$content" | sed 's/^[[:space:]]*//')
+        echo "::warning file=${file},line=${lineno}::Destructive DDL detected (DROP INDEX without CONCURRENTLY locks readers): ${content}"
+        file_hits=$((file_hits + 1))
+      done <<< "$drop_index_matches"
+    fi
+
+    if [ "$file_hits" -gt 0 ]; then
+      echo "  ⚠️  ${file}: ${file_hits} destructive pattern(s)"
+      TOTAL_HITS=$((TOTAL_HITS + file_hits))
+    fi
+  done <<< "$CHANGED_FILES"
+
+  if [ "$TOTAL_HITS" -eq 0 ]; then
+    echo "✅ No destructive DDL patterns detected in changed migrations."
+  else
+    echo ""
+    echo "::warning::Detected ${TOTAL_HITS} destructive DDL pattern(s) across changed migrations. See docs/handbook/DB_MIGRATION.md for the safe-migration playbook (2-step migrations, backfill, view-based replacement)."
+  fi
+
+  # Always succeed — this check informs reviewers, it does not block merge.
+  exit 0
+}
+
+if [ "$MODE" = "--ci" ] || [ -z "$MODE" ]; then
+  run_ci_mode
 else
-  echo "❌ Error: SQLの生成に失敗しました。スキーマファイルの設定を確認してください。"
-  exit 1
+  run_developer_mode "$MODE"
 fi


### PR DESCRIPTION
## Summary
- Reworks `scripts/prisma/migrate-diff.sh` into a dual-mode tool. Developer mode (positional name arg) keeps the existing scaffolding behavior. CI scan mode (no args) diffs added/modified migration `.sql` files against the PR base branch (default `origin/develop`, configurable via `MIGRATE_DIFF_BASE_REF`) and emits `::warning::` GitHub Actions annotations for destructive DDL: `DROP TABLE`, `DROP COLUMN`, `ALTER COLUMN ... TYPE`, `RENAME`, `DROP INDEX` without `CONCURRENTLY`, `DROP VIEW` / `DROP MATERIALIZED VIEW`, `ALTER TABLE ... DROP`, `TRUNCATE`. Always exits 0 — the check informs reviewers, it does not block merge.
- Wires the scan into the `build` job in `.github/workflows/ci.yml` as a non-blocking step gated on `pull_request` events. Sets `fetch-depth: 0` on the build checkout so the `merge-base` against `origin/<base_ref>` resolves under shallow CI clones (otherwise the scan would silently no-op).
- Adds `docs/handbook/DB_MIGRATION.md` with the safe-migration playbook (2-step expand/contract, batched backfill, view-based replacement, `DROP INDEX CONCURRENTLY`) and a reviewer checklist. Cross-links it from `DEPLOYMENT.md`.

## Test plan
- [x] `bash -n scripts/prisma/migrate-diff.sh` (syntax check)
- [x] `actionlint` v1.7.7 against the full `.github/workflows/` tree (clean)
- [x] Local smoke test of CI mode against a synthetic git history with destructive DDL — all 8 patterns flagged (DROP TABLE, DROP COLUMN, ALTER TABLE ... DROP, ALTER COLUMN ... TYPE, RENAME COLUMN, DROP MATERIALIZED VIEW, TRUNCATE, non-CONCURRENTLY DROP INDEX) and `DROP INDEX CONCURRENTLY` correctly skipped; exit code 0
- [x] Local smoke test against a synthetic safe migration (CREATE TABLE / ADD COLUMN / CREATE INDEX CONCURRENTLY / DROP INDEX CONCURRENTLY) — no warnings; exit code 0
- [x] Local smoke test in this repo with no migration changes vs `origin/develop` — emits the "no new or modified migration .sql files" message; exit code 0
- [ ] Confirm CI build job emits the new step on this PR and (since this PR adds no migrations) reports the no-op message
- [ ] Confirm a follow-up PR that touches a migration `.sql` surfaces `::warning::` annotations on the PR check summary

Closes #977

https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG)_