### PR TITLE
ci/docker: pre-P3 hardening (CI docker build + @/ assertion + openssl runtime)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,63 @@ jobs:
       - name: Build (typecheck + emit)
         run: pnpm build
 
+      # tsc-alias (in `pnpm build`) is supposed to rewrite every `@/` import in
+      # the compiled output to a relative path. The runtime image deliberately
+      # does **not** ship `tsconfig-paths/register` or `tsconfig.json` (#1015),
+      # so any `@/` import that survives into `dist/` will fail at runtime with
+      # `ERR_MODULE_NOT_FOUND`. Catch that drift at PR time rather than at
+      # deploy time. `grep -q` exits 0 on first match, so we negate to fail
+      # the step when residual `@/` is found.
+      - name: Assert tsc-alias rewrote all `@/` imports in dist
+        run: |
+          if grep -rqE '(from |require\()"@/' dist/; then
+            echo "::error::Found unrewritten \`@/\` imports in dist/. tsc-alias may have failed or new import shape (e.g. dynamic import) is not handled. Fix tsc-alias config or restore tsconfig-paths/register."
+            grep -rnE '(from |require\()"@/' dist/ | head -20
+            exit 1
+          fi
+          echo "✅ dist/ contains no unresolved \`@/\` imports."
+
+      # Validate that both Dockerfiles actually build with the just-built
+      # `node_modules` + `dist` in the build context. This catches Dockerfile
+      # syntax / package / COPY-path regressions at PR time instead of at
+      # deploy time (cf. the six-hotfix series in May 2026 — #1016, #1017,
+      # #1019, #1020, #1021, #1022 — each of which would have surfaced here
+      # if this step had existed). `--load` keeps the image local and
+      # restricts buildx to the docker driver, no registry push needed.
+      # The runtime stage is built (not just the builder) so apt-get install
+      # and the pnpm prune + .prisma snapshot/restore path are exercised.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
+
+      - name: Validate Dockerfile build (internal API)
+        run: |
+          docker buildx build \
+            --file Dockerfile \
+            --target runtime \
+            --tag civicship-api:ci-validate \
+            --load \
+            .
+
+      - name: Validate Dockerfile build (external API)
+        run: |
+          docker buildx build \
+            --file Dockerfile.external \
+            --target runtime \
+            --tag civicship-api-external:ci-validate \
+            --load \
+            .
+
+      # Smoke-test the runtime image: instantiating PrismaClient triggers
+      # query-engine binary detection (the OpenSSL-target match that broke
+      # in #1022). If the engine binary doesn't match the runtime's libssl,
+      # construction throws synchronously and node exits non-zero. We run
+      # under the image's default USER (`node`) and don't connect to a DB,
+      # so this is a pure load-time check, not a query check.
+      - name: Smoke-test runtime image (Prisma engine load)
+        run: |
+          docker run --rm civicship-api:ci-validate \
+            node -e "const { PrismaClient } = require('@prisma/client'); new PrismaClient(); console.log('prisma engine loaded');"
+
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,8 @@ WORKDIR /app
 # 非特権に戻す (root 実行時間を最小化)。
 USER root
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends openssl ca-certificates \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends openssl ca-certificates \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 USER node
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,17 +90,16 @@ WORKDIR /app
 # debian 12 の openssl パッケージは openssl 3.x なので、generate 済バイナリ
 # (binaryTargets = ["native","debian-openssl-3.0.x","linux-arm64-openssl-3.0.x"])
 # とそろう。`ca-certificates` は Cloud SQL / 外部 HTTPS 接続の TLS 検証用。
+# `USER root` は apt-get install のためだけに局所昇格、直後に `USER node` で
+# 非特権に戻す (root 実行時間を最小化)。
 USER root
 RUN apt-get update \
     && apt-get install -y --no-install-recommends openssl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
+USER node
 
 ENV NODE_ENV=production \
     PORT=3000
-
-# `node:20-slim` ships a `node` user (uid/gid 1000) created for exactly
-# this purpose. Run the app as that user instead of root.
-USER node
 
 # Copy only what's needed at runtime, owned by the non-root user.
 COPY --from=builder --chown=node:node /app/node_modules ./node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,19 @@ FROM node:20-slim AS runtime
 
 WORKDIR /app
 
+# Prisma Query Engine 検出のため `openssl` + `ca-certificates` を入れる。
+# `node:20-slim` (debian 12 slim) はベースに openssl を含まないため、libssl
+# が見つからないと Prisma の runtime detection が `debian-openssl-1.1.x` に
+# fallback し、`prisma generate` が生成した `debian-openssl-3.0.x` 用バイナリ
+# とミスマッチして PrismaClientInitializationError で起動失敗する。
+# debian 12 の openssl パッケージは openssl 3.x なので、generate 済バイナリ
+# (binaryTargets = ["native","debian-openssl-3.0.x","linux-arm64-openssl-3.0.x"])
+# とそろう。`ca-certificates` は Cloud SQL / 外部 HTTPS 接続の TLS 検証用。
+USER root
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends openssl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
 ENV NODE_ENV=production \
     PORT=3000
 

