### PR TITLE
ci/deploy: Trivy CRITICAL を advisory + 3-layer visibility に

### DIFF
--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -190,26 +190,28 @@ jobs:
             .
 
       # Trivy scan は docker push 直後 / Cloud Run deploy 前に走らせる。
-      # CRITICAL (`exit-code: '1'`) は deploy を block する; CI 側でも同 image
-      # を build 直後に scan (ci.yml:build) するため、PR 段階で既に同じ判定が
-      # 走っており、このゲートは「PR をすり抜けた何か」への最終防衛線。
-      # 既知だが当面 fix できない CVE は `.trivyignore` に期限 + 担当付きで
-      # 登録 — docs/handbook/SECURITY.md の運用手順を参照。
-      # HIGH は引き続き advisory (`exit-code: '0'`) で sarif を Security タブへ。
+      # CRITICAL も HIGH も **advisory** (`exit-code: '0'`) で運用:
+      # Trivy DB は日次更新、明日新 CVE が追加されると上流 fix を待つしかない
+      # CRITICAL ですら自動で deploy を止めてしまい、無関係な fix も巻き込んで
+      # 全 deploy が stall する。代わりに sarif を Security タブに上げ、件数
+      # を ::warning:: として workflow run の最上部に出すことで「**人間が必ず
+      # 気付く**」が、自動ゲートはしない、という政策にする。
+      # 再 blocking 化の条件 (CVE 0 件状態が継続 + .trivyignore 整備 + 週次
+      # review 体制) は docs/handbook/SECURITY.md 参照。
       # `ignore-unfixed: true` で fix が出ていない CVE は雑音になるので除外。
       # MAIN_IMAGE_SHA (#974) が定義された環境ではそちらを優先し、未定義の
       # 場合は :latest tag (MAIN_IMAGE) を scan する。
-      - name: Scan image (Trivy CRITICAL — blocking)
+      - name: Scan image (Trivy CRITICAL — advisory)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.MAIN_IMAGE_SHA || env.MAIN_IMAGE }}
           severity: CRITICAL
-          exit-code: '1'
+          exit-code: '0'
           ignore-unfixed: true
           format: sarif
           output: trivy-critical.sarif
 
-      - name: Scan image (Trivy HIGH — warning)
+      - name: Scan image (Trivy HIGH — advisory)
         if: always()
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -219,6 +221,24 @@ jobs:
           ignore-unfixed: true
           format: sarif
           output: trivy-high.sarif
+
+      # Surface CVE counts as `::warning::` annotations so the deploy job's
+      # summary makes the result loud. sarif's `runs[].results[]` is the
+      # canonical CVE list (`level: error` ≈ Trivy CRITICAL with default
+      # mapping). We stay advisory: never `exit 1` here.
+      - name: Surface Trivy CVE count (advisory warning)
+        if: always()
+        run: |
+          set -euo pipefail
+          for sev in critical high; do
+            sarif="trivy-${sev}.sarif"
+            [ -s "$sarif" ] || continue
+            count=$(jq '[.runs[]?.results[]?] | length' "$sarif")
+            echo "${sev^^}: ${count}"
+            if [ "$count" -gt 0 ]; then
+              echo "::warning::Trivy ${sev^^}: ${count} CVEs in the deployed image. Review the Security tab (category: trivy-${sev}) and update .trivyignore / fix the offending package. Advisory only — deploy not blocked."
+            fi
+          done
 
       - name: Upload Trivy CRITICAL results to Security tab
         if: always()

--- a/.github/workflows/_deploy-external-api.yml
+++ b/.github/workflows/_deploy-external-api.yml
@@ -140,20 +140,21 @@ jobs:
             .
 
       # Trivy scan は docker push 直後 / Cloud Run deploy 前に走らせる。
