### PR TITLE
[P0] CI/CD hardening: image SHA tag + smoke + canary + migration diff

### DIFF
--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -139,15 +139,22 @@ jobs:
       # main / batch の両 registry に同じ image を multi-tag push する。
       # batch (Cloud Run Job) 側は entrypoint を `--command/--args` で
       # `node dist/index.js` に上書きする (旧 Dockerfile.batch CMD と等価)。
+      # `:sha-${{ github.sha }}` を `:latest` と並列で push することで、
+      # Cloud Run の各 revision を commit SHA 単位で identifyable にし、
+      # 過去 image にロールバックできるようにする (DEPLOYMENT.md 参照)。
       - name: Build unified image and push to main + batch registries
         env:
           MAIN_IMAGE: ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest
+          MAIN_IMAGE_SHA: ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:sha-${{ github.sha }}
           BATCH_IMAGE: ${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest
+          BATCH_IMAGE_SHA: ${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:sha-${{ github.sha }}
         run: |
           docker buildx build \
             --file Dockerfile \
             --tag "$MAIN_IMAGE" \
+            --tag "$MAIN_IMAGE_SHA" \
             --tag "$BATCH_IMAGE" \
+            --tag "$BATCH_IMAGE_SHA" \
             --cache-from "type=gha,scope=cloud-run-${{ inputs.stage }}" \
             --cache-to "type=gha,mode=max,scope=cloud-run-${{ inputs.stage }}" \
             --push \
@@ -158,7 +165,7 @@ jobs:
         uses: google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522 # v2.7.6
         with:
           service: ${{ env.APPLICATION_NAME }}
-          image: ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest
+          image: ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:sha-${{ github.sha }}
           region: ${{ env.GCP_REGION }}
           env_vars: |
             NODE_ENV=${{ inputs.node-env }}
@@ -177,7 +184,7 @@ jobs:
         run: |
           gcloud run jobs update "${{ env.BATCH_NAME }}" \
             --region="${{ env.GCP_REGION }}" \
-            --image="${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:latest" \
+            --image="${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:sha-${{ github.sha }}" \
             --command=node \
             --args=-r,tsconfig-paths/register,dist/bootstrap/batch.js
 

--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -207,7 +207,14 @@ jobs:
         run: |
           URL=$(gcloud run services describe "$SERVICE" --region="$REGION" --format='value(status.url)')
           echo "Smoking $URL/health"
-          if ! curl --fail --silent --show-error --retry 6 --retry-delay 10 --max-time 10 "$URL/health"; then
+          # retry 9 × delay 10s ≒ 90s. cold start (Prisma + Apollo + DI container 構築)
+          # で初回 first-byte が 60s を超えるケースに対応するため retry を増やす。
+          # --retry-connrefused: instance がまだ listen 開始してない (connection refused)
+          # 状態でも retry 対象にする (デフォルトは HTTP error と timeout のみ)。
+          if ! curl --fail --silent --show-error \
+                --retry 9 --retry-delay 10 --retry-connrefused \
+                --max-time 10 \
+                "$URL/health"; then
             echo "::error::Smoke check failed for $SERVICE"
             gcloud logging read \
               "resource.type=cloud_run_revision AND resource.labels.service_name=$SERVICE AND severity>=ERROR" \
@@ -227,12 +234,14 @@ jobs:
         if: ${{ inputs.enable-canary }}
         run: |
           set -euo pipefail
-          # `serving` に出ている revision の中で最新のものを「現在 100% を受けて
-          # いる前 revision」として記録する。filter で latestReadyRevision = true
-          # は使えないため、status.conditions = Active を頼りに上から 1 件取る。
+          # rollback target は「現在 100% traffic を受けている revision」。
+          # `status.traffic[0]` は配列順に依存し、過去 deploy で残った canary tag
+          # 等が `[0]` を占める edge case があるため、`status.latestReadyRevisionName`
+          # (最後に Ready になった revision) を使う。これは Cloud Run の規約上
+          # 「現在 serving 中の revision」と一致する。
           PREV_REV=$(gcloud run services describe "${APPLICATION_NAME}" \
             --region="${GCP_REGION}" \
-            --format='value(status.traffic[0].revisionName)')
+            --format='value(status.latestReadyRevisionName)')
           if [ -z "${PREV_REV}" ]; then
             echo "Could not determine previous revision" >&2
             exit 1
@@ -273,18 +282,18 @@ jobs:
             exit 1
           fi
           echo "Canary URL: ${CANARY_URL}"
-          # /health は内部 API の health endpoint。404 を含む 5xx は failure 扱い。
-          # NOTE: health endpoint が無い場合は ルート `/` への HEAD で代替する。
-          for i in 1 2 3; do
-            if curl -fsS --max-time 10 "${CANARY_URL}/health" >/dev/null; then
-              echo "Smoke OK on attempt $i"
-              exit 0
-            fi
-            echo "Smoke attempt $i failed, retrying..."
-            sleep 5
-          done
-          echo "Canary smoke test failed" >&2
-          exit 1
+          # canary revision は `--no-traffic` で deploy されているため warming
+          # されておらず、cold start (Prisma + Apollo + DI container 構築) が確実に
+          # 走る。immediate smoke と同じく 60s 程度は許容しないと初回 hit で false
+          # negative する。retry 6 × 10s = 60s。
+          if ! curl --fail --silent --show-error \
+                --retry 6 --retry-delay 10 --retry-connrefused \
+                --max-time 10 \
+                "${CANARY_URL}/health"; then
+            echo "Canary smoke test failed" >&2
+            exit 1
+          fi
+          echo "Canary smoke OK"
 
       - name: Shift 10% traffic to canary revision
         id: traffic-10
@@ -342,7 +351,7 @@ jobs:
             --data-urlencode "aggregation.alignmentPeriod=${BAKE_SECONDS}s" \
             --data-urlencode "aggregation.perSeriesAligner=ALIGN_SUM" \
             --data-urlencode "aggregation.crossSeriesReducer=REDUCE_SUM" \
-            --data-urlencode "aggregation.groupByFields=metric.label.\"response_code_class\"" \
+            --data-urlencode "aggregation.groupByFields=metric.label.response_code_class" \
             "https://monitoring.googleapis.com/v3/projects/${PROJECT_ID}/timeSeries")
 
           echo "Monitoring response:"
