### PR TITLE
ci(lint): make ESLint a required check (Prettier stays non-blocking)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,14 +63,17 @@ jobs:
       - name: Setup civicship environment
         uses: ./.github/actions/setup-civicship
 
-      # ESLint (no --fix) と Prettier --check で source の lint / format 違反を検出する。
-      # 現状 src/ には既存違反 (ESLint 841 errors / Prettier 265 files) が残存している
-      # ため、暫定的に failure を `::warning::` に降格し job は green を維持する。
-      # 既存違反の解消後 (separate PR) に `|| echo` を外して required check 化する。
-      - name: Lint (ESLint + Prettier check, non-blocking)
+      # ESLint は PR #1007 / #1008 / #1009 で issue #978 の backlog (841 errors → 0)
+      # を解消したので required check に格上げ。新規違反は CI で落とす。
+      # Prettier は formatting backlog (267 files) が残っているので暫定で
+      # `::warning::` 降格。一括フォーマット PR で潰したら blocking 化する。
+      - name: ESLint check
+        run: pnpm exec eslint src/
+
+      - name: Prettier check (non-blocking, formatting backlog from #978)
         run: |
-          if ! pnpm lint:check; then
-            echo "::warning::existing lint failures (ESLint / Prettier) — see step log; failures are non-blocking until backlog is fixed (issue #978)"
+          if ! pnpm exec prettier --check src/; then
+            echo "::warning::existing Prettier failures (267 files) — non-blocking until a one-shot `prettier --write src/` PR lands"
           fi
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Prettier check (non-blocking, formatting backlog from #978)
         run: |
           if ! pnpm exec prettier --check src/; then
-            echo "::warning::existing Prettier failures (267 files) — non-blocking until a one-shot `prettier --write src/` PR lands"
+            echo '::warning::existing Prettier failures (267 files) — non-blocking until a one-shot prettier --write PR lands'
           fi
 
   build:


### PR DESCRIPTION
## Summary
Promotes ESLint from a `::warning::` shim to a required CI check. Prettier stays non-blocking until its formatting backlog is cleared.

## Background
The lint job in `.github/workflows/ci.yml` was wrapping `pnpm lint:check` (which runs ESLint + Prettier) in a `if ! ... then echo ::warning::` shim, because issue #978 had ~841 ESLint errors and ~265 Prettier-dirty files at the time. That meant lint regressions silently slipped through.

PR #1007 / #1008 / #1009 took the ESLint count from **841 → 0**, so we can now gate on it.

## Change
Split the single combined step into two:

```yaml
- name: ESLint check
  run: pnpm exec eslint src/

- name: Prettier check (non-blocking, formatting backlog from #978)
  run: |
    if ! pnpm exec prettier --check src/; then
      echo "::warning::existing Prettier failures (267 files) — non-blocking until a one-shot `prettier --write src/` PR lands"
    fi
```

- **ESLint**: required. New `as any`, `no-unused-vars`, `no-empty-object-type` etc. will fail CI.
- **Prettier**: still warning-only until a separate `prettier --write src/` PR lands. Splitting the steps lets us promote each independently without coupling the two backlogs.

## Test plan
- [x] `pnpm exec eslint src/` exits 0 locally.
- [x] `pnpm exec prettier --check src/` exits 1 locally (267 files dirty) — confirms the warning shim still suppresses it.
- [ ] CI on this PR: ESLint step green, Prettier step shows the `::warning::` annotation.

## Follow-up
- One-shot Prettier formatting PR (`prettier --write src/`) → then drop the warning shim from this Prettier step too.

https://claude.ai/code/session_01Rs8kgHhtcTWCRuf68ReYtq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rs8kgHhtcTWCRuf68ReYtq)_