-      # CRITICAL は blocking (`exit-code: '1'`) — ci.yml の build job 内で
-      # PR 段階に同 image を scan しており、ここは「PR をすり抜けた何か」への
-      # 最終防衛線。詳細は _deploy-cloud-run.yml の同名 step + SECURITY.md。
-      - name: Scan image (Trivy CRITICAL — blocking)
+      # CRITICAL も HIGH も **advisory** (`exit-code: '0'`) で運用。
+      # 詳細な運用ポリシー (PR 時 + deploy 時の visibility / 再 blocking 化条件)
+      # は _deploy-cloud-run.yml の同名 step コメント + docs/handbook/SECURITY.md
+      # を参照。両 image (internal / external) で完全に同じ政策。
+      - name: Scan image (Trivy CRITICAL — advisory)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.EXTERNAL_IMAGE_SHA || env.EXTERNAL_IMAGE }}
           severity: CRITICAL
-          exit-code: '1'
+          exit-code: '0'
           ignore-unfixed: true
           format: sarif
           output: trivy-critical.sarif
 
-      - name: Scan image (Trivy HIGH — warning)
+      - name: Scan image (Trivy HIGH — advisory)
         if: always()
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -163,6 +164,22 @@ jobs:
           ignore-unfixed: true
           format: sarif
           output: trivy-high.sarif
+
+      # Surface CVE counts as `::warning::` annotations so the deploy job's
+      # summary makes the result loud. Same logic as _deploy-cloud-run.yml.
+      - name: Surface Trivy CVE count (advisory warning)
+        if: always()
+        run: |
+          set -euo pipefail
+          for sev in critical high; do
+            sarif="trivy-${sev}.sarif"
+            [ -s "$sarif" ] || continue
+            count=$(jq '[.runs[]?.results[]?] | length' "$sarif")
+            echo "${sev^^}: ${count}"
+            if [ "$count" -gt 0 ]; then
+              echo "::warning::Trivy ${sev^^}: ${count} CVEs in the deployed external-api image. Review the Security tab (category: trivy-external-${sev}) and update .trivyignore / fix the offending package. Advisory only — deploy not blocked."
+            fi
+          done
 
       - name: Upload Trivy CRITICAL results to Security tab
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,13 @@ jobs:
       # restricts buildx to the docker driver, no registry push needed.
       # The runtime stage is built (not just the builder) so apt-get install
       # and the pnpm prune + .prisma snapshot/restore path are exercised.
+      #
+      # `--cache-to type=gha,scope=civicship-trivy,mode=max` writes a layer
+      # cache that the separate `trivy` job below reuses via `--cache-from`,
+      # so it can rebuild the same image without re-running tsc / pnpm
+      # install / apt-get from scratch. mode=max caches all stages, not just
+      # the final runtime stage, since trivy needs runtime + builder layers
+      # for full coverage.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
 
@@ -232,6 +239,7 @@ jobs:
             --file Dockerfile \
             --target runtime \
             --tag civicship-api:ci-validate \
+            --cache-to type=gha,scope=civicship-trivy-internal,mode=max \
             --load \
             .
 
@@ -241,6 +249,7 @@ jobs:
             --file Dockerfile.external \
             --target runtime \
             --tag civicship-api-external:ci-validate \
+            --cache-to type=gha,scope=civicship-trivy-external,mode=max \
             --load \
             .
 
@@ -255,20 +264,178 @@ jobs:
           docker run --rm civicship-api:ci-validate \
             node -e "const { PrismaClient } = require('@prisma/client'); new PrismaClient(); console.log('prisma engine loaded');"
 
