### PR TITLE
[P3] CI/CD hardening: paths-filter + composite setup + schema order/tzdata

### DIFF
--- a/.github/actions/setup-civicship/action.yml
+++ b/.github/actions/setup-civicship/action.yml
@@ -1,0 +1,50 @@
+name: 'Setup civicship-api dev environment'
+description: >
+  Sets up pnpm + Node.js, installs dependencies, optionally applies Prisma
+  migrations to the target database, then generates the Prisma client (with
+  TypedSQL) and the GraphQL TypeScript types. Used by both CI jobs (build /
+  test matrix) and reusable deploy workflows so the repeated bootstrap steps
+  stay in one place.
+
+inputs:
+  database-url:
+    description: DATABASE_URL used by `prisma migrate deploy` and `prisma generate --sql`.
+    required: true
+  run-migrate:
+    description: '"true" to run `pnpm db:deploy` (Prisma migrate deploy) before generating clients. Set "false" for environments where migrations are applied out-of-band (e.g. external API deploy).'
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Setup pnpm
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+    - name: Setup Node.js
+      uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+      with:
+        node-version: '20'
+        cache: 'pnpm'
+
+    - name: Install dependencies (lockfile integrity check)
+      shell: bash
+      run: pnpm install --frozen-lockfile --prefer-offline
+
+    - name: Apply Prisma migrations
+      # TypedSQL (`--sql`) は DB 接続を必要とするため、db:generate の前に
+      # migration を当ててスキーマを用意する。view / materialized view も
+      # migration.sql 経由でのみ作成される。
+      if: inputs.run-migrate == 'true'
+      shell: bash
+      env:
+        DATABASE_URL: ${{ inputs.database-url }}
+      run: pnpm db:deploy
+
+    - name: Generate Prisma client (with TypedSQL) and GraphQL types
+      shell: bash
+      env:
+        DATABASE_URL: ${{ inputs.database-url }}
+      run: |
+        pnpm db:generate
+        pnpm gql:generate

--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -32,6 +32,11 @@ on:
         type: boolean
         required: false
         default: false
+      git-tag-prefix:
+        description: Prefix prepended to the timestamp git tag (e.g. "internal-api-").
+        type: string
+        required: false
+        default: ''
 
 jobs:
   deploy:
@@ -64,14 +69,16 @@ jobs:
     steps:
       # `audit` mode: log egress (GCP / npm registry / GitHub) without blocking.
       # `block` mode would require maintaining an allowlist for every gcloud
-      # endpoint and is fragile across SDK updates. `disable-sudo` is left
-      # enabled (default) because the "Create Git tag" step installs tzdata
-      # via apt-get on prd. Audit logs surface in the job summary and let us
-      # detect unexpected egress (e.g. credential exfiltration) post-hoc.
+      # endpoint and is fragile across SDK updates. Audit logs surface in the
+      # job summary and let us detect unexpected egress (e.g. credential
+      # exfiltration) post-hoc. `disable-sudo: true` matches ci.yml — no step
+      # in this workflow needs sudo (the "Create Git tag" step uses
+      # `TZ=Asia/Tokyo date` instead of installing tzdata).
       - name: Harden runner
         uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
+          disable-sudo: true
 
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -115,14 +122,6 @@ jobs:
 
       - name: Generate GraphQL types
         run: pnpm gql:generate
-
-      - name: Install and Publish via Rover CLI
-        env:
-          APOLLO_KEY: ${{ env.APOLLO_KEY }}
-        run: |
-          curl -sSL https://rover.apollo.dev/nix/latest | sh
-          export PATH="$HOME/.rover/bin:$PATH"
-          rover graph publish "civicship-api-jq1988@${{ inputs.apollo-variant }}" --schema ./docs/schema.graphql
 
       - name: Build TypeScript output (consumed by Docker COPY)
         run: pnpm build
@@ -181,18 +180,26 @@ jobs:
             --command=node \
             --args=-r,tsconfig-paths/register,dist/bootstrap/batch.js
 
