### PR TITLE
ci(deploy): #986 — Apollo schema publish を deploy 後に + tzdata install 廃止

### DIFF
--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -98,14 +98,18 @@ jobs:
     steps:
       # `audit` mode: log egress (GCP / npm registry / GitHub) without blocking.
       # `block` mode would require maintaining an allowlist for every gcloud
-      # endpoint and is fragile across SDK updates. `disable-sudo` is left
-      # enabled (default) because the "Create Git tag" step installs tzdata
-      # via apt-get on prd. Audit logs surface in the job summary and let us
-      # detect unexpected egress (e.g. credential exfiltration) post-hoc.
+      # endpoint and is fragile across SDK updates. Audit logs surface in the
+      # job summary and let us detect unexpected egress (e.g. credential
+      # exfiltration) post-hoc.
+      # `disable-sudo: true`: tzdata install を `TZ=Asia/Tokyo` env に置き
+      # 換えた (#986) ことで sudo 不要になったため、deploy job 全体で root
+      # 昇格を禁止する。これで「step が想定外に root を取得する」攻撃面
+      # を一段塞げる。
       - name: Harden runner
         uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
+          disable-sudo: true
 
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -149,14 +153,6 @@ jobs:
 
       - name: Generate GraphQL types
         run: pnpm gql:generate
-
-      - name: Install and Publish via Rover CLI
-        env:
-          APOLLO_KEY: ${{ env.APOLLO_KEY }}
-        run: |
-          curl -sSL https://rover.apollo.dev/nix/latest | sh
-          export PATH="$HOME/.rover/bin:$PATH"
-          rover graph publish "civicship-api-jq1988@${{ inputs.apollo-variant }}" --schema ./docs/schema.graphql
 
       - name: Build TypeScript output (consumed by Docker COPY)
         run: pnpm build
@@ -480,6 +476,22 @@ jobs:
             --region="${GCP_REGION}" \
             --to-revisions="${PREV_REV}=100"
 
+      # Apollo Studio に schema を publish するのは **deploy 成功 + smoke OK 後**
+      # にする (#986)。先に publish してしまうと、build / deploy が失敗したとき
+      # に新 schema だけが Studio に登録され、サーバ側は旧コードのまま — クライ
+      # アントが advertised なフィールドを叩いて壊れる、という inconsistency を
+      # 招く。デフォルトの `if: success()` 仕様で、immediate path / canary
+      # promote 100% のいずれも通った場合だけ走る。canary が rollback された
+      # 場合は `Rollback to previous revision` step が走った時点で job result が
+      # failure 化するので、本 step は skip される (= 旧 schema のまま維持)。
+      - name: Publish GraphQL schema to Apollo Studio
+        env:
+          APOLLO_KEY: ${{ env.APOLLO_KEY }}
+        run: |
+          curl -sSL https://rover.apollo.dev/nix/latest | sh
+          export PATH="$HOME/.rover/bin:$PATH"
+          rover graph publish "civicship-api-jq1988@${{ inputs.apollo-variant }}" --schema ./docs/schema.graphql
+
       - name: Update Cloud Run Job (batch) to new image
         # docker push :latest alone does not roll the Cloud Run Job to the new
         # image — Cloud Run Jobs pin the image digest at deploy time, so we
@@ -499,17 +511,16 @@ jobs:
             --args=dist/bootstrap/batch.js
 
       - name: Create Git tag
+        # TZ env でプロセス単位に JST を効かせる。tzdata の system-wide install
+        # は不要 (#986) — apt 経由のネット I/O / sudo が消えるので、harden-runner
+        # で `disable-sudo: true` を有効化できる。
         if: ${{ inputs.create-git-tag }}
+        env:
+          TZ: Asia/Tokyo
         run: |
-          sudo apt-get update && sudo apt-get install -y tzdata
-          sudo ln -fs /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
-          sudo dpkg-reconfigure -f noninteractive tzdata
-
           TAG_NAME=$(date +"%Y%m%d%H%M%S")
-
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-
           git tag "$TAG_NAME"
           git push origin "$TAG_NAME"
 

