### PR TITLE
fix(auth): tighten isGraphQLBody type guard against non-object payloads

### DIFF
--- a/src/presentation/middleware/auth/index.ts
+++ b/src/presentation/middleware/auth/index.ts
@@ -12,7 +12,24 @@ import { runRequestSecurityChecks } from "@/presentation/middleware/auth/securit
 function isGraphQLBody(
   body: unknown,
 ): body is { operationName?: string; query?: string } {
-  return typeof body === "object" && body !== null;
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return false;
+  }
+  if (
+    "operationName" in body &&
+    body.operationName !== undefined &&
+    typeof body.operationName !== "string"
+  ) {
+    return false;
+  }
+  if (
+    "query" in body &&
+    body.query !== undefined &&
+    typeof body.query !== "string"
+  ) {
+    return false;
+  }
+  return true;
 }
 
 async function createContext({ req }: { req: Request }): Promise<IContext> {


### PR DESCRIPTION
## Summary
Addresses the high-priority Gemini review on #1009 / `auth/middleware/index.ts`.

The previous `isGraphQLBody` only checked that `body` was an object and not null:

```ts
function isGraphQLBody(body: unknown): body is { operationName?: string; query?: string } {
  return typeof body === "object" && body !== null;
}
```

The predicate narrows to `{ operationName?: string, query?: string }`, but the runtime check is far weaker than the type promise. If `body` is an array, or `query` is e.g. a number, downstream `query.trim().split(...)` crashes the request handler.

## Fix
Tighten the guard to:
- reject arrays (`Array.isArray`)
- when `operationName` is present, require it to be `string` (or `undefined`)
- when `query` is present, require it to be `string` (or `undefined`)

```ts
function isGraphQLBody(
  body: unknown,
): body is { operationName?: string; query?: string } {
  if (typeof body !== "object" || body === null || Array.isArray(body)) {
    return false;
  }
  if (
    "operationName" in body &&
    body.operationName !== undefined &&
    typeof body.operationName !== "string"
  ) {
    return false;
  }
  if (
    "query" in body &&
    body.query !== undefined &&
    typeof body.query !== "string"
  ) {
    return false;
  }
  return true;
}
```

Implementation uses `in`-narrowing rather than `as Record<string, unknown>` to keep the no-`as` discipline established in #1008.

## Test plan
- [x] `pnpm tsc --noEmit` shows no new type errors.
- [x] Single-file change (no auto-fix collateral from `prettier --write`).
- [ ] CI: lint + build + all test suites pass.

https://claude.ai/code/session_01Rs8kgHhtcTWCRuf68ReYtq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rs8kgHhtcTWCRuf68ReYtq)_