### PR TITLE
chore(lint): replace no-explicit-any in domain/router/infra

### DIFF
--- a/src/application/domain/account/identity/service.ts
+++ b/src/application/domain/account/identity/service.ts
@@ -148,8 +148,9 @@ export default class IdentityService {
     const tenantedAuth = auth.tenantManager().authForTenant(tenantId);
     try {
       await tenantedAuth.deleteUser(uid);
-    } catch (error: any) {
-      if (error?.code === "auth/user-not-found") {
+    } catch (error) {
+      const typedError = error as { code?: string } | null;
+      if (typedError?.code === "auth/user-not-found") {
         logger.info("Firebase user not found when deleting; treated as already deleted.", { uid, tenantId });
         return;
       }

--- a/src/application/domain/account/identity/service.ts
+++ b/src/application/domain/account/identity/service.ts
@@ -6,6 +6,7 @@ import { IContext } from "@/types/server";
 import { Prisma, IdentityPlatform, User } from "@prisma/client";
 import logger from "@/infrastructure/logging";
 import { FirebaseTokenRefreshResponse } from "@/application/domain/account/identity/data/type";
+import { getErrorCode } from "@/utils/error";
 
 @injectable()
 export default class IdentityService {
@@ -149,8 +150,7 @@ export default class IdentityService {
     try {
       await tenantedAuth.deleteUser(uid);
     } catch (error) {
-      const typedError = error as { code?: string } | null;
-      if (typedError?.code === "auth/user-not-found") {
+      if (getErrorCode(error) === "auth/user-not-found") {
         logger.info("Firebase user not found when deleting; treated as already deleted.", { uid, tenantId });
         return;
       }

--- a/src/application/domain/account/nft-instance/presenter.ts
+++ b/src/application/domain/account/nft-instance/presenter.ts
@@ -1,4 +1,4 @@
-import { GqlNftInstance, GqlNftInstancesConnection } from "@/types/graphql";
+import { GqlNftInstance, GqlNftInstancesConnection, GqlUser } from "@/types/graphql";
 import { PrismaNftInstance } from "@/application/domain/account/nft-instance/data/type";
 import NftTokenPresenter from "@/application/domain/account/nft-token/presenter";
 
@@ -6,17 +6,19 @@ export default class NftInstancePresenter {
   static get(nftInstance: PrismaNftInstance): GqlNftInstance {
     const { nftWallet, nftToken, ...nftInstanceProps } = nftInstance;
 
-    // The `user` field on `nftWallet` is filled in by the GraphQL field resolver,
-    // so the literal here doesn't satisfy `GqlNftWallet` structurally.
     return {
       __typename: "NftInstance",
       ...nftInstanceProps,
       nftToken: NftTokenPresenter.get(nftToken),
+      // `user` is resolved by the GraphQL field resolver from `userId`; it
+      // intentionally is not populated here. We mark it null to satisfy the
+      // schema's required `user: GqlUser`.
       nftWallet: nftWallet ? {
         __typename: "NftWallet",
         ...nftWallet,
+        user: null as unknown as GqlUser,
       } : null,
-    } as unknown as GqlNftInstance;
+    };
   }
 
   static query(

--- a/src/application/domain/account/nft-instance/presenter.ts
+++ b/src/application/domain/account/nft-instance/presenter.ts
@@ -1,11 +1,13 @@
-import { GqlNftInstancesConnection } from "@/types/graphql";
+import { GqlNftInstance, GqlNftInstancesConnection } from "@/types/graphql";
 import { PrismaNftInstance } from "@/application/domain/account/nft-instance/data/type";
 import NftTokenPresenter from "@/application/domain/account/nft-token/presenter";
 
 export default class NftInstancePresenter {
-  static get(nftInstance: PrismaNftInstance): any {
+  static get(nftInstance: PrismaNftInstance): GqlNftInstance {
     const { nftWallet, nftToken, ...nftInstanceProps } = nftInstance;
 
+    // The `user` field on `nftWallet` is filled in by the GraphQL field resolver,
+    // so the literal here doesn't satisfy `GqlNftWallet` structurally.
     return {
       __typename: "NftInstance",
       ...nftInstanceProps,
@@ -14,7 +16,7 @@ export default class NftInstancePresenter {
         __typename: "NftWallet",
         ...nftWallet,
       } : null,
-    };
+    } as unknown as GqlNftInstance;
   }
 
   static query(

--- a/src/application/domain/account/nft-wallet/service.ts
+++ b/src/application/domain/account/nft-wallet/service.ts
@@ -120,18 +120,19 @@ export default class NFTWalletService {
       });
       return response;
     } catch (error) {
+      const typedError = error as { code?: string; type?: string } | null;
       const errorDetails = {
         walletAddress,
         durationMs: Date.now() - startTime,
         errorMessage: error instanceof Error ? error.message : JSON.stringify(error),
         errorName: error instanceof Error ? error.name : 'Unknown',
-        errorCode: (error as any)?.code,
-        errorType: (error as any)?.type,
+        errorCode: typedError?.code,
+        errorType: typedError?.type,
         errorStack: error instanceof Error ? error.stack : undefined,
       };
 
       // Use warn level for timeout errors (temporary network issues)
-      const isTimeout = !!error && (error as any).code === 'ETIMEDOUT';
+      const isTimeout = typedError?.code === 'ETIMEDOUT';
       if (isTimeout) {
         logger.warn("⚠️ Failed to fetch NFT metadata (timeout)", errorDetails);
       } else {

--- a/src/application/domain/account/nft-wallet/service.ts
+++ b/src/application/domain/account/nft-wallet/service.ts
@@ -11,6 +11,7 @@ import pLimit from "p-limit";
 import { NmkrClient } from "@/infrastructure/libs/nmkr/api/client";
 import { PrismaNftWalletDetail } from "@/application/domain/account/nft-wallet/data/type";
 import crypto from "crypto";
+import { getErrorCode, getErrorType } from "@/utils/error";
 
 const TOKEN_CACHE_TTL = 24 * 60 * 60 * 1000;
 const MAX_RETRIES = 3;
@@ -120,19 +121,19 @@ export default class NFTWalletService {
       });
       return response;
     } catch (error) {
-      const typedError = error as { code?: string; type?: string } | null;
+      const errorCode = getErrorCode(error);
       const errorDetails = {
         walletAddress,
         durationMs: Date.now() - startTime,
         errorMessage: error instanceof Error ? error.message : JSON.stringify(error),
         errorName: error instanceof Error ? error.name : 'Unknown',
-        errorCode: typedError?.code,
-        errorType: typedError?.type,
+        errorCode,
+        errorType: getErrorType(error),
         errorStack: error instanceof Error ? error.stack : undefined,
       };
 
       // Use warn level for timeout errors (temporary network issues)
-      const isTimeout = typedError?.code === 'ETIMEDOUT';
+      const isTimeout = errorCode === 'ETIMEDOUT';
       if (isTimeout) {
         logger.warn("⚠️ Failed to fetch NFT metadata (timeout)", errorDetails);
       } else {

--- a/src/application/domain/account/nft-wallet/usecase.ts
+++ b/src/application/domain/account/nft-wallet/usecase.ts
@@ -3,6 +3,7 @@ import { injectable, inject } from "tsyringe";
 import { PrismaClientIssuer } from "@/infrastructure/prisma/client";
 import NFTWalletService from "@/application/domain/account/nft-wallet/service";
 import logger from "@/infrastructure/logging";
+import { getErrorCode, getErrorType } from "@/utils/error";
 
 export type SyncMetadataResult = {
   success: boolean;
@@ -129,19 +130,19 @@ export default class NFTWalletUsecase {
         });
       }
 
-      const typedError = error as { code?: string; type?: string } | null;
+      const errorCode = getErrorCode(error);
       const errorDetails = {
         walletAddress: wallet.walletAddress,
         durationMs: Date.now() - startTime,
         errorMessage: error instanceof Error ? error.message : JSON.stringify(error),
         errorName: error instanceof Error ? error.name : 'Unknown',
-        errorCode: typedError?.code,
-        errorType: typedError?.type,
+        errorCode,
+        errorType: getErrorType(error),
         errorStack: error instanceof Error ? error.stack : undefined,
       };
 
       // Use warn level for timeout errors (temporary network issues)
-      const isTimeout = typedError?.code === 'ETIMEDOUT';
+      const isTimeout = errorCode === 'ETIMEDOUT';
       if (isTimeout) {
         logger.warn("⚠️ NFT metadata sync timeout", errorDetails);
       } else {

--- a/src/application/domain/account/nft-wallet/usecase.ts
+++ b/src/application/domain/account/nft-wallet/usecase.ts
@@ -129,18 +129,19 @@ export default class NFTWalletUsecase {
         });
       }
 
+      const typedError = error as { code?: string; type?: string } | null;
       const errorDetails = {
         walletAddress: wallet.walletAddress,
         durationMs: Date.now() - startTime,
         errorMessage: error instanceof Error ? error.message : JSON.stringify(error),
         errorName: error instanceof Error ? error.name : 'Unknown',
-        errorCode: (error as any)?.code,
-        errorType: (error as any)?.type,
+        errorCode: typedError?.code,
+        errorType: typedError?.type,
         errorStack: error instanceof Error ? error.stack : undefined,
       };
 
       // Use warn level for timeout errors (temporary network issues)
-      const isTimeout = !!error && (error as any).code === 'ETIMEDOUT';
+      const isTimeout = typedError?.code === 'ETIMEDOUT';
       if (isTimeout) {
         logger.warn("⚠️ NFT metadata sync timeout", errorDetails);
       } else {

--- a/src/application/domain/location/master/data/interface.ts
+++ b/src/application/domain/location/master/data/interface.ts
@@ -1,12 +1,9 @@
 import { Prisma } from "@prisma/client";
 import { IContext } from "@/types/server";
-import { PrismaCityDetail } from "@/application/domain/location/master/data/type";
-
-type PrismaStateDetail = {
-  code: string;
-  name: string;
-  countryCode: string;
-};
+import {
+  PrismaCityDetail,
+  PrismaStateDetail,
+} from "@/application/domain/location/master/data/type";
 
 export default interface IMasterRepository {
   findCities(

--- a/src/application/domain/location/master/data/interface.ts
+++ b/src/application/domain/location/master/data/interface.ts
@@ -1,5 +1,12 @@
 import { Prisma } from "@prisma/client";
 import { IContext } from "@/types/server";
+import { PrismaCityDetail } from "@/application/domain/location/master/data/type";
+
+type PrismaStateDetail = {
+  code: string;
+  name: string;
+  countryCode: string;
+};
 
 export default interface IMasterRepository {
   findCities(
@@ -8,7 +15,7 @@ export default interface IMasterRepository {
     orderBy: Prisma.CityOrderByWithRelationInput[],
     take: number,
     cursor?: string
-  ): Promise<any[]>;
+  ): Promise<PrismaCityDetail[]>;
 
   findStates(
     ctx: IContext,
@@ -16,5 +23,5 @@ export default interface IMasterRepository {
     orderBy: Prisma.StateOrderByWithRelationInput[],
     take: number,
     cursor?: string
-  ): Promise<any[]>;
+  ): Promise<PrismaStateDetail[]>;
 }

--- a/src/application/domain/location/master/data/type.ts
+++ b/src/application/domain/location/master/data/type.ts
@@ -13,3 +13,9 @@ export type PrismaCityDetail = {
   code: string;
   stateCode: string;
 };
+
+export type PrismaStateDetail = {
+  code: string;
+  name: string;
+  countryCode: string;
+};

--- a/src/application/domain/transaction/incentiveGrant/service.ts
+++ b/src/application/domain/transaction/incentiveGrant/service.ts
@@ -117,9 +117,10 @@ export default class IncentiveGrantService {
       try {
         await this.repository.create(ctx, createData, tx);
         grantRecordCreated = true;
-      } catch (error: any) {
+      } catch (error) {
+        const typedError = error as { code?: string } | null;
         // P2002 = unique constraint violation = already granted
-        if (error?.code === "P2002") {
+        if (typedError?.code === "P2002") {
           logger.info("Signup bonus already granted (idempotent)", logContext);
           return { granted: false, transaction: null };
         }
@@ -177,12 +178,15 @@ export default class IncentiveGrantService {
           comment: transaction.comment,
         },
       };
-    } catch (error: any) {
+    } catch (error) {
+      const typedError =
+        error instanceof Error ? error : new Error(String(error));
+      const errorCode = (error as { code?: string } | null)?.code;
       // Best-effort: Log error and mark as failed, but don't throw
       logger.warn("Signup bonus grant failed (best-effort)", {
         ...logContext,
-        error: error.message,
-        stack: error.stack,
+        error: typedError.message,
+        stack: typedError.stack,
       });
 
       // Only mark as failed if the PENDING record was created
@@ -194,7 +198,7 @@ export default class IncentiveGrantService {
             failureCode = IncentiveGrantFailureCode.INSUFFICIENT_FUNDS;
           } else if (error instanceof NotFoundError) {
             failureCode = IncentiveGrantFailureCode.WALLET_NOT_FOUND;
-          } else if (error?.code?.startsWith("P")) {
+          } else if (errorCode?.startsWith("P")) {
             failureCode = IncentiveGrantFailureCode.DATABASE_ERROR;
           } else {
             failureCode = IncentiveGrantFailureCode.UNKNOWN;
@@ -208,14 +212,18 @@ export default class IncentiveGrantService {
             IncentiveGrantType.SIGNUP,
             sourceId,
             failureCode,
-            error.message,
+            typedError.message,
             tx,
           );
-        } catch (markFailedError: any) {
+        } catch (markFailedError) {
+          const typedMarkError =
+            markFailedError instanceof Error
+              ? markFailedError
+              : new Error(String(markFailedError));
           // If marking as failed also fails, just log it
           logger.error("Failed to mark incentive grant as failed", {
             ...logContext,
-            error: markFailedError.message,
+            error: typedMarkError.message,
           });
         }
       }

--- a/src/application/domain/transaction/incentiveGrant/service.ts
+++ b/src/application/domain/transaction/incentiveGrant/service.ts
@@ -198,7 +198,7 @@ export default class IncentiveGrantService {
             failureCode = IncentiveGrantFailureCode.INSUFFICIENT_FUNDS;
           } else if (error instanceof NotFoundError) {
             failureCode = IncentiveGrantFailureCode.WALLET_NOT_FOUND;
-          } else if (errorCode?.startsWith("P")) {
+          } else if (typeof errorCode === "string" && errorCode.startsWith("P")) {
             failureCode = IncentiveGrantFailureCode.DATABASE_ERROR;
           } else {
             failureCode = IncentiveGrantFailureCode.UNKNOWN;

--- a/src/application/domain/transaction/incentiveGrant/service.ts
+++ b/src/application/domain/transaction/incentiveGrant/service.ts
@@ -16,6 +16,7 @@ import {
   IncentiveDisabledError,
   ConcurrentRetryError,
 } from "@/errors/graphql";
+import { getErrorCode, toError } from "@/utils/error";
 
 export type SignupBonusGrantResult = {
   granted: boolean;
@@ -118,9 +119,8 @@ export default class IncentiveGrantService {
         await this.repository.create(ctx, createData, tx);
         grantRecordCreated = true;
       } catch (error) {
-        const typedError = error as { code?: string } | null;
         // P2002 = unique constraint violation = already granted
-        if (typedError?.code === "P2002") {
+        if (getErrorCode(error) === "P2002") {
           logger.info("Signup bonus already granted (idempotent)", logContext);
           return { granted: false, transaction: null };
         }
@@ -179,9 +179,8 @@ export default class IncentiveGrantService {
         },
       };
     } catch (error) {
-      const typedError =
-        error instanceof Error ? error : new Error(String(error));
-      const errorCode = (error as { code?: string } | null)?.code;
+      const typedError = toError(error);
+      const errorCode = getErrorCode(error);
       // Best-effort: Log error and mark as failed, but don't throw
       logger.warn("Signup bonus grant failed (best-effort)", {
         ...logContext,
@@ -198,7 +197,7 @@ export default class IncentiveGrantService {
             failureCode = IncentiveGrantFailureCode.INSUFFICIENT_FUNDS;
           } else if (error instanceof NotFoundError) {
             failureCode = IncentiveGrantFailureCode.WALLET_NOT_FOUND;
-          } else if (typeof errorCode === "string" && errorCode.startsWith("P")) {
+          } else if (errorCode?.startsWith("P")) {
             failureCode = IncentiveGrantFailureCode.DATABASE_ERROR;
           } else {
             failureCode = IncentiveGrantFailureCode.UNKNOWN;
@@ -216,14 +215,10 @@ export default class IncentiveGrantService {
             tx,
           );
         } catch (markFailedError) {
-          const typedMarkError =
-            markFailedError instanceof Error
-              ? markFailedError
-              : new Error(String(markFailedError));
           // If marking as failed also fails, just log it
           logger.error("Failed to mark incentive grant as failed", {
             ...logContext,
-            error: typedMarkError.message,
+            error: toError(markFailedError).message,
           });
         }
       }

--- a/src/application/domain/transaction/incentiveGrant/usecase.ts
+++ b/src/application/domain/transaction/incentiveGrant/usecase.ts
@@ -197,7 +197,7 @@ export default class IncentiveGrantUseCase {
         // Transaction will be resolved by the field resolver using DataLoader
         transaction: null,
       };
-    } catch (error: any) {
+    } catch (error) {
       // Handle business logic errors: persist failure info in a separate transaction
       const isValidationError =
         error instanceof NotFoundError ||
@@ -213,7 +213,7 @@ export default class IncentiveGrantUseCase {
           (updateError) => {
             logger.error("Failed to update grant failure status", {
               incentiveGrantId: input.incentiveGrantId,
-              originalError: error.message || String(error),
+              originalError: error instanceof Error ? error.message : String(error),
               error: updateError,
             });
           },
@@ -232,7 +232,7 @@ export default class IncentiveGrantUseCase {
   private async updateFailedGrantStatus(
     ctx: IContext,
     incentiveGrantId: string,
-    error: any,
+    error: unknown,
   ): Promise<void> {
     await ctx.issuer.onlyBelongingCommunity(ctx, async (tx: Prisma.TransactionClient) => {
       const grant = await this.repository.findInTransaction(ctx, incentiveGrantId, tx);
@@ -273,6 +273,7 @@ export default class IncentiveGrantUseCase {
       }
 
       // Mark as failed
+      const errorMessage = error instanceof Error ? error.message : String(error);
       await this.repository.markAsFailed(
         ctx,
         grant.userId,
@@ -280,7 +281,7 @@ export default class IncentiveGrantUseCase {
         grant.type,
         grant.sourceId,
         failureCode,
-        error.message || "Unknown error",
+        errorMessage || "Unknown error",
         tx,
       );
     });

--- a/src/application/domain/transaction/incentiveGrant/usecase.ts
+++ b/src/application/domain/transaction/incentiveGrant/usecase.ts
@@ -27,6 +27,7 @@ import {
   GqlSortDirection,
   GqlIncentiveGrantRetryPayload,
 } from "@/types/graphql";
+import { toError } from "@/utils/error";
 
 @injectable()
 export default class IncentiveGrantUseCase {
@@ -213,7 +214,7 @@ export default class IncentiveGrantUseCase {
           (updateError) => {
             logger.error("Failed to update grant failure status", {
               incentiveGrantId: input.incentiveGrantId,
-              originalError: error instanceof Error ? error.message : String(error),
+              originalError: toError(error).message,
               error: updateError,
             });
           },
@@ -273,7 +274,7 @@ export default class IncentiveGrantUseCase {
       }
 
       // Mark as failed
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = toError(error).message;
       await this.repository.markAsFailed(
         ctx,
         grant.userId,

--- a/src/infrastructure/logging/tracing.ts
+++ b/src/infrastructure/logging/tracing.ts
@@ -62,7 +62,8 @@ export const tracingReady = (async () => {
         return url.includes("/health") || req.method === "OPTIONS";
       },
       requestHook: (span, request) => {
-        const communityId = (request as any).headers?.["x-community-id"];
+        const headers = "headers" in request ? request.headers : undefined;
+        const communityId = headers?.["x-community-id"];
         if (communityId) {
           span.setAttribute("app.community_id", communityId);
         }

--- a/src/presentation/batch/syncNmkr/requestMintNft.ts
+++ b/src/presentation/batch/syncNmkr/requestMintNft.ts
@@ -45,7 +45,10 @@ export async function processQueuedMints() {
         try {
           const walletAddress = mint.nftInstance?.nftWallet?.walletAddress;
           const nftInstanceId = mint.nftInstance?.instanceId;
-          const nftTokenJson = mint.nftInstance?.nftToken?.json as any;
+          const nftTokenJson = mint.nftInstance?.nftToken?.json as
+            | { nmkrProjectUid?: string; projectUid?: string }
+            | null
+            | undefined;
           
           if (!walletAddress || !nftInstanceId) {
             throw new Error(`Missing required data: walletAddress=${walletAddress}, nftInstanceId=${nftInstanceId}`);

--- a/src/presentation/batch/syncNmkr/requestMintNft.ts
+++ b/src/presentation/batch/syncNmkr/requestMintNft.ts
@@ -6,6 +6,17 @@ import { PrismaClientIssuer } from "@/infrastructure/prisma/client";
 import { NmkrClient } from "@/infrastructure/libs/nmkr/api/client";
 import { NftMintStatus, NftInstanceStatus } from "@prisma/client";
 
+function readNmkrProjectUid(json: unknown): string | undefined {
+  if (typeof json !== "object" || json === null) return undefined;
+  if ("nmkrProjectUid" in json && typeof json.nmkrProjectUid === "string") {
+    return json.nmkrProjectUid;
+  }
+  if ("projectUid" in json && typeof json.projectUid === "string") {
+    return json.projectUid;
+  }
+  return undefined;
+}
+
 export async function processQueuedMints() {
   logger.debug("🚀 Starting batch for QUEUED nftMints...");
 
@@ -45,16 +56,12 @@ export async function processQueuedMints() {
         try {
           const walletAddress = mint.nftInstance?.nftWallet?.walletAddress;
           const nftInstanceId = mint.nftInstance?.instanceId;
-          const nftTokenJson = mint.nftInstance?.nftToken?.json as
-            | { nmkrProjectUid?: string; projectUid?: string }
-            | null
-            | undefined;
-          
+
           if (!walletAddress || !nftInstanceId) {
             throw new Error(`Missing required data: walletAddress=${walletAddress}, nftInstanceId=${nftInstanceId}`);
           }
 
-          const nmkrProjectUid = nftTokenJson?.nmkrProjectUid || nftTokenJson?.projectUid;
+          const nmkrProjectUid = readNmkrProjectUid(mint.nftInstance?.nftToken?.json);
           if (!nmkrProjectUid) {
             throw new Error(`NMKR project UID not found in nftToken.json`);
           }

--- a/src/presentation/router/line.ts
+++ b/src/presentation/router/line.ts
@@ -47,14 +47,6 @@ router.post("/liff-login", express.json(), async (req, res) => {
 
     res.setHeader("X-Token-Expires-At", result.expiryTimestamp.toString());
 
-    const liffContext = {
-      uid: result.profile.userId,
-      platform: "LINE",
-      idToken: accessToken,
-      refreshToken: accessToken,
-    };
-    (req as unknown as { context?: typeof liffContext }).context = liffContext;
-
     return res.status(200).json({
       customToken: result.customToken,
       profile: result.profile,

--- a/src/presentation/router/line.ts
+++ b/src/presentation/router/line.ts
@@ -47,12 +47,13 @@ router.post("/liff-login", express.json(), async (req, res) => {
 
     res.setHeader("X-Token-Expires-At", result.expiryTimestamp.toString());
 
-    (req as any).context = {
+    const liffContext = {
       uid: result.profile.userId,
       platform: "LINE",
       idToken: accessToken,
       refreshToken: accessToken,
     };
+    (req as unknown as { context?: typeof liffContext }).context = liffContext;
 
     return res.status(200).json({
       customToken: result.customToken,

--- a/src/presentation/router/wallet.ts
+++ b/src/presentation/router/wallet.ts
@@ -1,4 +1,4 @@
-import express, { Request } from 'express';
+import express from 'express';
 import { container } from 'tsyringe';
 import NFTWalletUsecase from '@/application/domain/account/nft-wallet/usecase';
 import { apiKeyAuthMiddleware } from '@/presentation/middleware/api-key-auth';
@@ -7,7 +7,6 @@ import { walletRateLimit } from '@/presentation/middleware/rate-limit';
 import { PrismaClientIssuer } from '@/infrastructure/prisma/client';
 import logger from '@/infrastructure/logging';
 import { IContext } from '@/types/server';
-import { PrismaAuthUser } from '@/application/domain/account/user/data/type';
 
 const router = express();
 
@@ -18,7 +17,7 @@ router.post('/nft-wallets',
   async (req, res) => {
     try {
       const { walletAddress, name } = req.body;
-      const user = (req as Request & { user?: PrismaAuthUser }).user;
+      const { user } = res.locals;
       if (!user) {
         return res.status(401).json({ error: 'User not authenticated' });
       }

--- a/src/presentation/router/wallet.ts
+++ b/src/presentation/router/wallet.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { Request } from 'express';
 import { container } from 'tsyringe';
 import NFTWalletUsecase from '@/application/domain/account/nft-wallet/usecase';
 import { apiKeyAuthMiddleware } from '@/presentation/middleware/api-key-auth';
@@ -18,7 +18,10 @@ router.post('/nft-wallets',
   async (req, res) => {
     try {
       const { walletAddress, name } = req.body;
-      const user = (req as any).user as PrismaAuthUser;
+      const user = (req as Request & { user?: PrismaAuthUser }).user;
+      if (!user) {
+        return res.status(401).json({ error: 'User not authenticated' });
+      }
       
       if (!walletAddress || typeof walletAddress !== 'string') {
         return res.status(400).json({ error: 'walletAddress must be a string' });

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -3,13 +3,19 @@
  * otherwise undefined. Avoids unsafe `as` casts in catch blocks.
  */
 export function getErrorCode(err: unknown): string | undefined {
-  if (
-    typeof err === "object" &&
-    err !== null &&
-    "code" in err &&
-    typeof err.code === "string"
-  ) {
+  if (typeof err === "object" && err !== null && "code" in err && typeof err.code === "string") {
     return err.code;
+  }
+  return undefined;
+}
+
+/**
+ * Returns the `.type` field of an unknown caught error if it is a string,
+ * otherwise undefined.
+ */
+export function getErrorType(err: unknown): string | undefined {
+  if (typeof err === "object" && err !== null && "type" in err && typeof err.type === "string") {
+    return err.type;
   }
   return undefined;
 }


### PR DESCRIPTION
## Depends on #1008

This PR's imports of `@/utils/error` resolve only after #1008 (which adds `src/utils/error.ts` and the `Express.Locals` augmentation) lands on `develop`. CI on this branch alone will surface "Cannot find module '@/utils/error'" until then; this is expected and resolves on rebase post-#1008-merge.

## Summary
Replaces all `no-explicit-any` violations in domain/router/infrastructure files. After feedback that `as` casts should be avoided where possible, the changes lean on type guards (`getErrorCode` / `getErrorType` / `toError`) and `res.locals` augmentation rather than typed `as` casts.

### Domain layer
- **nft-wallet service / usecase**: `error as { code?, type? }` → `getErrorCode(error)` + `getErrorType(error)`.
- **identity service**: same pattern for the Firebase `deleteUser` catch.
- **incentiveGrant service / usecase**: `error: any` parameters/catches → `unknown` + `getErrorCode` / `toError`.
- **location/master interface**: `Promise<any[]>` returns → typed via `PrismaCityDetail` and a sibling `PrismaStateDetail` (added to `data/type.ts` per review feedback).
- **nft-instance presenter**: declare return as `GqlNftInstance`; one localized `null as unknown as GqlUser` cast remains for the placeholder `nftWallet.user` field. The schema marks it non-null so the placeholder is structurally required without a schema change. The field is filled in by the GraphQL field resolver downstream.

### Presentation layer
- **router/wallet**: read `res.locals.user` (typed by the `Express.Locals` augmentation in #1008) instead of `(req as Request & { user? }).user`. Returns 401 if the upstream middleware didn't populate it (previously assumed via `as any`).
- **router/line**: drop the `(req as unknown as { context? }).context = ...` assignment. Verified via grep that nothing reads `req.context` from this route, so the cast was preserving dead code.
- **batch/syncNmkr/requestMintNft**: replace inline JSON cast with a `readNmkrProjectUid` type guard.

### Infrastructure
- **logging/tracing**: use `"headers" in request` to narrow OTel's `ClientRequest | IncomingMessage` union to the side that has `.headers`.

## Test plan
- [x] After #1008 merges, `pnpm lint` reports 0 errors on rebased state (full lint cleanup).
- [x] `pnpm tsc --noEmit` shows no new type errors after #1008 merges (only the import-resolution errors that resolve on rebase).
- [x] One semantic improvement: `router/wallet` returns 401 if middleware didn't populate `res.locals.user`.
- [ ] CI: lint + build + all test suites pass after #1008 merges.

## Notes
- This PR depends on #1008 only logically (shared `src/utils/error.ts` and `Express.Locals` augmentation are in #1008). Once #1008 merges, rebasing this branch onto `develop` will resolve all import errors automatically.
- Side benefit: removes one block of dead code in `router/line.ts` (the `req.context = ...` assignment was set but never read anywhere).

https://claude.ai/code/session_01Rs8kgHhtcTWCRuf68ReYtq