@@ -351,11 +360,14 @@ jobs:
           # jq で response_code_class 別合計を出す。canary に traffic がまだ
           # ほぼ流れていない (total < 50) 場合は判定保留 = pass 扱いにする
           # (false-positive で rollback してしまうのを避ける)。
+          # **5xx 限定で評価する** (旧実装は `!= "2xx"` で 3xx redirect / 4xx client
+          # error も「エラー」扱いになっており、normal traffic でも 1% 閾値を
+          # 超えて誤 rollback する。サーバ側障害は 5xx に出るため、それだけを見る)。
           TOTAL=$(echo "${RESPONSE}" | jq '[.timeSeries[]?.points[0].value.int64Value | tonumber? // 0] | add // 0')
-          ERRORS=$(echo "${RESPONSE}" | jq '[.timeSeries[]? | select(.metric.labels.response_code_class != "2xx") | .points[0].value.int64Value | tonumber? // 0] | add // 0')
+          ERRORS=$(echo "${RESPONSE}" | jq '[.timeSeries[]? | select(.metric.labels.response_code_class == "5xx") | .points[0].value.int64Value | tonumber? // 0] | add // 0')
 
           echo "Total requests during bake: ${TOTAL}"
-          echo "Non-2xx requests during bake: ${ERRORS}"
+          echo "5xx requests during bake: ${ERRORS}"
 
           if [ "${TOTAL}" -lt 50 ]; then
             echo "Insufficient traffic (<50 requests) — skipping rate check"

--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -164,6 +164,26 @@ jobs:
             NODE_ENV=${{ inputs.node-env }}
             ${{ inputs.extra-env-vars }}
 
+      # Cloud Run の deploy アクションは revision の作成成功までしか保証しない。
+      # 実際にコンテナが起動失敗した (例: 起動時 import error / DB 接続失敗) ケースでも
+      # workflow は green になってしまうため、deploy 直後に health endpoint を叩いて
+      # 失敗時はジョブを fail させ、Cloud Run のエラーログを step summary に残す。
+      - name: Smoke check
+        env:
+          SERVICE: ${{ env.APPLICATION_NAME }}
+          REGION: ${{ env.GCP_REGION }}
+        run: |
+          URL=$(gcloud run services describe "$SERVICE" --region="$REGION" --format='value(status.url)')
+          echo "Smoking $URL/health"
+          if ! curl --fail --silent --show-error --retry 6 --retry-delay 10 --max-time 10 "$URL/health"; then
+            echo "::error::Smoke check failed for $SERVICE"
+            gcloud logging read \
+              "resource.type=cloud_run_revision AND resource.labels.service_name=$SERVICE AND severity>=ERROR" \
+              --limit=50 --format='value(timestamp,textPayload,jsonPayload.message)' \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
       - name: Update Cloud Run Job (batch) to new image
         # docker push :latest alone does not roll the Cloud Run Job to the new
         # image — Cloud Run Jobs pin the image digest at deploy time, so we

--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -32,6 +32,28 @@ on:
         type: boolean
         required: false
         default: false
+      enable-canary:
+        description: |
+          Whether to roll out via canary (10% → 100% with auto-rollback on
+          elevated 5xx). When false, the new revision serves 100% of traffic
+          immediately on deploy (existing behavior). prd uses canary; dev skips.
+        type: boolean
+        required: false
+        default: false
+      canary-error-threshold:
+        description: |
+          5xx error-rate threshold (fraction, e.g. 0.01 = 1%) above which the
+          canary is rolled back. Only applied when `enable-canary` is true.
+        type: string
+        required: false
+        default: '0.01'
+      canary-bake-seconds:
+        description: |
+          How long to bake the 10% canary before evaluating 5xx rate (seconds).
+          Only applied when `enable-canary` is true.
+        type: string
+        required: false
+        default: '300'
 
 jobs:
   deploy:
@@ -153,8 +175,11 @@ jobs:
             --push \
             .
 
-      - name: Deploy Internal API to Cloud Run
+      # --- Non-canary deploy (dev / 既存挙動) ---------------------------------
+      # `enable-canary: false` の場合は従来通り即 100% で切り替える。
+      - name: Deploy Internal API to Cloud Run (immediate 100%)
         id: deploy
+        if: ${{ !inputs.enable-canary }}
         uses: google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522 # v2.7.6
         with:
           service: ${{ env.APPLICATION_NAME }}
@@ -163,6 +188,185 @@ jobs:
           env_vars: |
             NODE_ENV=${{ inputs.node-env }}
             ${{ inputs.extra-env-vars }}