-      # Shift the deploy-time Trivy gate left: scan the just-built image at PR
-      # time so CRITICAL CVEs are caught before merge instead of at deploy.
-      # `exit-code: '1'` for CRITICAL is the same blocking policy applied in
-      # the deploy workflow (`_deploy-cloud-run.yml`); HIGH is advisory.
-      # `.trivyignore` (repo root) is the escape hatch — see
-      # docs/handbook/SECURITY.md for the registration rules.
-      - name: Scan runtime image (Trivy CRITICAL — blocking)
+  # ---------------------------------------------------------------------------
+  # Trivy CVE scan — split out as its own job (per repo design decision).
+  #
+  # Why a separate job (vs inline in `build`):
+  #   - Independent status check on the PR (visible as `trivy` in the checks
+  #     pane instead of buried inside `build`).
+  #   - Independent retry: transient Trivy DB fetch errors only re-run this
+  #     job, not the full pnpm install + tsc + docker build.
+  #   - Logical separation: scanning ≠ artifact production.
+  #
+  # Why advisory (`exit-code: '0'`) and not blocking:
+  #   - Trivy DB updates daily; a CVE added today blocks an image that was
+  #     clean yesterday — there's no fix we can apply for upstream-pending
+  #     CVEs, and blocking deploys for them stalls unrelated work.
+  #   - The Trivy SARIF upload to GitHub Code Scanning has been intermittent
+  #     (`No summary of scanned files reported by Trivy` on the Security tab),
+  #     so we can't rely on the default Security-tab surface alone.
+  #   - Instead: emit a `::warning::` annotation when CRITICAL count > 0 so
+  #     the count is loud and visible in the PR checks summary, plus the full
+  #     CVE table is in this job's log. Treat advisory as "you must look,
+  #     not the gate that decides for you."
+  #   - Re-blocking conditions are tracked in docs/handbook/SECURITY.md
+  #     ("Severity Policy / Re-escalation").
+  trivy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+          disable-sudo: true
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
+
+      # Rebuild the runtime image inheriting the layer cache the `build` job
+      # wrote with `--cache-to type=gha,scope=civicship-trivy-*,mode=max`. With
+      # all stages cached this finishes in seconds and produces an image
+      # bit-for-bit identical to what `build` smoke-tested.
+      #
+      # NOTE: trivy needs the build context too, since the multi-stage builder
+      # COPYs `node_modules/` and `dist/` from the runner FS. We need pnpm
+      # install + db:generate + pnpm build before the `docker buildx` here.
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies (lockfile integrity check)
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      # Postgres is needed because `pnpm db:generate` uses `prisma generate
+      # --sql` (TypedSQL), which introspects the live DB. We use a throwaway
+      # local container instead of a service container so this job stays self-
+      # contained and doesn't perturb the `build` / `test` job services.
+      - name: Spin up local Postgres for prisma generate --sql
+        run: |
+          docker run -d \
+            --name pg-trivy \
+            -e POSTGRES_USER=civicship \
+            -e POSTGRES_PASSWORD=civicship \
+            -e POSTGRES_DB=civicship_ci \
+            -p 5432:5432 \
+            postgres:16-alpine
+          for _ in $(seq 1 30); do
+            if docker exec pg-trivy pg_isready -U civicship -d civicship_ci -q; then break; fi
+            sleep 1
+          done
+
+      - name: Apply Prisma migrations + generate client + GraphQL types
+        env:
+          DATABASE_URL: postgresql://civicship:civicship@localhost:5432/civicship_ci
+        run: |
+          pnpm db:deploy
+          pnpm db:generate
+          pnpm gql:generate
+
+      - name: Build TypeScript output
+        run: pnpm build
+
+      - name: Build images (cache-from gha)
+        run: |
+          docker buildx build \
+            --file Dockerfile \
+            --target runtime \
+            --tag civicship-api:trivy \
+            --cache-from type=gha,scope=civicship-trivy-internal \
+            --load \
+            .
+          docker buildx build \
+            --file Dockerfile.external \
+            --target runtime \
+            --tag civicship-api-external:trivy \
+            --cache-from type=gha,scope=civicship-trivy-external \
+            --load \
+            .
+
+      # Two trivy invocations per image: one with `format: table` for human
+      # readable output in the step log, one with `format: json` to a file
+      # so the next step can count CRITICAL hits and emit a `::warning::`
+      # annotation. Both use `exit-code: '0'` (advisory). `.trivyignore`
+      # (repo root) is honored by both.
+      - name: Trivy CRITICAL scan (table — log visibility, internal)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: civicship-api:ci-validate
+          image-ref: civicship-api:trivy
           severity: CRITICAL
-          exit-code: '1'
+          exit-code: '0'
           ignore-unfixed: true
           format: table
