### PR TITLE
refactor(authz): community scoping を ctx.communityId に統一 + report系を IsCommunityOwner で許可

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -2070,40 +2070,40 @@ type MembershipsConnection {
 
 type Mutation {
   approveReport(id: ID!): ApproveReportPayload
-  articleCreate(input: ArticleCreateInput!, permission: CheckCommunityPermissionInput!): ArticleCreatePayload
-  articleDelete(id: ID!, permission: CheckCommunityPermissionInput!): ArticleDeletePayload
-  articleUpdateContent(id: ID!, input: ArticleUpdateContentInput!, permission: CheckCommunityPermissionInput!): ArticleUpdateContentPayload
+  articleCreate(input: ArticleCreateInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): ArticleCreatePayload
+  articleDelete(id: ID!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): ArticleDeletePayload
+  articleUpdateContent(id: ID!, input: ArticleUpdateContentInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): ArticleUpdateContentPayload
   communityCreate(input: CommunityCreateInput!): CommunityCreatePayload
-  communityDelete(id: ID!, permission: CheckCommunityPermissionInput!): CommunityDeletePayload
-  communityUpdateProfile(id: ID!, input: CommunityUpdateProfileInput!, permission: CheckCommunityPermissionInput!): CommunityUpdateProfilePayload
-  evaluationBulkCreate(input: EvaluationBulkCreateInput!, permission: CheckCommunityPermissionInput!): EvaluationBulkCreatePayload
-  generateReport(input: GenerateReportInput!, permission: CheckCommunityPermissionInput!): GenerateReportPayload
+  communityDelete(id: ID!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): CommunityDeletePayload
+  communityUpdateProfile(id: ID!, input: CommunityUpdateProfileInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): CommunityUpdateProfilePayload
+  evaluationBulkCreate(input: EvaluationBulkCreateInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): EvaluationBulkCreatePayload
+  generateReport(input: GenerateReportInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): GenerateReportPayload
   identityCheckPhoneUser(input: IdentityCheckPhoneUserInput!): IdentityCheckPhoneUserPayload!
-  incentiveGrantRetry(input: IncentiveGrantRetryInput!, permission: CheckCommunityPermissionInput!): IncentiveGrantRetryPayload
+  incentiveGrantRetry(input: IncentiveGrantRetryInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): IncentiveGrantRetryPayload
   linkPhoneAuth(input: LinkPhoneAuthInput!, permission: CheckIsSelfPermissionInput!): LinkPhoneAuthPayload
   membershipAcceptMyInvitation(input: MembershipSetInvitationStatusInput!, permission: CheckIsSelfPermissionInput!): MembershipSetInvitationStatusPayload
-  membershipAssignManager(input: MembershipSetRoleInput!, permission: CheckCommunityPermissionInput!): MembershipSetRolePayload
-  membershipAssignMember(input: MembershipSetRoleInput!, permission: CheckCommunityPermissionInput!): MembershipSetRolePayload
-  membershipAssignOwner(input: MembershipSetRoleInput!, permission: CheckCommunityPermissionInput!): MembershipSetRolePayload
-  membershipCancelInvitation(input: MembershipSetInvitationStatusInput!, permission: CheckCommunityPermissionInput!): MembershipSetInvitationStatusPayload
+  membershipAssignManager(input: MembershipSetRoleInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): MembershipSetRolePayload
+  membershipAssignMember(input: MembershipSetRoleInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): MembershipSetRolePayload
+  membershipAssignOwner(input: MembershipSetRoleInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): MembershipSetRolePayload
+  membershipCancelInvitation(input: MembershipSetInvitationStatusInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): MembershipSetInvitationStatusPayload
   membershipDenyMyInvitation(input: MembershipSetInvitationStatusInput!, permission: CheckIsSelfPermissionInput!): MembershipSetInvitationStatusPayload
-  membershipInvite(input: MembershipInviteInput!, permission: CheckCommunityPermissionInput!): MembershipInvitePayload
-  membershipRemove(input: MembershipRemoveInput!, permission: CheckCommunityPermissionInput!): MembershipRemovePayload
+  membershipInvite(input: MembershipInviteInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): MembershipInvitePayload
+  membershipRemove(input: MembershipRemoveInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): MembershipRemovePayload
   membershipWithdraw(input: MembershipWithdrawInput!, permission: CheckIsSelfPermissionInput!): MembershipWithdrawPayload
   mutationEcho: String!
-  opportunityCreate(input: OpportunityCreateInput!, permission: CheckCommunityPermissionInput!): OpportunityCreatePayload
+  opportunityCreate(input: OpportunityCreateInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): OpportunityCreatePayload
   opportunityDelete(id: ID!, permission: CheckOpportunityPermissionInput!): OpportunityDeletePayload
   opportunitySetPublishStatus(id: ID!, input: OpportunitySetPublishStatusInput!, permission: CheckOpportunityPermissionInput!): OpportunitySetPublishStatusPayload
   opportunitySlotCreate(input: OpportunitySlotCreateInput!, opportunityId: ID!, permission: CheckOpportunityPermissionInput!): OpportunitySlotCreatePayload
   opportunitySlotSetHostingStatus(id: ID!, input: OpportunitySlotSetHostingStatusInput!, permission: CheckOpportunityPermissionInput!): OpportunitySlotSetHostingStatusPayload
   opportunitySlotsBulkUpdate(input: OpportunitySlotsBulkUpdateInput!, permission: CheckOpportunityPermissionInput!): OpportunitySlotsBulkUpdatePayload
   opportunityUpdateContent(id: ID!, input: OpportunityUpdateContentInput!, permission: CheckOpportunityPermissionInput!): OpportunityUpdateContentPayload
-  participationBulkCreate(input: ParticipationBulkCreateInput!, permission: CheckCommunityPermissionInput!): ParticipationBulkCreatePayload
+  participationBulkCreate(input: ParticipationBulkCreateInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): ParticipationBulkCreatePayload
   participationCreatePersonalRecord(input: ParticipationCreatePersonalRecordInput!): ParticipationCreatePersonalRecordPayload
   participationDeletePersonalRecord(id: ID!, permission: CheckIsSelfPermissionInput!): ParticipationDeletePayload
-  placeCreate(input: PlaceCreateInput!, permission: CheckCommunityPermissionInput!): PlaceCreatePayload
-  placeDelete(id: ID!, permission: CheckCommunityPermissionInput!): PlaceDeletePayload
-  placeUpdate(id: ID!, input: PlaceUpdateInput!, permission: CheckCommunityPermissionInput!): PlaceUpdatePayload
+  placeCreate(input: PlaceCreateInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): PlaceCreatePayload
+  placeDelete(id: ID!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): PlaceDeletePayload
+  placeUpdate(id: ID!, input: PlaceUpdateInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): PlaceUpdatePayload
   publishReport(finalContent: String!, id: ID!): PublishReportPayload
   rejectReport(id: ID!): RejectReportPayload
   reservationAccept(id: ID!, permission: CheckOpportunityPermissionInput!): ReservationSetStatusPayload
@@ -2112,26 +2112,26 @@ type Mutation {
   reservationJoin(id: ID!): ReservationSetStatusPayload
   reservationReject(id: ID!, input: ReservationRejectInput!, permission: CheckOpportunityPermissionInput!): ReservationSetStatusPayload
   storePhoneAuthToken(input: StorePhoneAuthTokenInput!, permission: CheckIsSelfPermissionInput!): StorePhoneAuthTokenPayload
-  submitReportFeedback(input: SubmitReportFeedbackInput!, permission: CheckCommunityPermissionInput!): SubmitReportFeedbackPayload
+  submitReportFeedback(input: SubmitReportFeedbackInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): SubmitReportFeedbackPayload
   ticketClaim(input: TicketClaimInput!): TicketClaimPayload
-  ticketIssue(input: TicketIssueInput!, permission: CheckCommunityPermissionInput!): TicketIssuePayload
-  ticketPurchase(input: TicketPurchaseInput!, permission: CheckCommunityPermissionInput!): TicketPurchasePayload
+  ticketIssue(input: TicketIssueInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): TicketIssuePayload
+  ticketPurchase(input: TicketPurchaseInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): TicketPurchasePayload
   ticketRefund(id: ID!, input: TicketRefundInput!, permission: CheckIsSelfPermissionInput!): TicketRefundPayload
   ticketUse(id: ID!, permission: CheckIsSelfPermissionInput!): TicketUsePayload
   transactionDonateSelfPoint(input: TransactionDonateSelfPointInput!, permission: CheckIsSelfPermissionInput!): TransactionDonateSelfPointPayload
-  transactionGrantCommunityPoint(input: TransactionGrantCommunityPointInput!, permission: CheckCommunityPermissionInput!): TransactionGrantCommunityPointPayload
-  transactionIssueCommunityPoint(input: TransactionIssueCommunityPointInput!, permission: CheckCommunityPermissionInput!): TransactionIssueCommunityPointPayload
-  transactionUpdateMetadata(communityPermission: CheckCommunityPermissionInput, id: ID!, input: TransactionUpdateMetadataInput!, permission: CheckIsSelfPermissionInput): TransactionUpdateMetadataPayload
-  updatePortalConfig(input: CommunityPortalConfigInput!, permission: CheckCommunityPermissionInput!): CommunityPortalConfig!
+  transactionGrantCommunityPoint(input: TransactionGrantCommunityPointInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): TransactionGrantCommunityPointPayload
+  transactionIssueCommunityPoint(input: TransactionIssueCommunityPointInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): TransactionIssueCommunityPointPayload
+  transactionUpdateMetadata(communityPermission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."), id: ID!, input: TransactionUpdateMetadataInput!, permission: CheckIsSelfPermissionInput): TransactionUpdateMetadataPayload
+  updatePortalConfig(input: CommunityPortalConfigInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): CommunityPortalConfig!
   updateReportTemplate(communityId: ID, input: UpdateReportTemplateInput!, variant: ReportVariant!): UpdateReportTemplatePayload
-  updateSignupBonusConfig(input: UpdateSignupBonusConfigInput!, permission: CheckCommunityPermissionInput!): CommunitySignupBonusConfig!
+  updateSignupBonusConfig(input: UpdateSignupBonusConfigInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): CommunitySignupBonusConfig!
   userDeleteMe(permission: CheckIsSelfPermissionInput!): UserDeletePayload
   userSignUp(input: UserSignUpInput!): CurrentUserPayload
   userUpdateMyProfile(input: UserUpdateProfileInput!, permission: CheckIsSelfPermissionInput!): UserUpdateProfilePayload
-  utilityCreate(input: UtilityCreateInput!, permission: CheckCommunityPermissionInput!): UtilityCreatePayload
-  utilityDelete(id: ID!, permission: CheckCommunityPermissionInput!): UtilityDeletePayload
-  utilitySetPublishStatus(id: ID!, input: UtilitySetPublishStatusInput!, permission: CheckCommunityPermissionInput!): UtilitySetPublishStatusPayload
-  utilityUpdateInfo(id: ID!, input: UtilityUpdateInfoInput!, permission: CheckCommunityPermissionInput!): UtilityUpdateInfoPayload
+  utilityCreate(input: UtilityCreateInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): UtilityCreatePayload
+  utilityDelete(id: ID!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): UtilityDeletePayload
+  utilitySetPublishStatus(id: ID!, input: UtilitySetPublishStatusInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): UtilitySetPublishStatusPayload
+  utilityUpdateInfo(id: ID!, input: UtilityUpdateInfoInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): UtilityUpdateInfoPayload
 
   """
   ユーザー: 投票実行。
@@ -2147,14 +2147,14 @@ type Mutation {
   一致していなければならない（バックエンドで検証、違反時は `VALIDATION_ERROR`）。
   詳細は VoteGate 型の説明を参照。
   """
-  voteTopicCreate(input: VoteTopicCreateInput!, permission: CheckCommunityPermissionInput!): VoteTopicCreatePayload!
+  voteTopicCreate(input: VoteTopicCreateInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): VoteTopicCreatePayload!
 
   """
   管理者: 投票テーマ削除。UPCOMING フェーズ（投票開始前）のみ許可。
   OPEN / CLOSED フェーズでは `VOTE_TOPIC_NOT_EDITABLE` エラーが返る。
   gate / powerPolicy / options は onDelete: Cascade で自動削除される（UPCOMING 限定なので ballots は存在しない）。
   """
-  voteTopicDelete(id: ID!, permission: CheckCommunityPermissionInput!): VoteTopicDeletePayload!
+  voteTopicDelete(id: ID!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): VoteTopicDeletePayload!
 
   """
   管理者: 投票テーマを更新する。UPCOMING フェーズ（投票開始前）のみ許可。
@@ -2162,7 +2162,7 @@ type Mutation {
   options は全量置換される（UPCOMING なので投票0件が保証されており安全）。
   gate / powerPolicy も同時に再設定可能。
   """
-  voteTopicUpdate(id: ID!, input: VoteTopicUpdateInput!, permission: CheckCommunityPermissionInput!): VoteTopicUpdatePayload!
+  voteTopicUpdate(id: ID!, input: VoteTopicUpdateInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): VoteTopicUpdatePayload!
 }
 
 """ログインユーザーの投票資格と現状。再投票可能性の判定にも利用する。"""
@@ -2852,7 +2852,7 @@ type Query {
   exceeds ~20 communities).
   """
   analyticsDashboard(input: AnalyticsDashboardInput): AnalyticsDashboardPayload!
-  article(id: ID!, permission: CheckCommunityPermissionInput!): Article
+  article(id: ID!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): Article
   articles(cursor: String, filter: ArticleFilterInput, first: Int, sort: ArticleSortInput): ArticlesConnection!
   cities(cursor: String, filter: CitiesInput, first: Int, sort: CitiesSortInput): CitiesConnection!
   communities(cursor: String, filter: CommunityFilterInput, first: Int, sort: CommunitySortInput): CommunitiesConnection!
@@ -2881,7 +2881,7 @@ type Query {
   nftToken(id: ID!): NftToken
   nftTokens(cursor: String, filter: NftTokenFilterInput, first: Int, sort: NftTokenSortInput): NftTokensConnection!
   opportunities(cursor: String, filter: OpportunityFilterInput, first: Int, sort: OpportunitySortInput): OpportunitiesConnection!
-  opportunity(id: ID!, permission: CheckCommunityPermissionInput!): Opportunity
+  opportunity(id: ID!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): Opportunity
   opportunitySlot(id: ID!): OpportunitySlot
   opportunitySlots(cursor: String, filter: OpportunitySlotFilterInput, first: Int, sort: OpportunitySlotSortInput): OpportunitySlotsConnection!
   participation(id: ID!): Participation
@@ -2899,7 +2899,7 @@ type Query {
   reportTemplateStats(variant: ReportVariant!, version: Int): ReportTemplateStats!
   reportTemplateStatsBreakdown(cursor: String, first: Int = 20, includeInactive: Boolean = false, kind: ReportTemplateKind = GENERATION, variant: ReportVariant!, version: Int): ReportTemplateStatsBreakdownConnection!
   reportTemplates(communityId: ID, includeInactive: Boolean = false, kind: ReportTemplateKind = GENERATION, variant: ReportVariant!): [ReportTemplate!]!
-  reports(communityId: ID!, cursor: String, first: Int, permission: CheckCommunityPermissionInput!, status: ReportStatus, variant: ReportVariant): ReportsConnection!
+  reports(communityId: ID!, cursor: String, first: Int, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."), status: ReportStatus, variant: ReportVariant): ReportsConnection!
   reportsAll(communityId: ID, cursor: String, first: Int, publishedAfter: Datetime, publishedBefore: Datetime, status: ReportStatus, variant: ReportVariant): ReportsConnection!
   reservation(id: ID!): Reservation
   reservationHistories(cursor: String, filter: ReservationHistoryFilterInput, first: Int, sort: ReservationHistorySortInput): ReservationHistoriesConnection!
@@ -2920,7 +2920,7 @@ type Query {
   user(id: ID!): User
   users(cursor: String, filter: UserFilterInput, first: Int, sort: UserSortInput): UsersConnection!
   utilities(cursor: String, filter: UtilityFilterInput, first: Int, sort: UtilitySortInput): UtilitiesConnection!
-  utility(id: ID!, permission: CheckCommunityPermissionInput!): Utility
+  utility(id: ID!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): Utility
   vcIssuanceRequest(id: ID!): VcIssuanceRequest
   vcIssuanceRequests(cursor: String, filter: VcIssuanceRequestFilterInput, first: Int, sort: VcIssuanceRequestSortInput): VcIssuanceRequestsConnection!
 

--- a/src/__tests__/auth/mutation.onlyCommunityOwner.test.ts
+++ b/src/__tests__/auth/mutation.onlyCommunityOwner.test.ts
@@ -160,10 +160,16 @@ describe("Owner-only mutations - AuthZ", () => {
       [undefined, false],
     ])(`${name} - role %p should be allowed = %p`, async (role, allowed) => {
       const context = {
-        currentUser: role ? { 
-          id: "user-1",
-          memberships: [{ communityId: "community-1", role }]
-        } : undefined,
+        // IsCommunityOwner は ctx.communityId（auth ミドルウェアが
+        // x-community-id ヘッダから注入）のみを参照するので、
+        // テストでも明示的にセットする。
+        communityId: "community-1",
+        currentUser: role
+          ? {
+              id: "user-1",
+              memberships: [{ communityId: "community-1", role }],
+            }
+          : undefined,
       };
 
       const app = await createApolloTestServer(context);

--- a/src/__tests__/e2e/dataIntegrity.test.ts
+++ b/src/__tests__/e2e/dataIntegrity.test.ts
@@ -68,8 +68,16 @@ describe("Data Integrity and Concurrency E2E Tests", () => {
 
     await TestDataSourceHelper.refreshCurrentPoints();
 
-    const ctx1 = { currentUser: { id: user1.id }, issuer } as IContext;
-    const ctx2 = { currentUser: { id: user2.id }, issuer } as IContext;
+    const ctx1 = {
+      currentUser: { id: user1.id },
+      issuer,
+      communityId: community.id,
+    } as IContext;
+    const ctx2 = {
+      currentUser: { id: user2.id },
+      issuer,
+      communityId: community.id,
+    } as IContext;
 
     await transactionUseCase.ownerGrantCommunityPoint(ctx1, {
       input: { transferPoints: 300, toUserId: user1.id },
@@ -130,7 +138,11 @@ describe("Data Integrity and Concurrency E2E Tests", () => {
 
     await TestDataSourceHelper.refreshCurrentPoints();
 
-    const ctx = { currentUser: { id: user.id }, issuer } as IContext;
+    const ctx = {
+      currentUser: { id: user.id },
+      issuer,
+      communityId: community.id,
+    } as IContext;
 
     await transactionUseCase.ownerGrantCommunityPoint(ctx, {
       input: { transferPoints: 50, toUserId: user.id },
@@ -199,7 +211,11 @@ describe("Data Integrity and Concurrency E2E Tests", () => {
     await TestDataSourceHelper.refreshCurrentPoints();
 
     for (let i = 0; i < users.length; i++) {
-      const ctx = { currentUser: { id: users[i].id }, issuer } as IContext;
+      const ctx = {
+        currentUser: { id: users[i].id },
+        issuer,
+        communityId: community.id,
+      } as IContext;
       await transactionUseCase.ownerGrantCommunityPoint(ctx, {
         input: { transferPoints: 1000, toUserId: users[i].id },
         permission: { communityId: community.id },
@@ -207,7 +223,11 @@ describe("Data Integrity and Concurrency E2E Tests", () => {
     }
 
     for (let i = 0; i < users.length - 1; i++) {
-      const ctx = { currentUser: { id: users[i].id }, issuer } as IContext;
+      const ctx = {
+        currentUser: { id: users[i].id },
+        issuer,
+        communityId: community.id,
+      } as IContext;
       await transactionUseCase.userDonateSelfPointToAnother(ctx, {
         input: {
           communityId: community.id,

--- a/src/__tests__/e2e/userJourney.test.ts
+++ b/src/__tests__/e2e/userJourney.test.ts
@@ -90,7 +90,11 @@ describe("End-to-End User Journey Integration Tests", () => {
 
     await TestDataSourceHelper.refreshCurrentPoints();
 
-    const grantCtx = { currentUser: { id: userId }, issuer } as IContext;
+    const grantCtx = {
+      currentUser: { id: userId },
+      issuer,
+      communityId: community.id,
+    } as IContext;
 
     await transactionUseCase.ownerGrantCommunityPoint(grantCtx, {
       input: { transferPoints: 500, toUserId: userId },
@@ -149,7 +153,7 @@ describe("End-to-End User Journey Integration Tests", () => {
       currentPrefecture: CurrentPrefecture.KAGAWA,
     });
 
-    const ownerCtx = { currentUser: { id: owner.id }, issuer } as IContext;
+    const ownerCtxNoCommunity = { currentUser: { id: owner.id }, issuer } as IContext;
 
     const communityResult = await communityUseCase.userCreateCommunityAndJoin(
       {
@@ -158,11 +162,17 @@ describe("End-to-End User Journey Integration Tests", () => {
           pointName: "pts",
         },
       },
-      ownerCtx,
+      ownerCtxNoCommunity,
     );
 
     expect(communityResult.community).toBeDefined();
     const communityId = communityResult.community!.id;
+
+    const ownerCtx = {
+      currentUser: { id: owner.id },
+      issuer,
+      communityId,
+    } as IContext;
 
     await transactionUseCase.ownerIssueCommunityPoint(
       {
@@ -187,7 +197,11 @@ describe("End-to-End User Journey Integration Tests", () => {
       });
     }
 
-    const user1Ctx = { currentUser: { id: users[0].id }, issuer } as IContext;
+    const user1Ctx = {
+      currentUser: { id: users[0].id },
+      issuer,
+      communityId,
+    } as IContext;
     await transactionUseCase.userDonateSelfPointToAnother(user1Ctx, {
       input: {
         communityId,
@@ -197,7 +211,11 @@ describe("End-to-End User Journey Integration Tests", () => {
       permission: { userId: users[0].id },
     });
 
-    const user2Ctx = { currentUser: { id: users[1].id }, issuer } as IContext;
+    const user2Ctx = {
+      currentUser: { id: users[1].id },
+      issuer,
+      communityId,
+    } as IContext;
     await transactionUseCase.userDonateSelfPointToAnother(user2Ctx, {
       input: {
         communityId,

--- a/src/__tests__/integration/pointTransfer/boundaryValues.test.ts
+++ b/src/__tests__/integration/pointTransfer/boundaryValues.test.ts
@@ -51,7 +51,11 @@ describe("Point Transfer Boundary Value Tests", () => {
 
     await TestDataSourceHelper.refreshCurrentPoints();
 
-    const ctx = { currentUser: { id: user.id }, issuer } as IContext;
+    const ctx = {
+      currentUser: { id: user.id },
+      issuer,
+      communityId: community.id,
+    } as IContext;
 
     const input = {
       transferPoints: 1000000, // Large but valid amount
@@ -78,7 +82,7 @@ describe("Point Transfer Boundary Value Tests", () => {
     });
 
     const largeAmount = 1000000000; // 1 billion, within INT4 range
-    
+
     await TestDataSourceHelper.createTransaction({
       toWallet: { connect: { id: communityWallet.id } },
       toPointChange: largeAmount,
@@ -104,7 +108,7 @@ describe("Point Transfer Boundary Value Tests", () => {
     });
 
     const maxInt4 = 2147483647;
-    
+
     await TestDataSourceHelper.createTransaction({
       toWallet: { connect: { id: communityWallet.id } },
       toPointChange: maxInt4,
@@ -175,7 +179,9 @@ describe("Point Transfer Boundary Value Tests", () => {
     const fromWalletUpdated = await TestDataSourceHelper.findWallet(fromWallet.id);
     const toWalletUpdated = await TestDataSourceHelper.findWallet(toWallet.id);
 
-    expect(fromWalletUpdated?.currentPointView?.currentPoint).toBe(BigInt(safeInitialAmount) - BigInt(transferAmount));
+    expect(fromWalletUpdated?.currentPointView?.currentPoint).toBe(
+      BigInt(safeInitialAmount) - BigInt(transferAmount),
+    );
     expect(toWalletUpdated?.currentPointView?.currentPoint).toBe(BigInt(transferAmount));
   });
 
@@ -191,7 +197,7 @@ describe("Point Transfer Boundary Value Tests", () => {
     });
 
     const largeValue = 2000000000; // 2 billion, within INT4 range
-    
+
     await TestDataSourceHelper.createTransaction({
       toWallet: { connect: { id: communityWallet.id } },
       toPointChange: largeValue,

--- a/src/__tests__/integration/pointTransfer/evaluatePassParticipation.test.ts
+++ b/src/__tests__/integration/pointTransfer/evaluatePassParticipation.test.ts
@@ -61,10 +61,6 @@ describe("Point Reward Tests", () => {
       currentPrefecture: CurrentPrefecture.KAGAWA,
     });
     opportunityOwnerUserId = opportunityOwnerUserInserted.id;
-    ctx = {
-      currentUser: { id: opportunityOwnerUserId },
-      issuer,
-    } as unknown as IContext;
 
     const participationUserInserted = await TestDataSourceHelper.createUser({
       name: testSetup.userName,
@@ -83,6 +79,12 @@ describe("Point Reward Tests", () => {
       website: undefined,
     });
     communityId = communityInserted.id;
+
+    ctx = {
+      currentUser: { id: opportunityOwnerUserId },
+      issuer,
+      communityId,
+    } as unknown as IContext;
 
     await TestDataSourceHelper.createMembership({
       user: { connect: { id: opportunityOwnerUserId } },
@@ -278,12 +280,12 @@ describe("Point Reward Tests", () => {
 
     const vcRequests = await TestDataSourceHelper.findAllVCIssuanceRequests();
     expect(vcRequests).toHaveLength(1);
-    
+
     const vcRequest = vcRequests[0];
     expect(vcRequest.status).toBe(VcIssuanceStatus.PENDING);
     expect(vcRequest.evaluationId).toBeDefined();
     expect(vcRequest.userId).toBe(participationUserId);
-    
+
     const claims = vcRequest.claims as unknown as EvaluationCredentialClaim;
     expect(claims.type).toBe("EvaluationCredential");
     expect(claims.evaluator).toBeDefined();
@@ -403,8 +405,8 @@ describe("Point Reward Tests", () => {
 
     const vcRequests = await TestDataSourceHelper.findAllVCIssuanceRequests();
     expect(vcRequests).toHaveLength(2);
-    
-    vcRequests.forEach(vcRequest => {
+
+    vcRequests.forEach((vcRequest) => {
       expect(vcRequest.status).toBe(VcIssuanceStatus.PENDING);
       expect(vcRequest.userId).toBe(participationUserId);
       const claims = vcRequest.claims as unknown as EvaluationCredentialClaim;
@@ -495,8 +497,8 @@ describe("Point Reward Tests", () => {
 
     const vcRequests = await TestDataSourceHelper.findAllVCIssuanceRequests();
     expect(vcRequests).toHaveLength(2);
-    
-    vcRequests.forEach(vcRequest => {
+
+    vcRequests.forEach((vcRequest) => {
       expect(vcRequest.status).toBe(VcIssuanceStatus.PENDING);
       expect(vcRequest.userId).toBe(participationUserId);
       const claims = vcRequest.claims as unknown as EvaluationCredentialClaim;

--- a/src/__tests__/integration/pointTransfer/grantCommunityPoint.error.test.ts
+++ b/src/__tests__/integration/pointTransfer/grantCommunityPoint.error.test.ts
@@ -37,7 +37,11 @@ describe("Point Grant Error Handling Tests", () => {
       pointName: "test-points",
     });
 
-    const ctx = { currentUser: { id: user.id }, issuer } as IContext;
+    const ctx = {
+      currentUser: { id: user.id },
+      issuer,
+      communityId: community.id,
+    } as IContext;
 
     const input: GqlTransactionGrantCommunityPointInput = {
       transferPoints: 100,
@@ -59,7 +63,11 @@ describe("Point Grant Error Handling Tests", () => {
       currentPrefecture: CurrentPrefecture.KAGAWA,
     });
 
-    const ctx = { currentUser: { id: user.id }, issuer } as IContext;
+    const ctx = {
+      currentUser: { id: user.id },
+      issuer,
+      communityId: "non-existent-community-id",
+    } as IContext;
 
     const input: GqlTransactionGrantCommunityPointInput = {
       transferPoints: 100,
@@ -73,5 +81,4 @@ describe("Point Grant Error Handling Tests", () => {
       }),
     ).rejects.toThrow(/not found/i);
   });
-
 });

--- a/src/__tests__/integration/pointTransfer/grantCommunityPoint.test.ts
+++ b/src/__tests__/integration/pointTransfer/grantCommunityPoint.test.ts
@@ -34,12 +34,12 @@ describe("Point Grant Tests", () => {
       slug: "recipient-slug",
       currentPrefecture: CurrentPrefecture.KAGAWA,
     });
-    const ctx = { currentUser: { id: user.id }, issuer } as IContext;
-
     const community = await TestDataSourceHelper.createCommunity({
       name: "community-grant",
       pointName: "c-point",
     });
+
+    const ctx = { currentUser: { id: user.id }, issuer, communityId: community.id } as IContext;
 
     const communityWallet = await TestDataSourceHelper.createWallet({
       type: WalletType.COMMUNITY,
@@ -85,13 +85,13 @@ describe("Point Grant Tests", () => {
       slug: "recipient-slug",
       currentPrefecture: CurrentPrefecture.KAGAWA,
     });
-    const ctx = { currentUser: { id: user.id }, issuer } as IContext;
-
     const community = await TestDataSourceHelper.createCommunity({
       name: "community-grant",
       pointName: "c-point",
     });
-    
+
+    const ctx = { currentUser: { id: user.id }, issuer, communityId: community.id } as IContext;
+
     const communityWallet = await TestDataSourceHelper.createWallet({
       type: WalletType.COMMUNITY,
       community: { connect: { id: community.id } },
@@ -126,8 +126,6 @@ describe("Point Grant Tests", () => {
       slug: "recipient-slug",
       currentPrefecture: CurrentPrefecture.KAGAWA,
     });
-    const ctx = { currentUser: { id: user.id }, issuer } as IContext;
-
     const communityA = await TestDataSourceHelper.createCommunity({
       name: "community-a",
       pointName: "a-point",
@@ -137,6 +135,12 @@ describe("Point Grant Tests", () => {
       name: "community-b",
       pointName: "b-point",
     });
+
+    const ctx = {
+      currentUser: { id: user.id },
+      issuer,
+      communityId: communityA.id,
+    } as IContext;
 
     const communityWalletA = await TestDataSourceHelper.createWallet({
       type: WalletType.COMMUNITY,
@@ -170,8 +174,12 @@ describe("Point Grant Tests", () => {
 
     await TestDataSourceHelper.refreshCurrentPoints();
 
-    const communityWalletABalanceBefore = await TestDataSourceHelper.getCurrentPoints(communityWalletA.id);
-    const communityWalletBBalanceBefore = await TestDataSourceHelper.getCurrentPoints(communityWalletB.id);
+    const communityWalletABalanceBefore = await TestDataSourceHelper.getCurrentPoints(
+      communityWalletA.id,
+    );
+    const communityWalletBBalanceBefore = await TestDataSourceHelper.getCurrentPoints(
+      communityWalletB.id,
+    );
 
     expect(communityWalletABalanceBefore).toBe(100);
     expect(communityWalletBBalanceBefore).toBe(200);
@@ -187,9 +195,13 @@ describe("Point Grant Tests", () => {
 
     await TestDataSourceHelper.refreshCurrentPoints();
 
-    const communityWalletABalanceAfter = await TestDataSourceHelper.getCurrentPoints(communityWalletA.id);
+    const communityWalletABalanceAfter = await TestDataSourceHelper.getCurrentPoints(
+      communityWalletA.id,
+    );
     const memberWalletABalanceAfter = await TestDataSourceHelper.getCurrentPoints(memberWalletA.id);
-    const communityWalletBBalanceAfter = await TestDataSourceHelper.getCurrentPoints(communityWalletB.id);
+    const communityWalletBBalanceAfter = await TestDataSourceHelper.getCurrentPoints(
+      communityWalletB.id,
+    );
 
     expect(communityWalletABalanceAfter).toBe(100 - GRANT_POINTS);
     expect(memberWalletABalanceAfter).toBe(GRANT_POINTS);

--- a/src/__tests__/integration/pointTransfer/issueCommunityPoint.error.test.ts
+++ b/src/__tests__/integration/pointTransfer/issueCommunityPoint.error.test.ts
@@ -32,17 +32,24 @@ describe("Point Issuance Error Handling Tests", () => {
       currentPrefecture: CurrentPrefecture.KAGAWA,
     });
 
-    const ctx = { currentUser: { id: user.id }, issuer } as IContext;
+    const ctx = {
+      currentUser: { id: user.id },
+      issuer,
+      communityId: "non-existent-community-id",
+    } as IContext;
 
     const input: GqlTransactionIssueCommunityPointInput = {
       transferPoints: 1000,
     };
 
     await expect(
-      transactionUseCase.ownerIssueCommunityPoint({
-        input,
-        permission: { communityId: "non-existent-community-id" },
-      }, ctx),
+      transactionUseCase.ownerIssueCommunityPoint(
+        {
+          input,
+          permission: { communityId: "non-existent-community-id" },
+        },
+        ctx,
+      ),
     ).rejects.toThrow(/not found/i);
   });
 });

--- a/src/__tests__/integration/pointTransfer/issueCommunityPoint.test.ts
+++ b/src/__tests__/integration/pointTransfer/issueCommunityPoint.test.ts
@@ -34,15 +34,16 @@ describe("Point Issue Tests", () => {
       slug: "issuer-slug",
       currentPrefecture: CurrentPrefecture.KAGAWA,
     });
-    const ctx = {
-      currentUser: { id: user.id },
-      issuer,
-    } as unknown as IContext;
-
     const community = await TestDataSourceHelper.createCommunity({
       name: "community-issue",
       pointName: "c-point",
     });
+
+    const ctx = {
+      currentUser: { id: user.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
 
     const wallet = await TestDataSourceHelper.createWallet({
       type: WalletType.COMMUNITY,

--- a/src/__tests__/integration/vote/voteTopicCreate.test.ts
+++ b/src/__tests__/integration/vote/voteTopicCreate.test.ts
@@ -68,7 +68,11 @@ describe("Vote Integration: VoteTopicCreate", () => {
       role: Role.MANAGER,
     });
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     const result = await voteUseCase.managerCreateVoteTopic(ctx, {
       input: makeValidInput(community.id),
       permission: { communityId: community.id },
@@ -101,7 +105,11 @@ describe("Vote Integration: VoteTopicCreate", () => {
 
     const nftToken = await createNftToken();
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     const result = await voteUseCase.managerCreateVoteTopic(ctx, {
       input: makeValidInput(community.id, {
         gate: { type: GqlVoteGateType.Nft, nftTokenId: nftToken.id },
@@ -133,7 +141,11 @@ describe("Vote Integration: VoteTopicCreate", () => {
       pointName: "pt",
     });
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: communityB.id,
+    } as unknown as IContext;
     await expect(
       voteUseCase.managerCreateVoteTopic(ctx, {
         input: makeValidInput(communityA.id),
@@ -154,7 +166,11 @@ describe("Vote Integration: VoteTopicCreate", () => {
     });
 
     const now = new Date();
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     await expect(
       voteUseCase.managerCreateVoteTopic(ctx, {
         input: makeValidInput(community.id, {
@@ -179,7 +195,11 @@ describe("Vote Integration: VoteTopicCreate", () => {
     });
 
     const sameTime = new Date(Date.now() + 3_600_000);
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     await expect(
       voteUseCase.managerCreateVoteTopic(ctx, {
         input: makeValidInput(community.id, {
@@ -204,7 +224,11 @@ describe("Vote Integration: VoteTopicCreate", () => {
       pointName: "pt",
     });
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     await expect(
       voteUseCase.managerCreateVoteTopic(ctx, {
         input: makeValidInput(community.id, {
@@ -226,7 +250,11 @@ describe("Vote Integration: VoteTopicCreate", () => {
       pointName: "pt",
     });
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     await expect(
       voteUseCase.managerCreateVoteTopic(ctx, {
         input: makeValidInput(community.id, {
@@ -251,7 +279,11 @@ describe("Vote Integration: VoteTopicCreate", () => {
       pointName: "pt",
     });
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     await expect(
       voteUseCase.managerCreateVoteTopic(ctx, {
         input: makeValidInput(community.id, {
@@ -278,7 +310,11 @@ describe("Vote Integration: VoteTopicCreate", () => {
       pointName: "pt",
     });
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     await expect(
       voteUseCase.managerCreateVoteTopic(ctx, {
         input: makeValidInput(community.id, {
@@ -304,7 +340,11 @@ describe("Vote Integration: VoteTopicCreate", () => {
     // NFT gate ではなく MEMBERSHIP gate の場合でも policy 側は独立して検証される
     const nftToken = await createNftToken(); // gate 用ではなく policy 検証のため
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     await expect(
       voteUseCase.managerCreateVoteTopic(ctx, {
         input: makeValidInput(community.id, {
@@ -330,7 +370,11 @@ describe("Vote Integration: VoteTopicCreate", () => {
     const tokenA = await createNftToken();
     const tokenB = await createNftToken();
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     await expect(
       voteUseCase.managerCreateVoteTopic(ctx, {
         input: makeValidInput(community.id, {
@@ -348,7 +392,11 @@ describe("Vote Integration: VoteTopicCreate", () => {
 
     const nftToken = await createNftToken();
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     const result = await voteUseCase.managerCreateVoteTopic(ctx, {
       input: makeValidInput(community.id, {
         gate: { type: GqlVoteGateType.Nft, nftTokenId: nftToken.id },
@@ -367,7 +415,11 @@ describe("Vote Integration: VoteTopicCreate", () => {
 
     const nftToken = await createNftToken();
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     const result = await voteUseCase.managerCreateVoteTopic(ctx, {
       input: makeValidInput(community.id, {
         gate: { type: GqlVoteGateType.Membership },

--- a/src/__tests__/integration/vote/voteTopicDelete.test.ts
+++ b/src/__tests__/integration/vote/voteTopicDelete.test.ts
@@ -56,7 +56,11 @@ describe("Vote Integration: VoteTopicDelete", () => {
       endsAt: new Date(now.getTime() + 3_600_000),
     });
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     const result = await voteUseCase.managerDeleteVoteTopic(ctx, {
       id: topic.id,
       permission: { communityId: community.id },
@@ -89,7 +93,11 @@ describe("Vote Integration: VoteTopicDelete", () => {
       role: Role.MANAGER,
     });
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     await expect(
       voteUseCase.managerDeleteVoteTopic(ctx, {
         id: "nonexistent-topic-id",
@@ -130,7 +138,11 @@ describe("Vote Integration: VoteTopicDelete", () => {
       endsAt: new Date(now.getTime() + 3_600_000),
     });
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: communityB.id,
+    } as unknown as IContext;
     await expect(
       voteUseCase.managerDeleteVoteTopic(ctx, {
         id: topic.id,
@@ -168,7 +180,11 @@ describe("Vote Integration: VoteTopicDelete", () => {
       endsAt: new Date(now.getTime() + 3_600_000),
     });
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     await expect(
       voteUseCase.managerDeleteVoteTopic(ctx, {
         id: topic.id,
@@ -208,7 +224,11 @@ describe("Vote Integration: VoteTopicDelete", () => {
       endsAt: new Date(now.getTime() - 60_000),
     });
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     await expect(
       voteUseCase.managerDeleteVoteTopic(ctx, {
         id: topic.id,

--- a/src/__tests__/integration/vote/voteTopicUpdate.test.ts
+++ b/src/__tests__/integration/vote/voteTopicUpdate.test.ts
@@ -65,7 +65,11 @@ describe("Vote Integration: VoteTopicUpdate", () => {
       endsAt: new Date(now.getTime() + 3_600_000),
     });
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     const result = await voteUseCase.managerUpdateVoteTopic(ctx, {
       id: topic.id,
       input: makeValidUpdateInput({ title: "Brand New Title" }),
@@ -100,7 +104,11 @@ describe("Vote Integration: VoteTopicUpdate", () => {
       endsAt: new Date(now.getTime() + 3_600_000),
     });
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     await voteUseCase.managerUpdateVoteTopic(ctx, {
       id: topic.id,
       input: makeValidUpdateInput({
@@ -134,7 +142,11 @@ describe("Vote Integration: VoteTopicUpdate", () => {
 
     const nftToken = await createNftToken();
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     const result = await voteUseCase.managerUpdateVoteTopic(ctx, {
       id: topic.id,
       input: makeValidUpdateInput({
@@ -162,7 +174,11 @@ describe("Vote Integration: VoteTopicUpdate", () => {
 
     const nftToken = await createNftToken();
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     const result = await voteUseCase.managerUpdateVoteTopic(ctx, {
       id: topic.id,
       input: makeValidUpdateInput({
@@ -172,9 +188,9 @@ describe("Vote Integration: VoteTopicUpdate", () => {
     });
 
     expect(result.voteTopic.powerPolicy.type).toBe("NFT_COUNT");
-    expect(
-      (result.voteTopic.powerPolicy as unknown as { nftTokenId: string }).nftTokenId,
-    ).toBe(nftToken.id);
+    expect((result.voteTopic.powerPolicy as unknown as { nftTokenId: string }).nftTokenId).toBe(
+      nftToken.id,
+    );
   });
 
   // ─── 異常系: フェーズ制約 ─────────────────────────────────────────────────
@@ -190,7 +206,11 @@ describe("Vote Integration: VoteTopicUpdate", () => {
       endsAt: new Date(now.getTime() + 3_600_000),
     });
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     await expect(
       voteUseCase.managerUpdateVoteTopic(ctx, {
         id: topic.id,
@@ -211,7 +231,11 @@ describe("Vote Integration: VoteTopicUpdate", () => {
       endsAt: new Date(now.getTime() - 60_000),
     });
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     await expect(
       voteUseCase.managerUpdateVoteTopic(ctx, {
         id: topic.id,
@@ -226,7 +250,11 @@ describe("Vote Integration: VoteTopicUpdate", () => {
   it("should throw NotFoundError when the topic id does not exist", async () => {
     const { manager, community } = await setupManagerAndCommunity("manager-upd-nf");
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     await expect(
       voteUseCase.managerUpdateVoteTopic(ctx, {
         id: "nonexistent-topic-id",
@@ -253,7 +281,11 @@ describe("Vote Integration: VoteTopicUpdate", () => {
       endsAt: new Date(now.getTime() + 3_600_000),
     });
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: communityB.id,
+    } as unknown as IContext;
     await expect(
       voteUseCase.managerUpdateVoteTopic(ctx, {
         id: topic.id,
@@ -276,7 +308,11 @@ describe("Vote Integration: VoteTopicUpdate", () => {
       endsAt: new Date(now.getTime() + 3_600_000),
     });
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     await expect(
       voteUseCase.managerUpdateVoteTopic(ctx, {
         id: topic.id,
@@ -300,7 +336,11 @@ describe("Vote Integration: VoteTopicUpdate", () => {
       endsAt: new Date(now.getTime() + 3_600_000),
     });
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     await expect(
       voteUseCase.managerUpdateVoteTopic(ctx, {
         id: topic.id,
@@ -323,7 +363,11 @@ describe("Vote Integration: VoteTopicUpdate", () => {
       endsAt: new Date(now.getTime() + 3_600_000),
     });
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     await expect(
       voteUseCase.managerUpdateVoteTopic(ctx, {
         id: topic.id,
@@ -353,7 +397,11 @@ describe("Vote Integration: VoteTopicUpdate", () => {
     const tokenA = await createNftToken();
     const tokenB = await createNftToken();
 
-    const ctx = { currentUser: { id: manager.id }, issuer } as unknown as IContext;
+    const ctx = {
+      currentUser: { id: manager.id },
+      issuer,
+      communityId: community.id,
+    } as unknown as IContext;
     await expect(
       voteUseCase.managerUpdateVoteTopic(ctx, {
         id: topic.id,

--- a/src/__tests__/integration/walletCreation/grantCommunityPoint.test.ts
+++ b/src/__tests__/integration/walletCreation/grantCommunityPoint.test.ts
@@ -43,12 +43,6 @@ describe("Transaction GrantCommunityPoint Integration Tests", () => {
     const userInserted = await TestDataSourceHelper.createUser(createUserInput);
     const userId = userInserted.id;
 
-    const ctx = {
-      uid: userId,
-      currentUser: { id: userId },
-      issuer,
-    } as unknown as IContext;
-
     const communityName = "community-1";
     const pointName = "community-1-point";
 
@@ -62,6 +56,13 @@ describe("Transaction GrantCommunityPoint Integration Tests", () => {
     };
     const communityInserted = await TestDataSourceHelper.createCommunity(createCommunityInput);
     const communityId = communityInserted.id;
+
+    const ctx = {
+      uid: userId,
+      currentUser: { id: userId },
+      issuer,
+      communityId,
+    } as unknown as IContext;
 
     const createWalletInput = {
       type: WalletType.COMMUNITY,

--- a/src/__tests__/unit/report/feedback/feedbackUsecase.test.ts
+++ b/src/__tests__/unit/report/feedback/feedbackUsecase.test.ts
@@ -17,6 +17,7 @@ describe("ReportFeedbackUseCase.submitReportFeedback", () => {
   const userId = "user-1";
 
   const fakeCtx = {
+    communityId,
     currentUser: { id: userId, sysRole: "USER" },
     issuer: {
       // Pass-through both variants: the usecase wraps the whole

--- a/src/__tests__/unit/report/usecase.test.ts
+++ b/src/__tests__/unit/report/usecase.test.ts
@@ -87,6 +87,7 @@ describe("ReportUseCase.generateReport", () => {
   // test-only: production IContext pulls in issuer / auth / loader wiring
   // we don't exercise here; the cast keeps the mock shape minimal.
   const fakeCtx = {
+    communityId,
     issuer: {
       onlyBelongingCommunity: (
         _ctx: IContext,
@@ -812,15 +813,15 @@ describe("ReportUseCase A-3 community last-publish pointer maintenance", () => {
   const communityId = "kibotcha";
   const fakeTx = {} as never;
   const fakeCtx = {
+    communityId,
+    isAdmin: true,
     issuer: {
       onlyBelongingCommunity: (
         _ctx: IContext,
         fn: (tx: unknown) => Promise<unknown>,
       ): Promise<unknown> => fn(fakeTx),
-      admin: (
-        _ctx: IContext,
-        fn: (tx: unknown) => Promise<unknown>,
-      ): Promise<unknown> => fn(fakeTx),
+      admin: (_ctx: IContext, fn: (tx: unknown) => Promise<unknown>): Promise<unknown> =>
+        fn(fakeTx),
     },
     currentUser: { id: "admin-user" },
   } as unknown as IContext;

--- a/src/application/domain/account/community/config/schema/mutation.graphql
+++ b/src/application/domain/account/community/config/schema/mutation.graphql
@@ -1,73 +1,79 @@
 input CommunityConfigInput {
-    lineConfig: CommunityLineConfigInput
-    portalConfig: CommunityPortalConfigInput
+  lineConfig: CommunityLineConfigInput
+  portalConfig: CommunityPortalConfigInput
 }
 
 input CommunityLineConfigInput {
-    channelId: String!
-    channelSecret: String!
-    accessToken: String!
-    liffId: String!
-    liffAppId: String
-    liffBaseUrl: String!
-    richMenus: [CommunityLineRichMenuConfigInput!]!
+  channelId: String!
+  channelSecret: String!
+  accessToken: String!
+  liffId: String!
+  liffAppId: String
+  liffBaseUrl: String!
+  richMenus: [CommunityLineRichMenuConfigInput!]!
 }
 
 input CommunityLineRichMenuConfigInput {
-    type: LineRichMenuType!
-    richMenuId: String!
+  type: LineRichMenuType!
+  richMenuId: String!
 }
 
 input CommunityPortalConfigInput {
-    tokenName: String
-    title: String
-    description: String
-    shortDescription: String
-    domain: String
-    faviconPrefix: String @deprecated(reason: "Use favicon instead")
-    favicon: ImageInput
-    logoPath: String @deprecated(reason: "Use logo instead")
-    logo: ImageInput
-    squareLogoPath: String @deprecated(reason: "Use squareLogo instead")
-    squareLogo: ImageInput
-    ogImagePath: String @deprecated(reason: "Use ogImage instead")
-    ogImage: ImageInput
-    enableFeatures: [String!]
-    rootPath: String
-    adminRootPath: String
-    regionName: String
-    regionKey: String
-    documents: [CommunityDocumentInput!]
-    commonDocumentOverrides: CommonDocumentOverridesInput
+  tokenName: String
+  title: String
+  description: String
+  shortDescription: String
+  domain: String
+  faviconPrefix: String @deprecated(reason: "Use favicon instead")
+  favicon: ImageInput
+  logoPath: String @deprecated(reason: "Use logo instead")
+  logo: ImageInput
+  squareLogoPath: String @deprecated(reason: "Use squareLogo instead")
+  squareLogo: ImageInput
+  ogImagePath: String @deprecated(reason: "Use ogImage instead")
+  ogImage: ImageInput
+  enableFeatures: [String!]
+  rootPath: String
+  adminRootPath: String
+  regionName: String
+  regionKey: String
+  documents: [CommunityDocumentInput!]
+  commonDocumentOverrides: CommonDocumentOverridesInput
 }
 
 input CommunityDocumentInput {
-    id: String!
-    title: String!
-    path: String!
-    type: String!
-    order: Int
+  id: String!
+  title: String!
+  path: String!
+  type: String!
+  order: Int
 }
 
 input CommonDocumentOverridesInput {
-    terms: CommunityDocumentInput
-    privacy: CommunityDocumentInput
+  terms: CommunityDocumentInput
+  privacy: CommunityDocumentInput
 }
 
 input UpdateSignupBonusConfigInput {
-    isEnabled: Boolean!
-    bonusPoint: Int!
-    message: String
+  isEnabled: Boolean!
+  bonusPoint: Int!
+  message: String
 }
 
 extend type Mutation {
-    updateSignupBonusConfig(
-        input: UpdateSignupBonusConfigInput!,
-        permission: CheckCommunityPermissionInput!
-    ): CommunitySignupBonusConfig! @authz(rules: [IsCommunityManager])
+  updateSignupBonusConfig(
+    input: UpdateSignupBonusConfigInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): CommunitySignupBonusConfig! @authz(rules: [IsCommunityManager])
 
-    updatePortalConfig(
-        input: CommunityPortalConfigInput!,
-        permission: CheckCommunityPermissionInput!
-    ): CommunityPortalConfig! @authz(rules: [IsCommunityManager])
+  updatePortalConfig(
+    input: CommunityPortalConfigInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): CommunityPortalConfig! @authz(rules: [IsCommunityManager])
 }

--- a/src/application/domain/account/community/schema/mutation.graphql
+++ b/src/application/domain/account/community/schema/mutation.graphql
@@ -2,74 +2,74 @@
 # Community Mutation Definitions
 # ------------------------------
 extend type Mutation {
-    communityCreate(input: CommunityCreateInput!): CommunityCreatePayload
-    @authz(rules: [IsAdmin])
+  communityCreate(input: CommunityCreateInput!): CommunityCreatePayload @authz(rules: [IsAdmin])
 
-    communityDelete(
-        id: ID!,
-        permission:CheckCommunityPermissionInput!
-    ): CommunityDeletePayload
-    @authz(rules: [IsCommunityOwner])
+  communityDelete(
+    id: ID!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): CommunityDeletePayload @authz(rules: [IsCommunityOwner])
 
-    communityUpdateProfile(
-        id: ID!,
-        input: CommunityUpdateProfileInput!,
-        permission:CheckCommunityPermissionInput!
-    ): CommunityUpdateProfilePayload
-    @authz(rules: [IsCommunityManager])
+  communityUpdateProfile(
+    id: ID!
+    input: CommunityUpdateProfileInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): CommunityUpdateProfilePayload @authz(rules: [IsCommunityManager])
 }
 
 # ------------------------------
 # Community Mutation Input Definitions
 # ------------------------------
 input CommunityCreateInput {
-    originalId: String
+  originalId: String
 
-    name: String!
-    pointName: String!
-    image: ImageInput
-    bio: String
-    establishedAt: Datetime
-    website: String
+  name: String!
+  pointName: String!
+  image: ImageInput
+  bio: String
+  establishedAt: Datetime
+  website: String
 
-    config: CommunityConfigInput
+  config: CommunityConfigInput
 
-    #for admin
-    createdBy: ID
+  #for admin
+  createdBy: ID
 }
 
 input CommunityUpdateProfileInput {
-    name: String!
-    pointName: String!
-    image: ImageInput
-    bio: String
-    establishedAt: Datetime
-    website: String
+  name: String!
+  pointName: String!
+  image: ImageInput
+  bio: String
+  establishedAt: Datetime
+  website: String
 }
 
 # ------------------------------
 # Community Mutation Success Type Definitions
 # ------------------------------
 type CommunityCreateSuccess {
-    community: Community!
+  community: Community!
 }
 
 type CommunityDeleteSuccess {
-    communityId: String!
+  communityId: String!
 }
 
 type CommunityUpdateProfileSuccess {
-    community: Community!
+  community: Community!
 }
 
 # ------------------------------
 # Community Mutation Union (Payload) Definitions
 # ------------------------------
-union CommunityCreatePayload =
-    CommunityCreateSuccess
+union CommunityCreatePayload = CommunityCreateSuccess
 
-union CommunityDeletePayload =
-    CommunityDeleteSuccess
+union CommunityDeletePayload = CommunityDeleteSuccess
 
-union CommunityUpdateProfilePayload =
-    CommunityUpdateProfileSuccess
+union CommunityUpdateProfilePayload = CommunityUpdateProfileSuccess

--- a/src/application/domain/account/community/usecase.ts
+++ b/src/application/domain/account/community/usecase.ts
@@ -17,7 +17,7 @@ import { CommunityPortalConfigResult } from "@/application/domain/account/commun
 import { IContext } from "@/types/server";
 import CommunityService from "@/application/domain/account/community/service";
 import CommunityPresenter from "@/application/domain/account/community/presenter";
-import { clampFirst, getCurrentUserId } from "@/application/domain/utils";
+import { clampFirst, getCommunityIdFromCtx, getCurrentUserId } from "@/application/domain/utils";
 import WalletService from "@/application/domain/account/wallet/service";
 import { inject, injectable } from "tsyringe";
 import CommunitySignupBonusConfigService from "@/application/domain/account/community/config/incentive/signup/service";
@@ -78,7 +78,10 @@ export default class CommunityUseCase {
       });
     } catch (err) {
       await this.communityService.deleteFirebaseTenant(tenantId).catch((cleanupErr) => {
-        logger.error("Failed to clean up Firebase tenant after community creation failure; manual cleanup required", { tenantId, cleanupErr });
+        logger.error(
+          "Failed to clean up Firebase tenant after community creation failure; manual cleanup required",
+          { tenantId, cleanupErr },
+        );
       });
       throw err;
     }
@@ -105,21 +108,23 @@ export default class CommunityUseCase {
   }
 
   async managerUpdateSignupBonusConfig(
-    { input, permission }: GqlMutationUpdateSignupBonusConfigArgs,
+    { input }: GqlMutationUpdateSignupBonusConfigArgs,
     ctx: IContext,
   ): Promise<CommunitySignupBonusConfig> {
+    const communityId = getCommunityIdFromCtx(ctx);
     return ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
-      return this.signupBonusConfigService.update(ctx, permission.communityId, input, tx);
+      return this.signupBonusConfigService.update(ctx, communityId, input, tx);
     });
   }
 
   async managerUpdatePortalConfig(
-    { input, permission }: GqlMutationUpdatePortalConfigArgs,
+    { input }: GqlMutationUpdatePortalConfigArgs,
     ctx: IContext,
   ): Promise<CommunityPortalConfigResult> {
+    const communityId = getCommunityIdFromCtx(ctx);
     await ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
-      await this.portalConfigService.update(ctx, permission.communityId, input, tx);
+      await this.portalConfigService.update(ctx, communityId, input, tx);
     });
-    return this.portalConfigService.getPortalConfig(ctx, permission.communityId);
+    return this.portalConfigService.getPortalConfig(ctx, communityId);
   }
 }

--- a/src/application/domain/account/membership/schema/mutation.graphql
+++ b/src/application/domain/account/membership/schema/mutation.graphql
@@ -2,132 +2,136 @@
 # Membership Mutation Definitions
 # ------------------------------
 extend type Mutation {
-    # invite
-    membershipInvite(
-        input: MembershipInviteInput!
-        permission:CheckCommunityPermissionInput!
-    ): MembershipInvitePayload
-    @authz(rules: [IsCommunityOwner])
+  # invite
+  membershipInvite(
+    input: MembershipInviteInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): MembershipInvitePayload @authz(rules: [IsCommunityOwner])
 
-    membershipCancelInvitation(
-        input: MembershipSetInvitationStatusInput!
-        permission:CheckCommunityPermissionInput!
-    ): MembershipSetInvitationStatusPayload
-    @authz(rules: [IsCommunityOwner])
+  membershipCancelInvitation(
+    input: MembershipSetInvitationStatusInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): MembershipSetInvitationStatusPayload @authz(rules: [IsCommunityOwner])
 
-    membershipAcceptMyInvitation(
-        input: MembershipSetInvitationStatusInput!
-        permission: CheckIsSelfPermissionInput!
-    ): MembershipSetInvitationStatusPayload
-    @authz(rules: [IsSelf])
+  membershipAcceptMyInvitation(
+    input: MembershipSetInvitationStatusInput!
+    permission: CheckIsSelfPermissionInput!
+  ): MembershipSetInvitationStatusPayload @authz(rules: [IsSelf])
 
-    membershipDenyMyInvitation(
-        input: MembershipSetInvitationStatusInput!
-        permission: CheckIsSelfPermissionInput!
-    ): MembershipSetInvitationStatusPayload
-    @authz(rules: [IsSelf])
+  membershipDenyMyInvitation(
+    input: MembershipSetInvitationStatusInput!
+    permission: CheckIsSelfPermissionInput!
+  ): MembershipSetInvitationStatusPayload @authz(rules: [IsSelf])
 
-    # join
-    membershipWithdraw(
-        input: MembershipWithdrawInput!
-        permission: CheckIsSelfPermissionInput!
-    ): MembershipWithdrawPayload
-    @authz(rules: [IsSelf])
+  # join
+  membershipWithdraw(
+    input: MembershipWithdrawInput!
+    permission: CheckIsSelfPermissionInput!
+  ): MembershipWithdrawPayload @authz(rules: [IsSelf])
 
-    # role
-    membershipAssignOwner(
-        input: MembershipSetRoleInput!
-        permission:CheckCommunityPermissionInput!
-    ): MembershipSetRolePayload
-    @authz(rules: [IsCommunityOwner])
+  # role
+  membershipAssignOwner(
+    input: MembershipSetRoleInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): MembershipSetRolePayload @authz(rules: [IsCommunityOwner])
 
-    membershipAssignManager(
-        input: MembershipSetRoleInput!
-        permission:CheckCommunityPermissionInput!
-    ): MembershipSetRolePayload
-    @authz(rules: [IsCommunityOwner])
+  membershipAssignManager(
+    input: MembershipSetRoleInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): MembershipSetRolePayload @authz(rules: [IsCommunityOwner])
 
-    membershipAssignMember(
-        input: MembershipSetRoleInput!
-        permission:CheckCommunityPermissionInput!
-    ): MembershipSetRolePayload
-    @authz(rules: [IsCommunityManager])
+  membershipAssignMember(
+    input: MembershipSetRoleInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): MembershipSetRolePayload @authz(rules: [IsCommunityManager])
 
-    membershipRemove(
-        input: MembershipRemoveInput!
-        permission:CheckCommunityPermissionInput!
-    ): MembershipRemovePayload
-    @authz(rules: [IsCommunityOwner])
+  membershipRemove(
+    input: MembershipRemoveInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): MembershipRemovePayload @authz(rules: [IsCommunityOwner])
 }
 
 # ------------------------------
 # Membership Mutation Input Definitions
 # ------------------------------
 input MembershipInviteInput {
-    userId: ID!
-    communityId: ID!
-    role: Role
+  userId: ID!
+  communityId: ID!
+  role: Role
 }
 
 input MembershipSetInvitationStatusInput {
-    userId: ID!
-    communityId: ID!
+  userId: ID!
+  communityId: ID!
 }
 
 input MembershipWithdrawInput {
-    userId: ID!
-    communityId: ID!
+  userId: ID!
+  communityId: ID!
 }
 
 input MembershipSetRoleInput {
-    userId: ID!
-    communityId: ID!
+  userId: ID!
+  communityId: ID!
 }
 
 input MembershipRemoveInput {
-    userId: ID!
-    communityId: ID!
+  userId: ID!
+  communityId: ID!
 }
 
 # ------------------------------
 # Membership Mutation Success Type Definitions
 # ------------------------------
 type MembershipInviteSuccess {
-    membership: Membership!
+  membership: Membership!
 }
 
 type MembershipSetRoleSuccess {
-    membership: Membership!
+  membership: Membership!
 }
 
 type MembershipRemoveSuccess {
-    userId: ID!
-    communityId: ID!
+  userId: ID!
+  communityId: ID!
 }
 
 type MembershipWithdrawSuccess {
-    userId: ID!
-    communityId: ID!
+  userId: ID!
+  communityId: ID!
 }
 
 type MembershipSetInvitationStatusSuccess {
-    membership: Membership!
+  membership: Membership!
 }
 
 # ------------------------------
 # Membership Mutation Union (Payload) Definitions
 # ------------------------------
-union MembershipInvitePayload =
-    MembershipInviteSuccess
+union MembershipInvitePayload = MembershipInviteSuccess
 
-union MembershipSetRolePayload =
-    MembershipSetRoleSuccess
+union MembershipSetRolePayload = MembershipSetRoleSuccess
 
-union MembershipRemovePayload =
-    MembershipRemoveSuccess
+union MembershipRemovePayload = MembershipRemoveSuccess
 
-union MembershipWithdrawPayload =
-    MembershipWithdrawSuccess
+union MembershipWithdrawPayload = MembershipWithdrawSuccess
 
-union MembershipSetInvitationStatusPayload =
-    MembershipSetInvitationStatusSuccess
+union MembershipSetInvitationStatusPayload = MembershipSetInvitationStatusSuccess

--- a/src/application/domain/content/article/schema/mutation.graphql
+++ b/src/application/domain/content/article/schema/mutation.graphql
@@ -2,80 +2,83 @@
 # Article Mutation Definitions
 # ------------------------------
 extend type Mutation {
-    articleCreate(
-        input: ArticleCreateInput!
-        permission: CheckCommunityPermissionInput!
-    ): ArticleCreatePayload
-    @authz(rules: [IsCommunityManager])
+  articleCreate(
+    input: ArticleCreateInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): ArticleCreatePayload @authz(rules: [IsCommunityManager])
 
-    articleUpdateContent(
-        id: ID!
-        input: ArticleUpdateContentInput!
-        permission: CheckCommunityPermissionInput!
-    ): ArticleUpdateContentPayload
-    @authz(rules: [IsCommunityManager])
+  articleUpdateContent(
+    id: ID!
+    input: ArticleUpdateContentInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): ArticleUpdateContentPayload @authz(rules: [IsCommunityManager])
 
-    articleDelete(
-        id: ID!
-        permission: CheckCommunityPermissionInput!
-    ): ArticleDeletePayload
-    @authz(rules: [IsCommunityManager])
+  articleDelete(
+    id: ID!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): ArticleDeletePayload @authz(rules: [IsCommunityManager])
 }
 
 # ------------------------------
 # Article Mutation Input Definitions
 # ------------------------------
 input ArticleCreateInput {
-    title: String!
-    introduction: String!
-    body: String
-    thumbnail: ImageInput
-    category: ArticleCategory!
-    publishStatus: PublishStatus!
+  title: String!
+  introduction: String!
+  body: String
+  thumbnail: ImageInput
+  category: ArticleCategory!
+  publishStatus: PublishStatus!
 
-    authorIds: [ID!]!
-    relatedUserIds: [ID!]
-    relatedOpportunityIds: [ID!]
+  authorIds: [ID!]!
+  relatedUserIds: [ID!]
+  relatedOpportunityIds: [ID!]
 }
 
 input ArticleUpdateContentInput {
-    title: String!
-    introduction: String!
-    body: String
-    thumbnail: ImageInput
-    category: ArticleCategory!
+  title: String!
+  introduction: String!
+  body: String
+  thumbnail: ImageInput
+  category: ArticleCategory!
 
-    publishStatus: PublishStatus!
+  publishStatus: PublishStatus!
 
-    authorIds: [ID!]!
-    relatedUserIds: [ID!]
-    relatedOpportunityIds: [ID!]
+  authorIds: [ID!]!
+  relatedUserIds: [ID!]
+  relatedOpportunityIds: [ID!]
 
-    publishedAt: Datetime
+  publishedAt: Datetime
 }
 
 # ------------------------------
 # Article Mutation Success Type Definitions
 # ------------------------------
 type ArticleCreateSuccess {
-    article: Article!
+  article: Article!
 }
 
 type ArticleUpdateContentSuccess {
-    article: Article!
+  article: Article!
 }
 
 type ArticleDeleteSuccess {
-    articleId: ID!
+  articleId: ID!
 }
 # ------------------------------
 # Article Mutation Union (Payload) Definitions
 # ------------------------------
-union ArticleCreatePayload =
-    ArticleCreateSuccess
+union ArticleCreatePayload = ArticleCreateSuccess
 
-union ArticleUpdateContentPayload =
-    ArticleUpdateContentSuccess
+union ArticleUpdateContentPayload = ArticleUpdateContentSuccess
 
-union ArticleDeletePayload =
-    ArticleDeleteSuccess
+union ArticleDeletePayload = ArticleDeleteSuccess

--- a/src/application/domain/content/article/schema/query.graphql
+++ b/src/application/domain/content/article/schema/query.graphql
@@ -2,55 +2,61 @@
 # Article Query Definitions
 # ------------------------------
 extend type Query {
-    articles(
-        filter: ArticleFilterInput
-        sort: ArticleSortInput
-        cursor: String
-        first: Int
-    ): ArticlesConnection!
-    article(id: ID!, permission: CheckCommunityPermissionInput!): Article
+  articles(
+    filter: ArticleFilterInput
+    sort: ArticleSortInput
+    cursor: String
+    first: Int
+  ): ArticlesConnection!
+  article(
+    id: ID!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): Article
 }
 
 # ------------------------------
 # Article Connection Type Definitions
 # ------------------------------
 type ArticlesConnection {
-    edges: [ArticleEdge]
-    pageInfo: PageInfo!
-    totalCount: Int!
+  edges: [ArticleEdge]
+  pageInfo: PageInfo!
+  totalCount: Int!
 }
 
 type ArticleEdge implements Edge {
-    cursor: String!
-    node: Article
+  cursor: String!
+  node: Article
 }
 
 # ------------------------------
 # Article Query Input Definitions
 # ------------------------------
 input ArticleFilterInput {
-    keyword: String
-    categories: [String!]
-    publishStatus: [PublishStatus!]
+  keyword: String
+  categories: [String!]
+  publishStatus: [PublishStatus!]
 
-    authors: [ID!]
-    relatedUserIds: [ID!]
+  authors: [ID!]
+  relatedUserIds: [ID!]
 
-    dateFrom: Datetime
-    dateTo: Datetime
+  dateFrom: Datetime
+  dateTo: Datetime
 
-    cityCodes: [ID!]
-    stateCodes: [ID!]
+  cityCodes: [ID!]
+  stateCodes: [ID!]
 
-    communityId: ID
+  communityId: ID
 
-    and: [ArticleFilterInput!]
-    or: [ArticleFilterInput!]
-    not: ArticleFilterInput
+  and: [ArticleFilterInput!]
+  or: [ArticleFilterInput!]
+  not: ArticleFilterInput
 }
 
 input ArticleSortInput {
-    createdAt: SortDirection
-    publishedAt: SortDirection
-    startsAt: SortDirection
+  createdAt: SortDirection
+  publishedAt: SortDirection
+  startsAt: SortDirection
 }

--- a/src/application/domain/content/article/usecase.ts
+++ b/src/application/domain/content/article/usecase.ts
@@ -15,13 +15,18 @@ import { IContext } from "@/types/server";
 import ArticleService from "@/application/domain/content/article/service";
 import ArticlePresenter from "@/application/domain/content/article/presenter";
 import { PublishStatus } from "@prisma/client";
-import { canViewArticleByPublishStatus, clampFirst, getMembershipRolesByCtx } from "@/application/domain/utils";
+import {
+  canViewArticleByPublishStatus,
+  clampFirst,
+  getCommunityIdFromCtx,
+  getMembershipRolesByCtx,
+} from "@/application/domain/utils";
 import { articleInclude } from "@/application/domain/content/article/data/type";
 import { injectable, inject } from "tsyringe";
 
 @injectable()
 export default class ArticleUseCase {
-  constructor(@inject("ArticleService") private service: ArticleService) { }
+  constructor(@inject("ArticleService") private service: ArticleService) {}
 
   async anyoneBrowseArticles(
     ctx: IContext,
@@ -65,10 +70,7 @@ export default class ArticleUseCase {
     return ArticlePresenter.query(data, hasNextPage, cursor);
   }
 
-  async visitorViewArticle(
-    ctx: IContext,
-    { id }: GqlQueryArticleArgs,
-  ): Promise<GqlArticle | null> {
+  async visitorViewArticle(ctx: IContext, { id }: GqlQueryArticleArgs): Promise<GqlArticle | null> {
     const record = await this.service.findArticle(ctx, id);
     if (!record) {
       return null;
@@ -77,7 +79,15 @@ export default class ArticleUseCase {
     // Check if user can view based on publishStatus and role
     const authorIds = record.authors.map((a) => a.id);
     const relatedUserIds = record.relatedUsers.map((u) => u.id);
-    if (!canViewArticleByPublishStatus(ctx, record.publishStatus, record.communityId, authorIds, relatedUserIds)) {
+    if (
+      !canViewArticleByPublishStatus(
+        ctx,
+        record.publishStatus,
+        record.communityId,
+        authorIds,
+        relatedUserIds,
+      )
+    ) {
       return null;
     }
 
@@ -87,11 +97,12 @@ export default class ArticleUseCase {
   }
 
   async managerCreateArticle(
-    { input, permission }: GqlMutationArticleCreateArgs,
+    { input }: GqlMutationArticleCreateArgs,
     ctx: IContext,
   ): Promise<GqlArticleCreatePayload> {
+    const communityId = getCommunityIdFromCtx(ctx);
     return ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
-      const record = await this.service.createArticle(ctx, input, permission.communityId, tx);
+      const record = await this.service.createArticle(ctx, input, communityId, tx);
       return ArticlePresenter.create(record);
     });
   }

--- a/src/application/domain/experience/evaluation/schema/mutation.graphql
+++ b/src/application/domain/experience/evaluation/schema/mutation.graphql
@@ -2,40 +2,41 @@
 # Evaluation Mutation Definitions
 # ------------------------------
 extend type Mutation {
-    evaluationBulkCreate(
-        input: EvaluationBulkCreateInput!
-        permission: CheckCommunityPermissionInput!
-    ): EvaluationBulkCreatePayload
-    @authz(rules: [IsCommunityManager])
+  evaluationBulkCreate(
+    input: EvaluationBulkCreateInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): EvaluationBulkCreatePayload @authz(rules: [IsCommunityManager])
 }
 
 # ------------------------------
 # Evaluation Mutation Input Definitions
 # ------------------------------
 input EvaluationCreateInput {
-    participationId: ID!
-    comment: String
+  participationId: ID!
+  comment: String
 }
 
 input EvaluationItem {
-    participationId: ID!
-    status: EvaluationStatus!
-    comment: String
+  participationId: ID!
+  status: EvaluationStatus!
+  comment: String
 }
 
 input EvaluationBulkCreateInput {
-    evaluations: [EvaluationItem!]!
+  evaluations: [EvaluationItem!]!
 }
 
 # ------------------------------
 # Evaluation Mutation Success Type Definitions
 # ------------------------------
 type EvaluationBulkCreateSuccess {
-    evaluations: [Evaluation!]!
+  evaluations: [Evaluation!]!
 }
 
 # ------------------------------
 # Evaluation Mutation Union (Payload) Definitions
 # ------------------------------
-union EvaluationBulkCreatePayload =
-    EvaluationBulkCreateSuccess
+union EvaluationBulkCreatePayload = EvaluationBulkCreateSuccess

--- a/src/application/domain/experience/evaluation/usecase.ts
+++ b/src/application/domain/experience/evaluation/usecase.ts
@@ -17,7 +17,7 @@ import EvaluationPresenter from "@/application/domain/experience/evaluation/pres
 import { PrismaEvaluation } from "@/application/domain/experience/evaluation/data/type";
 import WalletService from "@/application/domain/account/wallet/service";
 import WalletValidator from "@/application/domain/account/wallet/validator";
-import { clampFirst, getCurrentUserId } from "@/application/domain/utils";
+import { clampFirst, getCommunityIdFromCtx, getCurrentUserId } from "@/application/domain/utils";
 import { ITransactionService } from "@/application/domain/transaction/data/interface";
 import ParticipationService from "@/application/domain/experience/participation/service";
 import { CannotEvaluateBeforeOpportunityStartError, ValidationError } from "@/errors/graphql";
@@ -65,11 +65,11 @@ export default class EvaluationUseCase {
   }
 
   async managerBulkCreateEvaluations(
-    { input, permission }: GqlMutationEvaluationBulkCreateArgs,
+    { input }: GqlMutationEvaluationBulkCreateArgs,
     ctx: IContext,
   ): Promise<GqlEvaluationBulkCreatePayload> {
     const currentUserId = getCurrentUserId(ctx);
-    const communityId = permission.communityId;
+    const communityId = getCommunityIdFromCtx(ctx);
 
     const createdEvaluations = await this.createEvaluationsAndUpdateStatus(
       ctx,

--- a/src/application/domain/experience/opportunity/schema/mutation.graphql
+++ b/src/application/domain/experience/opportunity/schema/mutation.graphql
@@ -2,117 +2,112 @@
 # Opportunity Mutation Definitions
 # ------------------------------
 extend type Mutation {
-    opportunityCreate(
-        input: OpportunityCreateInput!
-        permission:CheckCommunityPermissionInput!
-    ): OpportunityCreatePayload
-    @authz(rules: [IsCommunityManager])
+  opportunityCreate(
+    input: OpportunityCreateInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): OpportunityCreatePayload @authz(rules: [IsCommunityManager])
 
-    opportunityDelete(
-        id: ID!
-        permission:CheckOpportunityPermissionInput!
-    ): OpportunityDeletePayload
-    @authz(rules: [CanManageOpportunity])
+  opportunityDelete(
+    id: ID!
+    permission: CheckOpportunityPermissionInput!
+  ): OpportunityDeletePayload @authz(rules: [CanManageOpportunity])
 
-    opportunityUpdateContent(
-        id: ID!,
-        input: OpportunityUpdateContentInput!
-        permission:CheckOpportunityPermissionInput!
-    ): OpportunityUpdateContentPayload
-    @authz(rules: [CanManageOpportunity])
+  opportunityUpdateContent(
+    id: ID!
+    input: OpportunityUpdateContentInput!
+    permission: CheckOpportunityPermissionInput!
+  ): OpportunityUpdateContentPayload @authz(rules: [CanManageOpportunity])
 
-    opportunitySetPublishStatus(
-        id: ID!
-        input: OpportunitySetPublishStatusInput!
-        permission:CheckOpportunityPermissionInput!
-    ): OpportunitySetPublishStatusPayload
-    @authz(rules: [CanManageOpportunity])
+  opportunitySetPublishStatus(
+    id: ID!
+    input: OpportunitySetPublishStatusInput!
+    permission: CheckOpportunityPermissionInput!
+  ): OpportunitySetPublishStatusPayload @authz(rules: [CanManageOpportunity])
 }
 
 # ------------------------------
 # Opportunity Mutation Input Definitions
 # ------------------------------
 input OpportunityCreateInput {
-    title: String!
-    description: String!
-    body: String
-    images: [ImageInput!]
+  title: String!
+  description: String!
+  body: String
+  images: [ImageInput!]
 
-    category: OpportunityCategory!
+  category: OpportunityCategory!
 
-    publishStatus: PublishStatus!
-    requireApproval: Boolean!
-    requiredUtilityIds: [ID!]
+  publishStatus: PublishStatus!
+  requireApproval: Boolean!
+  requiredUtilityIds: [ID!]
 
-    pointsToEarn: Int
-    pointsRequired: Int
-    feeRequired: Int
+  pointsToEarn: Int
+  pointsRequired: Int
+  feeRequired: Int
 
-    slots: [OpportunitySlotCreateInput!]
-    relatedArticleIds: [ID!]
-    placeId: ID
+  slots: [OpportunitySlotCreateInput!]
+  relatedArticleIds: [ID!]
+  placeId: ID
 
-    # for isAdmin
-    createdBy: ID
+  # for isAdmin
+  createdBy: ID
 }
 
 input OpportunityUpdateContentInput {
-    title: String!
-    description: String!
-    body: String
-    images: [ImageInput!]
+  title: String!
+  description: String!
+  body: String
+  images: [ImageInput!]
 
-    category: OpportunityCategory!
+  category: OpportunityCategory!
 
-    publishStatus: PublishStatus!
-    requireApproval: Boolean!
-    requiredUtilityIds: [ID!]
+  publishStatus: PublishStatus!
+  requireApproval: Boolean!
+  requiredUtilityIds: [ID!]
 
-    pointsToEarn: Int
-    pointsRequired: Int
-    feeRequired: Int
+  pointsToEarn: Int
+  pointsRequired: Int
+  feeRequired: Int
 
-    relatedArticleIds: [ID!]
-    placeId: ID
+  relatedArticleIds: [ID!]
+  placeId: ID
 
-    # for isAdmin
-    createdBy: ID
+  # for isAdmin
+  createdBy: ID
 }
 
 input OpportunitySetPublishStatusInput {
-    publishStatus: PublishStatus!
+  publishStatus: PublishStatus!
 }
 
 # ------------------------------
 # Opportunity Mutation Success Type Definitions
 # ------------------------------
 type OpportunityCreateSuccess {
-    opportunity: Opportunity!
+  opportunity: Opportunity!
 }
 
 type OpportunityDeleteSuccess {
-    opportunityId: ID!
+  opportunityId: ID!
 }
 
 type OpportunityUpdateContentSuccess {
-    opportunity: Opportunity!
+  opportunity: Opportunity!
 }
 
 type OpportunitySetPublishStatusSuccess {
-    opportunity: Opportunity!
+  opportunity: Opportunity!
 }
 
 # ------------------------------
 # Opportunity Mutation Union (Payload) Definitions
 # ------------------------------
-union OpportunityCreatePayload =
-    OpportunityCreateSuccess
+union OpportunityCreatePayload = OpportunityCreateSuccess
 
-union OpportunityDeletePayload =
-    OpportunityDeleteSuccess
+union OpportunityDeletePayload = OpportunityDeleteSuccess
 
-union OpportunityUpdateContentPayload =
-    OpportunityUpdateContentSuccess
+union OpportunityUpdateContentPayload = OpportunityUpdateContentSuccess
 
-union OpportunitySetPublishStatusPayload =
-    OpportunitySetPublishStatusSuccess
+union OpportunitySetPublishStatusPayload = OpportunitySetPublishStatusSuccess

--- a/src/application/domain/experience/opportunity/schema/query.graphql
+++ b/src/application/domain/experience/opportunity/schema/query.graphql
@@ -2,60 +2,66 @@
 # Opportunity Query Definitions
 # ------------------------------
 extend type Query {
-    opportunities(
-        filter: OpportunityFilterInput
-        sort: OpportunitySortInput
-        cursor: String
-        first: Int
-    ): OpportunitiesConnection!
-    opportunity(id: ID!, permission: CheckCommunityPermissionInput!): Opportunity
+  opportunities(
+    filter: OpportunityFilterInput
+    sort: OpportunitySortInput
+    cursor: String
+    first: Int
+  ): OpportunitiesConnection!
+  opportunity(
+    id: ID!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): Opportunity
 }
 
 # ------------------------------
 # Opportunity Connection Type Definitions
 # ------------------------------
 type OpportunitiesConnection {
-    edges: [OpportunityEdge!]!
-    pageInfo: PageInfo!
-    totalCount: Int!
+  edges: [OpportunityEdge!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
 }
 
 type OpportunityEdge implements Edge {
-    cursor: String!
-    node: Opportunity
+  cursor: String!
+  node: Opportunity
 }
 
 # ------------------------------
 # Opportunity Query Input Definitions
 # ------------------------------
 input OpportunityFilterInput {
-    keyword: String
+  keyword: String
 
-    category: OpportunityCategory
-    publishStatus: [PublishStatus!]
+  category: OpportunityCategory
+  publishStatus: [PublishStatus!]
 
-    communityIds: [ID!]
-    createdByUserIds: [ID!]
-    placeIds: [ID!]
-    cityCodes: [ID!]
-    stateCodes: [ID!]
-    articleIds: [ID!]
-    requiredUtilityIds: [ID!]
+  communityIds: [ID!]
+  createdByUserIds: [ID!]
+  placeIds: [ID!]
+  cityCodes: [ID!]
+  stateCodes: [ID!]
+  articleIds: [ID!]
+  requiredUtilityIds: [ID!]
 
-    isReservableWithTicket: Boolean
-    isReservableWithPoint: Boolean
+  isReservableWithTicket: Boolean
+  isReservableWithPoint: Boolean
 
-    # slot
-    slotHostingStatus: [OpportunitySlotHostingStatus!]
-    slotDateRange: DateTimeRangeFilter
-    slotRemainingCapacity: Int
+  # slot
+  slotHostingStatus: [OpportunitySlotHostingStatus!]
+  slotDateRange: DateTimeRangeFilter
+  slotRemainingCapacity: Int
 
-    and: [OpportunityFilterInput!]
-    or: [OpportunityFilterInput!]
-    not: OpportunityFilterInput
+  and: [OpportunityFilterInput!]
+  or: [OpportunityFilterInput!]
+  not: OpportunityFilterInput
 }
 
 input OpportunitySortInput {
-    createdAt: SortDirection
-    earliestSlotStartsAt: SortDirection
+  createdAt: SortDirection
+  earliestSlotStartsAt: SortDirection
 }

--- a/src/application/domain/experience/opportunity/usecase.ts
+++ b/src/application/domain/experience/opportunity/usecase.ts
@@ -19,6 +19,7 @@ import { PublishStatus } from "@prisma/client";
 import OpportunityService from "@/application/domain/experience/opportunity/service";
 import {
   clampFirst,
+  getCommunityIdFromCtx,
   getMembershipRolesByCtx,
 } from "@/application/domain/utils";
 import { inject, injectable } from "tsyringe";
@@ -100,11 +101,12 @@ export default class OpportunityUseCase {
   }
 
   async managerCreateOpportunity(
-    { input, permission }: GqlMutationOpportunityCreateArgs,
+    { input }: GqlMutationOpportunityCreateArgs,
     ctx: IContext,
   ): Promise<GqlOpportunityCreatePayload> {
+    const communityId = getCommunityIdFromCtx(ctx);
     return ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
-      const record = await this.service.createOpportunity(ctx, input, permission.communityId, tx);
+      const record = await this.service.createOpportunity(ctx, input, communityId, tx);
       return OpportunityPresenter.create(record);
     });
   }

--- a/src/application/domain/experience/participation/schema/mutation.graphql
+++ b/src/application/domain/experience/participation/schema/mutation.graphql
@@ -2,61 +2,58 @@
 # Participation Mutation Definitions
 # ------------------------------
 extend type Mutation {
-    participationBulkCreate(
-        input: ParticipationBulkCreateInput!
-        permission: CheckCommunityPermissionInput!
-    ): ParticipationBulkCreatePayload
-    @authz(rules: [IsCommunityManager])
+  participationBulkCreate(
+    input: ParticipationBulkCreateInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): ParticipationBulkCreatePayload @authz(rules: [IsCommunityManager])
 
-    participationCreatePersonalRecord(
-        input: ParticipationCreatePersonalRecordInput!
-    ): ParticipationCreatePersonalRecordPayload
-    @authz(rules: [IsUser])
+  participationCreatePersonalRecord(
+    input: ParticipationCreatePersonalRecordInput!
+  ): ParticipationCreatePersonalRecordPayload @authz(rules: [IsUser])
 
-    participationDeletePersonalRecord(
-        id: ID!
-        permission: CheckIsSelfPermissionInput!
-    ): ParticipationDeletePayload
-    @authz(rules: [IsSelf])
+  participationDeletePersonalRecord(
+    id: ID!
+    permission: CheckIsSelfPermissionInput!
+  ): ParticipationDeletePayload @authz(rules: [IsSelf])
 }
 
 # ------------------------------
 # Participation Mutation Input Definitions
 # ------------------------------
 input ParticipationBulkCreateInput {
-    userIds: [ID!]!
-    slotId: ID!
-    description: String
+  userIds: [ID!]!
+  slotId: ID!
+  description: String
 }
 
 input ParticipationCreatePersonalRecordInput {
-    description: String
-    images: [ImageInput!]
+  description: String
+  images: [ImageInput!]
 }
 
 # ------------------------------
 # Participation Mutation Success Type Definitions
 # ------------------------------
 type ParticipationBulkCreateSuccess {
-    participations: [Participation!]!
+  participations: [Participation!]!
 }
 
 type ParticipationCreatePersonalRecordSuccess {
-    participation: Participation!
+  participation: Participation!
 }
 
 type ParticipationDeleteSuccess {
-    participationId: ID!
+  participationId: ID!
 }
 
 # ------------------------------
 # Participation Mutation Union (Payload) Definitions
 # ------------------------------
-union ParticipationBulkCreatePayload =
-    ParticipationBulkCreateSuccess
+union ParticipationBulkCreatePayload = ParticipationBulkCreateSuccess
 
-union ParticipationCreatePersonalRecordPayload =
-    ParticipationCreatePersonalRecordSuccess
+union ParticipationCreatePersonalRecordPayload = ParticipationCreatePersonalRecordSuccess
 
-union ParticipationDeletePayload =
-    ParticipationDeleteSuccess
+union ParticipationDeletePayload = ParticipationDeleteSuccess

--- a/src/application/domain/location/place/schema/mutation.graphql
+++ b/src/application/domain/location/place/schema/mutation.graphql
@@ -2,24 +2,30 @@
 # Place Mutation Definitions
 # ------------------------------
 extend type Mutation {
-    placeCreate(
-        input: PlaceCreateInput!
-        permission: CheckCommunityPermissionInput!
-    ): PlaceCreatePayload
-    @authz(rules: [IsCommunityManager])
+  placeCreate(
+    input: PlaceCreateInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): PlaceCreatePayload @authz(rules: [IsCommunityManager])
 
-    placeDelete(
-        id: ID!
-        permission: CheckCommunityPermissionInput!
-    ): PlaceDeletePayload
-    @authz(rules: [IsCommunityManager])
+  placeDelete(
+    id: ID!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): PlaceDeletePayload @authz(rules: [IsCommunityManager])
 
-    placeUpdate(
-        id: ID!
-        input: PlaceUpdateInput!
-        permission: CheckCommunityPermissionInput!
-    ): PlaceUpdatePayload
-    @authz(rules: [IsCommunityManager])
+  placeUpdate(
+    id: ID!
+    input: PlaceUpdateInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): PlaceUpdatePayload @authz(rules: [IsCommunityManager])
 }
 
 # ------------------------------
@@ -27,84 +33,81 @@ extend type Mutation {
 # ------------------------------
 
 input PlaceCreateInput {
-    name: String!
-    address: String!
-    latitude: Decimal!
-    longitude: Decimal!
-    cityCode: ID!
-    isManual: Boolean!
-    googlePlaceId: String
-    mapLocation: JSON
+  name: String!
+  address: String!
+  latitude: Decimal!
+  longitude: Decimal!
+  cityCode: ID!
+  isManual: Boolean!
+  googlePlaceId: String
+  mapLocation: JSON
 
-    communityId: ID!
-    opportunityIds: [ID!]
+  communityId: ID!
+  opportunityIds: [ID!]
 }
 
 input PlaceUpdateInput {
-    id: ID!
+  id: ID!
 
-    name: String!
-    address: String!
-    latitude: Decimal!
-    longitude: Decimal!
-    cityCode: ID!
-    isManual: Boolean!
-    googlePlaceId: String
-    mapLocation: JSON
+  name: String!
+  address: String!
+  latitude: Decimal!
+  longitude: Decimal!
+  cityCode: ID!
+  isManual: Boolean!
+  googlePlaceId: String
+  mapLocation: JSON
 
-    opportunityIds: [ID!]
+  opportunityIds: [ID!]
 }
 
 input NestedPlacesBulkUpdateInput {
-    connectOrCreate: [NestedPlaceConnectOrCreateInput!]
-    disconnect: [ID!]
+  connectOrCreate: [NestedPlaceConnectOrCreateInput!]
+  disconnect: [ID!]
 }
 
 input NestedPlacesBulkConnectOrCreateInput {
-    data: [NestedPlaceConnectOrCreateInput!]
+  data: [NestedPlaceConnectOrCreateInput!]
 }
 
 input NestedPlaceConnectOrCreateInput {
-    where: ID
-    create: NestedPlaceCreateInput
+  where: ID
+  create: NestedPlaceCreateInput
 }
 
 input NestedPlaceCreateInput {
-    name: String!
-    address: String!
-    latitude: Decimal!
-    longitude: Decimal!
-    cityCode: ID!
-    isManual: Boolean!
-    googlePlaceId: String
-    mapLocation: JSON
+  name: String!
+  address: String!
+  latitude: Decimal!
+  longitude: Decimal!
+  cityCode: ID!
+  isManual: Boolean!
+  googlePlaceId: String
+  mapLocation: JSON
 
-    communityId: ID
+  communityId: ID
 }
 
 # ------------------------------
 # Place Mutation Success Type Definitions
 # ------------------------------
 type PlaceCreateSuccess {
-    place: Place!
+  place: Place!
 }
 
 type PlaceUpdateSuccess {
-    place: Place!
+  place: Place!
 }
 
 type PlaceDeleteSuccess {
-    id: ID!
+  id: ID!
 }
 
 # ------------------------------
 # Place Mutation Union (Payload) Definitions
 # ------------------------------
-union PlaceCreatePayload =
-    PlaceCreateSuccess
+union PlaceCreatePayload = PlaceCreateSuccess
 
-union PlaceUpdatePayload =
-    PlaceUpdateSuccess
+union PlaceUpdatePayload = PlaceUpdateSuccess
 
-union PlaceDeletePayload =
-    PlaceDeleteSuccess
+union PlaceDeletePayload = PlaceDeleteSuccess

--- a/src/application/domain/report/feedback/usecase.ts
+++ b/src/application/domain/report/feedback/usecase.ts
@@ -5,6 +5,7 @@ import { AuthenticationError, NotFoundError, ValidationError } from "@/errors/gr
 import ReportService from "@/application/domain/report/service";
 import ReportFeedbackService from "@/application/domain/report/feedback/service";
 import ReportFeedbackPresenter from "@/application/domain/report/feedback/presenter";
+import { getCommunityIdFromCtx } from "@/application/domain/utils";
 import {
   GqlMutationSubmitReportFeedbackArgs,
   GqlSubmitReportFeedbackPayload,
@@ -45,10 +46,11 @@ export default class ReportFeedbackUseCase {
    *      misbehaving client can't push multi-MB rows.
    *   3. The target `Report` exists and belongs to the community the
    *      caller already passed authz for — the `@authz IsCommunityMember`
-   *      rule checks `permission.communityId`, but we still need to
-   *      confirm the `reportId` is actually from that community; otherwise
-   *      a member of community A could rate a report of community B by
-   *      forging the report id.
+   *      rule checks the request community (resolved from
+   *      `x-community-id` header), but we still need to confirm the
+   *      `reportId` is actually from that community; otherwise a member
+   *      of community A could rate a report of community B by forging
+   *      the report id.
    *   4. One submit per (report, user). Pre-checked here so the client
    *      gets a structured ValidationError before the DB raises P2002 —
    *      friendlier message, same invariant. The @@unique([reportId, userId])
@@ -63,28 +65,27 @@ export default class ReportFeedbackUseCase {
    * second submit could land between the checks and the write.
    */
   async submitReportFeedback(
-    { input, permission }: GqlMutationSubmitReportFeedbackArgs,
+    { input }: GqlMutationSubmitReportFeedbackArgs,
     ctx: IContext,
   ): Promise<GqlSubmitReportFeedbackPayload> {
     const userId = ctx.currentUser?.id;
     if (!userId) {
       throw new AuthenticationError("User must be logged in to submit feedback");
     }
+    const ctxCommunityId = getCommunityIdFromCtx(ctx);
 
     if (!Number.isInteger(input.rating) || input.rating < 1 || input.rating > 5) {
       throw new ValidationError("rating must be an integer between 1 and 5", ["rating"]);
     }
     if (input.comment && input.comment.length > MAX_COMMENT_LENGTH) {
-      throw new ValidationError(
-        `comment cannot exceed ${MAX_COMMENT_LENGTH} characters`,
-        ["comment"],
-      );
+      throw new ValidationError(`comment cannot exceed ${MAX_COMMENT_LENGTH} characters`, [
+        "comment",
+      ]);
     }
     if (input.sectionKey && input.sectionKey.length > MAX_SECTION_KEY_LENGTH) {
-      throw new ValidationError(
-        `sectionKey cannot exceed ${MAX_SECTION_KEY_LENGTH} characters`,
-        ["sectionKey"],
-      );
+      throw new ValidationError(`sectionKey cannot exceed ${MAX_SECTION_KEY_LENGTH} characters`, [
+        "sectionKey",
+      ]);
     }
 
     // `ctx.issuer.public` is used here deliberately — `t_report_feedbacks`
@@ -96,8 +97,8 @@ export default class ReportFeedbackUseCase {
     // is already enforced in two places:
     //   1. `@authz IsCommunityMember` on the GraphQL mutation rejects
     //      non-members before the resolver is entered.
-    //   2. The explicit `report.communityId === permission.communityId`
-    //      check below stops a member of community A from forging a
+    //   2. The explicit `report.communityId === ctxCommunityId` check
+    //      below stops a member of community A from forging a
     //      `reportId` belonging to community B.
     // If we later want defence-in-depth via RLS, a follow-up PR can add
     // the member-write policy and swap this for `onlyBelongingCommunity`
@@ -107,11 +108,11 @@ export default class ReportFeedbackUseCase {
       if (!report) {
         throw new NotFoundError("Report", { id: input.reportId });
       }
-      if (report.communityId !== permission.communityId) {
+      if (report.communityId !== ctxCommunityId) {
         // We return a NotFoundError rather than AuthorizationError here
         // so a non-member can't probe existence of other communities'
         // reports by watching the error code. The authz rule already
-        // verified membership of `permission.communityId`.
+        // verified membership of `ctxCommunityId`.
         throw new NotFoundError("Report", { id: input.reportId });
       }
 
@@ -122,10 +123,7 @@ export default class ReportFeedbackUseCase {
         tx,
       );
       if (existing) {
-        throw new ValidationError(
-          "Feedback already submitted for this report",
-          ["reportId"],
-        );
+        throw new ValidationError("Feedback already submitted for this report", ["reportId"]);
       }
 
       try {
@@ -140,9 +138,7 @@ export default class ReportFeedbackUseCase {
             // enum is the source of truth and the GraphQL schema mirrors
             // it), so a plain assertion is enough — no `as unknown`
             // intermediate needed.
-            feedbackType: input.feedbackType
-              ? (input.feedbackType as FeedbackType)
-              : null,
+            feedbackType: input.feedbackType ? (input.feedbackType as FeedbackType) : null,
             sectionKey: input.sectionKey ?? null,
             comment: input.comment ?? null,
           },
@@ -155,10 +151,7 @@ export default class ReportFeedbackUseCase {
         // P2002 into the same ValidationError the pre-check would have
         // thrown so clients see one error code for the invariant.
         if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
-          throw new ValidationError(
-            "Feedback already submitted for this report",
-            ["reportId"],
-          );
+          throw new ValidationError("Feedback already submitted for this report", ["reportId"]);
         }
         throw e;
       }
@@ -180,11 +173,7 @@ export default class ReportFeedbackUseCase {
     { variant, version }: GqlQueryReportTemplateStatsArgs,
     ctx: IContext,
   ): Promise<GqlReportTemplateStats> {
-    const row = await this.feedbackService.getTemplateStats(
-      ctx,
-      variant,
-      version ?? undefined,
-    );
+    const row = await this.feedbackService.getTemplateStats(ctx, variant, version ?? undefined);
     return ReportFeedbackPresenter.templateStats(row);
   }
 

--- a/src/application/domain/report/schema/mutation.graphql
+++ b/src/application/domain/report/schema/mutation.graphql
@@ -40,7 +40,10 @@ input SubmitReportFeedbackInput {
 extend type Mutation {
   generateReport(
     input: GenerateReportInput!
-    permission: CheckCommunityPermissionInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
   ): GenerateReportPayload @authz(compositeRules: [{ or: [IsCommunityManager, IsAdmin] }])
 
   updateReportTemplate(
@@ -49,18 +52,25 @@ extend type Mutation {
     input: UpdateReportTemplateInput!
   ): UpdateReportTemplatePayload @authz(rules: [IsAdmin])
 
-  approveReport(id: ID!): ApproveReportPayload @authz(rules: [IsAdmin])
+  approveReport(id: ID!): ApproveReportPayload
+    @authz(compositeRules: [{ or: [IsCommunityOwner, IsAdmin] }])
 
-  publishReport(id: ID!, finalContent: String!): PublishReportPayload @authz(rules: [IsAdmin])
+  publishReport(id: ID!, finalContent: String!): PublishReportPayload
+    @authz(compositeRules: [{ or: [IsCommunityOwner, IsAdmin] }])
 
-  rejectReport(id: ID!): RejectReportPayload @authz(rules: [IsAdmin])
+  rejectReport(id: ID!): RejectReportPayload
+    @authz(compositeRules: [{ or: [IsCommunityOwner, IsAdmin] }])
 
   # PR-F4: Anyone in the target community (MEMBER or higher) may submit
   # a rating. The usecase additionally verifies that `input.reportId`
-  # belongs to `permission.communityId` — otherwise a member of
-  # community A could rate a report of community B by forging the id.
+  # belongs to the request community (`x-community-id` header) — otherwise
+  # a member of community A could rate a report of community B by forging
+  # the id.
   submitReportFeedback(
     input: SubmitReportFeedbackInput!
-    permission: CheckCommunityPermissionInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
   ): SubmitReportFeedbackPayload @authz(compositeRules: [{ or: [IsCommunityMember, IsAdmin] }])
 }

--- a/src/application/domain/report/schema/query.graphql
+++ b/src/application/domain/report/schema/query.graphql
@@ -16,14 +16,15 @@ extend type Query {
 
   report(id: ID!): Report @authz(compositeRules: [{ or: [IsCommunityOwner, IsAdmin] }])
 
-  reportTemplate(communityId: ID, variant: ReportVariant!): ReportTemplate @authz(rules: [IsAdmin])
+  reportTemplate(communityId: ID, variant: ReportVariant!): ReportTemplate
+    @authz(compositeRules: [{ or: [IsCommunityOwner, IsAdmin] }])
 
-  # PR-F4: SYS_ADMIN-only snapshot of how a (variant, version) is
+  # PR-F4: snapshot of how a (variant, version) is
   # performing — avg feedback rating, avg judge score, and Pearson's
   # correlation between them. Used to decide when the judge prompt
   # needs re-calibration (correlation < 0.7 → flagged).
   reportTemplateStats(variant: ReportVariant!, version: Int): ReportTemplateStats!
-    @authz(rules: [IsAdmin])
+    @authz(compositeRules: [{ or: [IsCommunityOwner, IsAdmin] }])
 
   # Phase 1 admin UI: same-variant template list (A/B candidates / past
   # versions). Single-row `reportTemplate` cannot expose the multiple
@@ -36,7 +37,7 @@ extend type Query {
     communityId: ID
     kind: ReportTemplateKind = GENERATION
     includeInactive: Boolean = false
-  ): [ReportTemplate!]! @authz(rules: [IsAdmin])
+  ): [ReportTemplate!]! @authz(compositeRules: [{ or: [IsCommunityOwner, IsAdmin] }])
 
   # Phase 1 admin UI: per-template quality breakdown for the A/B
   # comparison screen — rows are templates (one per `prompt version`
@@ -53,14 +54,16 @@ extend type Query {
     includeInactive: Boolean = false
     cursor: String
     first: Int = 20
-  ): ReportTemplateStatsBreakdownConnection! @authz(rules: [IsAdmin])
+  ): ReportTemplateStatsBreakdownConnection!
+    @authz(compositeRules: [{ or: [IsCommunityOwner, IsAdmin] }])
 
-  # Phase 1.5 sysAdmin: review-style list of individual feedbacks for a
+  # Phase 1.5: review-style list of individual feedbacks for a
   # template (variant + optional version). The `reportTemplateStatsBreakdown`
   # query above only exposes per-row aggregates (avgRating / avgJudgeScore),
-  # which hides the *why* behind a low score — sysAdmins iterating on
-  # prompts need to read the actual comments to spot recurring failure
-  # modes (tone drift, fabricated numbers, structural issues, etc.).
+  # which hides the *why* behind a low score — operators iterating on
+  # prompt iterators need to read the actual comments to spot
+  # recurring failure modes (tone drift, fabricated numbers, structural
+  # issues, etc.).
   #
   # Filters are oriented at the "drill into low ratings" workflow:
   #   - `version: null` rolls up across every revision of the variant.
@@ -85,9 +88,9 @@ extend type Query {
     maxRating: Int
     cursor: String
     first: Int = 20
-  ): ReportFeedbacksConnection! @authz(rules: [IsAdmin])
+  ): ReportFeedbacksConnection! @authz(compositeRules: [{ or: [IsCommunityOwner, IsAdmin] }])
 
-  # Phase 1.5 sysAdmin: aggregate stats for a template's feedback set,
+  # Phase 1.5: aggregate stats for a template's feedback set,
   # rendered as a "Customer Reviews"-style summary (avg rating + total
   # count + 1..5 distribution bar) on the template detail page.
   # `reportTemplateFeedbacks` returns the paginated list; this query
@@ -106,10 +109,11 @@ extend type Query {
     variant: ReportVariant!
     version: Int
     kind: ReportTemplateKind = GENERATION
-  ): AdminTemplateFeedbackStats! @authz(rules: [IsAdmin])
+  ): AdminTemplateFeedbackStats! @authz(compositeRules: [{ or: [IsCommunityOwner, IsAdmin] }])
 
-  # Phase 2 sysAdmin: cross-community report search. Same shape as
-  # `reports` but `permission` is dropped — IsAdmin alone gates access.
+  # Phase 2: cross-community report search. Same shape as
+  # `reports` but `permission` is dropped — scope is the community
+  # carried in `x-community-id` (or any community for SYS_ADMIN).
   # Order is `publishedAt DESC NULLS LAST, createdAt DESC` so DRAFT /
   # SKIPPED rows that have no publishedAt sink to the bottom rather
   # than leading the page. Filters are all optional so the same query
@@ -123,9 +127,9 @@ extend type Query {
     publishedBefore: Datetime
     cursor: String
     first: Int
-  ): ReportsConnection! @authz(rules: [IsAdmin])
+  ): ReportsConnection! @authz(compositeRules: [{ or: [IsCommunityOwner, IsAdmin] }])
 
-  # Phase 2 sysAdmin: per-community last-publish summary for the L1
+  # Phase 2: per-community last-publish summary for the L1
   # dashboard. Sort order `lastPublishedAt ASC NULLS FIRST` floats
   # dormant / never-published communities to the top so they are the
   # first things an operator sees. The `lastPublishedReportAt` column
@@ -134,5 +138,5 @@ extend type Query {
   # NOT exposed on the `Community` type to keep general community
   # reads cheap.
   reportSummaries(cursor: String, first: Int): AdminReportSummaryConnection!
-    @authz(rules: [IsAdmin])
+    @authz(compositeRules: [{ or: [IsCommunityOwner, IsAdmin] }])
 }

--- a/src/application/domain/report/schema/query.graphql
+++ b/src/application/domain/report/schema/query.graphql
@@ -8,10 +8,13 @@ extend type Query {
     status: ReportStatus
     cursor: String
     first: Int
-    permission: CheckCommunityPermissionInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
   ): ReportsConnection! @authz(compositeRules: [{ or: [IsCommunityManager, IsAdmin] }])
 
-  report(id: ID!): Report @authz(rules: [IsAdmin])
+  report(id: ID!): Report @authz(compositeRules: [{ or: [IsCommunityOwner, IsAdmin] }])
 
   reportTemplate(communityId: ID, variant: ReportVariant!): ReportTemplate @authz(rules: [IsAdmin])
 
@@ -130,8 +133,6 @@ extend type Query {
   # `publishReport` and `supersedeParentIfRegenerating` (A-3); it is
   # NOT exposed on the `Community` type to keep general community
   # reads cheap.
-  reportSummaries(
-    cursor: String
-    first: Int
-  ): AdminReportSummaryConnection! @authz(rules: [IsAdmin])
+  reportSummaries(cursor: String, first: Int): AdminReportSummaryConnection!
+    @authz(rules: [IsAdmin])
 }

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -1,10 +1,13 @@
 import { Prisma, ReportStatus, ReportTemplateKind } from "@prisma/client";
 import { inject, injectable } from "tsyringe";
 import { IContext } from "@/types/server";
-import { ValidationError } from "@/errors/graphql";
+import { AuthorizationError, ValidationError } from "@/errors/graphql";
+import { getCommunityIdFromCtx } from "@/application/domain/utils";
 import logger from "@/infrastructure/logging";
 import ReportService from "@/application/domain/report/service";
-import ReportJudgeService, { JudgeParseError } from "@/application/domain/report/template/judgeService";
+import ReportJudgeService, {
+  JudgeParseError,
+} from "@/application/domain/report/template/judgeService";
 import ReportTemplateSelector from "@/application/domain/report/template/selector";
 import ReportPresenter from "@/application/domain/report/presenter";
 import { WeeklyReportPayload } from "@/application/domain/report/types";
@@ -87,8 +90,7 @@ const WEEKLY_SUMMARY_JUDGE_CRITERIA = {
       "deepest_chain が null なら true。",
     active_users:
       "community_context.active_users_in_window の値がレポートに正確に記載されているか。",
-    total_members:
-      "community_context.total_members の値がレポートに正確に記載されているか。",
+    total_members: "community_context.total_members の値がレポートに正確に記載されているか。",
     no_phantom_comparison:
       "previous_period が null のとき、前週比・先週比・増加・減少等の比較表現がレポートに含まれていないか。" +
       "previous_period が non-null なら true。",
@@ -97,13 +99,11 @@ const WEEKLY_SUMMARY_JUDGE_CRITERIA = {
     deepest_chain_mentioned:
       "deepest_chain が non-null のとき、そのエピソードがレポートに言及されているか。" +
       "deepest_chain が null なら true。",
-    actionable_insights:
-      "来週に向けた具体的なアクション（「〇〇をする」形式）が含まれているか。",
+    actionable_insights: "来週に向けた具体的なアクション（「〇〇をする」形式）が含まれているか。",
     reason_distinction:
       "活動認定と感謝の贈り合いが正確に区別されているか。" +
       "活動認定をメンバー間の感謝として誤記していたら false。",
-    no_enum_names:
-      "DONATION / GRANT / ONBOARDING 等の内部キー名がそのまま出力されていないか。",
+    no_enum_names: "DONATION / GRANT / ONBOARDING 等の内部キー名がそのまま出力されていないか。",
   },
 } as const;
 
@@ -325,13 +325,13 @@ export default class ReportUseCase {
   // =========================================================================
 
   async generateReport(
-    { input, permission }: GqlMutationGenerateReportArgs,
+    { input }: GqlMutationGenerateReportArgs,
     ctx: IContext,
   ): Promise<GqlGenerateReportPayload> {
-    if (permission.communityId !== input.communityId) {
-      throw new ValidationError("communityId in input does not match permission.communityId", []);
+    const communityId = getCommunityIdFromCtx(ctx);
+    if (communityId !== input.communityId) {
+      throw new ValidationError("communityId in input does not match x-community-id header", []);
     }
-    const communityId = permission.communityId;
 
     const periodFrom = truncateToJstDate(input.periodFrom);
     const periodTo = truncateToJstDate(input.periodTo);
@@ -513,9 +513,7 @@ export default class ReportUseCase {
     // matches false-positive too easily (e.g. "21000" appearing as a
     // fragment of "210000") to be a useful signal — the raw counters
     // still flow into `coverageJson` for offline analysis.
-    const missedNames = coverage.top_user_names
-      .filter((u) => !u.mentioned)
-      .map((u) => u.name);
+    const missedNames = coverage.top_user_names.filter((u) => !u.mentioned).map((u) => u.name);
     if (missedNames.length > 0) {
       logger.warn("report.coverage.top_user_names_missed", {
         event: "report.coverage.top_user_names_missed",
@@ -563,9 +561,7 @@ export default class ReportUseCase {
     // either, so this branch is unreachable in practice but keeps the
     // call contract honest for future variants.
     const judgeCriteria =
-      report.variant === GqlReportVariant.WeeklySummary
-        ? WEEKLY_SUMMARY_JUDGE_CRITERIA
-        : undefined;
+      report.variant === GqlReportVariant.WeeklySummary ? WEEKLY_SUMMARY_JUDGE_CRITERIA : undefined;
 
     let judgeResult;
     try {
@@ -724,8 +720,8 @@ export default class ReportUseCase {
     periodFrom: Date,
     periodTo: Date,
   ): Promise<Prisma.ReportUncheckedCreateInput> {
-    // `communityId` is sourced from the already-authorized
-    // `permission.communityId` upstream, rather than re-reading
+    // `communityId` is sourced from the authorized request context
+    // (`x-community-id` header) upstream, rather than re-reading
     // `payload.community_id`, so the two cannot drift if the payload
     // builder's responsibilities change later.
     const parentRegenerateCount = await this.supersedeParentIfRegenerating(
@@ -795,11 +791,12 @@ export default class ReportUseCase {
   }
 
   async browseReports(
-    { communityId, variant, status, cursor, first, permission }: GqlQueryReportsArgs,
+    { communityId, variant, status, cursor, first }: GqlQueryReportsArgs,
     ctx: IContext,
   ): Promise<GqlReportsConnection> {
-    if (permission.communityId !== communityId) {
-      throw new ValidationError("communityId does not match permission.communityId", []);
+    const ctxCommunityId = getCommunityIdFromCtx(ctx);
+    if (ctxCommunityId !== communityId) {
+      throw new ValidationError("communityId does not match x-community-id header", []);
     }
     const clampedFirst = first
       ? clampInt(first, 1, MAX_REPORTS_PER_PAGE, "first")
@@ -816,7 +813,15 @@ export default class ReportUseCase {
 
   async viewReport({ id }: GqlQueryReportArgs, ctx: IContext): Promise<GqlReport | null> {
     const report = await this.service.getReportById(ctx, id);
-    return report ? ReportPresenter.report(report) : null;
+    if (!report) return null;
+    // Non-admin owners must only see reports of their own community.
+    // The IsCommunityOwner rule verifies ownership of `ctx.communityId`,
+    // but does not bind the report id to that community — without this
+    // check an owner could view another community's report by id.
+    if (!ctx.isAdmin && report.communityId !== ctx.communityId) {
+      return null;
+    }
+    return ReportPresenter.report(report);
   }
 
   async viewReportTemplate(
@@ -892,9 +897,10 @@ export default class ReportUseCase {
     { id }: GqlMutationApproveReportArgs,
     ctx: IContext,
   ): Promise<GqlApproveReportPayload> {
-    const report = await ctx.issuer.admin(ctx, async (tx) => {
+    const report = await ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
       const existing = await this.service.getReportById(ctx, id, tx);
       if (!existing) throw new Error(`Report ${id} not found`);
+      this.assertReportInScope(ctx, existing.communityId);
       this.service.assertStatusTransition(existing.status, ReportStatus.APPROVED);
       return this.service.updateReportStatus(ctx, id, ReportStatus.APPROVED, undefined, tx);
     });
@@ -905,9 +911,10 @@ export default class ReportUseCase {
     { id, finalContent }: GqlMutationPublishReportArgs,
     ctx: IContext,
   ): Promise<GqlPublishReportPayload> {
-    const report = await ctx.issuer.admin(ctx, async (tx) => {
+    const report = await ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
       const existing = await this.service.getReportById(ctx, id, tx);
       if (!existing) throw new Error(`Report ${id} not found`);
+      this.assertReportInScope(ctx, existing.communityId);
       this.service.assertStatusTransition(existing.status, ReportStatus.PUBLISHED);
       const updated = await this.service.updateReportStatus(
         ctx,
@@ -936,9 +943,10 @@ export default class ReportUseCase {
     { id }: GqlMutationRejectReportArgs,
     ctx: IContext,
   ): Promise<GqlRejectReportPayload> {
-    const report = await ctx.issuer.admin(ctx, async (tx) => {
+    const report = await ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
       const existing = await this.service.getReportById(ctx, id, tx);
       if (!existing) throw new Error(`Report ${id} not found`);
+      this.assertReportInScope(ctx, existing.communityId);
       this.service.assertStatusTransition(existing.status, ReportStatus.REJECTED);
       return this.service.updateReportStatus(ctx, id, ReportStatus.REJECTED, undefined, tx);
     });
@@ -948,7 +956,7 @@ export default class ReportUseCase {
   /**
    * Phase 2 sysAdmin: cross-community report search. The IsAdmin
    * directive on the GraphQL query is the only authz gate (no
-   * permission.communityId hand-off) — the usecase trusts the
+   * community scoping hand-off) — the usecase trusts the
    * directive and does not re-check sysRole.
    */
   async browseAllReports(
@@ -988,11 +996,7 @@ export default class ReportUseCase {
       cursor: args.cursor ?? undefined,
       first,
     });
-    return ReportPresenter.adminReportSummaryConnection(
-      result.items,
-      result.totalCount,
-      first,
-    );
+    return ReportPresenter.adminReportSummaryConnection(result.items, result.totalCount, first);
   }
 
   // =========================================================================
@@ -1003,6 +1007,17 @@ export default class ReportUseCase {
     await ctx.issuer.internal((tx) => this.service.refreshTransactionSummaryDaily(ctx, tx));
     await ctx.issuer.internal((tx) => this.service.refreshUserTransactionDaily(ctx, tx));
     await ctx.issuer.internal((tx) => this.service.refreshDonationTxEdges(ctx, tx));
+  }
+
+  // IsCommunityOwner gates approve/publish/reject by `ctx.communityId` only;
+  // it does not bind the report `id` to that community. Without this check
+  // an owner of community A could approve/publish/reject a report of
+  // community B by passing the foreign id. SYS_ADMIN bypasses scoping.
+  private assertReportInScope(ctx: IContext, reportCommunityId: string): void {
+    if (ctx.isAdmin) return;
+    if (reportCommunityId !== ctx.communityId) {
+      throw new AuthorizationError("Report does not belong to the current community");
+    }
   }
 }
 
@@ -1026,12 +1041,7 @@ function clampInt(value: number, min: number, max: number, name: string): number
  * legacy `browseReports`) keep their current behaviour to avoid
  * widening this PR's scope into a domain-wide refactor.
  */
-function validateIntInRange(
-  value: number,
-  min: number,
-  max: number,
-  name: string,
-): number {
+function validateIntInRange(value: number, min: number, max: number, name: string): number {
   if (!Number.isInteger(value) || value < min || value > max) {
     throw new ValidationError(
       `${name} must be an integer between ${min} and ${max}, got ${value}`,

--- a/src/application/domain/reward/ticket/schema/mutation.graphql
+++ b/src/application/domain/reward/ticket/schema/mutation.graphql
@@ -2,34 +2,31 @@
 # Ticket Mutation Definitions
 # ------------------------------
 extend type Mutation {
-    ticketIssue(
-        input: TicketIssueInput!
-        permission: CheckCommunityPermissionInput!
-    ): TicketIssuePayload
-    @authz(rules: [IsCommunityMember])
+  ticketIssue(
+    input: TicketIssueInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): TicketIssuePayload @authz(rules: [IsCommunityMember])
 
-    ticketClaim(
-        input: TicketClaimInput!
-    ): TicketClaimPayload
-    @authz(rules: [IsUser])
+  ticketClaim(input: TicketClaimInput!): TicketClaimPayload @authz(rules: [IsUser])
 
-    ticketPurchase(
-        input: TicketPurchaseInput!
-        permission: CheckCommunityPermissionInput!
-    ): TicketPurchasePayload
-    @authz(rules: [IsCommunityMember])
+  ticketPurchase(
+    input: TicketPurchaseInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): TicketPurchasePayload @authz(rules: [IsCommunityMember])
 
-    ticketRefund(
-        id: ID!
-        input: TicketRefundInput!
-        permission: CheckIsSelfPermissionInput!
-    ): TicketRefundPayload
-    @authz(rules: [IsSelf])
+  ticketRefund(
+    id: ID!
+    input: TicketRefundInput!
+    permission: CheckIsSelfPermissionInput!
+  ): TicketRefundPayload @authz(rules: [IsSelf])
 
-    ticketUse(
-        id: ID!
-        permission: CheckIsSelfPermissionInput!
-    ): TicketUsePayload
+  ticketUse(id: ID!, permission: CheckIsSelfPermissionInput!): TicketUsePayload
     @authz(rules: [IsSelf])
 }
 
@@ -37,64 +34,59 @@ extend type Mutation {
 # Ticket Mutation Input Definitions
 # ------------------------------
 input TicketIssueInput {
-    utilityId: ID!
-    qtyToBeIssued: Int!
+  utilityId: ID!
+  qtyToBeIssued: Int!
 }
 
 input TicketClaimInput {
-    ticketClaimLinkId: ID!
+  ticketClaimLinkId: ID!
 }
 
 input TicketPurchaseInput {
-    walletId: ID!
-    utilityId: ID!
-    communityId: ID!
-    pointsRequired: Int!
+  walletId: ID!
+  utilityId: ID!
+  communityId: ID!
+  pointsRequired: Int!
 }
 
 input TicketRefundInput {
-    walletId: ID!
-    communityId: ID!
-    pointsRequired: Int!
+  walletId: ID!
+  communityId: ID!
+  pointsRequired: Int!
 }
 
 # ------------------------------
 # Ticket Mutation Success Type Definitions
 # ------------------------------
 type TicketIssueSuccess {
-    issue: TicketIssuer!
+  issue: TicketIssuer!
 }
 
 type TicketPurchaseSuccess {
-    ticket: Ticket!
+  ticket: Ticket!
 }
 
 type TicketUseSuccess {
-    ticket: Ticket!
+  ticket: Ticket!
 }
 
 type TicketRefundSuccess {
-    ticket: Ticket!
+  ticket: Ticket!
 }
 
 type TicketClaimSuccess {
-    tickets: [Ticket!]!
+  tickets: [Ticket!]!
 }
 
 # ------------------------------
 # Ticket Mutation Union (Payload) Definitions
 # ------------------------------
-union TicketPurchasePayload =
-    TicketPurchaseSuccess
+union TicketPurchasePayload = TicketPurchaseSuccess
 
-union TicketUsePayload =
-    TicketUseSuccess
+union TicketUsePayload = TicketUseSuccess
 
-union TicketRefundPayload =
-    TicketRefundSuccess
+union TicketRefundPayload = TicketRefundSuccess
 
-union TicketIssuePayload =
-    TicketIssueSuccess
+union TicketIssuePayload = TicketIssueSuccess
 
-union TicketClaimPayload =
-    TicketClaimSuccess
+union TicketClaimPayload = TicketClaimSuccess

--- a/src/application/domain/reward/utility/schema/mutation.graphql
+++ b/src/application/domain/reward/utility/schema/mutation.graphql
@@ -2,85 +2,89 @@
 # Mutation Definitions
 # ------------------------------
 extend type Mutation {
-    utilityCreate(
-        input: UtilityCreateInput!
-        permission:CheckCommunityPermissionInput!
-    ): UtilityCreatePayload
-    @authz(rules: [IsCommunityManager])
+  utilityCreate(
+    input: UtilityCreateInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): UtilityCreatePayload @authz(rules: [IsCommunityManager])
 
-    utilityDelete(
-        id: ID!
-        permission:CheckCommunityPermissionInput!
-    ): UtilityDeletePayload
-    @authz(rules: [IsCommunityManager])
+  utilityDelete(
+    id: ID!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): UtilityDeletePayload @authz(rules: [IsCommunityManager])
 
-    utilityUpdateInfo(
-        id: ID!
-        input: UtilityUpdateInfoInput!
-        permission:CheckCommunityPermissionInput!
-    ): UtilityUpdateInfoPayload
-    @authz(rules: [IsCommunityManager])
+  utilityUpdateInfo(
+    id: ID!
+    input: UtilityUpdateInfoInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): UtilityUpdateInfoPayload @authz(rules: [IsCommunityManager])
 
-    utilitySetPublishStatus(
-        id: ID!
-        input: UtilitySetPublishStatusInput!
-        permission:CheckCommunityPermissionInput!
-    ): UtilitySetPublishStatusPayload
-    @authz(rules: [IsCommunityManager])
+  utilitySetPublishStatus(
+    id: ID!
+    input: UtilitySetPublishStatusInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): UtilitySetPublishStatusPayload @authz(rules: [IsCommunityManager])
 }
 
 # ------------------------------
 # Input Definitions
 # ------------------------------
 input UtilityCreateInput {
-    name: String!
-    description: String
-    images: [ImageInput!]
-    requiredForOpportunityIds: [String!]
-    pointsRequired: Int!
+  name: String!
+  description: String
+  images: [ImageInput!]
+  requiredForOpportunityIds: [String!]
+  pointsRequired: Int!
 }
 
 input UtilityUpdateInfoInput {
-    name: String!
-    description: String
-    images: [ImageInput!]
-    pointsRequired: Int!
+  name: String!
+  description: String
+  images: [ImageInput!]
+  pointsRequired: Int!
 }
 
 input UtilitySetPublishStatusInput {
-    publishStatus: PublishStatus!
+  publishStatus: PublishStatus!
 }
 
 # ------------------------------
 # Success Type Definitions
 # ------------------------------
 type UtilityCreateSuccess {
-    utility: Utility!
+  utility: Utility!
 }
 
 type UtilityDeleteSuccess {
-    utilityId: String!
+  utilityId: String!
 }
 
 type UtilityUpdateInfoSuccess {
-    utility: Utility!
+  utility: Utility!
 }
 
 type UtilitySetPublishStatusSuccess {
-    utility: Utility!
+  utility: Utility!
 }
 
 # ------------------------------
 # Union (Payload) Definitions
 # ------------------------------
-union UtilityCreatePayload =
-    UtilityCreateSuccess
+union UtilityCreatePayload = UtilityCreateSuccess
 
-union UtilityDeletePayload =
-    UtilityDeleteSuccess
+union UtilityDeletePayload = UtilityDeleteSuccess
 
-union UtilityUpdateInfoPayload =
-    UtilityUpdateInfoSuccess
+union UtilityUpdateInfoPayload = UtilityUpdateInfoSuccess
 
-union UtilitySetPublishStatusPayload =
-    UtilitySetPublishStatusSuccess
+union UtilitySetPublishStatusPayload = UtilitySetPublishStatusSuccess

--- a/src/application/domain/reward/utility/schema/query.graphql
+++ b/src/application/domain/reward/utility/schema/query.graphql
@@ -2,47 +2,50 @@
 # Query Definitions
 # ------------------------------
 extend type Query {
-    utilities(
-        filter: UtilityFilterInput
-        sort: UtilitySortInput
-        cursor: String
-        first: Int
-    ): UtilitiesConnection!
-    utility(
-        id: ID!
-        permission: CheckCommunityPermissionInput!
-    ): Utility
+  utilities(
+    filter: UtilityFilterInput
+    sort: UtilitySortInput
+    cursor: String
+    first: Int
+  ): UtilitiesConnection!
+  utility(
+    id: ID!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): Utility
 }
 
 # ------------------------------
 # Type Definitions for Queries
 # ------------------------------
 type UtilitiesConnection {
-    edges: [UtilityEdge]
-    pageInfo: PageInfo!
-    totalCount: Int!
+  edges: [UtilityEdge]
+  pageInfo: PageInfo!
+  totalCount: Int!
 }
 
 type UtilityEdge implements Edge {
-    cursor: String!
-    node: Utility
+  cursor: String!
+  node: Utility
 }
 
 # ------------------------------
 # Input Definitions for Queries
 # ------------------------------
 input UtilityFilterInput {
-    communityIds: [ID!]
-    ownerIds: [ID!]
+  communityIds: [ID!]
+  ownerIds: [ID!]
 
-    publishStatus: [PublishStatus!]
+  publishStatus: [PublishStatus!]
 
-    and: [UtilityFilterInput!]
-    or: [UtilityFilterInput!]
-    not: UtilityFilterInput
+  and: [UtilityFilterInput!]
+  or: [UtilityFilterInput!]
+  not: UtilityFilterInput
 }
 
 input UtilitySortInput {
-    createdAt: SortDirection
-    pointsRequired: SortDirection
+  createdAt: SortDirection
+  pointsRequired: SortDirection
 }

--- a/src/application/domain/reward/utility/usecase.ts
+++ b/src/application/domain/reward/utility/usecase.ts
@@ -14,7 +14,12 @@ import {
 } from "@/types/graphql";
 import { IContext } from "@/types/server";
 import { PublishStatus } from "@prisma/client";
-import { clampFirst, getCurrentUserId, getMembershipRolesByCtx } from "@/application/domain/utils";
+import {
+  clampFirst,
+  getCommunityIdFromCtx,
+  getCurrentUserId,
+  getMembershipRolesByCtx,
+} from "@/application/domain/utils";
 import { IUtilityService } from "./data/interface";
 import UtilityPresenter from "./presenter";
 
@@ -56,12 +61,9 @@ export default class UtilityUseCase {
     return UtilityPresenter.query(data, hasNextPage, cursor);
   }
 
-  async visitorViewUtility(
-    ctx: IContext,
-    { id, permission }: GqlQueryUtilityArgs,
-  ): Promise<GqlUtility | null> {
+  async visitorViewUtility(ctx: IContext, { id }: GqlQueryUtilityArgs): Promise<GqlUtility | null> {
     const currentUserId = ctx.currentUser?.id;
-    const communityIds = [permission.communityId];
+    const communityIds = [getCommunityIdFromCtx(ctx)];
 
     const { isManager, isMember } = getMembershipRolesByCtx(ctx, communityIds, currentUserId);
 
@@ -78,18 +80,13 @@ export default class UtilityUseCase {
 
   async managerCreateUtility(
     ctx: IContext,
-    { input, permission }: GqlMutationUtilityCreateArgs,
+    { input }: GqlMutationUtilityCreateArgs,
   ): Promise<GqlUtilityCreatePayload> {
     const currentUserId = getCurrentUserId(ctx);
+    const communityId = getCommunityIdFromCtx(ctx);
 
     return ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
-      const res = await this.service.createUtility(
-        ctx,
-        input,
-        currentUserId,
-        permission.communityId,
-        tx,
-      );
+      const res = await this.service.createUtility(ctx, input, currentUserId, communityId, tx);
       return UtilityPresenter.create(res);
     });
   }

--- a/src/application/domain/transaction/incentiveGrant/schema/mutation.graphql
+++ b/src/application/domain/transaction/incentiveGrant/schema/mutation.graphql
@@ -4,9 +4,11 @@
 extend type Mutation {
   incentiveGrantRetry(
     input: IncentiveGrantRetryInput!
-    permission: CheckCommunityPermissionInput!
-  ): IncentiveGrantRetryPayload
-  @authz(rules: [IsCommunityOwner])
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): IncentiveGrantRetryPayload @authz(rules: [IsCommunityOwner])
 }
 
 # ------------------------------
@@ -27,5 +29,4 @@ type IncentiveGrantRetrySuccess {
 # ------------------------------
 # IncentiveGrant Mutation Union (Payload) Definitions
 # ------------------------------
-union IncentiveGrantRetryPayload =
-  IncentiveGrantRetrySuccess
+union IncentiveGrantRetryPayload = IncentiveGrantRetrySuccess

--- a/src/application/domain/transaction/incentiveGrant/usecase.ts
+++ b/src/application/domain/transaction/incentiveGrant/usecase.ts
@@ -5,7 +5,7 @@ import IncentiveGrantService from "./service";
 import { IIncentiveGrantRepository } from "./data/interface";
 import CommunityService from "@/application/domain/account/community/service";
 import NotificationService from "@/application/domain/notification/service";
-import { clampFirst } from "@/application/domain/utils";
+import { clampFirst, getCommunityIdFromCtx } from "@/application/domain/utils";
 import { inject, injectable } from "tsyringe";
 import logger from "@/infrastructure/logging";
 import {
@@ -125,7 +125,8 @@ export default class IncentiveGrantUseCase {
     args: GqlMutationIncentiveGrantRetryArgs,
     ctx: IContext,
   ): Promise<GqlIncentiveGrantRetryPayload> {
-    const { input, permission } = args;
+    const { input } = args;
+    const ctxCommunityId = getCommunityIdFromCtx(ctx);
 
     try {
       // Execute retry in transaction
@@ -139,9 +140,9 @@ export default class IncentiveGrantUseCase {
           }
 
           // 2. Security check: Ensure the grant belongs to the community (before retry)
-          if (grant.communityId !== permission.communityId) {
+          if (grant.communityId !== ctxCommunityId) {
             throw new AuthorizationError(
-              `Grant ${input.incentiveGrantId} does not belong to community ${permission.communityId}`,
+              `Grant ${input.incentiveGrantId} does not belong to community ${ctxCommunityId}`,
             );
           }
 

--- a/src/application/domain/transaction/schema/mutation.graphql
+++ b/src/application/domain/transaction/schema/mutation.graphql
@@ -2,31 +2,36 @@
 # Transaction Mutation Definitions
 # ------------------------------
 extend type Mutation {
-    transactionIssueCommunityPoint(
-        input: TransactionIssueCommunityPointInput!
-        permission:CheckCommunityPermissionInput!
-    ): TransactionIssueCommunityPointPayload
-    @authz(rules: [IsCommunityOwner])
+  transactionIssueCommunityPoint(
+    input: TransactionIssueCommunityPointInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): TransactionIssueCommunityPointPayload @authz(rules: [IsCommunityOwner])
 
-    transactionGrantCommunityPoint(
-        input: TransactionGrantCommunityPointInput!
-        permission:CheckCommunityPermissionInput!
-    ): TransactionGrantCommunityPointPayload
-    @authz(rules: [IsCommunityOwner])
+  transactionGrantCommunityPoint(
+    input: TransactionGrantCommunityPointInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): TransactionGrantCommunityPointPayload @authz(rules: [IsCommunityOwner])
 
-    transactionDonateSelfPoint(
-        input: TransactionDonateSelfPointInput!
-        permission:CheckIsSelfPermissionInput!
-    ): TransactionDonateSelfPointPayload
-    @authz(rules: [IsSelf])
+  transactionDonateSelfPoint(
+    input: TransactionDonateSelfPointInput!
+    permission: CheckIsSelfPermissionInput!
+  ): TransactionDonateSelfPointPayload @authz(rules: [IsSelf])
 
-    transactionUpdateMetadata(
-        id: ID!
-        input: TransactionUpdateMetadataInput!
-        permission: CheckIsSelfPermissionInput
-        communityPermission: CheckCommunityPermissionInput
-    ): TransactionUpdateMetadataPayload
-    @authz(compositeRules: [{ or: [IsSelf, IsCommunityOwner] }])
+  transactionUpdateMetadata(
+    id: ID!
+    input: TransactionUpdateMetadataInput!
+    permission: CheckIsSelfPermissionInput
+    communityPermission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): TransactionUpdateMetadataPayload @authz(compositeRules: [{ or: [IsSelf, IsCommunityOwner] }])
 }
 
 # ------------------------------
@@ -62,35 +67,31 @@ input TransactionUpdateMetadataInput {
 # Transaction Mutation Success Type Definitions
 # ------------------------------
 type TransactionIssueCommunityPointSuccess {
-    transaction: Transaction!
+  transaction: Transaction!
 }
 
 type TransactionGrantCommunityPointSuccess {
-    transaction: Transaction!
+  transaction: Transaction!
 }
 
 type TransactionDonateSelfPointSuccess {
-    transaction: Transaction!
+  transaction: Transaction!
 }
 
 # ------------------------------
 # Transaction Mutation Union (Payload) Definitions
 # ------------------------------
-union TransactionIssueCommunityPointPayload =
-    TransactionIssueCommunityPointSuccess
+union TransactionIssueCommunityPointPayload = TransactionIssueCommunityPointSuccess
 
-union TransactionGrantCommunityPointPayload =
-    TransactionGrantCommunityPointSuccess
+union TransactionGrantCommunityPointPayload = TransactionGrantCommunityPointSuccess
 
-union TransactionDonateSelfPointPayload =
-    TransactionDonateSelfPointSuccess
+union TransactionDonateSelfPointPayload = TransactionDonateSelfPointSuccess
 
 # ------------------------------
 # TransactionUpdateMetadata Success / Payload
 # ------------------------------
 type TransactionUpdateMetadataSuccess {
-    transaction: Transaction!
+  transaction: Transaction!
 }
 
-union TransactionUpdateMetadataPayload =
-    TransactionUpdateMetadataSuccess
+union TransactionUpdateMetadataPayload = TransactionUpdateMetadataSuccess

--- a/src/application/domain/transaction/usecase.ts
+++ b/src/application/domain/transaction/usecase.ts
@@ -5,7 +5,7 @@ import MembershipService from "@/application/domain/account/membership/service";
 import WalletValidator from "@/application/domain/account/wallet/validator";
 import WalletService from "@/application/domain/account/wallet/service";
 import NotificationService from "@/application/domain/notification/service";
-import { clampFirst, getCurrentUserId } from "@/application/domain/utils";
+import { clampFirst, getCommunityIdFromCtx, getCurrentUserId } from "@/application/domain/utils";
 import { ITransactionService } from "@/application/domain/transaction/data/interface";
 import { AuthorizationError, NotFoundError } from "@/errors/graphql";
 import ImageService from "@/application/domain/content/image/service";
@@ -86,13 +86,11 @@ export default class TransactionUseCase {
   }
 
   async ownerIssueCommunityPoint(
-    { input, permission }: GqlMutationTransactionIssueCommunityPointArgs,
+    { input }: GqlMutationTransactionIssueCommunityPointArgs,
     ctx: IContext,
   ): Promise<GqlTransactionIssueCommunityPointPayload> {
-    const communityWallet = await this.walletService.findCommunityWalletOrThrow(
-      ctx,
-      permission.communityId,
-    );
+    const communityId = getCommunityIdFromCtx(ctx);
+    const communityWallet = await this.walletService.findCommunityWalletOrThrow(ctx, communityId);
     const uploadedImages = await this.uploadTransactionImages(input.images);
 
     const res = await ctx.issuer.onlyBelongingCommunity(
@@ -116,30 +114,22 @@ export default class TransactionUseCase {
 
   async ownerGrantCommunityPoint(
     ctx: IContext,
-    { input, permission }: GqlMutationTransactionGrantCommunityPointArgs,
+    { input }: GqlMutationTransactionGrantCommunityPointArgs,
   ): Promise<GqlTransactionGrantCommunityPointPayload> {
     const { toUserId, transferPoints, comment } = input;
     const currentUserId = getCurrentUserId(ctx);
-    const communityWallet = await this.walletService.findCommunityWalletOrThrow(
-      ctx,
-      permission.communityId,
-    );
+    const communityId = getCommunityIdFromCtx(ctx);
+    const communityWallet = await this.walletService.findCommunityWalletOrThrow(ctx, communityId);
     const uploadedImages = await this.uploadTransactionImages(input.images);
 
     const transaction = await ctx.issuer.onlyBelongingCommunity(
       ctx,
       async (tx: Prisma.TransactionClient) => {
-        await this.membershipService.joinIfNeeded(
-          ctx,
-          currentUserId,
-          permission.communityId,
-          tx,
-          toUserId,
-        );
+        await this.membershipService.joinIfNeeded(ctx, currentUserId, communityId, tx, toUserId);
         const { toWalletId } = await this.walletValidator.validateCommunityMemberTransfer(
           ctx,
           tx,
-          permission.communityId,
+          communityId,
           toUserId,
           transferPoints,
           TransactionReason.GRANT,

--- a/src/application/domain/transaction/usecase.ts
+++ b/src/application/domain/transaction/usecase.ts
@@ -222,7 +222,7 @@ export default class TransactionUseCase {
 
   async userUpdateTransactionMetadata(
     ctx: IContext,
-    { id, input, permission, communityPermission }: GqlMutationTransactionUpdateMetadataArgs,
+    { id, input }: GqlMutationTransactionUpdateMetadataArgs,
   ): Promise<GqlTransactionUpdateMetadataPayload> {
     const currentUserId = getCurrentUserId(ctx);
 
@@ -231,27 +231,29 @@ export default class TransactionUseCase {
       throw new NotFoundError(`TransactionNotFound: ID=${id}`);
     }
 
-    if (communityPermission?.communityId) {
-      const isOwner =
-        ctx.isAdmin ||
+    // The @authz directive admits IsSelf OR IsCommunityOwner. Pick the
+    // applicable authority here without relying on a client-supplied
+    // mode flag: prefer owner-mode when the caller actually owns the
+    // current community AND the txn was emitted from that community's
+    // wallet, otherwise fall back to self-mode (caller is the creator).
+    const ctxCommunityId = ctx.communityId;
+    const isOwnerOfCtxCommunity =
+      ctx.isAdmin ||
+      (!!ctxCommunityId &&
         ctx.currentUser?.memberships?.some(
-          (m) => m.communityId === communityPermission.communityId && m.role === Role.OWNER,
-        ) === true;
-      if (!isOwner) {
-        throw new AuthorizationError("User must be community owner");
-      }
+          (m) => m.communityId === ctxCommunityId && m.role === Role.OWNER,
+        ) === true);
+    const isCreator = existing.createdBy === currentUserId;
+
+    if (isOwnerOfCtxCommunity && ctxCommunityId) {
       const communityWallet = await this.walletService.findCommunityWalletOrThrow(
         ctx,
-        communityPermission.communityId,
+        ctxCommunityId,
       );
-      if (existing.from !== communityWallet.id) {
+      if (existing.from !== communityWallet.id && !isCreator) {
         throw new AuthorizationError("Transaction is not from the community wallet");
       }
-    } else if (permission?.userId) {
-      if (existing.createdBy !== currentUserId) {
-        throw new AuthorizationError("User is not the creator of this transaction");
-      }
-    } else {
+    } else if (!isCreator) {
       throw new AuthorizationError("Insufficient permissions to update transaction metadata");
     }
 

--- a/src/application/domain/utils.ts
+++ b/src/application/domain/utils.ts
@@ -13,6 +13,16 @@ export function getCurrentUserId(ctx: IContext, inputUserId?: string): string {
   return currentUserId;
 }
 
+// `x-community-id` ヘッダ由来。auth ミドルウェアで必須化されているため通常は必ず存在するが、
+// バッチ等で空コンテキストが渡る経路があるため明示的にガードする。
+export function getCommunityIdFromCtx(ctx: IContext): string {
+  const communityId = ctx.communityId;
+  if (!communityId) {
+    throw new AuthorizationError("communityId is required (missing x-community-id header)");
+  }
+  return communityId;
+}
+
 export function clampFirst(first: number | null | undefined): number {
   const LIMIT = 500;
   if (typeof first === "number" && first > LIMIT) {
@@ -106,11 +116,7 @@ export function canViewByPublishStatus(
   }
 
   // Check membership role
-  const { isManager, isMember } = getMembershipRolesByCtx(
-    ctx,
-    [communityId],
-    currentUserId,
-  );
+  const { isManager, isMember } = getMembershipRolesByCtx(ctx, [communityId], currentUserId);
 
   // Manager/Owner can view all statuses in their community
   if (isManager[communityId]) {
@@ -120,8 +126,7 @@ export function canViewByPublishStatus(
   // Member can view PUBLIC and COMMUNITY_INTERNAL
   if (isMember[communityId]) {
     return (
-      publishStatus === PublishStatus.PUBLIC ||
-      publishStatus === PublishStatus.COMMUNITY_INTERNAL
+      publishStatus === PublishStatus.PUBLIC || publishStatus === PublishStatus.COMMUNITY_INTERNAL
     );
   }
 
@@ -155,11 +160,7 @@ export function canViewArticleByPublishStatus(
   }
 
   // Check membership role
-  const { isManager, isMember } = getMembershipRolesByCtx(
-    ctx,
-    [communityId],
-    currentUserId,
-  );
+  const { isManager, isMember } = getMembershipRolesByCtx(ctx, [communityId], currentUserId);
 
   // Manager/Owner can view all statuses in their community
   if (isManager[communityId]) {
@@ -169,8 +170,7 @@ export function canViewArticleByPublishStatus(
   // Member can view PUBLIC and COMMUNITY_INTERNAL
   if (isMember[communityId]) {
     return (
-      publishStatus === PublishStatus.PUBLIC ||
-      publishStatus === PublishStatus.COMMUNITY_INTERNAL
+      publishStatus === PublishStatus.PUBLIC || publishStatus === PublishStatus.COMMUNITY_INTERNAL
     );
   }
 

--- a/src/application/domain/vote/schema/mutation.graphql
+++ b/src/application/domain/vote/schema/mutation.graphql
@@ -11,7 +11,10 @@ extend type Mutation {
   """
   voteTopicCreate(
     input: VoteTopicCreateInput!
-    permission: CheckCommunityPermissionInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
   ): VoteTopicCreatePayload! @authz(rules: [IsCommunityManager])
 
   """
@@ -23,7 +26,10 @@ extend type Mutation {
   voteTopicUpdate(
     id: ID!
     input: VoteTopicUpdateInput!
-    permission: CheckCommunityPermissionInput!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
   ): VoteTopicUpdatePayload! @authz(rules: [IsCommunityManager])
 
   """
@@ -39,8 +45,13 @@ extend type Mutation {
   OPEN / CLOSED フェーズでは `VOTE_TOPIC_NOT_EDITABLE` エラーが返る。
   gate / powerPolicy / options は onDelete: Cascade で自動削除される（UPCOMING 限定なので ballots は存在しない）。
   """
-  voteTopicDelete(id: ID!, permission: CheckCommunityPermissionInput!): VoteTopicDeletePayload!
-    @authz(rules: [IsCommunityManager])
+  voteTopicDelete(
+    id: ID!
+    permission: CheckCommunityPermissionInput
+      @deprecated(
+        reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present."
+      )
+  ): VoteTopicDeletePayload! @authz(rules: [IsCommunityManager])
 }
 
 input VoteTopicCreateInput {

--- a/src/application/domain/vote/usecase.ts
+++ b/src/application/domain/vote/usecase.ts
@@ -12,7 +12,12 @@ import {
 } from "@/types/graphql";
 import { IContext } from "@/types/server";
 import { AuthorizationError, ValidationError } from "@/errors/graphql";
-import { clampFirst, getCurrentUserId, getMembershipRolesByCtx } from "@/application/domain/utils";
+import {
+  clampFirst,
+  getCommunityIdFromCtx,
+  getCurrentUserId,
+  getMembershipRolesByCtx,
+} from "@/application/domain/utils";
 import VoteService from "./service";
 import VotePresenter, {
   GqlVoteTopicWithMeta,
@@ -105,13 +110,14 @@ export default class VoteUseCase {
 
   async managerCreateVoteTopic(
     ctx: IContext,
-    { input, permission }: GqlMutationVoteTopicCreateArgs,
+    { input }: GqlMutationVoteTopicCreateArgs,
   ): Promise<GqlVoteTopicCreatePayloadWithMeta> {
     const currentUserId = getCurrentUserId(ctx);
+    const ctxCommunityId = getCommunityIdFromCtx(ctx);
 
-    // permission で指定されたコミュニティと input のコミュニティが一致することを確認
-    if (permission.communityId !== input.communityId) {
-      throw new ValidationError("communityId in input does not match permission.communityId", []);
+    // ctx と input のコミュニティが一致することを確認（クライアントの取り違え防止）
+    if (ctxCommunityId !== input.communityId) {
+      throw new ValidationError("communityId in input does not match x-community-id header", []);
     }
 
     this.service.validateTopicInput(input);
@@ -128,14 +134,15 @@ export default class VoteUseCase {
 
   async managerUpdateVoteTopic(
     ctx: IContext,
-    { id, input, permission }: GqlMutationVoteTopicUpdateArgs,
+    { id, input }: GqlMutationVoteTopicUpdateArgs,
   ): Promise<GqlVoteTopicUpdatePayloadWithMeta> {
+    const ctxCommunityId = getCommunityIdFromCtx(ctx);
     this.service.validateTopicInput(input);
 
     return ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
       // 既存 topic を取得し、コミュニティ所属・UPCOMING フェーズを検証
       const existing = await this.service.getTopicWithRelations(ctx, id, tx);
-      if (existing.communityId !== permission.communityId) {
+      if (existing.communityId !== ctxCommunityId) {
         throw new AuthorizationError("TOPIC_NOT_IN_COMMUNITY");
       }
       this.service.validateTopicIsUpcoming(existing);
@@ -242,12 +249,13 @@ export default class VoteUseCase {
 
   async managerDeleteVoteTopic(
     ctx: IContext,
-    { id, permission }: GqlMutationVoteTopicDeleteArgs,
+    { id }: GqlMutationVoteTopicDeleteArgs,
   ): Promise<GqlVoteTopicDeleteSuccess> {
+    const ctxCommunityId = getCommunityIdFromCtx(ctx);
     return ctx.issuer.onlyBelongingCommunity(ctx, async (tx) => {
       // 削除前にコミュニティ所有チェック
       const topic = await this.service.getTopicWithRelations(ctx, id, tx);
-      if (topic.communityId !== permission.communityId) {
+      if (topic.communityId !== ctxCommunityId) {
         throw new AuthorizationError("TOPIC_NOT_IN_COMMUNITY");
       }
       // UPCOMING フェーズのみ削除を許可（OPEN / CLOSED は投票結果保護のためイミュータブル）

--- a/src/presentation/graphql/rules/index.ts
+++ b/src/presentation/graphql/rules/index.ts
@@ -78,23 +78,19 @@ const IsSelf = preExecRule({
 // 🔐 コミュニティのオーナーか
 const IsCommunityOwner = preExecRule({
   error: new AuthorizationError("User must be community owner"),
-})((
-  context: IContext,
-  args: { permission?: { communityId?: string }; communityPermission?: { communityId?: string } },
-) => {
+})((context: IContext) => {
   if (context.isAdmin) return true;
 
-  // Header-driven `context.communityId` is the source of truth — usecases
-  // resolve scope from it, so the authz check must compare ownership
-  // against the SAME id the operation will run under. Trusting
-  // `args.permission` first would let a caller pass authz with one
-  // community while the usecase mutates another.
-  const communityId =
-    context.communityId ?? args.permission?.communityId ?? args.communityPermission?.communityId;
+  // Scope is resolved from the `x-community-id` header — the auth
+  // middleware injects it from the authenticated session, so it's the
+  // only trusted source. Args (`permission` / `communityPermission`)
+  // are deprecated and ignored to keep the authz check and the
+  // operation aligned on the same community.
+  const communityId = context.communityId;
   if (!communityId) {
     logger.warn("IsCommunityOwner authorization FAILED", {
       rule: "IsCommunityOwner",
-      reason: "no_community_id_resolvable",
+      reason: "no_community_id_in_ctx",
     });
     return false;
   }
@@ -116,14 +112,14 @@ const IsCommunityOwner = preExecRule({
 // 🔐 コミュニティマネージャー（OWNER または MANAGER）
 const IsCommunityManager = preExecRule({
   error: new AuthorizationError("User must be community manager or owner"),
-})((context: IContext, args: { permission?: { communityId?: string } }) => {
+})((context: IContext) => {
   if (context.isAdmin) return true;
 
-  const communityId = context.communityId ?? args.permission?.communityId;
+  const communityId = context.communityId;
   if (!communityId) {
     logger.warn("IsCommunityManager authorization FAILED", {
       rule: "IsCommunityManager",
-      reason: "no_community_id_resolvable",
+      reason: "no_community_id_in_ctx",
     });
     return false;
   }
@@ -145,14 +141,14 @@ const IsCommunityManager = preExecRule({
 // 🔐 コミュニティメンバー（OWNER / MANAGER / MEMBER）
 const IsCommunityMember = preExecRule({
   error: new AuthorizationError("User must be a community member"),
-})((context: IContext, args: { permission?: { communityId?: string } }) => {
+})((context: IContext) => {
   if (context.isAdmin) return true;
 
-  const communityId = context.communityId ?? args.permission?.communityId;
+  const communityId = context.communityId;
   if (!communityId) {
     logger.warn("IsCommunityMember authorization FAILED", {
       rule: "IsCommunityMember",
-      reason: "no_community_id_resolvable",
+      reason: "no_community_id_in_ctx",
     });
     return false;
   }

--- a/src/presentation/graphql/rules/index.ts
+++ b/src/presentation/graphql/rules/index.ts
@@ -84,8 +84,13 @@ const IsCommunityOwner = preExecRule({
 ) => {
   if (context.isAdmin) return true;
 
+  // Header-driven `context.communityId` is the source of truth — usecases
+  // resolve scope from it, so the authz check must compare ownership
+  // against the SAME id the operation will run under. Trusting
+  // `args.permission` first would let a caller pass authz with one
+  // community while the usecase mutates another.
   const communityId =
-    args.permission?.communityId ?? args.communityPermission?.communityId ?? context.communityId;
+    context.communityId ?? args.permission?.communityId ?? args.communityPermission?.communityId;
   if (!communityId) {
     logger.warn("IsCommunityOwner authorization FAILED", {
       rule: "IsCommunityOwner",
@@ -114,7 +119,7 @@ const IsCommunityManager = preExecRule({
 })((context: IContext, args: { permission?: { communityId?: string } }) => {
   if (context.isAdmin) return true;
 
-  const communityId = args.permission?.communityId ?? context.communityId;
+  const communityId = context.communityId ?? args.permission?.communityId;
   if (!communityId) {
     logger.warn("IsCommunityManager authorization FAILED", {
       rule: "IsCommunityManager",
@@ -143,7 +148,7 @@ const IsCommunityMember = preExecRule({
 })((context: IContext, args: { permission?: { communityId?: string } }) => {
   if (context.isAdmin) return true;
 
-  const communityId = args.permission?.communityId ?? context.communityId;
+  const communityId = context.communityId ?? args.permission?.communityId;
   if (!communityId) {
     logger.warn("IsCommunityMember authorization FAILED", {
       rule: "IsCommunityMember",

--- a/src/presentation/graphql/rules/index.ts
+++ b/src/presentation/graphql/rules/index.ts
@@ -78,14 +78,18 @@ const IsSelf = preExecRule({
 // 🔐 コミュニティのオーナーか
 const IsCommunityOwner = preExecRule({
   error: new AuthorizationError("User must be community owner"),
-})((context: IContext, args: { permission?: { communityId?: string }; communityPermission?: { communityId?: string } }) => {
+})((
+  context: IContext,
+  args: { permission?: { communityId?: string }; communityPermission?: { communityId?: string } },
+) => {
   if (context.isAdmin) return true;
 
-  const communityId = args.permission?.communityId ?? args.communityPermission?.communityId;
+  const communityId =
+    args.permission?.communityId ?? args.communityPermission?.communityId ?? context.communityId;
   if (!communityId) {
     logger.warn("IsCommunityOwner authorization FAILED", {
       rule: "IsCommunityOwner",
-      reason: "no_community_id_in_args",
+      reason: "no_community_id_resolvable",
     });
     return false;
   }
@@ -110,11 +114,11 @@ const IsCommunityManager = preExecRule({
 })((context: IContext, args: { permission?: { communityId?: string } }) => {
   if (context.isAdmin) return true;
 
-  const communityId = args.permission?.communityId;
+  const communityId = args.permission?.communityId ?? context.communityId;
   if (!communityId) {
     logger.warn("IsCommunityManager authorization FAILED", {
       rule: "IsCommunityManager",
-      reason: "no_community_id_in_permission",
+      reason: "no_community_id_resolvable",
     });
     return false;
   }
@@ -139,11 +143,11 @@ const IsCommunityMember = preExecRule({
 })((context: IContext, args: { permission?: { communityId?: string } }) => {
   if (context.isAdmin) return true;
 
-  const communityId = args.permission?.communityId;
+  const communityId = args.permission?.communityId ?? context.communityId;
   if (!communityId) {
     logger.warn("IsCommunityMember authorization FAILED", {
       rule: "IsCommunityMember",
-      reason: "no_community_id_in_permission",
+      reason: "no_community_id_resolvable",
     });
     return false;
   }

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -2159,20 +2159,20 @@ export type GqlMutationApproveReportArgs = {
 
 export type GqlMutationArticleCreateArgs = {
   input: GqlArticleCreateInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
 export type GqlMutationArticleDeleteArgs = {
   id: Scalars['ID']['input'];
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
 export type GqlMutationArticleUpdateContentArgs = {
   id: Scalars['ID']['input'];
   input: GqlArticleUpdateContentInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
@@ -2183,26 +2183,26 @@ export type GqlMutationCommunityCreateArgs = {
 
 export type GqlMutationCommunityDeleteArgs = {
   id: Scalars['ID']['input'];
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
 export type GqlMutationCommunityUpdateProfileArgs = {
   id: Scalars['ID']['input'];
   input: GqlCommunityUpdateProfileInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
 export type GqlMutationEvaluationBulkCreateArgs = {
   input: GqlEvaluationBulkCreateInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
 export type GqlMutationGenerateReportArgs = {
   input: GqlGenerateReportInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
@@ -2213,7 +2213,7 @@ export type GqlMutationIdentityCheckPhoneUserArgs = {
 
 export type GqlMutationIncentiveGrantRetryArgs = {
   input: GqlIncentiveGrantRetryInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
@@ -2231,25 +2231,25 @@ export type GqlMutationMembershipAcceptMyInvitationArgs = {
 
 export type GqlMutationMembershipAssignManagerArgs = {
   input: GqlMembershipSetRoleInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
 export type GqlMutationMembershipAssignMemberArgs = {
   input: GqlMembershipSetRoleInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
 export type GqlMutationMembershipAssignOwnerArgs = {
   input: GqlMembershipSetRoleInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
 export type GqlMutationMembershipCancelInvitationArgs = {
   input: GqlMembershipSetInvitationStatusInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
@@ -2261,13 +2261,13 @@ export type GqlMutationMembershipDenyMyInvitationArgs = {
 
 export type GqlMutationMembershipInviteArgs = {
   input: GqlMembershipInviteInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
 export type GqlMutationMembershipRemoveArgs = {
   input: GqlMembershipRemoveInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
@@ -2279,7 +2279,7 @@ export type GqlMutationMembershipWithdrawArgs = {
 
 export type GqlMutationOpportunityCreateArgs = {
   input: GqlOpportunityCreateInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
@@ -2325,7 +2325,7 @@ export type GqlMutationOpportunityUpdateContentArgs = {
 
 export type GqlMutationParticipationBulkCreateArgs = {
   input: GqlParticipationBulkCreateInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
@@ -2342,20 +2342,20 @@ export type GqlMutationParticipationDeletePersonalRecordArgs = {
 
 export type GqlMutationPlaceCreateArgs = {
   input: GqlPlaceCreateInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
 export type GqlMutationPlaceDeleteArgs = {
   id: Scalars['ID']['input'];
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
 export type GqlMutationPlaceUpdateArgs = {
   id: Scalars['ID']['input'];
   input: GqlPlaceUpdateInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
@@ -2408,7 +2408,7 @@ export type GqlMutationStorePhoneAuthTokenArgs = {
 
 export type GqlMutationSubmitReportFeedbackArgs = {
   input: GqlSubmitReportFeedbackInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
@@ -2419,13 +2419,13 @@ export type GqlMutationTicketClaimArgs = {
 
 export type GqlMutationTicketIssueArgs = {
   input: GqlTicketIssueInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
 export type GqlMutationTicketPurchaseArgs = {
   input: GqlTicketPurchaseInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
@@ -2450,13 +2450,13 @@ export type GqlMutationTransactionDonateSelfPointArgs = {
 
 export type GqlMutationTransactionGrantCommunityPointArgs = {
   input: GqlTransactionGrantCommunityPointInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
 export type GqlMutationTransactionIssueCommunityPointArgs = {
   input: GqlTransactionIssueCommunityPointInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
@@ -2470,7 +2470,7 @@ export type GqlMutationTransactionUpdateMetadataArgs = {
 
 export type GqlMutationUpdatePortalConfigArgs = {
   input: GqlCommunityPortalConfigInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
@@ -2483,7 +2483,7 @@ export type GqlMutationUpdateReportTemplateArgs = {
 
 export type GqlMutationUpdateSignupBonusConfigArgs = {
   input: GqlUpdateSignupBonusConfigInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
@@ -2505,27 +2505,27 @@ export type GqlMutationUserUpdateMyProfileArgs = {
 
 export type GqlMutationUtilityCreateArgs = {
   input: GqlUtilityCreateInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
 export type GqlMutationUtilityDeleteArgs = {
   id: Scalars['ID']['input'];
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
 export type GqlMutationUtilitySetPublishStatusArgs = {
   id: Scalars['ID']['input'];
   input: GqlUtilitySetPublishStatusInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
 export type GqlMutationUtilityUpdateInfoArgs = {
   id: Scalars['ID']['input'];
   input: GqlUtilityUpdateInfoInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
@@ -2536,20 +2536,20 @@ export type GqlMutationVoteCastArgs = {
 
 export type GqlMutationVoteTopicCreateArgs = {
   input: GqlVoteTopicCreateInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
 export type GqlMutationVoteTopicDeleteArgs = {
   id: Scalars['ID']['input'];
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
 export type GqlMutationVoteTopicUpdateArgs = {
   id: Scalars['ID']['input'];
   input: GqlVoteTopicUpdateInput;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 /** ログインユーザーの投票資格と現状。再投票可能性の判定にも利用する。 */
@@ -3393,7 +3393,7 @@ export type GqlQueryAnalyticsDashboardArgs = {
 
 export type GqlQueryArticleArgs = {
   id: Scalars['ID']['input'];
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
@@ -3525,7 +3525,7 @@ export type GqlQueryOpportunitiesArgs = {
 
 export type GqlQueryOpportunityArgs = {
   id: Scalars['ID']['input'];
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
@@ -3651,7 +3651,7 @@ export type GqlQueryReportsArgs = {
   communityId: Scalars['ID']['input'];
   cursor?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
   status?: InputMaybe<GqlReportStatus>;
   variant?: InputMaybe<GqlReportVariant>;
 };
@@ -3794,7 +3794,7 @@ export type GqlQueryUtilitiesArgs = {
 
 export type GqlQueryUtilityArgs = {
   id: Scalars['ID']['input'];
-  permission: GqlCheckCommunityPermissionInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
 };
 
 
@@ -6966,40 +6966,40 @@ export type GqlMembershipsConnectionResolvers<ContextType = any, ParentType exte
 
 export type GqlMutationResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Mutation'] = GqlResolversParentTypes['Mutation']> = ResolversObject<{
   approveReport?: Resolver<Maybe<GqlResolversTypes['ApproveReportPayload']>, ParentType, ContextType, RequireFields<GqlMutationApproveReportArgs, 'id'>>;
-  articleCreate?: Resolver<Maybe<GqlResolversTypes['ArticleCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationArticleCreateArgs, 'input' | 'permission'>>;
-  articleDelete?: Resolver<Maybe<GqlResolversTypes['ArticleDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationArticleDeleteArgs, 'id' | 'permission'>>;
-  articleUpdateContent?: Resolver<Maybe<GqlResolversTypes['ArticleUpdateContentPayload']>, ParentType, ContextType, RequireFields<GqlMutationArticleUpdateContentArgs, 'id' | 'input' | 'permission'>>;
+  articleCreate?: Resolver<Maybe<GqlResolversTypes['ArticleCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationArticleCreateArgs, 'input'>>;
+  articleDelete?: Resolver<Maybe<GqlResolversTypes['ArticleDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationArticleDeleteArgs, 'id'>>;
+  articleUpdateContent?: Resolver<Maybe<GqlResolversTypes['ArticleUpdateContentPayload']>, ParentType, ContextType, RequireFields<GqlMutationArticleUpdateContentArgs, 'id' | 'input'>>;
   communityCreate?: Resolver<Maybe<GqlResolversTypes['CommunityCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationCommunityCreateArgs, 'input'>>;
-  communityDelete?: Resolver<Maybe<GqlResolversTypes['CommunityDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationCommunityDeleteArgs, 'id' | 'permission'>>;
-  communityUpdateProfile?: Resolver<Maybe<GqlResolversTypes['CommunityUpdateProfilePayload']>, ParentType, ContextType, RequireFields<GqlMutationCommunityUpdateProfileArgs, 'id' | 'input' | 'permission'>>;
-  evaluationBulkCreate?: Resolver<Maybe<GqlResolversTypes['EvaluationBulkCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationEvaluationBulkCreateArgs, 'input' | 'permission'>>;
-  generateReport?: Resolver<Maybe<GqlResolversTypes['GenerateReportPayload']>, ParentType, ContextType, RequireFields<GqlMutationGenerateReportArgs, 'input' | 'permission'>>;
+  communityDelete?: Resolver<Maybe<GqlResolversTypes['CommunityDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationCommunityDeleteArgs, 'id'>>;
+  communityUpdateProfile?: Resolver<Maybe<GqlResolversTypes['CommunityUpdateProfilePayload']>, ParentType, ContextType, RequireFields<GqlMutationCommunityUpdateProfileArgs, 'id' | 'input'>>;
+  evaluationBulkCreate?: Resolver<Maybe<GqlResolversTypes['EvaluationBulkCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationEvaluationBulkCreateArgs, 'input'>>;
+  generateReport?: Resolver<Maybe<GqlResolversTypes['GenerateReportPayload']>, ParentType, ContextType, RequireFields<GqlMutationGenerateReportArgs, 'input'>>;
   identityCheckPhoneUser?: Resolver<GqlResolversTypes['IdentityCheckPhoneUserPayload'], ParentType, ContextType, RequireFields<GqlMutationIdentityCheckPhoneUserArgs, 'input'>>;
-  incentiveGrantRetry?: Resolver<Maybe<GqlResolversTypes['IncentiveGrantRetryPayload']>, ParentType, ContextType, RequireFields<GqlMutationIncentiveGrantRetryArgs, 'input' | 'permission'>>;
+  incentiveGrantRetry?: Resolver<Maybe<GqlResolversTypes['IncentiveGrantRetryPayload']>, ParentType, ContextType, RequireFields<GqlMutationIncentiveGrantRetryArgs, 'input'>>;
   linkPhoneAuth?: Resolver<Maybe<GqlResolversTypes['LinkPhoneAuthPayload']>, ParentType, ContextType, RequireFields<GqlMutationLinkPhoneAuthArgs, 'input' | 'permission'>>;
   membershipAcceptMyInvitation?: Resolver<Maybe<GqlResolversTypes['MembershipSetInvitationStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationMembershipAcceptMyInvitationArgs, 'input' | 'permission'>>;
-  membershipAssignManager?: Resolver<Maybe<GqlResolversTypes['MembershipSetRolePayload']>, ParentType, ContextType, RequireFields<GqlMutationMembershipAssignManagerArgs, 'input' | 'permission'>>;
-  membershipAssignMember?: Resolver<Maybe<GqlResolversTypes['MembershipSetRolePayload']>, ParentType, ContextType, RequireFields<GqlMutationMembershipAssignMemberArgs, 'input' | 'permission'>>;
-  membershipAssignOwner?: Resolver<Maybe<GqlResolversTypes['MembershipSetRolePayload']>, ParentType, ContextType, RequireFields<GqlMutationMembershipAssignOwnerArgs, 'input' | 'permission'>>;
-  membershipCancelInvitation?: Resolver<Maybe<GqlResolversTypes['MembershipSetInvitationStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationMembershipCancelInvitationArgs, 'input' | 'permission'>>;
+  membershipAssignManager?: Resolver<Maybe<GqlResolversTypes['MembershipSetRolePayload']>, ParentType, ContextType, RequireFields<GqlMutationMembershipAssignManagerArgs, 'input'>>;
+  membershipAssignMember?: Resolver<Maybe<GqlResolversTypes['MembershipSetRolePayload']>, ParentType, ContextType, RequireFields<GqlMutationMembershipAssignMemberArgs, 'input'>>;
+  membershipAssignOwner?: Resolver<Maybe<GqlResolversTypes['MembershipSetRolePayload']>, ParentType, ContextType, RequireFields<GqlMutationMembershipAssignOwnerArgs, 'input'>>;
+  membershipCancelInvitation?: Resolver<Maybe<GqlResolversTypes['MembershipSetInvitationStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationMembershipCancelInvitationArgs, 'input'>>;
   membershipDenyMyInvitation?: Resolver<Maybe<GqlResolversTypes['MembershipSetInvitationStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationMembershipDenyMyInvitationArgs, 'input' | 'permission'>>;
-  membershipInvite?: Resolver<Maybe<GqlResolversTypes['MembershipInvitePayload']>, ParentType, ContextType, RequireFields<GqlMutationMembershipInviteArgs, 'input' | 'permission'>>;
-  membershipRemove?: Resolver<Maybe<GqlResolversTypes['MembershipRemovePayload']>, ParentType, ContextType, RequireFields<GqlMutationMembershipRemoveArgs, 'input' | 'permission'>>;
+  membershipInvite?: Resolver<Maybe<GqlResolversTypes['MembershipInvitePayload']>, ParentType, ContextType, RequireFields<GqlMutationMembershipInviteArgs, 'input'>>;
+  membershipRemove?: Resolver<Maybe<GqlResolversTypes['MembershipRemovePayload']>, ParentType, ContextType, RequireFields<GqlMutationMembershipRemoveArgs, 'input'>>;
   membershipWithdraw?: Resolver<Maybe<GqlResolversTypes['MembershipWithdrawPayload']>, ParentType, ContextType, RequireFields<GqlMutationMembershipWithdrawArgs, 'input' | 'permission'>>;
   mutationEcho?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
-  opportunityCreate?: Resolver<Maybe<GqlResolversTypes['OpportunityCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationOpportunityCreateArgs, 'input' | 'permission'>>;
+  opportunityCreate?: Resolver<Maybe<GqlResolversTypes['OpportunityCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationOpportunityCreateArgs, 'input'>>;
   opportunityDelete?: Resolver<Maybe<GqlResolversTypes['OpportunityDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationOpportunityDeleteArgs, 'id' | 'permission'>>;
   opportunitySetPublishStatus?: Resolver<Maybe<GqlResolversTypes['OpportunitySetPublishStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationOpportunitySetPublishStatusArgs, 'id' | 'input' | 'permission'>>;
   opportunitySlotCreate?: Resolver<Maybe<GqlResolversTypes['OpportunitySlotCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationOpportunitySlotCreateArgs, 'input' | 'opportunityId' | 'permission'>>;
   opportunitySlotSetHostingStatus?: Resolver<Maybe<GqlResolversTypes['OpportunitySlotSetHostingStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationOpportunitySlotSetHostingStatusArgs, 'id' | 'input' | 'permission'>>;
   opportunitySlotsBulkUpdate?: Resolver<Maybe<GqlResolversTypes['OpportunitySlotsBulkUpdatePayload']>, ParentType, ContextType, RequireFields<GqlMutationOpportunitySlotsBulkUpdateArgs, 'input' | 'permission'>>;
   opportunityUpdateContent?: Resolver<Maybe<GqlResolversTypes['OpportunityUpdateContentPayload']>, ParentType, ContextType, RequireFields<GqlMutationOpportunityUpdateContentArgs, 'id' | 'input' | 'permission'>>;
-  participationBulkCreate?: Resolver<Maybe<GqlResolversTypes['ParticipationBulkCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationParticipationBulkCreateArgs, 'input' | 'permission'>>;
+  participationBulkCreate?: Resolver<Maybe<GqlResolversTypes['ParticipationBulkCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationParticipationBulkCreateArgs, 'input'>>;
   participationCreatePersonalRecord?: Resolver<Maybe<GqlResolversTypes['ParticipationCreatePersonalRecordPayload']>, ParentType, ContextType, RequireFields<GqlMutationParticipationCreatePersonalRecordArgs, 'input'>>;
   participationDeletePersonalRecord?: Resolver<Maybe<GqlResolversTypes['ParticipationDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationParticipationDeletePersonalRecordArgs, 'id' | 'permission'>>;
-  placeCreate?: Resolver<Maybe<GqlResolversTypes['PlaceCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationPlaceCreateArgs, 'input' | 'permission'>>;
-  placeDelete?: Resolver<Maybe<GqlResolversTypes['PlaceDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationPlaceDeleteArgs, 'id' | 'permission'>>;
-  placeUpdate?: Resolver<Maybe<GqlResolversTypes['PlaceUpdatePayload']>, ParentType, ContextType, RequireFields<GqlMutationPlaceUpdateArgs, 'id' | 'input' | 'permission'>>;
+  placeCreate?: Resolver<Maybe<GqlResolversTypes['PlaceCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationPlaceCreateArgs, 'input'>>;
+  placeDelete?: Resolver<Maybe<GqlResolversTypes['PlaceDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationPlaceDeleteArgs, 'id'>>;
+  placeUpdate?: Resolver<Maybe<GqlResolversTypes['PlaceUpdatePayload']>, ParentType, ContextType, RequireFields<GqlMutationPlaceUpdateArgs, 'id' | 'input'>>;
   publishReport?: Resolver<Maybe<GqlResolversTypes['PublishReportPayload']>, ParentType, ContextType, RequireFields<GqlMutationPublishReportArgs, 'finalContent' | 'id'>>;
   rejectReport?: Resolver<Maybe<GqlResolversTypes['RejectReportPayload']>, ParentType, ContextType, RequireFields<GqlMutationRejectReportArgs, 'id'>>;
   reservationAccept?: Resolver<Maybe<GqlResolversTypes['ReservationSetStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationReservationAcceptArgs, 'id' | 'permission'>>;
@@ -7008,30 +7008,30 @@ export type GqlMutationResolvers<ContextType = any, ParentType extends GqlResolv
   reservationJoin?: Resolver<Maybe<GqlResolversTypes['ReservationSetStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationReservationJoinArgs, 'id'>>;
   reservationReject?: Resolver<Maybe<GqlResolversTypes['ReservationSetStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationReservationRejectArgs, 'id' | 'input' | 'permission'>>;
   storePhoneAuthToken?: Resolver<Maybe<GqlResolversTypes['StorePhoneAuthTokenPayload']>, ParentType, ContextType, RequireFields<GqlMutationStorePhoneAuthTokenArgs, 'input' | 'permission'>>;
-  submitReportFeedback?: Resolver<Maybe<GqlResolversTypes['SubmitReportFeedbackPayload']>, ParentType, ContextType, RequireFields<GqlMutationSubmitReportFeedbackArgs, 'input' | 'permission'>>;
+  submitReportFeedback?: Resolver<Maybe<GqlResolversTypes['SubmitReportFeedbackPayload']>, ParentType, ContextType, RequireFields<GqlMutationSubmitReportFeedbackArgs, 'input'>>;
   ticketClaim?: Resolver<Maybe<GqlResolversTypes['TicketClaimPayload']>, ParentType, ContextType, RequireFields<GqlMutationTicketClaimArgs, 'input'>>;
-  ticketIssue?: Resolver<Maybe<GqlResolversTypes['TicketIssuePayload']>, ParentType, ContextType, RequireFields<GqlMutationTicketIssueArgs, 'input' | 'permission'>>;
-  ticketPurchase?: Resolver<Maybe<GqlResolversTypes['TicketPurchasePayload']>, ParentType, ContextType, RequireFields<GqlMutationTicketPurchaseArgs, 'input' | 'permission'>>;
+  ticketIssue?: Resolver<Maybe<GqlResolversTypes['TicketIssuePayload']>, ParentType, ContextType, RequireFields<GqlMutationTicketIssueArgs, 'input'>>;
+  ticketPurchase?: Resolver<Maybe<GqlResolversTypes['TicketPurchasePayload']>, ParentType, ContextType, RequireFields<GqlMutationTicketPurchaseArgs, 'input'>>;
   ticketRefund?: Resolver<Maybe<GqlResolversTypes['TicketRefundPayload']>, ParentType, ContextType, RequireFields<GqlMutationTicketRefundArgs, 'id' | 'input' | 'permission'>>;
   ticketUse?: Resolver<Maybe<GqlResolversTypes['TicketUsePayload']>, ParentType, ContextType, RequireFields<GqlMutationTicketUseArgs, 'id' | 'permission'>>;
   transactionDonateSelfPoint?: Resolver<Maybe<GqlResolversTypes['TransactionDonateSelfPointPayload']>, ParentType, ContextType, RequireFields<GqlMutationTransactionDonateSelfPointArgs, 'input' | 'permission'>>;
-  transactionGrantCommunityPoint?: Resolver<Maybe<GqlResolversTypes['TransactionGrantCommunityPointPayload']>, ParentType, ContextType, RequireFields<GqlMutationTransactionGrantCommunityPointArgs, 'input' | 'permission'>>;
-  transactionIssueCommunityPoint?: Resolver<Maybe<GqlResolversTypes['TransactionIssueCommunityPointPayload']>, ParentType, ContextType, RequireFields<GqlMutationTransactionIssueCommunityPointArgs, 'input' | 'permission'>>;
+  transactionGrantCommunityPoint?: Resolver<Maybe<GqlResolversTypes['TransactionGrantCommunityPointPayload']>, ParentType, ContextType, RequireFields<GqlMutationTransactionGrantCommunityPointArgs, 'input'>>;
+  transactionIssueCommunityPoint?: Resolver<Maybe<GqlResolversTypes['TransactionIssueCommunityPointPayload']>, ParentType, ContextType, RequireFields<GqlMutationTransactionIssueCommunityPointArgs, 'input'>>;
   transactionUpdateMetadata?: Resolver<Maybe<GqlResolversTypes['TransactionUpdateMetadataPayload']>, ParentType, ContextType, RequireFields<GqlMutationTransactionUpdateMetadataArgs, 'id' | 'input'>>;
-  updatePortalConfig?: Resolver<GqlResolversTypes['CommunityPortalConfig'], ParentType, ContextType, RequireFields<GqlMutationUpdatePortalConfigArgs, 'input' | 'permission'>>;
+  updatePortalConfig?: Resolver<GqlResolversTypes['CommunityPortalConfig'], ParentType, ContextType, RequireFields<GqlMutationUpdatePortalConfigArgs, 'input'>>;
   updateReportTemplate?: Resolver<Maybe<GqlResolversTypes['UpdateReportTemplatePayload']>, ParentType, ContextType, RequireFields<GqlMutationUpdateReportTemplateArgs, 'input' | 'variant'>>;
-  updateSignupBonusConfig?: Resolver<GqlResolversTypes['CommunitySignupBonusConfig'], ParentType, ContextType, RequireFields<GqlMutationUpdateSignupBonusConfigArgs, 'input' | 'permission'>>;
+  updateSignupBonusConfig?: Resolver<GqlResolversTypes['CommunitySignupBonusConfig'], ParentType, ContextType, RequireFields<GqlMutationUpdateSignupBonusConfigArgs, 'input'>>;
   userDeleteMe?: Resolver<Maybe<GqlResolversTypes['UserDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationUserDeleteMeArgs, 'permission'>>;
   userSignUp?: Resolver<Maybe<GqlResolversTypes['CurrentUserPayload']>, ParentType, ContextType, RequireFields<GqlMutationUserSignUpArgs, 'input'>>;
   userUpdateMyProfile?: Resolver<Maybe<GqlResolversTypes['UserUpdateProfilePayload']>, ParentType, ContextType, RequireFields<GqlMutationUserUpdateMyProfileArgs, 'input' | 'permission'>>;
-  utilityCreate?: Resolver<Maybe<GqlResolversTypes['UtilityCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationUtilityCreateArgs, 'input' | 'permission'>>;
-  utilityDelete?: Resolver<Maybe<GqlResolversTypes['UtilityDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationUtilityDeleteArgs, 'id' | 'permission'>>;
-  utilitySetPublishStatus?: Resolver<Maybe<GqlResolversTypes['UtilitySetPublishStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationUtilitySetPublishStatusArgs, 'id' | 'input' | 'permission'>>;
-  utilityUpdateInfo?: Resolver<Maybe<GqlResolversTypes['UtilityUpdateInfoPayload']>, ParentType, ContextType, RequireFields<GqlMutationUtilityUpdateInfoArgs, 'id' | 'input' | 'permission'>>;
+  utilityCreate?: Resolver<Maybe<GqlResolversTypes['UtilityCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationUtilityCreateArgs, 'input'>>;
+  utilityDelete?: Resolver<Maybe<GqlResolversTypes['UtilityDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationUtilityDeleteArgs, 'id'>>;
+  utilitySetPublishStatus?: Resolver<Maybe<GqlResolversTypes['UtilitySetPublishStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationUtilitySetPublishStatusArgs, 'id' | 'input'>>;
+  utilityUpdateInfo?: Resolver<Maybe<GqlResolversTypes['UtilityUpdateInfoPayload']>, ParentType, ContextType, RequireFields<GqlMutationUtilityUpdateInfoArgs, 'id' | 'input'>>;
   voteCast?: Resolver<GqlResolversTypes['VoteCastPayload'], ParentType, ContextType, RequireFields<GqlMutationVoteCastArgs, 'input'>>;
-  voteTopicCreate?: Resolver<GqlResolversTypes['VoteTopicCreatePayload'], ParentType, ContextType, RequireFields<GqlMutationVoteTopicCreateArgs, 'input' | 'permission'>>;
-  voteTopicDelete?: Resolver<GqlResolversTypes['VoteTopicDeletePayload'], ParentType, ContextType, RequireFields<GqlMutationVoteTopicDeleteArgs, 'id' | 'permission'>>;
-  voteTopicUpdate?: Resolver<GqlResolversTypes['VoteTopicUpdatePayload'], ParentType, ContextType, RequireFields<GqlMutationVoteTopicUpdateArgs, 'id' | 'input' | 'permission'>>;
+  voteTopicCreate?: Resolver<GqlResolversTypes['VoteTopicCreatePayload'], ParentType, ContextType, RequireFields<GqlMutationVoteTopicCreateArgs, 'input'>>;
+  voteTopicDelete?: Resolver<GqlResolversTypes['VoteTopicDeletePayload'], ParentType, ContextType, RequireFields<GqlMutationVoteTopicDeleteArgs, 'id'>>;
+  voteTopicUpdate?: Resolver<GqlResolversTypes['VoteTopicUpdatePayload'], ParentType, ContextType, RequireFields<GqlMutationVoteTopicUpdateArgs, 'id' | 'input'>>;
 }>;
 
 export type GqlMyVoteEligibilityResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['MyVoteEligibility'] = GqlResolversParentTypes['MyVoteEligibility']> = ResolversObject<{
@@ -7435,7 +7435,7 @@ export type GqlPublishReportSuccessResolvers<ContextType = any, ParentType exten
 export type GqlQueryResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Query'] = GqlResolversParentTypes['Query']> = ResolversObject<{
   analyticsCommunity?: Resolver<GqlResolversTypes['AnalyticsCommunityPayload'], ParentType, ContextType, RequireFields<GqlQueryAnalyticsCommunityArgs, 'input'>>;
   analyticsDashboard?: Resolver<GqlResolversTypes['AnalyticsDashboardPayload'], ParentType, ContextType, Partial<GqlQueryAnalyticsDashboardArgs>>;
-  article?: Resolver<Maybe<GqlResolversTypes['Article']>, ParentType, ContextType, RequireFields<GqlQueryArticleArgs, 'id' | 'permission'>>;
+  article?: Resolver<Maybe<GqlResolversTypes['Article']>, ParentType, ContextType, RequireFields<GqlQueryArticleArgs, 'id'>>;
   articles?: Resolver<GqlResolversTypes['ArticlesConnection'], ParentType, ContextType, Partial<GqlQueryArticlesArgs>>;
   cities?: Resolver<GqlResolversTypes['CitiesConnection'], ParentType, ContextType, Partial<GqlQueryCitiesArgs>>;
   communities?: Resolver<GqlResolversTypes['CommunitiesConnection'], ParentType, ContextType, Partial<GqlQueryCommunitiesArgs>>;
@@ -7458,7 +7458,7 @@ export type GqlQueryResolvers<ContextType = any, ParentType extends GqlResolvers
   nftToken?: Resolver<Maybe<GqlResolversTypes['NftToken']>, ParentType, ContextType, RequireFields<GqlQueryNftTokenArgs, 'id'>>;
   nftTokens?: Resolver<GqlResolversTypes['NftTokensConnection'], ParentType, ContextType, Partial<GqlQueryNftTokensArgs>>;
   opportunities?: Resolver<GqlResolversTypes['OpportunitiesConnection'], ParentType, ContextType, Partial<GqlQueryOpportunitiesArgs>>;
-  opportunity?: Resolver<Maybe<GqlResolversTypes['Opportunity']>, ParentType, ContextType, RequireFields<GqlQueryOpportunityArgs, 'id' | 'permission'>>;
+  opportunity?: Resolver<Maybe<GqlResolversTypes['Opportunity']>, ParentType, ContextType, RequireFields<GqlQueryOpportunityArgs, 'id'>>;
   opportunitySlot?: Resolver<Maybe<GqlResolversTypes['OpportunitySlot']>, ParentType, ContextType, RequireFields<GqlQueryOpportunitySlotArgs, 'id'>>;
   opportunitySlots?: Resolver<GqlResolversTypes['OpportunitySlotsConnection'], ParentType, ContextType, Partial<GqlQueryOpportunitySlotsArgs>>;
   participation?: Resolver<Maybe<GqlResolversTypes['Participation']>, ParentType, ContextType, RequireFields<GqlQueryParticipationArgs, 'id'>>;
@@ -7476,7 +7476,7 @@ export type GqlQueryResolvers<ContextType = any, ParentType extends GqlResolvers
   reportTemplateStats?: Resolver<GqlResolversTypes['ReportTemplateStats'], ParentType, ContextType, RequireFields<GqlQueryReportTemplateStatsArgs, 'variant'>>;
   reportTemplateStatsBreakdown?: Resolver<GqlResolversTypes['ReportTemplateStatsBreakdownConnection'], ParentType, ContextType, RequireFields<GqlQueryReportTemplateStatsBreakdownArgs, 'first' | 'includeInactive' | 'kind' | 'variant'>>;
   reportTemplates?: Resolver<Array<GqlResolversTypes['ReportTemplate']>, ParentType, ContextType, RequireFields<GqlQueryReportTemplatesArgs, 'includeInactive' | 'kind' | 'variant'>>;
-  reports?: Resolver<GqlResolversTypes['ReportsConnection'], ParentType, ContextType, RequireFields<GqlQueryReportsArgs, 'communityId' | 'permission'>>;
+  reports?: Resolver<GqlResolversTypes['ReportsConnection'], ParentType, ContextType, RequireFields<GqlQueryReportsArgs, 'communityId'>>;
   reportsAll?: Resolver<GqlResolversTypes['ReportsConnection'], ParentType, ContextType, Partial<GqlQueryReportsAllArgs>>;
   reservation?: Resolver<Maybe<GqlResolversTypes['Reservation']>, ParentType, ContextType, RequireFields<GqlQueryReservationArgs, 'id'>>;
   reservationHistories?: Resolver<GqlResolversTypes['ReservationHistoriesConnection'], ParentType, ContextType, Partial<GqlQueryReservationHistoriesArgs>>;
@@ -7497,7 +7497,7 @@ export type GqlQueryResolvers<ContextType = any, ParentType extends GqlResolvers
   user?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType, RequireFields<GqlQueryUserArgs, 'id'>>;
   users?: Resolver<GqlResolversTypes['UsersConnection'], ParentType, ContextType, Partial<GqlQueryUsersArgs>>;
   utilities?: Resolver<GqlResolversTypes['UtilitiesConnection'], ParentType, ContextType, Partial<GqlQueryUtilitiesArgs>>;
-  utility?: Resolver<Maybe<GqlResolversTypes['Utility']>, ParentType, ContextType, RequireFields<GqlQueryUtilityArgs, 'id' | 'permission'>>;
+  utility?: Resolver<Maybe<GqlResolversTypes['Utility']>, ParentType, ContextType, RequireFields<GqlQueryUtilityArgs, 'id'>>;
   vcIssuanceRequest?: Resolver<Maybe<GqlResolversTypes['VcIssuanceRequest']>, ParentType, ContextType, RequireFields<GqlQueryVcIssuanceRequestArgs, 'id'>>;
   vcIssuanceRequests?: Resolver<GqlResolversTypes['VcIssuanceRequestsConnection'], ParentType, ContextType, Partial<GqlQueryVcIssuanceRequestsArgs>>;
   verifyTransactions?: Resolver<Maybe<Array<GqlResolversTypes['TransactionVerificationResult']>>, ParentType, ContextType, RequireFields<GqlQueryVerifyTransactionsArgs, 'txIds'>>;


### PR DESCRIPTION
## なぜ

レポート系の操作（`approveReport` / `publishReport` / `rejectReport` / 単体 `report` 取得）が `IsAdmin` だけで gate されていて、コミュニティオーナーが自コミュニティのレポートを承認/公開/却下できなかった。さらに参照系クエリも全て IsAdmin 縛りで、owner が自コミュニティのテンプレートやフィードバックを見られなかった。

合わせて、コミュニティ単位の操作で長らく引きずってる `permission: CheckCommunityPermissionInput` 引数を整理した。フロントエンドは認証セッションから `x-community-id` ヘッダを差し込んでいるので、この情報源 1 つに寄せたほうが安全で簡潔。

## なに

### 1. authz と usecase を `ctx.communityId` に統一

- `IsCommunityOwner` / `IsCommunityManager` / `IsCommunityMember` ルールは **`ctx.communityId` のみ**を読む（args.permission フォールバック削除）。`x-community-id` ヘッダは auth ミドルウェアで必須化されてるので欠落しない。引数で渡された communityId を信頼するパスがなくなったので、「ヘッダと引数で別の id を送って authz を擦り抜ける」筋がそもそも存在しなくなる。
- 14 ドメインの usecase で `permission.communityId` 参照を削除し、`getCommunityIdFromCtx(ctx)` 経由で `ctx.communityId` に統一（vote / report / account/community(+config) / account/membership / content/article / location/place / reward/utility(+ticket) / transaction(+incentiveGrant) / experience/opportunity(+evaluation/participation)）。
- `permission.communityId !== input.communityId` の冗長なクロスチェックは ctx ベースに置換または削除。

### 2. `permission: CheckCommunityPermissionInput` を `@deprecated` 化

- 全 38 箇所のスキーマで `permission: CheckCommunityPermissionInput!` → `CheckCommunityPermissionInput @deprecated(reason: ...)` に変更（required → optional は GraphQL 的に後方互換）。
- 既存クライアントが送り続けても壊れない、ただ無視される。後続 PR で完全削除。
- `transaction.userUpdateTransactionMetadata` の `communityPermission` も同様。owner-mode/self-mode の判別はクライアント明示に頼らず、usecase 内で「ctx.communityId のオーナーかつ txn が当該コミュニティウォレット発」なら owner-mode、そうでなく「自分が txn 作成者」なら self-mode、と自動判別する形にした。

### 3. レポート系の Query / Mutation を IsCommunityOwner に開放

`IsAdmin` → `IsCommunityOwner OR IsAdmin` に切替（Query は全部、Mutation は read-only 系を除く approve/publish/reject）：

**Mutation（書き込み・状態遷移）** — usecase 側で `assertReportInScope` により `report.communityId === ctx.communityId` を非 admin に対して必ず検証。
- `approveReport`
- `publishReport`
- `rejectReport`

**Query（参照系）** — read-only。owner が自コミュニティのテンプレート/フィードバック/集計を確認できる。秘匿情報はない前提で全開放。
- `report(id)`
- `reportTemplate` / `reportTemplates`（プロンプト定義）
- `reportTemplateStats` / `reportTemplateStatsBreakdown`（A/B メトリクス）
- `reportTemplateFeedbacks` / `reportTemplateFeedbackStats`（フィードバック）
- `reportsAll` / `reportSummaries`（cross-community ビュー）

approve/publish/reject は `ctx.issuer.admin` → `ctx.issuer.onlyBelongingCommunity` に切替（t_reports の RLS は membership ベースなのでオーナーでも通る、admin は従来どおり bypass）。

**`IsAdmin` のまま据え置き**：
- `updateReportTemplate`（mutation）— プロンプト書き換えは全コミュニティに影響するので owner には開けない

### 4. ヘルパー追加

`src/application/domain/utils.ts` に `getCommunityIdFromCtx(ctx)` を追加。バッチ等で空コンテキストが渡る経路に備えて明示的にガード。

## 進捗カウント (grep ベース)

このPRで変えた箇所が「全体に対して何%カバーできているか」を可視化したもの。

### GraphQL スキーマ — `CheckCommunityPermissionInput` 引数

| 項目 | 件数 |
|---|---|
| 引数として宣言されている総数（型定義行を除く） | **38** |
| `@deprecated` 付与済み | **38** ✅ (100%) |

確認コマンド:
```sh
grep -rE "permission: CheckCommunityPermissionInput|communityPermission: CheckCommunityPermissionInput" src --include="*.graphql" | wc -l
grep -rA3 "CheckCommunityPermissionInput$" src --include="*.graphql" | grep -c "@deprecated"
```

### Backend usecase — 引数経由の community 取得

| 項目 | 件数 |
|---|---|
| `permission.communityId` / `communityPermission.communityId` の参照 | **0** ✅ |
| `getCommunityIdFromCtx` を使う usecase ファイル数 | **11** |

確認コマンド:
```sh
grep -rE "permission\.communityId|permission\?\.communityId|communityPermission\.communityId|communityPermission\?\.communityId" src/application --include="*.ts" | wc -l
```

### AuthZ rules — `presentation/graphql/rules/index.ts`

| 項目 | 件数 |
|---|---|
| コミュニティ系ルール総数（Owner / Manager / Member） | **3** |
| `args.permission?.communityId` を参照しているルール | **0** ✅ |
| `ctx.communityId` のみを参照しているルール | **3** ✅ (100%) |

`IsSelf` / `CanManageOpportunity` は別の `Check*PermissionInput` を使う仕様（`userId` / `opportunityId`）なのでこのPRの対象外。

### レポート系の権限ゲート

| 項目 | 件数 |
|---|---|
| `IsCommunityOwner OR IsAdmin` に開放したもの（query 8 + mutation 4 = report系の参照/状態遷移系すべて） | **12** |
| `IsAdmin` のまま据え置き（書き込み系・全コミュ影響） | **1** (`updateReportTemplate`) |

確認コマンド:
```sh
grep -E "@authz" src/application/domain/report/schema/*.graphql
```

## テスト

- [x] `pnpm gql:generate` 成功
- [x] `npx tsc --noEmit` 本体コードはエラーなし
- [x] `npx eslint src/` クリーン
- [x] `pnpm test`（unit, --runInBand）→ **723 passed / 0 failed**
- [x] `pnpm test src/__tests__/unit/report` → **192 passed / 0 failed**
- [x] e2e / integration / auth テストの ctx 構築箇所に `communityId` を追加（migrate された usecase を呼ぶテストのみ）。`vote*` の「permission ≠ input」エラーケースは ctx を不一致側に置く形に書き直し
- [ ] e2e / integration / auth は CI で確認

## 互換性

- GraphQL: 既存クライアント（`permission` を送ってる側）は壊れない。required → optional 化のみで、引数の値は **無視される**
- フロント側の対応: 段階的に `permission` 送信をやめてヘッダ送信に統一（このPRをマージすれば送らなくても動く）
- `permission` 引数の完全削除は別PR

## 残タスク（フォローアップ）

- `permission` 引数の完全削除（クライアント移行完了後）
- `Report.template` フィールドリゾルバー（`controller/resolver.ts:70` の admin チェック）はオーナーに見せる必要がないので据え置き — 必要になったら別PRで開放

https://claude.ai/code/session_015Q9cMGYD34tXCoEGSLv3BB