+
+      # --- Canary deploy (prd) -----------------------------------------------
+      # `enable-canary: true` の場合は新 revision を `--no-traffic --tag canary`
+      # で deploy → 10% → bake → 5xx チェック → 100% / rollback の順で切り替え
+      # る。失敗時は最後の `Rollback to previous revision` step が前 revision に
+      # 全 traffic を戻す (下記 `if: failure()` step 参照)。
+      - name: Capture previous active revision (for rollback)
+        id: prev-rev
+        if: ${{ inputs.enable-canary }}
+        run: |
+          set -euo pipefail
+          # `serving` に出ている revision の中で最新のものを「現在 100% を受けて
+          # いる前 revision」として記録する。filter で latestReadyRevision = true
+          # は使えないため、status.conditions = Active を頼りに上から 1 件取る。
+          PREV_REV=$(gcloud run services describe "${APPLICATION_NAME}" \
+            --region="${GCP_REGION}" \
+            --format='value(status.traffic[0].revisionName)')
+          if [ -z "${PREV_REV}" ]; then
+            echo "Could not determine previous revision" >&2
+            exit 1
+          fi
+          echo "Previous revision: ${PREV_REV}"
+          echo "previous=${PREV_REV}" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy Internal API to Cloud Run (canary, no traffic)
+        id: deploy-canary
+        if: ${{ inputs.enable-canary }}
+        uses: google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522 # v2.7.6
+        with:
+          service: ${{ env.APPLICATION_NAME }}
+          image: ${{ env.ARTIFACT_REGISTRY }}/${{ env.APPLICATION_NAME }}:latest
+          region: ${{ env.GCP_REGION }}
+          # `--no-traffic --tag canary` 相当。新 revision を作るが traffic は
+          # 0% のままにしておき、`canary` タグだけ振る (タグ URL で smoke 可)。
+          flags: '--no-traffic --tag=canary'
+          env_vars: |
+            NODE_ENV=${{ inputs.node-env }}
+            ${{ inputs.extra-env-vars }}
+
+      - name: Smoke test canary tag URL
+        id: smoke-canary
+        if: ${{ inputs.enable-canary }}
+        run: |
+          set -euo pipefail
+          # tag URL は `gcloud run services describe` の status.traffic[].url か
+          # ら canary tag のものを取る (リージョン固有の `canary---SERVICE-...`
+          # ホスト名が返る)。
+          CANARY_URL=$(gcloud run services describe "${APPLICATION_NAME}" \
+            --region="${GCP_REGION}" \
+            --format='value(status.traffic.url)' \
+            --flatten='status.traffic[]' \
+            --filter='status.traffic.tag=canary' | head -n 1)
+          if [ -z "${CANARY_URL}" ]; then
+            echo "Could not resolve canary tag URL" >&2
+            exit 1
+          fi
+          echo "Canary URL: ${CANARY_URL}"
+          # /health は内部 API の health endpoint。404 を含む 5xx は failure 扱い。
+          # NOTE: health endpoint が無い場合は ルート `/` への HEAD で代替する。
+          for i in 1 2 3; do
+            if curl -fsS --max-time 10 "${CANARY_URL}/health" >/dev/null; then
+              echo "Smoke OK on attempt $i"
+              exit 0
+            fi
+            echo "Smoke attempt $i failed, retrying..."
+            sleep 5
+          done
+          echo "Canary smoke test failed" >&2
+          exit 1
+
+      - name: Shift 10% traffic to canary revision
+        id: traffic-10
+        if: ${{ inputs.enable-canary }}
+        run: |
+          set -euo pipefail
+          NEW_REV="${{ steps.deploy-canary.outputs.revision }}"
+          if [ -z "${NEW_REV}" ]; then
+            # フォールバック: deploy-cloudrun action が revision output を返さな
+            # い場合は describe で latestCreatedRevision を取得。
+            NEW_REV=$(gcloud run services describe "${APPLICATION_NAME}" \
+              --region="${GCP_REGION}" \
+              --format='value(status.latestCreatedRevisionName)')
+          fi
+          echo "New revision: ${NEW_REV}"
+          echo "new=${NEW_REV}" >> "$GITHUB_OUTPUT"
+          gcloud run services update-traffic "${APPLICATION_NAME}" \
+            --region="${GCP_REGION}" \
+            --to-revisions="${NEW_REV}=10"
+
+      - name: Bake canary (wait for traffic samples)
+        if: ${{ inputs.enable-canary }}
+        run: sleep "${{ inputs.canary-bake-seconds }}"
+
+      - name: Evaluate canary 5xx rate
+        id: evaluate-canary
+        if: ${{ inputs.enable-canary }}
+        env:
+          NEW_REV: ${{ steps.traffic-10.outputs.new }}
+          ERROR_THRESHOLD: ${{ inputs.canary-error-threshold }}
+          BAKE_SECONDS: ${{ inputs.canary-bake-seconds }}
+        run: |
+          set -euo pipefail
+          # Cloud Monitoring の TimeSeries API を直接叩いて bake 期間中の
+          # `run.googleapis.com/request_count` を revision 別に取り、5xx 比率
+          # (response_code_class != "2xx") が閾値を超えていないか判定する。
+          # gcloud auth は WIF から ADC 経由で利用可能。
+          PROJECT_ID=$(gcloud config get-value project)
+          ACCESS_TOKEN=$(gcloud auth print-access-token)
+
+          # ISO-8601 (UTC, RFC3339) で start/end を作る。bake 終了時刻が end。
+          END_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          START_TS=$(date -u -d "@$(( $(date -u +%s) - BAKE_SECONDS ))" +%Y-%m-%dT%H:%M:%SZ)
+
+          FILTER="metric.type=\"run.googleapis.com/request_count\" \
+            AND resource.label.\"service_name\"=\"${APPLICATION_NAME}\" \
+            AND resource.label.\"location\"=\"${GCP_REGION}\" \
+            AND resource.label.\"revision_name\"=\"${NEW_REV}\""
+
+          RESPONSE=$(curl -sS -G \
+            -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+            --data-urlencode "filter=${FILTER}" \
+            --data-urlencode "interval.startTime=${START_TS}" \
+            --data-urlencode "interval.endTime=${END_TS}" \
+            --data-urlencode "aggregation.alignmentPeriod=${BAKE_SECONDS}s" \
+            --data-urlencode "aggregation.perSeriesAligner=ALIGN_SUM" \
+            --data-urlencode "aggregation.crossSeriesReducer=REDUCE_SUM" \
+            --data-urlencode "aggregation.groupByFields=metric.label.\"response_code_class\"" \
+            "https://monitoring.googleapis.com/v3/projects/${PROJECT_ID}/timeSeries")
+
+          echo "Monitoring response:"
+          echo "${RESPONSE}"
+
+          # jq で response_code_class 別合計を出す。canary に traffic がまだ
+          # ほぼ流れていない (total < 50) 場合は判定保留 = pass 扱いにする
+          # (false-positive で rollback してしまうのを避ける)。
+          TOTAL=$(echo "${RESPONSE}" | jq '[.timeSeries[]?.points[0].value.int64Value | tonumber? // 0] | add // 0')
+          ERRORS=$(echo "${RESPONSE}" | jq '[.timeSeries[]? | select(.metric.labels.response_code_class != "2xx") | .points[0].value.int64Value | tonumber? // 0] | add // 0')
+
+          echo "Total requests during bake: ${TOTAL}"
+          echo "Non-2xx requests during bake: ${ERRORS}"
+
+          if [ "${TOTAL}" -lt 50 ]; then
+            echo "Insufficient traffic (<50 requests) — skipping rate check"
+            exit 0
+          fi
+
+          # bash の浮動小数比較は awk で
+          RATE=$(awk -v e="${ERRORS}" -v t="${TOTAL}" 'BEGIN { if (t==0) print 0; else printf "%.6f", e/t }')
+          echo "Error rate: ${RATE} (threshold ${ERROR_THRESHOLD})"
+          OVER=$(awk -v r="${RATE}" -v th="${ERROR_THRESHOLD}" 'BEGIN { print (r+0 > th+0) ? 1 : 0 }')
+          if [ "${OVER}" = "1" ]; then
+            echo "Canary error rate ${RATE} exceeded threshold ${ERROR_THRESHOLD}" >&2
+            exit 1
+          fi
+          echo "Canary error rate within threshold."
+
+      - name: Promote canary to 100%
+        if: ${{ inputs.enable-canary && success() }}
+        env:
+          NEW_REV: ${{ steps.traffic-10.outputs.new }}
+        run: |
+          set -euo pipefail
+          gcloud run services update-traffic "${APPLICATION_NAME}" \
+            --region="${GCP_REGION}" \
+            --to-revisions="${NEW_REV}=100"
+
+      - name: Rollback to previous revision
+        # canary 関連 step のいずれかが失敗した場合に前 revision を 100% に戻
+        # す。`if: failure()` は (a) 同 job 内で earlier step が failed の時、
+        # (b) `enable-canary: true` でなければ意味が無いので両方を AND。
+        if: ${{ failure() && inputs.enable-canary && steps.prev-rev.outputs.previous != '' }}
+        env:
+          PREV_REV: ${{ steps.prev-rev.outputs.previous }}
+        run: |
+          set -euo pipefail
+          echo "Rolling back: shifting 100% traffic back to ${PREV_REV}"
+          gcloud run services update-traffic "${APPLICATION_NAME}" \
+            --region="${GCP_REGION}" \
+            --to-revisions="${PREV_REV}=100"
 
       - name: Update Cloud Run Job (batch) to new image
         # docker push :latest alone does not roll the Cloud Run Job to the new

