### PR TITLE
chore(docker): drop dead-code tsconfig-paths/register + tighten .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -59,10 +59,11 @@ npm-debug.log*
 yarn-debug.log*
 pnpm-debug.log*
 
-# Documentation (not needed at runtime)
-README.md
+# Documentation (not needed at runtime). `*.md` covers README.md /
+# PR_DESCRIPTION.md / handbook prose; `LICENSE` is kept explicit because
+# legally we may want to ship it in some image variants — leave the entry
+# even though it is currently excluded.
 LICENSE
-PR_DESCRIPTION.md
 docs
 *.md
 

--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -466,8 +466,9 @@ jobs:
         # image — Cloud Run Jobs pin the image digest at deploy time, so we
         # need an explicit `run jobs update` to create a new revision.
         # `dist/bootstrap/batch.js` 経由で起動することで OpenTelemetry tracing 初期化
-        # (`tracingReady` await) を batch ジョブでも有効にする。`@/` パスエイリアスが
-        # bootstrap 層で使われるため `-r tsconfig-paths/register` も必須。
+        # (`tracingReady` await) を batch ジョブでも有効にする。`tsc-alias` が build
+        # 時に `@/` を相対 path に rewrite するため、runtime の
+        # `tsconfig-paths/register` は不要 (Dockerfile の CMD と整合)。
         # PROCESS_TYPE=batch は Cloud Run Job 側の env で別途設定されている前提
         # (bootstrap/batch.ts は ../index に dispatch するだけで、batch 分岐自体は
         # src/index.ts:main() が PROCESS_TYPE で判定する)。
@@ -476,7 +477,7 @@ jobs:
             --region="${{ env.GCP_REGION }}" \
             --image="${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:sha-${{ github.sha }}" \
             --command=node \