+
+      - name: Trivy CRITICAL scan (json — count parsing, internal)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: civicship-api:trivy
+          severity: CRITICAL
+          exit-code: '0'
+          ignore-unfixed: true
+          format: json
+          output: trivy-internal.json
+
+      - name: Trivy CRITICAL scan (table — log visibility, external)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: civicship-api-external:trivy
+          severity: CRITICAL
+          exit-code: '0'
+          ignore-unfixed: true
+          format: table
+
+      - name: Trivy CRITICAL scan (json — count parsing, external)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: civicship-api-external:trivy
+          severity: CRITICAL
+          exit-code: '0'
+          ignore-unfixed: true
+          format: json
+          output: trivy-external.json
+
+      # Surface CRITICAL count as a `::warning::` annotation so reviewers see
+      # it in the PR checks summary without expanding step logs. We also list
+      # the first 20 hits (pkg + CVE-ID + fix-status) so the warning has
+      # actionable detail right next to the count.
+      - name: Surface CRITICAL count + top hits
+        run: |
+          set -euo pipefail
+          for variant in internal external; do
+            json="trivy-${variant}.json"
+            count=$(jq '[.Results[]?.Vulnerabilities[]?] | length' "$json")
+            echo "${variant}: ${count} CRITICAL"
+            if [ "$count" -gt 0 ]; then
+              echo "::warning::Trivy found ${count} CRITICAL vulnerabilities in the ${variant} runtime image. Review .trivyignore / fix the offending package or document an exception. See trivy job log for the full table."
+              jq -r '.Results[]? | select(.Vulnerabilities) | .Vulnerabilities[] | "  \(.PkgName)@\(.InstalledVersion)  \(.VulnerabilityID)  fix=\(.FixedVersion // "<none>")"' "$json" | head -20
+            fi
+          done
+
+      - name: Tear down Postgres
+        if: always()
+        run: docker rm -f pg-trivy 2>/dev/null || true
+
+
 
   test:
     runs-on: ubuntu-latest
@@ -419,7 +586,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [lint, build, test]
+    needs: [lint, build, trivy, test]
     if: always()
     permissions:
       contents: read
@@ -430,12 +597,22 @@ jobs:
         run: |
           lint='${{ needs.lint.result }}'
           build='${{ needs.build.result }}'
+          trivy='${{ needs.trivy.result }}'
           test='${{ needs.test.result }}'
-          echo "lint=$lint build=$build test=$test"
-          if [ "$lint" != "success" ] || [ "$build" != "success" ] || [ "$test" != "success" ]; then
-            echo "::error::One or more required jobs failed"
-            exit 1
-          fi
+          echo "lint=$lint build=$build trivy=$trivy test=$test"
+          # `trivy` is advisory: success or failure (advisory step shouldn't
+          # actually fail, but if Trivy job's infra step crashes we don't want
+          # to gate aggregator on it). Treat it like skipped.
+          for j in "$lint" "$build" "$test"; do
+            case "$j" in
+              success|skipped) ;;
+              *) echo "::error::required job failed: $j"; exit 1 ;;
+            esac
+          done
+          case "$trivy" in
+            success|skipped|failure) ;;  # advisory — never gate
+            *) echo "::warning::trivy job had unexpected result: $trivy" ;;
+          esac
           echo "All required jobs passed"
 
       # 以下、coverage 集約 step。閾値 gate は設けない:

--- a/.trivyignore
+++ b/.trivyignore
@@ -36,6 +36,6 @@
 # 再 blocking (= `exit-code: '1'`) 化の条件:
 #   - 4 週間以上 CRITICAL 件数 0 を維持できている
 #   - .trivyignore に期限切れ entry が無い (月次棚卸しを完了している)
-#   - 週次の Trivy review 体制 (担当 + 議事録) が SECURITY.md に明文化されている
+#   - 週次の Trivy review 体制 (担当者 + 議事録 / 議題) が SECURITY.md に明文化されている
 #   3 つを全て満たしたら blocking に戻す。SECURITY.md の "Severity Policy" を
 #   合わせて更新すること。