--- a/Dockerfile.external
+++ b/Dockerfile.external
@@ -44,6 +44,13 @@ FROM node:20-slim AS runtime
 
 WORKDIR /app
 
+# See `Dockerfile` runtime stage for rationale on installing openssl +
+# ca-certificates (required for Prisma engine detection on node:20-slim).
+USER root
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends openssl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
 ENV NODE_ENV=production \
     PORT=3000
 

--- a/Dockerfile.external
+++ b/Dockerfile.external
@@ -49,7 +49,8 @@ WORKDIR /app
 # `USER root` は apt-get install のための局所昇格、直後に `USER node` に戻す。
 USER root
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends openssl ca-certificates \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends openssl ca-certificates \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 USER node
 

--- a/Dockerfile.external
+++ b/Dockerfile.external
@@ -46,15 +46,15 @@ WORKDIR /app
 
 # See `Dockerfile` runtime stage for rationale on installing openssl +
 # ca-certificates (required for Prisma engine detection on node:20-slim).
+# `USER root` は apt-get install のための局所昇格、直後に `USER node` に戻す。
 USER root
 RUN apt-get update \
     && apt-get install -y --no-install-recommends openssl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
+USER node
 
 ENV NODE_ENV=production \
     PORT=3000
-
-USER node
 
 COPY --from=builder --chown=node:node /app/node_modules ./node_modules
 COPY --from=builder --chown=node:node /app/dist ./dist


### PR DESCRIPTION
## Summary

P3 (#1004) merge **前** にやるべき hardening を 1 PR にまとめました。中身は 3 種:

### 1. Runtime stage に openssl + ca-certificates (= #1022 を吸収)

`node:20-slim` は libssl 同梱無しで、Prisma の runtime detection が
`debian-openssl-1.1.x` にフォールバック → 生成済 binary (3.0.x) と mismatch
→ Cloud Run 起動失敗。両 Dockerfile の runtime stage に局所 `USER root` →
`apt-get install -y --no-install-recommends openssl ca-certificates` →
`USER node` を追加。

→ **#1022 はこの PR に subsume されたので close で良い。**

### 2. CI で `dist/` に `@/` 残存ゼロ assertion

#1015 で `tsconfig-paths/register` / `tsconfig.json` を runtime image から
削除した。tsc-alias が build 時に `@/` を全て相対 path に rewrite すること
が前提だが、今は **CI でその前提を担保していない**。`pnpm build` の直後に
`grep -rqE '(from |require\\()"@/' dist/` を assertion 化、残存があれば
PR を赤くする。

### 3. CI で `docker buildx build` + Prisma engine 起動 smoke

直近 6 連 hotfix (#1016 #1017 #1019 #1020 #1021 #1022) はすべて Dockerfile
または deploy workflow の regression で、**deploy 時に初めて発覚**した。CI
で実 image を build (両 Dockerfile, runtime stage まで)、`docker run` で
`new PrismaClient()` を一発走らせる smoke を追加。

これで **将来 Dockerfile を触る PR は CI 段階で破綻が見える**。

## Test plan

- [x] yaml parse OK
- [x] ローカルで `dist/` の `@/` 残存ゼロ assertion 動作確認 (PASS)
- [ ] Merge 後の CI build job で:
  - [ ] `Assert tsc-alias rewrote all @/ imports in dist` 緑
  - [ ] `Validate Dockerfile build (internal API)` 緑
  - [ ] `Validate Dockerfile build (external API)` 緑
  - [ ] `Smoke-test runtime image (Prisma engine load)` 緑 (= openssl install が runtime に効いてる)
- [ ] Merge 後 push が dev deploy 走らせて Cloud Run revision が起動 (これまでの 5 連 hotfix が全て解消済か実証)

## なぜ P3 (#1004) の前にやるか

P3 の paths-filter / composite action / schema reorder は機能追加。これらを
入れる前に **既に merge 済の P0/P1/P2 がしっかり動く状態を担保したい**。
特に Dockerfile 系は #1003 で merge してから 6 連 hotfix を出し続けた、
構造的に CI gate が無いことが根本原因なので、ここで断ち切る。

## 補足

snapshot/restore `.prisma` の hack は今回は触らない (Dockerfile 側の comment
で十分文書化済)。distroless / digest pin / Trivy blocking 化等は H2 (短期)
として別 PR で順次。

## Closes / Subsumes

- Subsumes #1022 (cherry-picked + bundled here)
- Pre-P3 hardening per session retrospective

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG)_