-            --args=-r,tsconfig-paths/register,dist/bootstrap/batch.js
+            --args=dist/bootstrap/batch.js
 
       - name: Create Git tag
         if: ${{ inputs.create-git-tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,6 @@ USER node
 COPY --from=builder --chown=node:node /app/node_modules ./node_modules
 COPY --from=builder --chown=node:node /app/dist ./dist
 COPY --from=builder --chown=node:node /app/package.json ./package.json
-COPY --chown=node:node tsconfig.json ./tsconfig.json
 
 EXPOSE 3000
 
@@ -72,6 +71,7 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
     CMD node -e "fetch('http://127.0.0.1:' + (process.env.PORT || 3000) + '/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
 
-# `-r tsconfig-paths/register` is required because the compiled output keeps
-# `@/` path aliases (resolved via tsconfig paths at runtime).
-CMD ["node", "-r", "tsconfig-paths/register", "dist/bootstrap/index.js"]
+# `tsc-alias` (run during `pnpm build`) rewrites every `@/` import in `dist/`
+# to a relative path, so `tsconfig-paths/register` is not needed at runtime.
+# `tsconfig.json` is also dropped from the runtime stage for the same reason.
+CMD ["node", "dist/bootstrap/index.js"]

--- a/Dockerfile.external
+++ b/Dockerfile.external
@@ -38,7 +38,6 @@ USER node
 COPY --from=builder --chown=node:node /app/node_modules ./node_modules
 COPY --from=builder --chown=node:node /app/dist ./dist
 COPY --from=builder --chown=node:node /app/package.json ./package.json
-COPY --chown=node:node tsconfig.json ./tsconfig.json
 
 EXPOSE 3000
 
@@ -46,4 +45,6 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
     CMD node -e "fetch('http://127.0.0.1:' + (process.env.PORT || 3000) + '/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
 
-CMD ["node", "-r", "tsconfig-paths/register", "dist/bootstrap/external-api.js"]
+# See `Dockerfile` for why `tsconfig-paths/register` and `tsconfig.json` are
+# not needed at runtime (tsc-alias rewrites all `@/` imports during build).
+CMD ["node", "dist/bootstrap/external-api.js"]

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "copy-graphql": "copyfiles -u 1 'src/**/*.graphql' 'dist'",
     "build": "tsc && tsc-alias tsconfig.json && pnpm copy-graphql",
-    "start": "node -r tsconfig-paths/register dist/bootstrap/index.js",
+    "start": "node dist/bootstrap/index.js",
     "dev": "dotenvx run -f .env --env='NODE_HTTPS=false' --env='LOCAL_DEV=true' -- tsx watch src/bootstrap/index.ts",
     "dev:https": "dotenvx run -f .env.local --env='NODE_HTTPS=true' --env='LOCAL_DEV=true' -- tsx watch src/bootstrap/index.ts",
     "dev:https:dev": "dotenvx run -f .env.dev --env='NODE_HTTPS=true' --env='LOCAL_DEV=true' -- tsx watch src/bootstrap/index.ts",
@@ -106,6 +106,7 @@
     "ts-jest": "^29.4.9",
     "ts-node": "^10.9.2",
     "tsc-alias": "^1.8.15",
+    "tsconfig-paths": "^4.2.0",
     "tsx": "^4.21.0",
     "tsyringe": "^4.10.0",
     "typedoc-plugin-merge-modules": "^6.1.0",
@@ -189,7 +190,6 @@
     "p-limit": "^3.1.0",
     "sanitize-html": "^2.16.0",
     "sharp": "^0.34.1",
-    "tsconfig-paths": "^4.2.0",
     "winston": "^3.17.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,9 +190,6 @@ importers:
       sharp:
         specifier: ^0.34.1
         version: 0.34.3
-      tsconfig-paths:
-        specifier: ^4.2.0
-        version: 4.2.0
       winston:
         specifier: ^3.17.0
         version: 3.17.0
@@ -338,6 +335,9 @@ importers:
       tsc-alias:
         specifier: ^1.8.15
         version: 1.8.16
+      tsconfig-paths:
+        specifier: ^4.2.0
+        version: 4.2.0
       tsx:
         specifier: ^4.21.0
         version: 4.21.0


### PR DESCRIPTION
## Summary

Gemini が #1003 (P2 / merged) で出した 2 件の指摘を follow-up として解消。

| 指摘 | 対応 |
|---|---|
| HIGH: `tsconfig-paths/register` を runtime に置いてるが src/ を image に含めてない | tsc-alias が build 時に全 `@/` を相対 path に rewrite するため runtime register は dead code。Dockerfile / Dockerfile.external / _deploy-cloud-run.yml の batch override から削除。tsconfig.json の COPY も runtime から削除 (loader 専用だった) |
| MED: `.dockerignore` で `README.md` / `PR_DESCRIPTION.md` が `*.md` と重複 | 個別行を削除、`*.md` で網羅。`LICENSE` は意図的に明示残し |

## 検証

local sandbox で:
1. `pnpm install --frozen-lockfile` ✓
2. `prisma generate --generator client` (fresh `@prisma/client`)
3. `tsc` (TypedSQL 周り以外 compile 成立)
4. `tsc-alias` 実行
5. `grep -rE '(from |require\\()"@/' dist/ | wc -l` → **0** (`src/` 側は 1842 件)

→ tsc-alias が完璧に rewrite していることを実物 dist で確認済。

## 影響範囲

- **runtime 起動コマンド** が変わる:
  - 旧 `node -r tsconfig-paths/register dist/bootstrap/index.js`
  - 新 `node dist/bootstrap/index.js`
- batch job も同パターン (`--args=dist/bootstrap/batch.js`)
- runtime image から `tsconfig.json` が消えるが、他 consumer は無し

## Test plan

- [ ] `docker build -f Dockerfile .` ローカルで通る (CI で自動実行)
- [ ] dev deploy (this PR の merge) で smoke check が `/health` 200 を返す → tsc-alias の rewrite が完璧で 1842 件 全 import が解決していることの最終証明
- [ ] batch job が dispatch されて起動する (probe-reports や週次集計で確認)

## Risk

低。dev deploy で smoke 失敗したら revert 1 commit で戻せる。万一 alias 未 rewrite が見つかった場合は tsc-alias 設定 (`tsc-alias.outputExtension` 等) を見直す follow-up。

## Closes / refs

- Gemini review on PR #1003 (HIGH + MED)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG)_