### PR TITLE
ci/docker: #1013 bot review followup — `@/` grep 拡張 + pg readiness fail-loud

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -46,10 +46,15 @@
 # Test / coverage artifacts (not needed at runtime). `test` / `tests`
 # don't exist in this repo today (we use `__tests__/` everywhere), but
 # kept as defense-in-depth for any tooling that auto-creates them.
+# Both root and `**/<name>` forms are listed for parity with the existing
+# `__tests__` pattern (some Docker BuildKit setups historically required
+# both for full coverage).
 __tests__
 **/__tests__
 test
+**/test
 tests
+**/tests
 *.test.ts
 *.spec.ts
 coverage

--- a/.dockerignore
+++ b/.dockerignore
@@ -43,9 +43,13 @@
 .env.*
 !.env.sample
 
-# Test / coverage artifacts (not needed at runtime)
+# Test / coverage artifacts (not needed at runtime). `test` / `tests`
+# don't exist in this repo today (we use `__tests__/` everywhere), but
+# kept as defense-in-depth for any tooling that auto-creates them.
 __tests__
 **/__tests__
+test
+tests
 *.test.ts
 *.spec.ts
 coverage

--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -88,7 +88,7 @@ jobs:
       # MAIN_IMAGE / MAIN_IMAGE_SHA を job-level env に出すことで、build/push step
       # と Trivy scan step (build step 後の独立 step) から同じ参照で扱えるように
       # する。`:sha-${{ github.sha }}` は Cloud Run revision を commit 単位で
-      # identifyable にし、過去 image にロールバックできるようにするため (#974)。
+      # identifiable にし、過去 image にロールバックできるようにするため (#974)。
       # Trivy 側は `MAIN_IMAGE_SHA || MAIN_IMAGE` の fallback で sha tag 優先。
       MAIN_IMAGE: ${{ secrets.ARTIFACT_REGISTRY }}/${{ secrets.APPLICATION_NAME }}:latest
       MAIN_IMAGE_SHA: ${{ secrets.ARTIFACT_REGISTRY }}/${{ secrets.APPLICATION_NAME }}:sha-${{ github.sha }}
@@ -174,7 +174,7 @@ jobs:
       # batch (Cloud Run Job) 側は entrypoint を `--command/--args` で
       # `node dist/index.js` に上書きする (旧 Dockerfile.batch CMD と等価)。
       # `:sha-${{ github.sha }}` を `:latest` と並列で push することで、
-      # Cloud Run の各 revision を commit SHA 単位で identifyable にし、
+      # Cloud Run の各 revision を commit SHA 単位で identifiable にし、
       # 過去 image にロールバックできるようにする (DEPLOYMENT.md 参照)。
       - name: Build unified image and push to main + batch registries
         run: |

--- a/.github/workflows/_deploy-external-api.yml
+++ b/.github/workflows/_deploy-external-api.yml
@@ -63,7 +63,7 @@ jobs:
       # EXTERNAL_IMAGE / EXTERNAL_IMAGE_SHA を job-level env に出すことで、
       # build/push step と Trivy scan step (build step 後の独立 step) から同じ
       # 参照で扱えるようにする。`:sha-${{ github.sha }}` は Cloud Run revision
-      # を commit 単位で identifyable にし、過去 image にロールバックできるよう
+      # を commit 単位で identifiable にし、過去 image にロールバックできるよう
       # にするため (#974)。Trivy 側は `EXTERNAL_IMAGE_SHA || EXTERNAL_IMAGE` の
       # fallback で sha tag 優先。
       EXTERNAL_IMAGE: ${{ secrets.ARTIFACT_REGISTRY }}/${{ secrets.EXTERNAL_API_NAME }}:latest
@@ -126,7 +126,7 @@ jobs:
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
 
       # `:sha-${{ github.sha }}` を `:latest` と並列で push することで、
-      # Cloud Run の各 revision を commit SHA 単位で identifyable にし、
+      # Cloud Run の各 revision を commit SHA 単位で identifiable にし、
       # 過去 image にロールバックできるようにする (DEPLOYMENT.md 参照)。
       - name: Build and push External API image
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,11 +205,20 @@ jobs:
       # `ERR_MODULE_NOT_FOUND`. Catch that drift at PR time rather than at
       # deploy time. `grep -q` exits 0 on first match, so we negate to fail
       # the step when residual `@/` is found.
+      #
+      # Pattern covers all import shapes that tsc emits / users write:
+      #   - Static  : `from "@/x"` / `from '@/x'`
+      #   - CJS     : `require("@/x")` / `require('@/x')`
+      #   - Dynamic : `import("@/x")` / `import('@/x')`
+      # Both single and double quotes are matched so the assertion stays
+      # robust against future formatter / source-style changes.
       - name: Assert tsc-alias rewrote all `@/` imports in dist
+        env:
+          AT_IMPORT_PATTERN: '(from |require\(|import\()["'']@/'
         run: |