--- a/.trivyignore
+++ b/.trivyignore
@@ -10,14 +10,32 @@
 #
 # 詳細は docs/handbook/SECURITY.md の "Container Image Scanning (Trivy)" を参照。
 #
-# 運用フロー (PR-time visibility):
-#   - `ci.yml` の `Scan runtime image (Trivy CRITICAL — blocking)` step が
-#     PR を開くたびに走り CRITICAL がヒットすると CI 赤 + log に CVE table。
-#     対応は以下の優先順:
-#       (a) **fix**: 依存 / base image を bump、もしくは利用方を変えて到達可能性
-#           を断つ。fix が出ているなら最善。
-#       (b) **ignore**: ここに entry を追加 (理由 + 期限 + 担当付き)。fix 待ち
-#           や不到達 path の場合のみ、暫定回避として使う。
-#   - `_deploy-cloud-run.yml` の Trivy 同設定 + sarif 出力で最終 gate。
-#     Trivy DB は日次更新で CI 緑→deploy 赤になり得る (新規 CVE が CI 後に
-#     追加された場合)、そのときも上記 (a)/(b) の優先順で対応する。
+# 運用フロー (advisory mode + 強い可視化):
+#   現在 Trivy CRITICAL / HIGH は **advisory** (`exit-code: '0'`) で運用している。
+#   日次 DB 更新で新規 CVE がいつでも増え、上流 fix を待つしかない CRITICAL
+#   ですら自動で deploy を止めるとサービス全体が無関係な fix も巻き込んで
+#   stall する、という運用上の困難から、以下の **3 層の可視化** で代替する。
+#
+#   1. PR-time: `ci.yml` の `trivy` job が runtime image を scan し、CRITICAL
+#      件数を `::warning::` annotation として PR checks 概要に出す。
+#      件数が 0 でない PR は人間が必ず気付く前提。
+#   2. Deploy-time: `_deploy-cloud-run.yml` / `_deploy-external-api.yml` で
+#      docker push 直後の image を再 scan、件数を `::warning::` で
+#      workflow run summary 最上部に。Trivy DB drift で deploy 時点で新規に
+#      増えた CVE もここで surface される。
+#   3. Security tab: 両 workflow が sarif を Code Scanning に upload する
+#      (category: trivy-critical / trivy-high / trivy-external-*)。
+#
+#   CVE がヒットした時の対応優先順:
+#     (a) **fix**: 依存 / base image を bump、もしくは利用方を変えて到達可能性
+#         を断つ。fix が出ているなら最善。
+#     (b) **ignore**: ここに entry を追加 (影響範囲 / 理由 / 期限 / 担当付き)。
+#         fix 待ちや不到達 path の場合のみ、暫定回避として使う。期限切れ
+#         entry は月次棚卸しで削除する。
+#
+# 再 blocking (= `exit-code: '1'`) 化の条件:
+#   - 4 週間以上 CRITICAL 件数 0 を維持できている
+#   - .trivyignore に期限切れ entry が無い (月次棚卸しを完了している)
+#   - 週次の Trivy review 体制 (担当 + 議事録) が SECURITY.md に明文化されている
+#   3 つを全て満たしたら blocking に戻す。SECURITY.md の "Severity Policy" を
+#   合わせて更新すること。

--- a/docs/handbook/SECURITY.md
+++ b/docs/handbook/SECURITY.md
@@ -470,8 +470,8 @@ advisory はあくまで暫定運用で、以下を **全て** 満たしたら C
 - `_deploy-cloud-run.yml` / `_deploy-external-api.yml` の
   `Scan image (Trivy CRITICAL — advisory)` を `exit-code: '1'` に変更し step 名
   を "blocking" に戻す。
-- `ci.yml:trivy` を必須 (`needs: [..., trivy]` の case 文で `failure)` を error
-  扱いに) する。
+- `ci.yml:trivy` を必須ジョブに戻す (集約 `ci` job の結果判定で trivy の
+  `failure` を許容しないように変更する)。
 - 本表 (Severity Policy) の CRITICAL 行を `1` / "block" に戻し、上記 advisory
   のセクションを削除。
 

