### PR TITLE
fix(ci): unblock dev/prd deploys — add security-events:write to caller workflows (broken since #1003)

### DIFF
--- a/.github/workflows/deploy-external-api-dev.yml
+++ b/.github/workflows/deploy-external-api-dev.yml
@@ -12,11 +12,12 @@ concurrency:
   cancel-in-progress: false
 
 # Caller permissions must be a superset of the reusable workflow's permissions
-# (`_deploy-external-api.yml`: id-token:write + contents:write). Setting them
-# explicitly here also silences CodeQL's missing-permissions warning.
+# (`_deploy-external-api.yml`: id-token:write + contents:write + security-events:write).
+# Setting them explicitly here also silences CodeQL's missing-permissions warning.
 permissions:
   id-token: write
   contents: write
+  security-events: write
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-external-api-prd.yml
+++ b/.github/workflows/deploy-external-api-prd.yml
@@ -16,11 +16,12 @@ concurrency:
   cancel-in-progress: false
 
 # Caller permissions must be a superset of the reusable workflow's permissions
-# (`_deploy-external-api.yml`: id-token:write + contents:write). Setting them
-# explicitly here also silences CodeQL's missing-permissions warning.
+# (`_deploy-external-api.yml`: id-token:write + contents:write + security-events:write).
+# Setting them explicitly here also silences CodeQL's missing-permissions warning.
 permissions:
   id-token: write
   contents: write
+  security-events: write
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-to-cloud-run-dev.yml
+++ b/.github/workflows/deploy-to-cloud-run-dev.yml
@@ -12,11 +12,12 @@ concurrency:
   cancel-in-progress: false
 
 # Caller permissions must be a superset of the reusable workflow's permissions
-# (`_deploy-cloud-run.yml`: id-token:write + contents:write). Setting them
-# explicitly here also silences CodeQL's missing-permissions warning.
+# (`_deploy-cloud-run.yml`: id-token:write + contents:write + security-events:write).
+# Setting them explicitly here also silences CodeQL's missing-permissions warning.
 permissions:
   id-token: write
   contents: write
+  security-events: write
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-to-cloud-run-prd.yml
+++ b/.github/workflows/deploy-to-cloud-run-prd.yml
@@ -16,11 +16,12 @@ concurrency:
   cancel-in-progress: false
 
 # Caller permissions must be a superset of the reusable workflow's permissions
-# (`_deploy-cloud-run.yml`: id-token:write + contents:write). Setting them
-# explicitly here also silences CodeQL's missing-permissions warning.
+# (`_deploy-cloud-run.yml`: id-token:write + contents:write + security-events:write).
+# Setting them explicitly here also silences CodeQL's missing-permissions warning.
 permissions:
   id-token: write
   contents: write
+  security-events: write
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary

🚨 **Hotfix: dev / prd deploy が PR #1003 (P2) merge 以降 100% 失敗してた**

`gh run list` の結果:
```
X  Merge branch 'master' into develop          push  ID 25300147266  1s
X  Merge pull request #1015                    push  ID 25299812728  1s
X  Merge pull request #1003                    push  ID 25298839922  1s
✓  Merge branch 'master' into develop          push  ID 25298733030  ← P2 merge 前最後の成功
```

## 原因

P2 (#1003) で reusable workflow `_deploy-cloud-run.yml` / `_deploy-external-api.yml` に `security-events: write` を追加 (Trivy sarif upload のため)。しかし caller workflow 4 本に同 permission を伝播させ忘れた。

GitHub Actions の規約: **caller の `permissions:` は reusable の superset でなければならない**。違反すると workflow が startup 段階で reject (= 1s elapsed の即死)。

確認: Cloud Run dev image は pre-P2 commit (`sha-980b87e`) で固定されてる:
```bash
$ gcloud run services describe kyoso-dev-civicship-api --region=us-central1 \
    --format='value(spec.template.spec.containers[0].image)'
us-central1-docker.pkg.dev/.../kyoso-dev-civicship-api:sha-980b87eadb19f7a4a46cb4a987c2ffaa4c0324e0
```

## 修正

4 caller workflow の `permissions:` ブロックに `security-events: write` を追加:

- `.github/workflows/deploy-to-cloud-run-dev.yml`
- `.github/workflows/deploy-to-cloud-run-prd.yml`
- `.github/workflows/deploy-external-api-dev.yml`
- `.github/workflows/deploy-external-api-prd.yml`

コメントも更新して将来の readers に明示。

## Test plan

- [x] actionlint / yaml parse OK
- [ ] Merge 後、自動 trigger される dev deploy が成功し、Cloud Run image が `:sha-<this-merge-commit>` に更新される
- [ ] Cloud Run service が `/health` 200 を返す
- [ ] batch job の `--args` が `dist/bootstrap/batch.js` のみ (#1015 の効果)

## Priority

🔴 **HIGH** — 現在 dev deploy 完全停止中、P3 (#1004) も merge できない (deploy が失敗するから)。即 merge 推奨。

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG)_