+      # Publish the schema to Apollo Studio only after the Cloud Run service
+      # (and batch job) has been updated successfully. Publishing earlier risks
+      # advertising a schema that the running service does not yet implement
+      # if the deploy fails for any reason.
+      - name: Install and Publish via Rover CLI
+        env:
+          APOLLO_KEY: ${{ env.APOLLO_KEY }}
+        run: |
+          curl -sSL https://rover.apollo.dev/nix/latest | sh
+          export PATH="$HOME/.rover/bin:$PATH"
+          rover graph publish "civicship-api-jq1988@${{ inputs.apollo-variant }}" --schema ./docs/schema.graphql
+
       - name: Create Git tag
         if: ${{ inputs.create-git-tag }}
+        env:
+          TZ: Asia/Tokyo
         run: |
-          sudo apt-get update && sudo apt-get install -y tzdata
-          sudo ln -fs /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
-          sudo dpkg-reconfigure -f noninteractive tzdata
-
-          TAG_NAME=$(date +"%Y%m%d%H%M%S")
-
+          TAG_NAME="${{ inputs.git-tag-prefix }}$(date +'%Y%m%d%H%M%S')"
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-
           git tag "$TAG_NAME"
           git push origin "$TAG_NAME"
 

--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -78,18 +78,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha || '' }}
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-
-      - name: Set up Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
-        with:
-          node-version: '20'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --prefer-offline
-
       - name: Authenticate to Google Cloud (Workload Identity Federation)
         uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70 # v2.1.6
         with:
@@ -106,15 +94,13 @@ jobs:
           jumpbox-zone: ${{ env.JUMPBOX_ZONE }}
           db-name: ${{ env.DB_NAME }}
 
-      - name: Run prisma generate and migrate deploy
-        env:
-          DATABASE_URL: postgresql://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
-        run: |
-          pnpm db:generate
-          pnpm db:deploy
-
-      - name: Generate GraphQL types
-        run: pnpm gql:generate
+      # composite action の `pnpm db:deploy` で本番 / dev DB に対して
+      # prisma migrate deploy を実行する。jumpbox 経由 DATABASE_URL を渡す。
+      - name: Setup civicship environment (pnpm + node + deps + prisma + gql)
+        uses: ./.github/actions/setup-civicship
+        with:
+          database-url: postgresql://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
+          run-migrate: 'true'
 
       - name: Install and Publish via Rover CLI
         env:

--- a/.github/workflows/_deploy-external-api.yml
+++ b/.github/workflows/_deploy-external-api.yml
@@ -59,11 +59,14 @@ jobs:
       JUMPBOX_ZONE: ${{ secrets.JUMPBOX_ZONE }}
 
     steps:
-      # See _deploy-cloud-run.yml for rationale on audit mode + sudo.
+      # See _deploy-cloud-run.yml for rationale on audit mode. `disable-sudo:
+      # true` matches ci.yml — the "Create Git tag" step uses
+      # `TZ=Asia/Tokyo date` instead of installing tzdata via apt-get.
       - name: Harden runner
         uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
+          disable-sudo: true
 
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -140,16 +143,12 @@ jobs:
 
       - name: Create Git tag
         if: ${{ inputs.create-git-tag }}
+        env:
+          TZ: Asia/Tokyo
         run: |
-          sudo apt-get update && sudo apt-get install -y tzdata
-          sudo ln -fs /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
-          sudo dpkg-reconfigure -f noninteractive tzdata
-
-          TAG_NAME="${{ inputs.git-tag-prefix }}$(date +"%Y%m%d%H%M%S")"
-
+          TAG_NAME="${{ inputs.git-tag-prefix }}$(date +'%Y%m%d%H%M%S')"
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-
           git tag "$TAG_NAME"
           git push origin "$TAG_NAME"
 

--- a/.github/workflows/_deploy-external-api.yml
+++ b/.github/workflows/_deploy-external-api.yml
@@ -70,18 +70,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha || '' }}
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-
-      - name: Set up Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
-        with:
-          node-version: '20'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --prefer-offline
-
       - name: Authenticate to Google Cloud (Workload Identity Federation)
         uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70 # v2.1.6
         with:
@@ -98,10 +86,14 @@ jobs:
           jumpbox-zone: ${{ env.JUMPBOX_ZONE }}
           db-name: ${{ env.DB_NAME }}
 