--- a/docs/handbook/SECURITY.md
+++ b/docs/handbook/SECURITY.md
@@ -406,11 +406,17 @@ Cloud Run にデプロイされる image は、`docker push` 直後 / `gcloud ru
 
 ### Severity Policy
 
-| Severity | exit-code | 振る舞い                                   |
-| -------- | --------- | ------------------------------------------ |
-| CRITICAL | `1`       | **deploy / PR を block** (CI build job + deploy job 両方) |
-| HIGH     | `0`       | warning。job は通り、結果は Security タブで確認 |
-| その他   | -         | scan 対象外 (MEDIUM 以下は雑音になりやすい)   |
+| Severity | exit-code | 振る舞い                                                          |
+| -------- | --------- | ----------------------------------------------------------------- |
+| CRITICAL | `0`       | **advisory** (deploy も PR も block しない)。件数を `::warning::` で surface + Security タブに sarif upload |
+| HIGH     | `0`       | advisory。同上                                                    |
+| その他   | -         | scan 対象外 (MEDIUM 以下は雑音になりやすい)                       |
+
+**なぜ advisory に下げているか**: Trivy DB は日次で更新されるため、昨日まで
+clean だった image が今日 CRITICAL を抱える、というドリフトが日常的に起きる。
+上流 fix を待つしかない CVE のために自動で deploy を止めると、無関係な fix も
+含めた全 deploy が stall するため、現状は「人間が必ず気付く可視化」を備えた
+上で advisory にしている。再 blocking の条件は下記参照。
 
 両 severity の結果は SARIF として GitHub の **Security → Code scanning alerts**
 タブに upload される (`github/codeql-action/upload-sarif`)。`category` を
@@ -420,28 +426,54 @@ Cloud Run にデプロイされる image は、`docker push` 直後 / `gcloud ru
 `ignore-unfixed: true` を付けているため、upstream で fix が未公開の CVE は
 対象外となる。
 
-#### Two-layer scan (PR + deploy)
+#### 3-layer visibility (PR + deploy + Security tab)
 
-同じ Trivy gate を **PR の CI** (`ci.yml:build`) と **deploy workflow**
-(`_deploy-{cloud-run,external-api}.yml`) の両方で走らせる:
+同じ Trivy scan を **PR の CI** (`ci.yml:trivy` job) と **deploy workflow**
+(`_deploy-{cloud-run,external-api}.yml`) の両方で走らせ、結果は 3 経路で surface
+する:
 
-- **PR CI**: 直前に `docker buildx build` した image を即 scan。CRITICAL が
-  出れば PR が赤くなり merge 不能。
-- **Deploy CI**: registry に push した image を scan。PR をすり抜けた何か
-  (例えば base image の re-tag) を最終防衛線として捕まえる。
+1. **PR CI** (`ci.yml:trivy`): build job が `--cache-to` で書いた layer cache
+   を再利用して runtime image を rebuild → scan。CRITICAL 件数を
+   `::warning::` annotation で PR checks 概要に出す。`build` から分離した独立
+   ジョブなので CI 全体の必須 check (`ci` aggregator) では advisory 扱い
+   (never gate) とし、Trivy DB の transient エラーで PR が永久 red にならない
+   ようにしてある。
+2. **Deploy CI**: registry に push した image を再 scan。Trivy DB が PR 時点
+   から更新されて新規 CVE が増えていてもここで surface される。同様に
+   `::warning::` を出すが、deploy は止めない。
+3. **Security tab**: 両 workflow が sarif を Code Scanning に upload。category
+   別に alert を追える。
 
-通常は PR CI で止まるので deploy CI の Trivy step は no-op に近いが、
-Dependabot 経由の base image bump 等で CRITICAL が後から発覚するパターン
-に備えて両方残す。
+#### CRITICAL の対処フロー (advisory mode)
 
-#### CRITICAL を block したときの対処
-
-1. CI 失敗 step の log で CVE-ID + 該当パッケージを確認。
+1. PR / deploy run の `::warning::` annotation または step log で CVE-ID + 該当
+   パッケージを確認。Security タブの該当 category でも同じ情報が見える。
 2. 次のいずれかを実施:
    - **Fix 可能**: base image / dependency を bump する PR を別途出す
      (Dependabot が自動で開いてる場合あり)。
    - **Fix 不可 / 不到達**: `.trivyignore` に追記 (下記運用ルール)。
