### PR TITLE
fix(docker): set CI=true to avoid pnpm prune --prod TTY abort

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,11 @@ COPY dist ./dist
 # Drop devDependencies from node_modules so the runtime stage only carries
 # what's needed at runtime. `--prod` keeps dependencies in the
 # `dependencies` field; devDependencies are removed.
+# pnpm 10 prompts for confirmation when removing modules unless `CI=true`
+# or `--config.confirm-modules-purge=false` is set; docker buildx has no
+# TTY so without this the build aborts with
+# `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`.
+ENV CI=true
 RUN pnpm prune --prod
 
 # ---------------------------------------------------------------------------

--- a/Dockerfile.external
+++ b/Dockerfile.external
@@ -21,6 +21,9 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY node_modules ./node_modules
 COPY dist ./dist
 
+# See `Dockerfile` for why `CI=true` is required before `pnpm prune --prod`
+# (pnpm 10 + non-TTY docker buildx context).
+ENV CI=true
 RUN pnpm prune --prod
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

🚨 **Hotfix #3** — #1017 で trivy-action 解決は通ったが、deploy が次の壁にぶつかった (run 25301817776):

```
#15 [builder 7/7] RUN pnpm prune --prod
#15 0.724  ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY  Aborted removal of modules directory due to no TTY
#15 0.724  If you are running pnpm in CI, set the CI environment variable to "true",
           or set "confirmModulesPurge" to "false".
```

## 原因

pnpm 10 が `prune --prod` 実行時に「modules directory を本当に消していいか?」とプロンプトを出す仕様になってる。docker buildx の `RUN` step は TTY 無しなので即 abort。

GitHub Actions runner 自体には `CI=true` が入ってるが、それは docker build context には伝播しない。

## 修正

両 Dockerfile の builder stage で `pnpm prune --prod` の直前に `ENV CI=true` を追加。runtime stage は pnpm 触らないので不要。

## P2 (#1003) の検証不足

P2 の Dockerfile multi-stage rewrite は `docker build` を実機で試さないまま merge された。今回の 3 連続 hotfix (#1016 / #1017 / #1018) は全部その代償:

1. **#1016**: caller workflow の permission 漏れ
2. **#1017**: 上流 action の sub-action tag 消失
3. **#1018 (本 PR)**: pnpm prune の TTY 要件

今回これで通れば確定だが、次に Dockerfile を大改修する PR では **dev に merge する前に手元 / CI で `docker build` を 1 回通す** ようにすべき (follow-up issue にする価値あり)。

## Priority

🔴 **HIGH** — まだ deploy 完全停止中。

## Test plan

- [x] yaml / Dockerfile syntax OK
- [ ] Merge 後の develop deploy run で `pnpm prune --prod` step を通過
- [ ] Trivy scan が image を見つけて scan 完走 (sarif が Security タブに上がる)
- [ ] Cloud Run image が `:sha-<this-merge-commit>` に更新
- [ ] /health 200

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG)_