### PR TITLE
fix(trivy): unblock deploy by populating .trivyignore (CVE list TBD from this PR's CI)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -13,7 +13,11 @@
 # 運用フロー (PR-time visibility):
 #   - `ci.yml` の `Scan runtime image (Trivy CRITICAL — blocking)` step が
 #     PR を開くたびに走り CRITICAL がヒットすると CI 赤 + log に CVE table。
-#     出た CVE をここに登録 (or fix) して再 push する。
+#     対応は以下の優先順:
+#       (a) **fix**: 依存 / base image を bump、もしくは利用方を変えて到達可能性
+#           を断つ。fix が出ているなら最善。
+#       (b) **ignore**: ここに entry を追加 (理由 + 期限 + 担当付き)。fix 待ち
+#           や不到達 path の場合のみ、暫定回避として使う。
 #   - `_deploy-cloud-run.yml` の Trivy 同設定 + sarif 出力で最終 gate。
 #     Trivy DB は日次更新で CI 緑→deploy 赤になり得る (新規 CVE が CI 後に
-#     追加された場合)、そのときは新 PR でここに追記して deploy を再 trigger。
+#     追加された場合)、そのときも上記 (a)/(b) の優先順で対応する。

--- a/.trivyignore
+++ b/.trivyignore
@@ -9,3 +9,11 @@
 #   3. 期限切れの ignore を月次で棚卸しし、不要になったら削除する。
 #
 # 詳細は docs/handbook/SECURITY.md の "Container Image Scanning (Trivy)" を参照。
+#
+# 運用フロー (PR-time visibility):
+#   - `ci.yml` の `Scan runtime image (Trivy CRITICAL — blocking)` step が
+#     PR を開くたびに走り CRITICAL がヒットすると CI 赤 + log に CVE table。
+#     出た CVE をここに登録 (or fix) して再 push する。
+#   - `_deploy-cloud-run.yml` の Trivy 同設定 + sarif 出力で最終 gate。
+#     Trivy DB は日次更新で CI 緑→deploy 赤になり得る (新規 CVE が CI 後に
+#     追加された場合)、そのときは新 PR でここに追記して deploy を再 trigger。


### PR DESCRIPTION
## Summary

🚨 deploy 復旧 + Trivy 運用整備の draft PR。

**現状**: #1024 で Trivy CRITICAL を blocking 化した直後の deploy が、空 `.trivyignore` のままだったため CRITICAL を検出して fail。Security タブの SARIF 取り込みもエラー (`No summary of scanned files reported by Trivy`) で alert 化されておらず、CVE list が見えない状態。

**この PR の役目**:
1. `.trivyignore` のコメント (運用フロー: CI vs deploy の DB drift 対策) を追記 → CI 起動 trigger
2. CI Trivy step (`format: table`, `severity: CRITICAL`, `exit-code: '1'`) が走り、log に CVE table を出力
3. その table を見て **次の commit で `.trivyignore` に CVE entries を populate**
4. CI 再走行で CRITICAL が空であることを確認
5. merge → 次の deploy が pass

## 進行中

- [x] PR open + 1st CI trigger
- [ ] CI が Trivy CRITICAL table を log に表示
- [ ] その CVE list を `.trivyignore` に追記 (理由 + 期限 + 担当)
- [ ] CI 再走行 → CRITICAL 0 件確認
- [ ] merge

## なぜ DB drift が起きたか

Trivy DB は日次更新。#1024 PR 時点 (= CI 走行) では CRITICAL ゼロだったが、merge 後の deploy run で DB が新しくなり、新規 CRITICAL が追加された結果 deploy が blocking。

これは **構造的に発生し得る現象**で、根絶できない (DB は常に更新されるから)。本 PR はその「発生したときの復旧フロー」を `.trivyignore` のコメントに明記。

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG)_