-3. PR を再 push → CI green を確認 → merge。
+3. **重要**: advisory mode のため対処しなくても deploy は止まらない。だから
+   こそ「気付いて対処する」運用を週次 review で担保する必要がある (下記
+   "Re-escalation conditions" 参照)。
+
+#### Re-escalation conditions (再 blocking 化の条件)
+
+advisory はあくまで暫定運用で、以下を **全て** 満たしたら CRITICAL を blocking
+(`exit-code: '1'`) に戻す:
+
+1. 4 週間以上、両 image で CRITICAL 件数 0 を維持できている (PR / deploy 両
+   workflow の `::warning::` 履歴で確認)。
+2. `.trivyignore` に **期限切れ entry が無い** (月次棚卸しを完了している)。
+3. 週次の Trivy review 体制 (担当者 + 議事録 / 議題) が確立している。
+
+戻すときは:
+- `_deploy-cloud-run.yml` / `_deploy-external-api.yml` の
+  `Scan image (Trivy CRITICAL — advisory)` を `exit-code: '1'` に変更し step 名
+  を "blocking" に戻す。
+- `ci.yml:trivy` を必須 (`needs: [..., trivy]` の case 文で `failure)` を error
+  扱いに) する。
+- 本表 (Severity Policy) の CRITICAL 行を `1` / "block" に戻し、上記 advisory
+  のセクションを削除。
 
 ### `.trivyignore`
 
@@ -455,24 +487,27 @@ CVE を一時的に除外できる。**追加時は必ず以下を併記**:
 
 ### Local 検証
 
-PR を出す前に手元で同じ scan を回したい場合:
+PR を出す前に手元で同じ scan を回したい場合 (advisory mode と同じ
+`exit-code 0`):
 
 ```bash
-# CRITICAL のみ blocking で確認
-trivy image --severity CRITICAL --exit-code 1 --ignore-unfixed \
+# CRITICAL の一覧を確認
+trivy image --severity CRITICAL --exit-code 0 --ignore-unfixed \
   asia-northeast1-docker.pkg.dev/<project>/<repo>/<image>:latest
 
-# HIGH の一覧を確認 (block しない)
+# HIGH の一覧を確認
 trivy image --severity HIGH --exit-code 0 --ignore-unfixed \
   asia-northeast1-docker.pkg.dev/<project>/<repo>/<image>:latest
 ```
 
-### Block 時の対処
+### CVE 検出時の対処
 
-deploy が CRITICAL で fail したら、まず scan log で CVE と該当パッケージを
-特定し、以下の優先順で対応する:
+PR / deploy run で `::warning::` が出た、または Security タブに新規 alert が
+追加されたら、以下の優先順で対応する (advisory なので緊急停止はしないが、
+**気付いた時点で対処する**):
 
 1. **Base image / dependency の bump** で fix 済み version に上げる (推奨)。
+   Dependabot が自動で PR を開いている場合はそれを優先 merge。
 2. **multi-stage build (`Dockerfile`) で当該パッケージを最終ステージから外す**。
 3. 上記が現実的でない場合のみ、`.trivyignore` に追記して暫定回避し、
    別 issue で恒久対応をトラックする。


### PR DESCRIPTION
## Summary

