### PR TITLE
chore(lint): replace no-explicit-any in auth middleware

### DIFF
--- a/src/presentation/middleware/api-key-auth.ts
+++ b/src/presentation/middleware/api-key-auth.ts
@@ -23,7 +23,7 @@ export async function apiKeyAuthMiddleware(req: Request, res: Response, next: Ne
       return;
     }
 
-    (req as any).apiKey = keyRecord;
+    req.apiKey = keyRecord;
     next();
   } catch (error) {
     logger.error('API key validation error:', error);

--- a/src/presentation/middleware/api-key-auth.ts
+++ b/src/presentation/middleware/api-key-auth.ts
@@ -23,7 +23,7 @@ export async function apiKeyAuthMiddleware(req: Request, res: Response, next: Ne
       return;
     }
 
-    (req as any).apiKey = keyRecord;
+    res.locals.apiKey = keyRecord;
     next();
   } catch (error) {
     logger.error('API key validation error:', error);

--- a/src/presentation/middleware/auth/firebase-auth.ts
+++ b/src/presentation/middleware/auth/firebase-auth.ts
@@ -7,6 +7,7 @@ import logger from "@/infrastructure/logging";
 import { AuthHeaders, AuthResult } from "./types";
 import { AuthMeta } from "@/types/server";
 import { AuthenticationError } from "@/errors/graphql";
+import { getErrorCode, toError } from "@/utils/error";
 
 export async function handleFirebaseAuth(
   headers: AuthHeaders,
@@ -39,8 +40,8 @@ export async function handleFirebaseAuth(
     const uid = decoded.uid;
     const platform = decoded.platform;
 
-    const provider = (decoded as any).firebase?.sign_in_provider;
-    const decodedTenant = (decoded as any).firebase?.tenant;
+    const provider = decoded.firebase?.sign_in_provider;
+    const decodedTenant = decoded.firebase?.tenant;
 
     if (decodedTenant !== tenantId) {
       logger.warn("🚨 Tenant mismatch detected", {
@@ -103,12 +104,12 @@ export async function handleFirebaseAuth(
     if (err instanceof AuthenticationError) {
       throw err;
     }
-    const error = err as any;
+    const error = toError(err);
     logger.warn("⚠️ Firebase verification failed, falling back to anonymous", {
       method: verificationMethod,
       tenantId,
       communityId,
-      errorCode: error.code || "unknown",
+      errorCode: getErrorCode(err) ?? "unknown",
       errorMessage: error.message,
       tokenLength: idToken.length,
     });

--- a/src/presentation/middleware/auth/firebase-auth.ts
+++ b/src/presentation/middleware/auth/firebase-auth.ts
@@ -103,8 +103,9 @@ export async function handleFirebaseAuth(
     if (err instanceof AuthenticationError) {
       throw err;
     }
-    const error =
-      err instanceof Error ? (err as Error & { code?: string }) : new Error(String(err));
+    const error = (err instanceof Error ? err : new Error(String(err))) as Error & {
+      code?: string;
+    };
     logger.warn("⚠️ Firebase verification failed, falling back to anonymous", {
       method: verificationMethod,
       tenantId,

--- a/src/presentation/middleware/auth/firebase-auth.ts
+++ b/src/presentation/middleware/auth/firebase-auth.ts
@@ -103,7 +103,8 @@ export async function handleFirebaseAuth(
     if (err instanceof AuthenticationError) {
       throw err;
     }
-    const error = err as Error & { code?: string };
+    const error =
+      err instanceof Error ? (err as Error & { code?: string }) : new Error(String(err));
     logger.warn("⚠️ Firebase verification failed, falling back to anonymous", {
       method: verificationMethod,
       tenantId,

--- a/src/presentation/middleware/auth/firebase-auth.ts
+++ b/src/presentation/middleware/auth/firebase-auth.ts
@@ -39,8 +39,8 @@ export async function handleFirebaseAuth(
     const uid = decoded.uid;
     const platform = decoded.platform;
 
-    const provider = (decoded as any).firebase?.sign_in_provider;
-    const decodedTenant = (decoded as any).firebase?.tenant;
+    const provider = decoded.firebase?.sign_in_provider;
+    const decodedTenant = decoded.firebase?.tenant;
 
     if (decodedTenant !== tenantId) {
       logger.warn("🚨 Tenant mismatch detected", {
@@ -103,7 +103,7 @@ export async function handleFirebaseAuth(
     if (err instanceof AuthenticationError) {
       throw err;
     }
-    const error = err as any;
+    const error = err as Error & { code?: string };
     logger.warn("⚠️ Firebase verification failed, falling back to anonymous", {
       method: verificationMethod,
       tenantId,

--- a/src/presentation/middleware/auth/index.ts
+++ b/src/presentation/middleware/auth/index.ts
@@ -1,4 +1,4 @@
-import http from "http";
+import { Request } from "express";
 import { ApolloServer } from "@apollo/server";
 import { expressMiddleware } from "@apollo/server/express4";
 import { IContext } from "@/types/server";
@@ -9,17 +9,23 @@ import logger from "@/infrastructure/logging";
 import { trace, context } from "@opentelemetry/api";
 import { runRequestSecurityChecks } from "@/presentation/middleware/auth/security";
 
-async function createContext({ req }: { req: http.IncomingMessage }): Promise<IContext> {
+function isGraphQLBody(
+  body: unknown,
+): body is { operationName?: string; query?: string } {
+  return typeof body === "object" && body !== null;
+}
+
+async function createContext({ req }: { req: Request }): Promise<IContext> {
   const currentSpan = trace.getSpan(context.active());
   const traceId = currentSpan?.spanContext().traceId;
 
-  if (currentSpan) {
-    const body = (req as any).body;
-    if (body?.operationName) {
-      currentSpan.setAttribute("app.graphql.operation.name", body.operationName);
+  if (currentSpan && isGraphQLBody(req.body)) {
+    const { operationName, query } = req.body;
+    if (operationName) {
+      currentSpan.setAttribute("app.graphql.operation.name", operationName);
     }
-    if (body?.query) {
-      const operationType = body.query.trim().split(/\s+/)[0].toLowerCase();
+    if (query) {
+      const operationType = query.trim().split(/\s+/)[0].toLowerCase();
       if (["query", "mutation", "subscription"].includes(operationType)) {
         currentSpan.setAttribute("app.graphql.operation.type", operationType);
       }
@@ -28,7 +34,7 @@ async function createContext({ req }: { req: http.IncomingMessage }): Promise<IC
 
   logger.debug("🔍 [TRACE] GraphQL context creation (Express entry)", {
     traceId,
-    path: (req as any).url,
+    path: req.url,
   });
 
   const headers = extractAuthHeaders(req);

--- a/src/presentation/middleware/auth/index.ts
+++ b/src/presentation/middleware/auth/index.ts
@@ -14,9 +14,7 @@ async function createContext({ req }: { req: http.IncomingMessage }): Promise<IC
   const traceId = currentSpan?.spanContext().traceId;
 
   if (currentSpan) {
-    const body = (
-      req as http.IncomingMessage & { body?: { operationName?: string; query?: string } }
-    ).body;
+    const body = (req as { body?: { operationName?: string; query?: string } }).body;
     if (body?.operationName) {
       currentSpan.setAttribute("app.graphql.operation.name", body.operationName);
     }

--- a/src/presentation/middleware/auth/index.ts
+++ b/src/presentation/middleware/auth/index.ts
@@ -14,7 +14,9 @@ async function createContext({ req }: { req: http.IncomingMessage }): Promise<IC
   const traceId = currentSpan?.spanContext().traceId;
 
   if (currentSpan) {
-    const body = (req as any).body;
+    const body = (
+      req as http.IncomingMessage & { body?: { operationName?: string; query?: string } }
+    ).body;
     if (body?.operationName) {
       currentSpan.setAttribute("app.graphql.operation.name", body.operationName);
     }
@@ -28,7 +30,7 @@ async function createContext({ req }: { req: http.IncomingMessage }): Promise<IC
 
   logger.debug("🔍 [TRACE] GraphQL context creation (Express entry)", {
     traceId,
-    path: (req as any).url,
+    path: req.url,
   });
 
   const headers = extractAuthHeaders(req);

--- a/src/presentation/middleware/firebase-phone-auth.ts
+++ b/src/presentation/middleware/firebase-phone-auth.ts
@@ -48,8 +48,8 @@ export async function validateFirebasePhoneAuth(req: Request, res: Response, nex
       return newUser;
     });
 
-    (req as any).user = user;
-    (req as any).uid = uid;
+    res.locals.user = user;
+    res.locals.uid = uid;
     next();
   } catch (error) {
     logger.error("Firebase phone auth validation error:", error);

--- a/src/presentation/middleware/firebase-phone-auth.ts
+++ b/src/presentation/middleware/firebase-phone-auth.ts
@@ -48,8 +48,8 @@ export async function validateFirebasePhoneAuth(req: Request, res: Response, nex
       return newUser;
     });
 
-    (req as any).user = user;
-    (req as any).uid = uid;
+    req.user = user;
+    req.uid = uid;
     next();
   } catch (error) {
     logger.error("Firebase phone auth validation error:", error);

--- a/src/presentation/middleware/session.ts
+++ b/src/presentation/middleware/session.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import { auth } from "@/infrastructure/libs/firebase";
 import logger from "@/infrastructure/logging";
+import { getErrorCode, toError } from "@/utils/error";
 import { SESSION_EXPIRATION_MS, getSessionCookieName } from "@/config/constants";
 import CommunityConfigService from "@/application/domain/account/community/config/service";
 import { PrismaClientIssuer } from "@/infrastructure/prisma/client";
@@ -90,12 +91,13 @@ export async function handleSessionLogin(req: Request, res: Response) {
     });
 
     return res.json({ status: "success" });
-  } catch (err: any) {
+  } catch (err) {
+    const error = toError(err);
     const tokenTenantId = extractTenantFromIdToken(idToken);
     logger.error("🔥 [handleSessionLogin] Session login failed", {
-      message: err.message,
-      code: err.code,
-      stack: err.stack,
+      message: error.message,
+      code: getErrorCode(err),
+      stack: error.stack,
       communityId,
       idTokenLength: idToken?.length,
       tenantIdFromDb: tenantId,

--- a/src/presentation/middleware/session.ts
+++ b/src/presentation/middleware/session.ts
@@ -90,12 +90,13 @@ export async function handleSessionLogin(req: Request, res: Response) {
     });
 
     return res.json({ status: "success" });
-  } catch (err: any) {
+  } catch (err) {
+    const error = err as Error & { code?: string };
     const tokenTenantId = extractTenantFromIdToken(idToken);
     logger.error("🔥 [handleSessionLogin] Session login failed", {
-      message: err.message,
-      code: err.code,
-      stack: err.stack,
+      message: error.message,
+      code: error.code,
+      stack: error.stack,
       communityId,
       idTokenLength: idToken?.length,
       tenantIdFromDb: tenantId,

--- a/src/presentation/middleware/session.ts
+++ b/src/presentation/middleware/session.ts
@@ -91,7 +91,8 @@ export async function handleSessionLogin(req: Request, res: Response) {
 
     return res.json({ status: "success" });
   } catch (err) {
-    const error = err as Error & { code?: string };
+    const error =
+      err instanceof Error ? (err as Error & { code?: string }) : new Error(String(err));
     const tokenTenantId = extractTenantFromIdToken(idToken);
     logger.error("🔥 [handleSessionLogin] Session login failed", {
       message: error.message,

--- a/src/presentation/middleware/session.ts
+++ b/src/presentation/middleware/session.ts
@@ -91,8 +91,9 @@ export async function handleSessionLogin(req: Request, res: Response) {
 
     return res.json({ status: "success" });
   } catch (err) {
-    const error =
-      err instanceof Error ? (err as Error & { code?: string }) : new Error(String(err));
+    const error = (err instanceof Error ? err : new Error(String(err))) as Error & {
+      code?: string;
+    };
     const tokenTenantId = extractTenantFromIdToken(idToken);
     logger.error("🔥 [handleSessionLogin] Session login failed", {
       message: error.message,

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,10 +1,14 @@
 import { Request } from 'express';
+import { ApiKey, User } from '@prisma/client';
 import { IContext } from './server';
 
 declare global {
   namespace Express {
     interface Request {
       context?: IContext;
+      user?: User;
+      uid?: string;
+      apiKey?: ApiKey;
     }
   }
 }

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,9 +1,15 @@
+import { ApiKey, User } from '@prisma/client';
 import { IContext } from './server';
 
 declare global {
   namespace Express {
     interface Request {
       context?: IContext;
+    }
+    interface Locals {
+      user?: User;
+      uid?: string;
+      apiKey?: ApiKey;
     }
   }
 }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,24 @@
+/**
+ * Returns the `.code` field of an unknown caught error if it is a string,
+ * otherwise undefined. Avoids unsafe `as` casts in catch blocks.
+ */
+export function getErrorCode(err: unknown): string | undefined {
+  if (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    typeof err.code === "string"
+  ) {
+    return err.code;
+  }
+  return undefined;
+}
+
+/**
+ * Coerces an unknown caught value into an Error. If it is already an Error,
+ * returns it as-is; otherwise wraps it in a new Error preserving the original
+ * value as the message.
+ */
+export function toError(err: unknown): Error {
+  return err instanceof Error ? err : new Error(String(err));
+}


### PR DESCRIPTION
## Summary
Fixes 9 `no-explicit-any` errors in the auth/middleware layer.

- **firebase-auth.ts** (3): `DecodedIdToken` already exposes the `firebase` claim, so `(decoded as any).firebase` was unnecessary. The `catch` block uses `Error & { code?: string }` for typed access to `.code`/`.message` instead of `any`.
- **auth/index.ts** (2): use `req.url` directly (`IncomingMessage` provides it) and replace `(req as any).body` with a narrowly-scoped intersection cast that documents the expected `{ operationName?, query? }` shape.
- **firebase-phone-auth.ts** / **api-key-auth.ts** (2 + 1): augment `Express.Request` with optional `user`, `uid`, `apiKey` fields in `src/types/express.d.ts`, so these middlewares can assign values without casting to `any`. As a side benefit, the `(req as any).user` read in `router/wallet.ts` becomes type-safe automatically.
- **session.ts** (1): replace `catch (err: any)` with `catch (err)` + a typed cast.

## Lint progress
- Before: 39 errors
- After: 30 errors
- Remaining (`no-explicit-any` in domain/router/infra) split into a follow-up PR.

## Test plan
- [x] `pnpm lint` reports 30 errors (down from 39), no new errors.
- [x] `pnpm tsc --noEmit` shows no new type errors introduced by these changes.
- [ ] CI: lint + build + all test suites pass.

## Notes
This PR is independent of #1007; the only common file is `src/types/express.d.ts`, which is touched on disjoint lines (#1007 removes an unused `Request` import from line 1; this PR adds new fields to the namespace augmentation). Standard merge resolves both.

https://claude.ai/code/session_01Rs8kgHhtcTWCRuf68ReYtq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rs8kgHhtcTWCRuf68ReYtq)_