-          if grep -rqE '(from |require\()"@/' dist/; then
-            echo "::error::Found unrewritten \`@/\` imports in dist/. tsc-alias may have failed or new import shape (e.g. dynamic import) is not handled. Fix tsc-alias config or restore tsconfig-paths/register."
-            grep -rnE '(from |require\()"@/' dist/ | head -20
+          if grep -rqE "$AT_IMPORT_PATTERN" dist/; then
+            echo "::error::Found unrewritten \`@/\` imports in dist/. tsc-alias may have failed or a new import shape is not handled. Fix tsc-alias config or restore tsconfig-paths/register."
+            grep -rnE "$AT_IMPORT_PATTERN" dist/ | head -20
             exit 1
           fi
           echo "✅ dist/ contains no unresolved \`@/\` imports."
@@ -331,6 +340,7 @@ jobs:
       # contained and doesn't perturb the `build` / `test` job services.
       - name: Spin up local Postgres for prisma generate --sql
         run: |
+          set -euo pipefail
           docker run -d \
             --name pg-trivy \
             -e POSTGRES_USER=civicship \
@@ -338,10 +348,23 @@ jobs:
             -e POSTGRES_DB=civicship_ci \
             -p 5432:5432 \
             postgres:16-alpine
+          # Wait up to 30s for Postgres to accept connections. If it never
+          # becomes ready, surface container logs and fail explicitly so the
+          # follow-up `db:deploy` doesn't blow up with a confusing connection
+          # error instead.
+          ready=false
           for _ in $(seq 1 30); do
-            if docker exec pg-trivy pg_isready -U civicship -d civicship_ci -q; then break; fi
+            if docker exec pg-trivy pg_isready -U civicship -d civicship_ci -q; then
+              ready=true
+              break
+            fi
             sleep 1
           done
+          if [ "$ready" != "true" ]; then
+            echo "::error::Postgres (pg-trivy) did not become ready within 30s"
+            docker logs pg-trivy || true
+            exit 1
+          fi
 
       - name: Apply Prisma migrations + generate client + GraphQL types
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,9 +78,10 @@ RUN find node_modules -type d -name .prisma -print0 \
 ENV CI=true
 RUN pnpm prune --prod
 
-# Restore the saved `.prisma/` directories. tar -P preserves absolute / as-is
-# paths, so the directories land back at the same `.pnpm/<pkg>/node_modules/
-# .prisma/` locations they came from.
+# Restore the saved `.prisma/` directories. The snapshot was created from
+# `find node_modules ...` (relative paths), and we extract from `WORKDIR
+# /app`, so the directories land back at the same
+# `node_modules/.pnpm/<pkg>/node_modules/.prisma/` locations they came from.
 RUN if [ -s /tmp/prisma-snapshot.tar ]; then \
       tar -xf /tmp/prisma-snapshot.tar \
         && rm /tmp/prisma-snapshot.tar; \


### PR DESCRIPTION
## Summary

#1013 で merge 前に解消できなかった bot review (Copilot / Gemini) の active な指摘を別 PR として取り込む。master merge 前のクリーンアップ。

## What changed

### 実害ある修正

- **`ci.yml:trivy` の `@/` 残存 grep を拡張** (#1013 review comment by copilot-pull-request-reviewer)
  - 現状: `(from |require\()"@/` のみ → dynamic import (`await import("@/...")`) や single quote 形を見逃す
  - 修正後: `(from |require\(|import\()["']@/` で 6 形 (static / require / dynamic × 'single' / "double") を網羅
  - 重要性: runtime image は `tsconfig-paths/register` を持たない (#1015) ので、grep が見逃した `@/` 残存は **Cloud Run 起動失敗に直結**

- **`ci.yml:trivy` の Postgres readiness fail-loud 化** (#1013 review comment by copilot-pull-request-reviewer)
  - 現状: pg_isready が 30 秒経っても通らない場合でも黙って後続に進む → `db:deploy` が分かりにくい connection error で落ちる
  - 修正後: ready flag で明示的に判定し、未起動なら `docker logs pg-trivy` を出して `exit 1`

### Cosmetic 修正

- `_deploy-cloud-run.yml` L91 / L177 + `_deploy-external-api.yml` L66 / L129: コメント中の `identifyable` → `identifiable` (typo)
- `Dockerfile` L81-83: `.prisma/` 復元コメントを実コマンド (`tar -xf` を `WORKDIR /app` から相対パスで実行) に整合させる
- `.dockerignore`: `test` / `tests` を防御的追加 (現状 repo に存在しないが、将来追加された時に build context に含まれないよう)

## なぜ別 PR

- #1013 (master ← develop) は既に **deploy job 含めて全 check 緑** で deploy も完走済み。bot review 指摘は実害ある 2 件 + cosmetic 4 件で、master merge 前の health check として独立 PR で取り込む方が tracking しやすい。
- 単純な追加修正なので #1013 と独立して develop にマージ可能。

## Test plan

- [x] `python3 -c "yaml.safe_load(...)"` で 3 つの workflow yaml が parse できることを確認
- [x] Bash で grep 拡張 pattern を 6 形のサンプルに対して試し、relative import を skip することを確認
- [ ] PR の trivy job で Postgres 起動 → migration → trivy scan が成功することを確認
- [ ] PR の build job (`Assert tsc-alias rewrote all @/ imports`) が緑のままであることを確認

## Follow-up

- master ← develop の #1013 マージは、この PR が develop に入った後で実施推奨。

https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG)_