H2 (#1024) で deploy workflow の Trivy CRITICAL を blocking (`exit-code: '1'`) にしたが、Trivy DB が日次で更新されるため、CI 緑で merge した PR が deploy 時点で新規 CRITICAL を抱え、上流 fix を待つしかない CVE で deploy 全体が stall する状態になった。

**緊急 revert ではなく根本修正** として、Trivy CRITICAL / HIGH を全て **advisory** に下げつつ、件数を 3 経路 (PR / deploy / Security tab) で必ず人間に見える化する構成に変更する。

## What changed

### `.github/workflows/ci.yml`
- `Scan runtime image (Trivy CRITICAL — blocking)` を `build` job から外し、独立した `trivy` job として切り出した。
  - 理由: 独立した PR check (`trivy` という名前で見える)、独立した retry、論理分離 (scan ≠ artifact production)。
- `build` job の docker buildx step に `--cache-to type=gha,scope=civicship-trivy-{internal,external},mode=max` を追加し、`trivy` job が `--cache-from` で同 layer cache を再利用 → image を秒単位で rebuild。
- `trivy` job: postgres + prisma generate --sql + pnpm build で build context を整え、両 image を rebuild → CRITICAL を **table** (log 可読) と **json** (件数 parse) の 2 形式で scan → 件数を `::warning::` annotation + 上位 20 件の CVE-ID を log に出す。
- 集約 `ci` job: `trivy` を needs に追加。advisory 扱いで `success | skipped | failure` 全てを許容 (Trivy DB の transient エラーで PR が永久 red にならないよう never gate)。

### `.github/workflows/_deploy-cloud-run.yml` + `_deploy-external-api.yml`
- `Scan image (Trivy CRITICAL — blocking)` → `Scan image (Trivy CRITICAL — advisory)`、`exit-code: '1'` → `'0'`。
- `Surface Trivy CVE count (advisory warning)` step を追加。`trivy-{critical,high}.sarif` を jq で parse、件数 > 0 なら `::warning::` で workflow run summary 最上部に通知 (deploy は止めない)。
- sarif の Security タブ upload (`category: trivy-{critical,high}` / `trivy-external-{critical,high}`) は維持。

### `.trivyignore`
- runbook コメントを書き直し: 3-layer visibility の説明 + CVE 検出時の対処優先順 (fix → ignore) + 再 blocking 化条件。

### `docs/handbook/SECURITY.md`
- Severity Policy 表を CRITICAL `1` (block) → `0` (advisory) に更新。
- "なぜ advisory に下げているか" の説明を追加。
- "Two-layer scan" → "3-layer visibility (PR + deploy + Security tab)" にリネーム + 内容更新。
- 新規 "Re-escalation conditions" セクションで blocking に戻す条件と手順を明文化。
- Local 検証コマンドの `--exit-code 1` → `0` (workflow と整合)。

## なぜ blocking ではなく advisory なのか

Trivy DB は **日次で更新** されるので、image 内容が変わっていなくても新規 CVE が追加されると突然 fail する。CRITICAL の上流 fix が出るまでは、

- `.trivyignore` に追加すれば deploy は再開できるが、それを「自動化された gate を通すためにする」と毎回 lazy ignore しがちになる。
- そもそも CI 緑で merge した PR が deploy 時に止まるのは、コード変更と無関係に runner 都合で deploy が止まる状況で、SRE 的にも望ましくない。

代わりに「人間が必ず気付く可視化を 3 経路で備える」(advisory mode) を選び、blocking に戻す条件を明文化した:

1. 4 週間以上 CRITICAL 件数 0 を維持
2. `.trivyignore` の期限切れ entry なし
3. 週次 Trivy review 体制 (担当 + 議事録) が確立

## Test plan

- [x] `python3 -m yaml.safe_load` で 3 つの workflow yaml が parse できることを確認
- [ ] PR を open した時点で `trivy` job が独立 check として走り、CRITICAL 件数が `::warning::` で出ることを確認
- [ ] 集約 `ci` job が trivy の結果に関わらず green のままであることを確認 (advisory 扱い)
- [ ] develop merge 後、deploy workflow が CRITICAL ヒットしても緑で deploy 完了することを確認、`Surface Trivy CVE count (advisory warning)` step が `::warning::` を吐くことを確認
- [ ] Security タブの `trivy-critical` / `trivy-high` (両 image) が引き続き populate されていることを確認

## Follow-up (別 PR)

- `.github/workflows/trivy-weekly.yml`: 週次 schedule で全 image を再 scan → 新規 CRITICAL があれば自動 issue 起票。advisory mode でも「気付く仕組み」を担保するための boost。

https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG)_