-      - name: Run prisma generate
-        env:
-          DATABASE_URL: postgresql://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
-        run: pnpm db:generate
+      # External API は Internal API 側 deploy で migrate 済みの DB を共有するため、
+      # ここでは `prisma migrate deploy` は実行しない (`run-migrate: 'false'`)。
+      # composite action 内で db:generate (TypedSQL) と gql:generate のみ実行する。
+      - name: Setup civicship environment (pnpm + node + deps + prisma + gql)
+        uses: ./.github/actions/setup-civicship
+        with:
+          database-url: postgresql://${{ env.DB_USER }}:${{ env.DB_PASSWORD }}@localhost:5432/${{ env.DB_NAME }}
+          run-migrate: 'false'
 
       - name: Build TypeScript output (consumed by Docker COPY)
         run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,10 @@ on:
   # branch protection の required status check として登録されているため、
   # paths-ignore で workflow ごと skip すると status が報告されず、docs-only
   # PR が永久に merge 不能になる (admin override が必要になる)。
-  # 軽量化が必要になったら job 側で changed-files filter (dorny/paths-filter
-  # 等) を使って expensive job (build / test) を条件付き skip し、aggregator は
-  # 必ず走る形にする。
+  # 代わりに job 側で changed-files filter (`filter` job + dorny/paths-filter)
+  # を使って expensive job (build / test) を条件付き skip し、aggregator (`ci`)
+  # は always() で必ず走らせる。aggregator 側では skipped を success と同等に
+  # 扱うことで required status check を緑に保つ。
 
 permissions:
   contents: read
@@ -21,6 +22,43 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Detect whether the PR touches code that affects build / test outputs.
+  # docs-only PR (README, handbook, schema doc 等) では expensive な build / test を
+  # skip して PR feedback loop を高速化する。aggregator job (`ci`) は always() で
+  # 走り、skipped を success と同等に扱うことで required status check を緑に保つ。
+  # workflow lint (lint job) は filter に依存させない: workflow 自体の文法 / 安全性
+  # チェックは docs-only PR でも常に必要。
+  filter:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    outputs:
+      code: ${{ steps.changes.outputs.code }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Detect code-affecting changes
+        id: changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            code:
+              - 'src/**'
+              - 'pnpm-lock.yaml'
+              - 'package.json'
+              - 'tsconfig*.json'
+              - '.github/workflows/**'
+              - '.github/actions/**'
+              - 'Dockerfile*'
+              - 'scripts/**'
+
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -49,6 +87,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: [filter]
+    if: needs.filter.outputs.code == 'true'
     permissions:
       contents: read
 
@@ -146,6 +186,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: [filter]
+    if: needs.filter.outputs.code == 'true'
     permissions:
       contents: read
     strategy:
@@ -287,13 +329,19 @@ jobs:
       contents: read
     steps:
       - name: Verify all required jobs passed
+        # docs-only PR では filter job が build / test を skip させるため、
+        # `skipped` も success と同等に扱う必要がある (skipped を fail 扱い
+        # すると aggregator が永久に赤くなり required check が通らない)。
+        # 一方 `cancelled` / `failure` 等の異常終了は明示的に fail させる。
         run: |
           lint='${{ needs.lint.result }}'
           build='${{ needs.build.result }}'
           test='${{ needs.test.result }}'
           echo "lint=$lint build=$build test=$test"
-          if [ "$lint" != "success" ] || [ "$build" != "success" ] || [ "$test" != "success" ]; then
-            echo "::error::One or more required jobs failed"
-            exit 1
-          fi
-          echo "All required jobs passed"
+          for j in "$lint" "$build" "$test"; do
+            case "$j" in
+              success|skipped) ;;
+              *) echo "::error::job failed: $j"; exit 1 ;;
+            esac
+          done
+          echo "All required jobs passed (skipped treated as success)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,17 +85,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+      - name: Setup civicship environment (pnpm + node + deps + prisma + gql)
+        uses: ./.github/actions/setup-civicship
         with:
-          node-version: '20'
-          cache: 'pnpm'
-
-      - name: Install dependencies (lockfile integrity check)
-        run: pnpm install --frozen-lockfile --prefer-offline
+          database-url: ${{ env.DATABASE_URL }}
 
       # Surface high/critical findings as a `::warning::` annotation visible
       # in the PR check summary, but do not fail the job (audit results can
@@ -107,18 +100,6 @@ jobs:
           if ! pnpm audit --audit-level=high; then
             echo "::warning::pnpm audit found high-severity vulnerabilities (non-blocking — see step log for details)"
           fi
-
-      - name: Apply Prisma migrations to CI database
-        # TypedSQL (`--sql`) は DB 接続を必要とするため、db:generate の前に
-        # migration を当ててスキーマを用意する。view / materialized view も
-        # migration.sql 経由でのみ作成される。
-        run: pnpm db:deploy
-
-      - name: Generate Prisma client (with TypedSQL)
-        run: pnpm db:generate
-
-      - name: Generate GraphQL types
-        run: pnpm gql:generate
 
       # Detect uncommitted regenerations of tracked generated files.
       - name: Check generated files are up to date
@@ -209,31 +190,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+      # `prisma db push` は schema.prisma のモデルのみ反映し、migration.sql を
+      # 実行しない。view (10 個) / materialized view (4 個) は migration.sql のみで
+      # 定義されているため、db push だと view/mv が作られず、それらに依存する test
+      # が構造的に fail する。composite action 内の `pnpm db:deploy`
+      # (= prisma migrate deploy) で migration を順次適用し、view/mv 含めた全スキーマを
+      # CI DB に反映する。
+      - name: Setup civicship environment (pnpm + node + deps + prisma + gql)
+        uses: ./.github/actions/setup-civicship
         with:
-          node-version: '20'
-          cache: 'pnpm'
-
-      - name: Install dependencies (lockfile integrity check)
-        run: pnpm install --frozen-lockfile --prefer-offline
-
-      - name: Apply Prisma migrations to CI database
-        # `prisma db push` は schema.prisma のモデルのみ反映し、migration.sql を
-        # 実行しない。view (10 個) / materialized view (4 個) は migration.sql のみで
-        # 定義されているため、db push だと view/mv が作られず、それらに依存する test
-        # が構造的に fail する。`pnpm db:deploy` (= prisma migrate deploy) で migration
-        # を順次適用し、view/mv 含めた全スキーマを CI DB に反映する。
-        run: pnpm db:deploy
-
-      - name: Generate Prisma client (with TypedSQL)
-        run: pnpm db:generate
-
-      - name: Generate GraphQL types
-        run: pnpm gql:generate
+          database-url: ${{ env.DATABASE_URL }}
 
       # ts-jest の transform 結果 cache を matrix 単位で永続化。
       # restore-keys で同一 matrix の最近の cache に fallback し、


### PR DESCRIPTION
## Summary

CI/CD hardening Epic #973 の **P3 (CI 効率化・運用改善) 3 件** を 1 PR に集約。

| Issue | 内容 |
|---|---|
| #984 | paths-filter で docs-only PR の build/test を skip (aggregator は必走) |
| #985 | 共通 setup を composite action (`.github/actions/setup-civicship`) に抽出 |
| #986 | Apollo schema publish 順序修正 + tzdata install 廃止 (TZ env で代替) |

旧個別 PR (#993 / #997 / #995) は本 PR に統合のため close。

## Test plan

- [ ] actionlint / yaml parse OK (ローカル確認済)
- [ ] docs-only PR で build/test job が skip され、aggregator が緑になる
- [ ] code 変更 PR では従来通り全 job 実行
- [ ] composite action 経由で 5 job の setup が単一定義から呼ばれる
- [ ] deploy 時の schema publish が deploy 成功後に走る
- [ ] `Create Git tag` step で apt-get install が呼ばれない

## Closes

Closes #984
Closes #985
Closes #986

## Notes

- composite action の `database-url` input は CI 用 (localhost) と deploy 用 (jumpbox tunnel) を呼び分け
- schema publish は本 PR では deploy 直後に位置。P0 #976 (canary) merge 後は smoke/canary 完了後に再配置する follow-up が必要

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG)_