### PR TITLE
ci(deploy): #986 followup — schema publish を batch update 後ろへ

### DIFF
--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -476,22 +476,6 @@ jobs:
             --region="${GCP_REGION}" \
             --to-revisions="${PREV_REV}=100"
 
-      # Apollo Studio に schema を publish するのは **deploy 成功 + smoke OK 後**
-      # にする (#986)。先に publish してしまうと、build / deploy が失敗したとき
-      # に新 schema だけが Studio に登録され、サーバ側は旧コードのまま — クライ
-      # アントが advertised なフィールドを叩いて壊れる、という inconsistency を
-      # 招く。デフォルトの `if: success()` 仕様で、immediate path / canary
-      # promote 100% のいずれも通った場合だけ走る。canary が rollback された
-      # 場合は `Rollback to previous revision` step が走った時点で job result が
-      # failure 化するので、本 step は skip される (= 旧 schema のまま維持)。
-      - name: Publish GraphQL schema to Apollo Studio
-        env:
-          APOLLO_KEY: ${{ env.APOLLO_KEY }}
-        run: |
-          curl -sSL https://rover.apollo.dev/nix/latest | sh
-          export PATH="$HOME/.rover/bin:$PATH"
-          rover graph publish "civicship-api-jq1988@${{ inputs.apollo-variant }}" --schema ./docs/schema.graphql
-
       - name: Update Cloud Run Job (batch) to new image
         # docker push :latest alone does not roll the Cloud Run Job to the new
         # image — Cloud Run Jobs pin the image digest at deploy time, so we
@@ -509,6 +493,26 @@ jobs:
             --image="${{ env.BATCH_ARTIFACT_REGISTRY }}/${{ env.BATCH_NAME }}:sha-${{ github.sha }}" \
             --command=node \
             --args=dist/bootstrap/batch.js
+
+      # Apollo Studio に schema を publish するのは **main API deploy + smoke OK
+      # + batch (Cloud Run Job) 更新 が全部通った後** にする (#986)。
+      # 先に publish してしまうと、build / deploy が失敗したときに新 schema だけ
+      # が Studio に登録され、サーバ側は旧コードのまま — クライアントが advertised
+      # なフィールドを叩いて壊れる、という inconsistency を招く。
+      # また、batch update より前に置くと Rover/Apollo 側の一時障害で publish が
+      # 落ちた瞬間に main API は新 revision・batch は旧 image という非対称デプロイ
+      # で止まるため、batch update の **後ろ** に置く必要がある。
+      # デフォルトの `if: success()` 仕様で、immediate path / canary promote 100%
+      # のいずれも通った場合だけ走る。canary が rollback された場合は
+      # `Rollback to previous revision` step が走った時点で job result が failure
+      # 化するので、本 step は skip される (= 旧 schema のまま維持)。
+      - name: Publish GraphQL schema to Apollo Studio
+        env:
+          APOLLO_KEY: ${{ env.APOLLO_KEY }}
+        run: |
+          curl -sSL https://rover.apollo.dev/nix/latest | sh
+          export PATH="$HOME/.rover/bin:$PATH"
+          rover graph publish "civicship-api-jq1988@${{ inputs.apollo-variant }}" --schema ./docs/schema.graphql
 
       - name: Create Git tag
         # TZ env でプロセス単位に JST を効かせる。tzdata の system-wide install


### PR DESCRIPTION
## Summary

#1028 (Copilot review followup) — Apollo Studio への schema publish step を `Update Cloud Run Job (batch)` step の **後ろ** に移します。

## Why

現状 (#1028 の merge 後) の step 順序は

1. Deploy Internal API (immediate / canary promote)
2. Smoke check
3. **Publish GraphQL schema to Apollo Studio**
4. Update Cloud Run Job (batch) to new image

になっており、step は default で `if: success()` チェーンなので、Rover/Apollo 側の一時障害で 3 が落ちると **main API は新 revision で 100% serving、batch (Cloud Run Job) は旧 image のまま** という非対称デプロイで workflow が止まります。

本 workflow は「main / batch を同一 image・同一 commit で同時に更新する」前提で組まれているため、schema publish は両 service の rollout が確定してから行うべきです。

## Fix

step 順序を以下に変更:

1. Deploy Internal API (immediate / canary promote)
2. Smoke check
3. Update Cloud Run Job (batch) to new image
4. **Publish GraphQL schema to Apollo Studio**

これで Apollo の一時障害は batch rollout を阻害せず、かつ「両 service が新 image で揃ったときだけ Studio に新 schema を登録する」という #986 の元意図 (= schema と server の整合性) も維持されます。canary が rollback された場合は `Rollback to previous revision` step が走った時点で job が failure 化するので publish は skip され、旧 schema のまま残ります (これは従来挙動と同じ)。

## Test plan

- [ ] dev 側 (`enable-canary: false`) で immediate deploy → batch update → schema publish の順で全 step が green になることを確認
- [ ] prd 側 (`enable-canary: true`) で canary promote 100% → batch update → schema publish の順で走ることを確認
- [ ] canary rollback 時に schema publish が skip されることを確認 (logs で step skipped を確認)

https://claude.ai/code/session_01VcqvdD9hZaCj6piW9h5Ld9

---
_Generated by [Claude Code](https://claude.ai/code/session_01VcqvdD9hZaCj6piW9h5Ld9)_