### PR TITLE
fix(ci): use format projection filter for canary tag URL

### DIFF
--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -331,11 +331,12 @@ jobs:
           # tag URL は `gcloud run services describe` の status.traffic[].url か
           # ら canary tag のものを取る (リージョン固有の `canary---SERVICE-...`
           # ホスト名が返る)。
+          # `gcloud run services describe` は `--filter` 非対応なので、
+          # projection 側の `.filter()` で canary tag だけ抽出する。
           CANARY_URL=$(gcloud run services describe "${APPLICATION_NAME}" \
             --region="${GCP_REGION}" \
-            --format='value(status.traffic.url)' \
-            --flatten='status.traffic[]' \
-            --filter='status.traffic.tag=canary' | head -n 1)
+            --format='value(status.traffic.filter("tag:canary").extract(url).flatten())' \
+            | head -n 1)
           if [ -z "${CANARY_URL}" ]; then
             echo "Could not resolve canary tag URL" >&2
             exit 1


### PR DESCRIPTION
## Summary
- `gcloud run services describe` は `--filter` フラグを受け付けず、prd デプロイの canary smoke ステップが `unrecognized arguments: --filter=status.traffic.tag=canary` で失敗していた
- tag 絞り込みを `--format` の projection 内 (`status.traffic.filter("tag:canary").extract(url).flatten()`) に移して、`describe` だけで canary タグの URL を取得できるようにした

## Test plan
- [ ] prd デプロイ workflow を再実行し、`Smoke test canary tag URL` ステップで canary URL が解決されること
- [ ] 解決された URL に対する `/health` smoke が成功すること

https://claude.ai/code/session_01MNQenNCqWs1DvUTey6xkaf

---
_Generated by [Claude Code](https://claude.ai/code/session_01MNQenNCqWs1DvUTey6xkaf)_