### PR TITLE
fix(ci): extract canary tag URL with jq instead of gcloud projection

### DIFF
--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -332,10 +332,12 @@ jobs:
           # ら canary tag のものを取る (リージョン固有の `canary---SERVICE-...`
           # ホスト名が返る)。
           # `gcloud run services describe` は `--filter` 非対応なので、
-          # projection 側の `.filter()` で canary tag だけ抽出する。
+          # `--format=json` で status.traffic を取り出して `jq` で canary tag の
+          # URL を抽出する (projection チェーンより読みやすく debug しやすい)。
           CANARY_URL=$(gcloud run services describe "${APPLICATION_NAME}" \
             --region="${GCP_REGION}" \
-            --format='value(status.traffic.filter("tag:canary").extract(url).flatten())' \
+            --format='json(status.traffic)' \
+            | jq -r '.status.traffic[] | select(.tag == "canary") | .url' \
             | head -n 1)
           if [ -z "${CANARY_URL}" ]; then
             echo "Could not resolve canary tag URL" >&2


### PR DESCRIPTION
## Summary
- Copilot のレビュー指摘を反映し、Cloud Run の canary tag URL 取得を `gcloud --format` の projection チェーン (`.filter().extract().flatten()`) から `--format=json(status.traffic)` + `jq` に変更
- projection チェーンは gcloud のバージョン差分に対して壊れやすく読みづらいため、ワークフローで既に利用している `jq` で `tag == "canary"` の URL を抽出する形に揃えて可読性とデバッグ容易性を向上

## Test plan
- [ ] canary 有効な deploy で `Smoke test canary tag URL` ステップが canary URL を解決できることを確認
- [ ] `/health` への smoke test が成功することを確認

https://claude.ai/code/session_01YSjewi1DW1Y9dJPv61wCfT

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSjewi1DW1Y9dJPv61wCfT)_