--- a/.github/workflows/_deploy-external-api.yml
+++ b/.github/workflows/_deploy-external-api.yml
@@ -70,11 +70,13 @@ jobs:
       EXTERNAL_IMAGE_SHA: ${{ secrets.ARTIFACT_REGISTRY }}/${{ secrets.EXTERNAL_API_NAME }}:sha-${{ github.sha }}
 
     steps:
-      # See _deploy-cloud-run.yml for rationale on audit mode + sudo.
+      # See _deploy-cloud-run.yml for rationale on audit mode + disable-sudo
+      # (#986).
       - name: Harden runner
         uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
+          disable-sudo: true
 
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -233,17 +235,15 @@ jobs:
           fi
 
       - name: Create Git tag
+        # TZ env でプロセス単位に JST を効かせる (#986)。詳細は
+        # _deploy-cloud-run.yml の同名 step コメント参照。
         if: ${{ inputs.create-git-tag }}
+        env:
+          TZ: Asia/Tokyo
         run: |
-          sudo apt-get update && sudo apt-get install -y tzdata
-          sudo ln -fs /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
-          sudo dpkg-reconfigure -f noninteractive tzdata
-
           TAG_NAME="${{ inputs.git-tag-prefix }}$(date +"%Y%m%d%H%M%S")"
-
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-
           git tag "$TAG_NAME"
           git push origin "$TAG_NAME"
 


### PR DESCRIPTION
## Summary

P3 (#1004) の構成要素 **#986** を最新 develop ベースで切り出した独立 PR。

**Closes #986.**

#1004 は #1024 / #1026 / #1027 で workflow 全体が大きく書き換わった結果、`mergeable_state: dirty` になり rebase 困難になっていたため close 推奨。代わりに各サブ issue (#984 / #985 / #986) を最新 develop ベースで個別 PR 化していく方針 (本 PR がその第一弾)。

## What changed

### 1. Apollo schema publish の順序修正

旧:
```
... → gql:generate → rover graph publish → build → docker push → deploy
```
build や deploy が失敗すると新 schema だけが先に Studio に登録され、サーバ側は旧コードのまま — クライアントが advertised なフィールドを叩いて壊れる、という inconsistency を招いていた。

新:
```
... → build → docker push → deploy → smoke / canary promote → ★publish★ → batch update → git tag
```
GitHub Actions のデフォルト `if: success()` で:
- immediate path: deploy + smoke 両方成功 → publish 走る
- canary path: promote 100% まで成功 → publish 走る
- canary 失敗: rollback step が走り job が failure 化 → publish skip (= 旧 schema のまま維持)

Step 名も `Publish GraphQL schema to Apollo Studio` にリネーム (rover install は副次的処理なので名前から外す)。

### 2. tzdata install 廃止

`Create Git tag` step で JST タグ生成のため毎回 `apt-get install tzdata` + `dpkg-reconfigure` を実行していたが、**`TZ=Asia/Tokyo` env でプロセス単位に切り替えれば同等の結果**。

これにより:
- 毎回のネット I/O / sudo / dpkg-reconfigure が消える
- `harden-runner` に `disable-sudo: true` を有効化 → deploy job 全体で root 昇格を禁止できる (= 想定外の root 操作の攻撃面を一段塞げる)

`_deploy-cloud-run.yml` / `_deploy-external-api.yml` 両方に同じ修正を適用。`_deploy-external-api.yml` は `git-tag-prefix` を保持。

## Test plan

- [x] `python3 yaml.safe_load` で 2 つの workflow yaml が parse できることを確認
- [ ] dev 環境 deploy で:
  - schema publish が deploy + smoke の **後** に走ることを確認
  - `Create Git tag` step (dev は `create-git-tag: false` なので skip 想定) を含む deploy が緑になることを確認
  - `disable-sudo: true` で deploy job が走り切ることを確認
- [ ] prd deploy で `git tag` が JST timestamp で push されることを確認 (次回 prd デプロイ時)
- [ ] canary 失敗パス (人為的に failure を起こすテスト) で schema publish が skip されることを確認

## Follow-up

- #984 (paths-filter) → 別 PR
- #985 (composite action 抽出) → 別 PR
- 旧 P3 PR #1004 は本 PR + 後続 2 PR で代替するため close 予定

https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdY1EZhgXiKXdVyoGcQ8qG)_