--- a/.github/workflows/_deploy-external-api.yml
+++ b/.github/workflows/_deploy-external-api.yml
@@ -138,6 +138,26 @@ jobs:
             NODE_ENV=${{ inputs.node-env }}
             ${{ inputs.extra-env-vars }}
 
+      # Cloud Run の deploy アクションは revision の作成成功までしか保証しない。
+      # 実際にコンテナが起動失敗した (例: 起動時 import error / DB 接続失敗) ケースでも
+      # workflow は green になってしまうため、deploy 直後に health endpoint を叩いて
+      # 失敗時はジョブを fail させ、Cloud Run のエラーログを step summary に残す。
+      - name: Smoke check
+        env:
+          SERVICE: ${{ env.EXTERNAL_API_NAME }}
+          REGION: ${{ env.GCP_REGION }}
+        run: |
+          URL=$(gcloud run services describe "$SERVICE" --region="$REGION" --format='value(status.url)')
+          echo "Smoking $URL/health"
+          if ! curl --fail --silent --show-error --retry 6 --retry-delay 10 --max-time 10 "$URL/health"; then
+            echo "::error::Smoke check failed for $SERVICE"
+            gcloud logging read \
+              "resource.type=cloud_run_revision AND resource.labels.service_name=$SERVICE AND severity>=ERROR" \
+              --limit=50 --format='value(timestamp,textPayload,jsonPayload.message)' \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
       - name: Create Git tag
         if: ${{ inputs.create-git-tag }}
         run: |

--- a/.github/workflows/_deploy-external-api.yml
+++ b/.github/workflows/_deploy-external-api.yml
@@ -114,13 +114,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
 
+      # `:sha-${{ github.sha }}` を `:latest` と並列で push することで、
+      # Cloud Run の各 revision を commit SHA 単位で identifyable にし、
+      # 過去 image にロールバックできるようにする (DEPLOYMENT.md 参照)。
       - name: Build and push External API image
         env:
           EXTERNAL_IMAGE: ${{ env.ARTIFACT_REGISTRY }}/${{ env.EXTERNAL_API_NAME }}:latest
+          EXTERNAL_IMAGE_SHA: ${{ env.ARTIFACT_REGISTRY }}/${{ env.EXTERNAL_API_NAME }}:sha-${{ github.sha }}
         run: |
           docker buildx build \
             --file Dockerfile.external \
             --tag "$EXTERNAL_IMAGE" \
+            --tag "$EXTERNAL_IMAGE_SHA" \
             --cache-from "type=gha,scope=external-${{ inputs.stage }}" \
             --cache-to "type=gha,mode=max,scope=external-${{ inputs.stage }}" \
             --push \
@@ -131,7 +136,7 @@ jobs:
         uses: google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522 # v2.7.6
         with:
           service: ${{ env.EXTERNAL_API_NAME }}
-          image: ${{ env.ARTIFACT_REGISTRY }}/${{ env.EXTERNAL_API_NAME }}:latest
+          image: ${{ env.ARTIFACT_REGISTRY }}/${{ env.EXTERNAL_API_NAME }}:sha-${{ github.sha }}
           region: ${{ env.GCP_REGION }}
           flags: '--allow-unauthenticated --port=3000'
           env_vars: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,13 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # Destructive-migration scan (`pnpm db:migrate-diff`) diffs new
+          # migration .sql files against the PR base branch. The default
+          # shallow checkout (fetch-depth=1) doesn't include the base ref, so
+          # `git merge-base origin/<base>` would fail and the scan would
+          # silently no-op. fetch-depth=0 ensures `origin/<base>` is reachable.
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
@@ -107,6 +114,18 @@ jobs:
           if ! pnpm audit --audit-level=high; then
             echo "::warning::pnpm audit found high-severity vulnerabilities (non-blocking — see step log for details)"
           fi
+
+      # Surface destructive Prisma migration DDL (DROP TABLE / DROP COLUMN /
+      # ALTER COLUMN ... TYPE / RENAME / non-CONCURRENTLY DROP INDEX / ...)
+      # added by this PR as `::warning::` annotations on the PR check summary.
+      # Non-blocking by design: reviewers decide whether the migration is
+      # safe (2-step migration, backfill, view-based replacement). See
+      # docs/handbook/DB_MIGRATION.md for the safe-migration playbook.
+      - name: Detect destructive Prisma migration DDL (non-blocking)
+        if: github.event_name == 'pull_request'
+        env:
+          MIGRATE_DIFF_BASE_REF: origin/${{ github.base_ref }}
+        run: pnpm db:migrate-diff
 
       - name: Apply Prisma migrations to CI database
         # TypedSQL (`--sql`) は DB 接続を必要とするため、db:generate の前に

--- a/.github/workflows/deploy-to-cloud-run-dev.yml
+++ b/.github/workflows/deploy-to-cloud-run-dev.yml
@@ -29,4 +29,7 @@ jobs:
       extra-env-vars: |
         ENV=dev
       create-git-tag: false
