### PR TITLE
chore(lint): fix unused-vars and empty-object-type errors

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,6 +28,7 @@ export default [
           varsIgnorePattern: "^_",
           caughtErrorsIgnorePattern: "^_",
           destructuredArrayIgnorePattern: "^_",
+          ignoreRestSiblings: true,
         },
       ],
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,5 +18,18 @@ export default [
     languageOptions: { globals: globals.node },
   },
   pluginJs.configs.recommended,
-  ...tseslint.configs.recommended
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+          destructuredArrayIgnorePattern: "^_",
+        },
+      ],
+    },
+  },
 ];

--- a/src/application/domain/account/community/config/incentive/signup/data/converter.ts
+++ b/src/application/domain/account/community/config/incentive/signup/data/converter.ts
@@ -17,7 +17,6 @@ export default class CommunitySignupBonusConfigConverter {
   ): Prisma.CommunitySignupBonusConfigUncheckedCreateInput {
     // For create operation, we need to handle the community relation differently
     // and convert update operations to simple values
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { community, ...updateData } = data;
 
     // Create a new object for create operation with primitive values

--- a/src/application/domain/account/community/data/converter.ts
+++ b/src/application/domain/account/community/data/converter.ts
@@ -46,7 +46,6 @@ export default class CommunityConverter {
     data: Prisma.CommunityCreateInput;
     image?: GqlImageInput;
   } {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { originalId, image, config, createdBy, ...prop } = input;
 
     return {

--- a/src/application/domain/experience/opportunity/data/converter.ts
+++ b/src/application/domain/experience/opportunity/data/converter.ts
@@ -62,7 +62,6 @@ export default class OpportunityConverter {
     data: Omit<Prisma.OpportunityCreateInput, "images">;
     images: GqlImageInput[];
   } => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { images, placeId, slots, createdBy, requiredUtilityIds, relatedArticleIds, ...rest } =
       input;
 

--- a/src/application/domain/experience/reservation/validator.ts
+++ b/src/application/domain/experience/reservation/validator.ts
@@ -56,7 +56,7 @@ export default class ReservationValidator {
     return { availableParticipationId: target.id };
   }
 
-  validateCancellable(slotStartAt: Date, opportunityId?: string) {
+  validateCancellable(slotStartAt: Date, _opportunityId?: string) {
     const now = new Date();
     
     // Use DEFAULT_CANCELLATION_DEADLINE_DAYS (1 day) for all activities

--- a/src/presentation/middleware/auth/security/index.ts
+++ b/src/presentation/middleware/auth/security/index.ts
@@ -18,7 +18,7 @@ import { PrismaClientIssuer } from "@/infrastructure/prisma/client";
 export async function runRequestSecurityChecks(
   req: http.IncomingMessage,
   headers: AuthHeaders,
-  issuer: PrismaClientIssuer
+  _issuer: PrismaClientIssuer
 ) {
   const url = req.url || "";
   const userAgent = Array.isArray(req.headers["user-agent"]) ? req.headers["user-agent"][0] : req.headers["user-agent"];

--- a/src/presentation/middleware/auth/types.ts
+++ b/src/presentation/middleware/auth/types.ts
@@ -47,7 +47,7 @@ export interface AuthResultBase {
 /**
  * Firebase認証成功時
  */
-export interface FirebaseAuthResult extends AuthResultBase {}
+export type FirebaseAuthResult = AuthResultBase;
 
 /**
  * 未認証リクエスト

--- a/src/presentation/middleware/custom-process-request.ts
+++ b/src/presentation/middleware/custom-process-request.ts
@@ -162,7 +162,7 @@ export const customProcessRequest = async (
       }
     });
 
-    busboy.on('file', (name: string, stream: NodeJS.ReadableStream, info: { filename: string; encoding: string; mimeType: string }) => {
+    busboy.on('file', (name: string, stream: NodeJS.ReadableStream, _info: { filename: string; encoding: string; mimeType: string }) => {
       fieldOrder.push(`file:${name}`);
       fileKeys.add(name);
       stream.resume();

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,4 +1,3 @@
-import { Request } from 'express';
 import { IContext } from './server';
 
 declare global {


### PR DESCRIPTION
## Summary
Fixes 11 lint errors (`no-unused-vars` + `no-empty-object-type`).

- Add `argsIgnorePattern: ^_` and friends to `@typescript-eslint/no-unused-vars`, matching the existing `_`-prefix convention already used in the codebase (e.g. `_authors`, `_relatedUsers`, `_next`, `_http`, `_domain`).
- Prefix four remaining intentionally-unused params with `_`:
  - `validateCancellable`'s `opportunityId` (kept for future per-activity logic; comment notes "for all activities")
  - `runRequestSecurityChecks`'s `issuer` (kept for future admin auth)
  - busboy file handler's `info`
- Drop the unused `Request` import from `express.d.ts`.
- Convert empty `interface FirebaseAuthResult extends AuthResultBase {}` to a type alias.

## Lint progress
- Before: 39 errors
- After: 28 errors
- Remaining (`no-explicit-any` in src/) will be split across two follow-up PRs by area: auth/middleware and domain/router/infra.

## Test plan
- [x] `pnpm lint` reports 28 errors (down from 39) and zero new errors.
- [x] `pnpm tsc --noEmit` shows no new type errors introduced by this change.
- [ ] CI: lint + build + all test suites pass.

https://claude.ai/code/session_01Rs8kgHhtcTWCRuf68ReYtq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rs8kgHhtcTWCRuf68ReYtq)_