### PR TITLE
fix(dependabot): drop npm-only `semver-*-days` from non-semver ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,10 +53,11 @@ updates:
       time: "06:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 5
+    # `cooldown.semver-*-days` is npm-specific; `github-actions` only accepts
+    # `default-days` (and `include`/`exclude`). 7 days approximates the weekly
+    # review cadence above.
     cooldown:
-      semver-major-days: 14
-      semver-minor-days: 10
-      semver-patch-days: 5
+      default-days: 7
     groups:
       actions-minor-patch:
         patterns: ["*"]
@@ -72,8 +73,8 @@ updates:
 
   # Docker base image digest tracking. Both `Dockerfile` and `Dockerfile.external`
   # pin `node:20-slim@sha256:<digest>` for reproducibility; Dependabot opens a PR
-  # when upstream re-tags `node:20-slim` to a new digest. Cooldown matches the
-  # other ecosystems so we don't get woken up by every nightly base re-build.
+  # when upstream re-tags `node:20-slim` to a new digest. Cooldown is set so we
+  # don't get woken up by every nightly base re-build.
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
@@ -82,10 +83,10 @@ updates:
       time: "06:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 5
+    # `cooldown.semver-*-days` is npm-specific; `docker` only accepts
+    # `default-days` (and `include`/`exclude`).
     cooldown:
-      semver-major-days: 14
-      semver-minor-days: 10
-      semver-patch-days: 5
+      default-days: 7
     labels:
       - "dependencies"
       - "docker"


### PR DESCRIPTION
## Summary
Removes `cooldown.semver-*-days` from the `github-actions` and `docker` ecosystem entries in `.github/dependabot.yml` and replaces them with `cooldown.default-days: 7`. The granular semver-tiered cooldown is npm-specific; Dependabot's config validator rejects it for non-semver ecosystems:

```
The property '#/updates/1/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/1/cooldown/semver-minor-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/1/cooldown/semver-patch-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/2/cooldown/semver-major-days' is not supported for the package ecosystem 'docker'.
The property '#/updates/2/cooldown/semver-minor-days' is not supported for the package ecosystem 'docker'.
The property '#/updates/2/cooldown/semver-patch-days' is not supported for the package ecosystem 'docker'.
```

This is the `.github/dependabot.yml` check that has been failing on every PR's CI.

## What changed

| ecosystem | before | after |
|---|---|---|
| `npm` | `semver-major: 14`, `semver-minor: 10`, `semver-patch: 5` | unchanged |
| `github-actions` | `semver-major: 14`, `semver-minor: 10`, `semver-patch: 5` (rejected) | `default-days: 7` |
| `docker` | `semver-major: 14`, `semver-minor: 10`, `semver-patch: 5` (rejected) | `default-days: 7` |

Picked `7` so the cooldown window aligns with the existing `weekly` schedule (Monday 06:00 JST) — a single week dampens nightly base-image churn without holding up security updates for long.

## Test plan
- [ ] CI: the `.github/dependabot.yml` config-validation check goes green.
- [ ] After merge, this same check goes green on the other open PRs (#1008, #1009).

## Notes
- `npm` keeps its granular semver-tiered cooldown — that's the only ecosystem where `semver-*-days` is supported.
- The relevant header comment was also updated to reflect the new docker config.

https://claude.ai/code/session_01Rs8kgHhtcTWCRuf68ReYtq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rs8kgHhtcTWCRuf68ReYtq)_