### PR TITLE
fix(docker): install openssl + ca-certificates in runtime stage for Prisma

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,17 +90,16 @@ WORKDIR /app
 # debian 12 の openssl パッケージは openssl 3.x なので、generate 済バイナリ
 # (binaryTargets = ["native","debian-openssl-3.0.x","linux-arm64-openssl-3.0.x"])
 # とそろう。`ca-certificates` は Cloud SQL / 外部 HTTPS 接続の TLS 検証用。
+# `USER root` は apt-get install のためだけに局所昇格、直後に `USER node` で
+# 非特権に戻す (root 実行時間を最小化)。
 USER root
 RUN apt-get update \
     && apt-get install -y --no-install-recommends openssl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
+USER node
 
 ENV NODE_ENV=production \
     PORT=3000
-
-# `node:20-slim` ships a `node` user (uid/gid 1000) created for exactly
-# this purpose. Run the app as that user instead of root.
-USER node
 
 # Copy only what's needed at runtime, owned by the non-root user.
 COPY --from=builder --chown=node:node /app/node_modules ./node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,19 @@ FROM node:20-slim AS runtime
 
 WORKDIR /app
 
+# Prisma Query Engine 検出のため `openssl` + `ca-certificates` を入れる。
+# `node:20-slim` (debian 12 slim) はベースに openssl を含まないため、libssl
+# が見つからないと Prisma の runtime detection が `debian-openssl-1.1.x` に
+# fallback し、`prisma generate` が生成した `debian-openssl-3.0.x` 用バイナリ
+# とミスマッチして PrismaClientInitializationError で起動失敗する。
+# debian 12 の openssl パッケージは openssl 3.x なので、generate 済バイナリ
+# (binaryTargets = ["native","debian-openssl-3.0.x","linux-arm64-openssl-3.0.x"])
+# とそろう。`ca-certificates` は Cloud SQL / 外部 HTTPS 接続の TLS 検証用。
+USER root
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends openssl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
 ENV NODE_ENV=production \
     PORT=3000
 

--- a/Dockerfile.external
+++ b/Dockerfile.external
@@ -44,6 +44,13 @@ FROM node:20-slim AS runtime
 
 WORKDIR /app
 
+# See `Dockerfile` runtime stage for rationale on installing openssl +
+# ca-certificates (required for Prisma engine detection on node:20-slim).
+USER root
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends openssl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
 ENV NODE_ENV=production \
     PORT=3000
 

--- a/Dockerfile.external
+++ b/Dockerfile.external
@@ -46,15 +46,15 @@ WORKDIR /app
 
 # See `Dockerfile` runtime stage for rationale on installing openssl +
 # ca-certificates (required for Prisma engine detection on node:20-slim).
+# `USER root` は apt-get install のための局所昇格、直後に `USER node` に戻す。
 USER root
 RUN apt-get update \
     && apt-get install -y --no-install-recommends openssl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
+USER node
 
 ENV NODE_ENV=production \
     PORT=3000
-
-USER node
 
 COPY --from=builder --chown=node:node /app/node_modules ./node_modules
 COPY --from=builder --chown=node:node /app/dist ./dist


### PR DESCRIPTION
## Summary

🚨 **Hotfix #6** — #1021 で TypedSQL は無事だったが Cloud Run runtime で:

```
PrismaClientInitializationError: Prisma Client could not locate the Query Engine for runtime "debian-openssl-1.1.x".
Please manually install OpenSSL via `apt-get update -y && apt-get install -y openssl`...
```

## 原因

- `schema.prisma` の `binaryTargets`: `["native", "debian-openssl-3.0.x", "linux-arm64-openssl-3.0.x"]` ← OpenSSL **3.x** 用しか生成しない
- 新 `node:20-slim` は **libssl 同梱無し** (旧 `node:20` フル image には入ってた)
- Prisma の runtime detection が libssl 見つからず「debian-openssl-1.1.x」にフォールバック → 生成済 binary とミスマッチ → 起動失敗

## 修正

両 Dockerfile の runtime stage で:

```dockerfile
USER root
RUN apt-get update \
    && apt-get install -y --no-install-recommends openssl ca-certificates \
    && rm -rf /var/lib/apt/lists/*
USER node
```

debian 12 の openssl パッケージ = OpenSSL 3.x → Prisma detection が `debian-openssl-3.0.x` になり既存 binary が読める。`ca-certificates` も TLS 用に同梱。

## Test plan

- [x] yaml/Dockerfile syntax OK
- [ ] Merge 後の dev deploy で Cloud Run revision が起動 (PrismaClientInitializationError 解消)
- [ ] /health 200
- [ ] external API 同様
- [ ] batch job も起動可能

## Hotfix series 

1. #1016: caller `security-events: write`
2. #1017: trivy-action bump
3. #1019: pnpm prune `CI=true` (後で #1021 に吸収)
4. #1020: deps 分類 fix
5. #1021: snapshot/restore `.prisma`
6. (本 PR): runtime stage に openssl

## Priority

🔴 **HIGH** — まだ runtime crash 中

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG)_