### PR TITLE
fix(ci): bump trivy-action to v0.36.0 (recover deploys)

### DIFF
--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -201,7 +201,7 @@ jobs:
       # MAIN_IMAGE_SHA (#974) が定義された環境ではそちらを優先し、未定義の
       # 場合は :latest tag (MAIN_IMAGE) を scan する。
       - name: Scan image (Trivy CRITICAL — advisory, see SECURITY.md for blocking rollout)
-        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.MAIN_IMAGE_SHA || env.MAIN_IMAGE }}
           severity: CRITICAL
@@ -212,7 +212,7 @@ jobs:
 
       - name: Scan image (Trivy HIGH — warning)
         if: always()
-        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.MAIN_IMAGE_SHA || env.MAIN_IMAGE }}
           severity: HIGH

--- a/.github/workflows/_deploy-external-api.yml
+++ b/.github/workflows/_deploy-external-api.yml
@@ -144,7 +144,7 @@ jobs:
       # 詳細な rationale + blocking 化への段階的移行手順は
       # _deploy-cloud-run.yml の同名 step + docs/handbook/SECURITY.md 参照。
       - name: Scan image (Trivy CRITICAL — advisory, see SECURITY.md for blocking rollout)
-        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.EXTERNAL_IMAGE_SHA || env.EXTERNAL_IMAGE }}
           severity: CRITICAL
@@ -155,7 +155,7 @@ jobs:
 
       - name: Scan image (Trivy HIGH — warning)
         if: always()
-        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.EXTERNAL_IMAGE_SHA || env.EXTERNAL_IMAGE }}
           severity: HIGH


### PR DESCRIPTION
## Summary

🚨 **Hotfix #2** — #1016 で permission propagation は通ったが、deploy が次の壁にぶつかった:

```
deploy / deploy: Set up job
! Unable to resolve action `aquasecurity/setup-trivy@v0.2.2`, unable to find version `v0.2.2`
```

`aquasecurity/trivy-action@v0.29.0` が内部で `aquasecurity/setup-trivy@v0.2.2` を sub-action として参照しているが、その tag が upstream で消えてる (移動 or 削除)。

## 修正

4 箇所の `trivy-action` 参照を v0.36.0 (latest stable, 動作確認済) に bump:

```diff
- aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
+ aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
```

## Impact

これが merge されれば:
- dev / prd deploy が通る (Trivy scan + sarif upload 完走)
- post-P2 image (multi-stage Dockerfile, no `tsconfig-paths/register`) が runtime に反映
- P3 (#1004) も merge 可能になる

## Priority

🔴 **HIGH** — 現在 deploy 完全停止中。

## Closes

- Recovers deploys broken since #1003 merge (combined with merged #1016 caller-permissions hotfix)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG)_