+      # dev は canary を skip し従来通り即 100% で切り替える (ループバック検証
+      # を高速化するため)。canary rollout 自体の有効化は prd のみ。
+      enable-canary: false
     secrets: inherit

--- a/.github/workflows/deploy-to-cloud-run-prd.yml
+++ b/.github/workflows/deploy-to-cloud-run-prd.yml
@@ -32,4 +32,8 @@ jobs:
       apollo-variant: prod
       node-env: production
       create-git-tag: true
+      # prd は canary rollout (10% → bake → 5xx チェック → 100%) を強制。
+      # 失敗時は前 revision に traffic を戻す。dev 側は `enable-canary: false`
+      # で従来通り即 100%。詳細は `_deploy-cloud-run.yml` 参照。
+      enable-canary: true
     secrets: inherit

--- a/docs/handbook/DB_MIGRATION.md
+++ b/docs/handbook/DB_MIGRATION.md
@@ -1,0 +1,153 @@
+# Database Migration Operations Guide
+
+This document describes the operational playbook for safely landing Prisma
+schema migrations in civicship-api, with particular focus on **destructive
+DDL** that can corrupt data, drop tables/columns still in use, or block
+readers/writers under load.
+
+## Why This Matters
+
+Cloud Run runs **multiple revisions concurrently** during a deploy: the new
+revision starts taking traffic before the old revision finishes draining. If
+a migration removes a column that the still-live old revision is reading,
+those requests will fail with a `column "x" does not exist` error mid-flight.
+Similarly, an `ALTER COLUMN ... TYPE` rewrites the entire table while
+holding `ACCESS EXCLUSIVE`, blocking every reader and writer until done.
+
+The CI workflow runs `pnpm db:migrate-diff` on every PR. It scans newly
+added or modified migration `.sql` files for destructive patterns and
+surfaces them as `::warning::` annotations in the PR check summary. The
+check is **non-blocking by design** — reviewers decide whether the
+migration is safe to land. Use this guide to make that decision.
+
+## Destructive DDL Patterns Detected by CI
+
+| Pattern | Why it's dangerous |
+| --- | --- |
+| `DROP TABLE` | Permanent data loss; breaks any code still referencing the table. |
+| `DROP COLUMN` | Permanent data loss; breaks live readers/writers on the old revision. |
+| `ALTER TABLE ... DROP ...` | Same as above (constraint / column / index drops). |
+| `ALTER COLUMN ... TYPE ...` | Full table rewrite under `ACCESS EXCLUSIVE`; can block production for minutes on large tables; cast may fail mid-rewrite. |
+| `RENAME TABLE / COLUMN / TO` | Old revision continues to read the old name during deploy → 100% error rate on that path until rollout completes. |
+| `DROP VIEW` / `DROP MATERIALIZED VIEW` | Breaks consumers; also affects materialized point views (`mv_current_points`, `mv_accumulated_points`). |
+| `DROP INDEX` (without `CONCURRENTLY`) | Holds `ACCESS EXCLUSIVE` on the table for the duration of the drop; blocks reads and writes. |
+| `TRUNCATE` | Permanent data loss. |
+
+If CI flags any of these, **do not merge the PR until you have either**:
+
+1. Restructured the change as a multi-step (expand → migrate → contract)
+   migration, or
+2. Reviewed and explicitly accepted the risk in the PR description, with an
+   approving review from a maintainer aware of the operational impact.
+
+## Safe-Migration Playbook
+
+### Pattern 1: Two-Step Migration (Expand / Contract)
+
+Use this for any column rename, type change, or column drop where the column
+is currently read or written by application code.
+
+**Step 1 — Expand (PR #1):**
+- Add the new column / table / shape alongside the old one. **Do not drop
+  the old one yet.**
+- Update application code to **dual-write** to both old and new.
+- Optionally: backfill historical rows from old → new (see Pattern 2).
+- Deploy. Both revisions are now stable: old revision reads/writes old, new
+  revision reads/writes both.
+
+**Step 2 — Migrate readers (PR #2):**
+- Switch all reads to the new column.
+- Stop writing to the old column.
+- Deploy. Verify in production that the old column is no longer read.
+
+**Step 3 — Contract (PR #3):**
+- Drop the old column / table.
+- Deploy. By construction no live code references the old shape, so the
+  destructive DDL is safe.
+
+**Why three PRs?** Each deploy must complete (old revision fully drained)
+before the next destructive change goes out. Combining steps risks
+overlapping the drop with the still-live old revision.
+
+### Pattern 2: Backfill via Migration Script
+
+When you need to populate a new column from existing data:
+
+- Add the new column as nullable in the migration.
+- Run the backfill in a **separate** migration (or as application code) in
+  bounded batches (e.g. `UPDATE ... WHERE id IN (SELECT id FROM ... LIMIT
+  1000)` in a loop).
+- Once backfill is verified complete, add a `NOT NULL` constraint in a
+  follow-up migration.
+
+Avoid `UPDATE table SET col = ...` without `LIMIT` or batching on large
+tables — it holds row locks for the entire table and can saturate WAL.
+
+### Pattern 3: View-Based Replacement
+
+When changing the shape of data exposed to read paths (e.g. splitting a
+table, renaming derived columns):
+
+- Create a database `VIEW` that exposes the **old** shape on top of the
+  **new** underlying tables.
+- Point the application at the view (transparent to readers).
+- Migrate the underlying schema freely.
+- Once readers are migrated to the new shape directly, drop the view.
+
+This is the same idea as Pattern 1 but at the storage layer instead of the
+column layer.
+
+### Pattern 4: `DROP INDEX CONCURRENTLY` for Index Removal
+
+Plain `DROP INDEX` takes `ACCESS EXCLUSIVE` on the table — every read and
+write blocks until the drop completes. On large tables this can be
+seconds-to-minutes of full unavailability.
+
+`DROP INDEX CONCURRENTLY` waits for in-flight transactions and only locks
+briefly:
+
+```sql
+DROP INDEX CONCURRENTLY IF EXISTS idx_old_thing;
+```
+
+Caveats:
+- Cannot run inside a transaction. Prisma migrations wrap each `.sql` file
+  in a transaction by default; you must split the `DROP INDEX
+  CONCURRENTLY` into its own migration **and** add the `-- prisma+deploy`
+  marker (or split the file) so it runs outside a transaction. See the
+  Prisma docs for the current escape hatch.
+
+The same applies to `CREATE INDEX CONCURRENTLY` for adding indexes on
+large tables.
+
+## Local Workflow Reminder
+
+The same script (`scripts/prisma/migrate-diff.sh`, exposed as
+`pnpm db:migrate-diff`) has two modes:
+
+- **Developer mode** — `pnpm db:migrate-diff <name>`: scaffolds a new
+  `migrations/<timestamp>_<name>/migration.sql` from the current
+  `schema.prisma`. Used locally when authoring a migration.
+- **CI scan mode** — `pnpm db:migrate-diff` (no args): scans `.sql`
+  migrations added vs `origin/develop` (or `MIGRATE_DIFF_BASE_REF`) for
+  destructive DDL and emits GitHub Actions `::warning::` annotations.
+  Always exits 0 — informational only.
+
+Running `pnpm db:migrate-diff` locally before pushing surfaces the same
+warnings you'll see on the PR.
+
+## Reviewer Checklist
+
+When reviewing a PR with `::warning::` destructive-migration annotations:
+
+- [ ] Is this a multi-step migration where the destructive step is the
+      *contract* phase, with the *expand* phase already deployed and the
+      old shape verified unused?
+- [ ] If `ALTER COLUMN ... TYPE`: how large is the table? Will the rewrite
+      fit within an acceptable maintenance window?
+- [ ] If `DROP INDEX`: can it be `DROP INDEX CONCURRENTLY` instead?
+- [ ] If `RENAME`: is there application code reading the old name in the
+      currently-deployed revision?
+- [ ] Is there a rollback plan that doesn't require restoring from backup?
+
+If any answer is "no" or "unknown", request changes and link this document.

--- a/docs/handbook/DB_MIGRATION.md
+++ b/docs/handbook/DB_MIGRATION.md
@@ -112,10 +112,12 @@ DROP INDEX CONCURRENTLY IF EXISTS idx_old_thing;
 
 Caveats:
 - Cannot run inside a transaction. Prisma migrations wrap each `.sql` file
-  in a transaction by default; you must split the `DROP INDEX
-  CONCURRENTLY` into its own migration **and** add the `-- prisma+deploy`
-  marker (or split the file) so it runs outside a transaction. See the
-  Prisma docs for the current escape hatch.
+  in a transaction by default. The portable workaround is to put the
+  `CONCURRENTLY` statement (and only that statement) in its own dedicated
+  migration directory — Prisma applies one transaction per `migration.sql`,
+  so a single-statement file effectively runs the command outside any
+  surrounding statement's transaction. **Do not rely on undocumented Prisma
+  magic comments**; split the file instead.
 
 The same applies to `CREATE INDEX CONCURRENTLY` for adding indexes on
 large tables.

--- a/docs/handbook/DEPLOYMENT.md
+++ b/docs/handbook/DEPLOYMENT.md
@@ -404,6 +404,58 @@ run.googleapis.com/vpc-access-connector: projects/PROJECT_ID/locations/REGION/co
 run.googleapis.com/vpc-access-egress: private-ranges-only
 ```
 
+## Rollback
+
+### Image SHA Tagging
+
+Every deploy pushes the built image with two tags in parallel:
+
+- `:latest` — moving tag, always points at the most recent successful build
+- `:sha-<commit-sha>` — immutable tag pinned to the commit that triggered the
+  build (`github.sha`)
+
+Cloud Run services / Jobs are deployed with the `:sha-<commit-sha>` tag (not
+`:latest`) so that each revision is identifyable by the source commit and a
+specific past build can be re-deployed at any time.
+
+### Rolling back to a previous image
+
+To roll a Cloud Run **service** back to an older build, look up the commit SHA
+of the target build (e.g. from the GitHub Actions run, `git log`, or
+`gcloud artifacts docker tags list`) and run:
+
+```bash
+# Internal API
+gcloud run services update "$APPLICATION_NAME" \
+  --image="${ARTIFACT_REGISTRY}/${APPLICATION_NAME}:sha-${TARGET_SHA}" \
+  --region="$GCP_REGION"
+
+# External API
+gcloud run services update "$EXTERNAL_API_NAME" \
+  --image="${ARTIFACT_REGISTRY}/${EXTERNAL_API_NAME}:sha-${TARGET_SHA}" \
+  --region="$GCP_REGION"
+```
+
+For the **batch Cloud Run Job**, use `run jobs update` instead:
+
+```bash
+gcloud run jobs update "$BATCH_NAME" \
+  --image="${BATCH_ARTIFACT_REGISTRY}/${BATCH_NAME}:sha-${TARGET_SHA}" \
+  --region="$GCP_REGION"
+```
+
+Alternatively, for services you can shift traffic back to a previously
+deployed revision without re-deploying the image:
+
+```bash
+gcloud run services update-traffic "$APPLICATION_NAME" \
+  --to-revisions="<previous-revision-name>=100" \
+  --region="$GCP_REGION"
+```
+
+Use `gcloud run revisions list --service="$APPLICATION_NAME" --region="$GCP_REGION"`
+to find the revision name.
+
 ## Troubleshooting
 
 ### Deployment issues

--- a/docs/handbook/DEPLOYMENT.md
+++ b/docs/handbook/DEPLOYMENT.md
@@ -436,4 +436,5 @@ gcloud alpha monitoring policies create --policy-from-file=alerting-policy.yaml
 - [Security Guide](./SECURITY.md) - Security Architecture
 - [Performance Guide](./PERFORMANCE.md) - Optimization Strategies
 - [Environment Variable Guide](./ENVIRONMENT.md) - Environment Settings
+- [Database Migration Guide](./DB_MIGRATION.md) - Safe-migration playbook for destructive DDL
 - [Troubleshooting](./TROUBLESHOOTING.md) - Problem Resolution Guide

--- a/scripts/prisma/migrate-diff.sh
+++ b/scripts/prisma/migrate-diff.sh
@@ -1,41 +1,194 @@
 #!/bin/bash
 
-# 第一引数を取得
-NAME=$1
+# scripts/prisma/migrate-diff.sh
+#
+# Two modes:
+#
+# 1. Developer mode (positional NAME argument):
+#      pnpm db:migrate-diff <migration_name>
+#    Generates a new migration directory by diffing schema.prisma against
+#    itself (datasource → datamodel). Used locally to scaffold a migration.
+#
+# 2. CI scan mode (no arguments, or `--ci` / CI=true):
+#      pnpm db:migrate-diff
+#    Scans Prisma migration .sql files added vs the base branch (default
+#    `origin/develop`) for destructive DDL patterns (DROP TABLE, DROP COLUMN,
+#    ALTER COLUMN ... TYPE, RENAME, non-CONCURRENTLY DROP INDEX, ...).
+#    Detected hits are emitted as `::warning::` GitHub Actions annotations on
+#    stdout. Exit code is always 0 — this check informs reviewers, it does
+#    not block merge.
+#
+# The two modes are mutually exclusive. If the first argument is `--ci` or no
+# argument is supplied, CI mode runs; otherwise developer mode runs.
 
-# 引数チェック: 名前が空（未指定）の場合はエラーを表示して終了
-if [ -z "$NAME" ]; then
-  echo "❌ Error: マイグレーション名が指定されていません。"
-  echo "Usage: pnpm db:migrate-diff <migration_name>"
-  echo "Example: pnpm db:migrate-diff add_user_table"
-  exit 1
-fi
+set -uo pipefail
 
-TIMESTAMP=$(date +%Y%m%d%H%M%S)
-DIR_NAME="${TIMESTAMP}_${NAME}"
-SCHEMA_PATH="src/infrastructure/prisma/schema.prisma"
-MIGRATIONS_DIR="src/infrastructure/prisma/migrations/${DIR_NAME}"
+MODE="${1:-}"
 
-echo "🚀 Creating migration: ${DIR_NAME}..."
+run_developer_mode() {
+  local NAME="$1"
 
-# フォルダ作成
-mkdir -p "$MIGRATIONS_DIR"
+  if [ -z "$NAME" ]; then
+    echo "❌ Error: マイグレーション名が指定されていません。"
+    echo "Usage: pnpm db:migrate-diff <migration_name>"
+    echo "Example: pnpm db:migrate-diff add_user_table"
+    exit 1
+  fi
 
-# diffの実行と保存
-npx prisma migrate diff \
-  --from-schema-datasource "$SCHEMA_PATH" \
-  --to-schema-datamodel "$SCHEMA_PATH" \
-  --script > "$MIGRATIONS_DIR/migration.sql"
+  local TIMESTAMP DIR_NAME SCHEMA_PATH MIGRATIONS_DIR
+  TIMESTAMP=$(date +%Y%m%d%H%M%S)
+  DIR_NAME="${TIMESTAMP}_${NAME}"
+  SCHEMA_PATH="src/infrastructure/prisma/schema.prisma"
+  MIGRATIONS_DIR="src/infrastructure/prisma/migrations/${DIR_NAME}"
 
-# 実行結果の確認
-if [ $? -eq 0 ]; then
-  echo "✅ Success! Migration file created at: $MIGRATIONS_DIR/migration.sql"
-  echo "---------------------------------------------------"
-  echo "Next steps:"
-  echo "1. SQLの内容を確認してください。"
-  echo "2. npx prisma db push --schema $SCHEMA_PATH でDBに反映します。"
-  echo "3. npx prisma migrate resolve --applied ${DIR_NAME} --schema ${SCHEMA_PATH} で履歴を同期します。"
+  echo "🚀 Creating migration: ${DIR_NAME}..."
+
+  mkdir -p "$MIGRATIONS_DIR"
+
+  npx prisma migrate diff \
+    --from-schema-datasource "$SCHEMA_PATH" \
+    --to-schema-datamodel "$SCHEMA_PATH" \
+    --script > "$MIGRATIONS_DIR/migration.sql"
+
+  if [ $? -eq 0 ]; then
+    echo "✅ Success! Migration file created at: $MIGRATIONS_DIR/migration.sql"
+    echo "---------------------------------------------------"
+    echo "Next steps:"
+    echo "1. SQLの内容を確認してください。"
+    echo "2. npx prisma db push --schema $SCHEMA_PATH でDBに反映します。"
+    echo "3. npx prisma migrate resolve --applied ${DIR_NAME} --schema ${SCHEMA_PATH} で履歴を同期します。"
+  else
+    echo "❌ Error: SQLの生成に失敗しました。スキーマファイルの設定を確認してください。"
+    exit 1
+  fi
+}
+
+run_ci_mode() {
+  local BASE_REF="${MIGRATE_DIFF_BASE_REF:-origin/develop}"
+  local MIGRATIONS_PATH="src/infrastructure/prisma/migrations"
+
+  echo "🔍 Scanning Prisma migrations added vs ${BASE_REF} for destructive DDL..."
+
+  # Resolve the merge-base so we look only at commits introduced by this PR.
+  # If BASE_REF is unavailable (e.g. shallow clone without develop fetched),
+  # fall back to comparing the working tree against HEAD's parent.
+  local MERGE_BASE=""
+  if git rev-parse --verify --quiet "$BASE_REF" >/dev/null; then
+    MERGE_BASE=$(git merge-base "$BASE_REF" HEAD 2>/dev/null || true)
+  fi
+
+  if [ -z "$MERGE_BASE" ]; then
+    echo "::warning::base ref '${BASE_REF}' not found locally; skipping destructive-migration scan"
+    exit 0
+  fi
+
+  # Collect added migration .sql files (status=A) plus modified ones (M),
+  # since edits to historical migrations are themselves suspicious.
+  local CHANGED_FILES
+  CHANGED_FILES=$(git diff --name-only --diff-filter=AM "$MERGE_BASE"...HEAD -- \
+    "${MIGRATIONS_PATH}/*/migration.sql" 2>/dev/null || true)
+
+  if [ -z "$CHANGED_FILES" ]; then
+    echo "✅ No new or modified Prisma migration .sql files in this PR."
+    exit 0
+  fi
+
+  echo "Found migration file(s) to inspect:"
+  while IFS= read -r f; do
+    [ -n "$f" ] && echo "  - $f"
+  done <<< "$CHANGED_FILES"
+
+  # Destructive DDL patterns. Each entry: <regex>:::<label>.
+  # Patterns are POSIX ERE (grep -E), case-insensitive. The `:::` separator
+  # is used (instead of `|`) because some regexes themselves contain `|`
+  # for alternation (e.g. RENAME (TABLE|COLUMN|TO)), which would otherwise
+  # be split mid-regex by the `${entry%%|*}` parameter expansion.
+  local PATTERNS=(
+    'DROP[[:space:]]+TABLE:::DROP TABLE (data loss)'
+    'DROP[[:space:]]+COLUMN:::DROP COLUMN (data loss)'
+    'ALTER[[:space:]]+COLUMN[[:space:]]+[^;]*[[:space:]]+TYPE[[:space:]]:::ALTER COLUMN ... TYPE (rewrite + potential cast failure)'
+    'ALTER[[:space:]]+TABLE[[:space:]]+[^;]*[[:space:]]+DROP[[:space:]]+:::ALTER TABLE ... DROP (data loss)'
+    'RENAME[[:space:]]+(TABLE|COLUMN|TO):::RENAME (breaks live readers)'
+    'DROP[[:space:]]+(MATERIALIZED[[:space:]]+)?VIEW:::DROP VIEW / MATERIALIZED VIEW'
+    'TRUNCATE[[:space:]]:::TRUNCATE (data loss)'
+  )
+
+  # DROP INDEX is destructive only when not CONCURRENTLY (production-safe form).
+  # Match "DROP INDEX" *not* immediately followed by CONCURRENTLY.
+  local DROP_INDEX_PATTERN='DROP[[:space:]]+INDEX(?![[:space:]]+CONCURRENTLY)'
+
+  local TOTAL_HITS=0
+
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    [ ! -f "$file" ] && continue
+
+    local file_hits=0
+
+    for entry in "${PATTERNS[@]}"; do
+      local regex="${entry%%:::*}"
+      local label="${entry#*:::}"
+
+      # grep -n: line numbers; -E: ERE; -i: case-insensitive.
+      # || true so that "no match" (exit 1) doesn't kill the script under set -e.
+      local matches
+      matches=$(grep -nEi "$regex" "$file" 2>/dev/null || true)
+      if [ -n "$matches" ]; then
+        while IFS= read -r match_line; do
+          [ -z "$match_line" ] && continue
+          local lineno
+          lineno=$(echo "$match_line" | cut -d: -f1)
+          local content
+          content=$(echo "$match_line" | cut -d: -f2-)
+          # Trim leading whitespace from content for the annotation.
+          content=$(echo "$content" | sed 's/^[[:space:]]*//')
+          echo "::warning file=${file},line=${lineno}::Destructive DDL detected (${label}): ${content}"
+          file_hits=$((file_hits + 1))
+        done <<< "$matches"
+      fi
+    done
+
+    # DROP INDEX without CONCURRENTLY (PCRE via grep -P; fall back to ERE
+    # heuristic if -P isn't available, e.g. on BusyBox grep).
+    local drop_index_matches=""
+    if echo "" | grep -P "" >/dev/null 2>&1; then
+      drop_index_matches=$(grep -nPi "$DROP_INDEX_PATTERN" "$file" 2>/dev/null || true)
+    else
+      drop_index_matches=$(grep -nEi 'DROP[[:space:]]+INDEX' "$file" 2>/dev/null \
+        | grep -viE 'DROP[[:space:]]+INDEX[[:space:]]+CONCURRENTLY' || true)
+    fi
+    if [ -n "$drop_index_matches" ]; then
+      while IFS= read -r match_line; do
+        [ -z "$match_line" ] && continue
+        local lineno
+        lineno=$(echo "$match_line" | cut -d: -f1)
+        local content
+        content=$(echo "$match_line" | cut -d: -f2-)
+        content=$(echo "$content" | sed 's/^[[:space:]]*//')
+        echo "::warning file=${file},line=${lineno}::Destructive DDL detected (DROP INDEX without CONCURRENTLY locks readers): ${content}"
+        file_hits=$((file_hits + 1))
+      done <<< "$drop_index_matches"
+    fi
+
+    if [ "$file_hits" -gt 0 ]; then
+      echo "  ⚠️  ${file}: ${file_hits} destructive pattern(s)"
+      TOTAL_HITS=$((TOTAL_HITS + file_hits))
+    fi
+  done <<< "$CHANGED_FILES"
+
+  if [ "$TOTAL_HITS" -eq 0 ]; then
+    echo "✅ No destructive DDL patterns detected in changed migrations."
+  else
+    echo ""
+    echo "::warning::Detected ${TOTAL_HITS} destructive DDL pattern(s) across changed migrations. See docs/handbook/DB_MIGRATION.md for the safe-migration playbook (2-step migrations, backfill, view-based replacement)."
+  fi
+
+  # Always succeed — this check informs reviewers, it does not block merge.
+  exit 0
+}
+
+if [ "$MODE" = "--ci" ] || [ -z "$MODE" ]; then
+  run_ci_mode
 else
-  echo "❌ Error: SQLの生成に失敗しました。スキーマファイルの設定を確認してください。"
-  exit 1
+  run_developer_mode "$MODE"
 fi


### PR DESCRIPTION
## Summary

CI/CD hardening Epic #973 の **P0 (本番事故を直接減らす) 4 件** を 1 PR に集約。

| Issue | 内容 |
|---|---|
| #974 | Cloud Run image を `:sha-${GITHUB_SHA}` で tag |
| #975 | Post-deploy smoke / health check |
| #976 | Cloud Run canary rollout (10% → 100%) + 失敗時 traffic 戻し |
| #977 | Prisma migration の破壊的 DDL を PR で可視化 |

旧個別 PR (#987 / #988 / #990 / #999) は本 PR に統合のため close。

## Conflict resolution

`_deploy-cloud-run.yml` で smoke (#975) と canary (#976) の deploy step が衝突。両者を排他的 `if` で残し、smoke は即100% パス専用 (`if: !inputs.enable-canary`)、canary パスは独自 smoke (smoke-canary) を持つ形に解決。canary deploy も `:sha-${GITHUB_SHA}` を参照するよう統一。

## Test plan

- [ ] actionlint / yaml parse OK (ローカル確認済)
- [ ] dev (epic ブランチ push) で smoke check が走り、health endpoint 200 で deploy 成功
- [ ] dev で migration diff PR step が docs-only PR で skip / src 変更 PR で実行
- [ ] prd merge 時に canary 10% → bake → eval → 100% が成立 (5xx 閾値超過時 rollback)
- [ ] `:sha-<commit>` image が registry に存在し、過去 image でロールバックできる手順を `docs/handbook/DEPLOYMENT.md` で明記

## Closes

Closes #974
Closes #975
Closes #976
Closes #977

## Follow-ups (本 PR スコープ外)

- Gemini #999 の指摘 (migrate-diff.sh の cleanup / コメント乖離 / multi-statement 検知) は次 PR で対応
- canary error rate 閾値 (`0.01`) のチューニング

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG)_