### PR TITLE
fix(report): unblock golden CI + cut coverage false-positives + dedup highlight quotes

### DIFF
--- a/scripts/ci/run-golden-cases.ts
+++ b/scripts/ci/run-golden-cases.ts
@@ -4,7 +4,7 @@ import { container } from "tsyringe";
 import { prismaClient } from "@/infrastructure/prisma/client";
 import { AnthropicLlmClient } from "@/infrastructure/libs/llm";
 import ReportService from "@/application/domain/report/service";
-import ReportJudgeService from "@/application/domain/report/judgeService";
+import ReportJudgeService from "@/application/domain/report/template/judgeService";
 import ReportRepository from "@/application/domain/report/data/repository";
 import { renderPromptTemplate } from "@/application/domain/report/util/promptRenderer";
 import { analyzeCoverage } from "@/application/domain/report/util/coverage";
@@ -144,15 +144,16 @@ async function runOneCase(
     };
   }
 
-  const template = pinnedVersion !== null
-    ? await service.getTemplateByVersion(
-        ctx,
-        goldenCase.variant,
-        ReportTemplateKind.GENERATION,
-        pinnedVersion,
-        null,
-      )
-    : await service.getTemplate(ctx, goldenCase.variant, null);
+  const template =
+    pinnedVersion !== null
+      ? await service.getTemplateByVersion(
+          ctx,
+          goldenCase.variant,
+          ReportTemplateKind.GENERATION,
+          pinnedVersion,
+          null,
+        )
+      : await service.getTemplate(ctx, goldenCase.variant, null);
   if (!template) {
     // When no version is pinned, `service.getTemplate` filters by
     // isActive=true, so surface "active" in the failure message — a
@@ -318,7 +319,9 @@ async function main() {
 
   const failed = outcomes.filter((o) => !o.pass);
   console.info(`\n=== Summary ===`);
-  console.info(`Total: ${outcomes.length}, Passed: ${outcomes.length - failed.length}, Failed: ${failed.length}`);
+  console.info(
+    `Total: ${outcomes.length}, Passed: ${outcomes.length - failed.length}, Failed: ${failed.length}`,
+  );
   if (failed.length > 0) {
     console.info(`Failures:`);
     for (const f of failed) {

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -4,7 +4,9 @@ import { IContext } from "@/types/server";
 import { ValidationError } from "@/errors/graphql";
 import logger from "@/infrastructure/logging";
 import ReportService from "@/application/domain/report/service";
-import ReportJudgeService, { JudgeParseError } from "@/application/domain/report/template/judgeService";
+import ReportJudgeService, {
+  JudgeParseError,
+} from "@/application/domain/report/template/judgeService";
 import ReportTemplateSelector from "@/application/domain/report/template/selector";
 import ReportPresenter from "@/application/domain/report/presenter";
 import { WeeklyReportPayload } from "@/application/domain/report/types";
@@ -87,8 +89,7 @@ const WEEKLY_SUMMARY_JUDGE_CRITERIA = {
       "deepest_chain が null なら true。",
     active_users:
       "community_context.active_users_in_window の値がレポートに正確に記載されているか。",
-    total_members:
-      "community_context.total_members の値がレポートに正確に記載されているか。",
+    total_members: "community_context.total_members の値がレポートに正確に記載されているか。",
     no_phantom_comparison:
       "previous_period が null のとき、前週比・先週比・増加・減少等の比較表現がレポートに含まれていないか。" +
       "previous_period が non-null なら true。",
@@ -97,13 +98,11 @@ const WEEKLY_SUMMARY_JUDGE_CRITERIA = {
     deepest_chain_mentioned:
       "deepest_chain が non-null のとき、そのエピソードがレポートに言及されているか。" +
       "deepest_chain が null なら true。",
-    actionable_insights:
-      "来週に向けた具体的なアクション（「〇〇をする」形式）が含まれているか。",
+    actionable_insights: "来週に向けた具体的なアクション（「〇〇をする」形式）が含まれているか。",
     reason_distinction:
       "活動認定と感謝の贈り合いが正確に区別されているか。" +
       "活動認定をメンバー間の感謝として誤記していたら false。",
-    no_enum_names:
-      "DONATION / GRANT / ONBOARDING 等の内部キー名がそのまま出力されていないか。",
+    no_enum_names: "DONATION / GRANT / ONBOARDING 等の内部キー名がそのまま出力されていないか。",
   },
 } as const;
 
@@ -508,21 +507,26 @@ export default class ReportUseCase {
     const coverage = analyzeCoverage(payload, outputMarkdown);
 
     // Coverage observability: surface top_user_names that the LLM
-    // failed to copy verbatim. Numeric fields (top_user_points etc.)
-    // are intentionally NOT logged here because their substring
-    // matches false-positive too easily (e.g. "21000" appearing as a
-    // fragment of "210000") to be a useful signal — the raw counters
-    // still flow into `coverageJson` for offline analysis.
-    const missedNames = coverage.top_user_names
-      .filter((u) => !u.mentioned)
-      .map((u) => u.name);
-    if (missedNames.length > 0) {
-      logger.warn("report.coverage.top_user_names_missed", {
-        event: "report.coverage.top_user_names_missed",
-        reportId: report.id,
-        variant: report.variant,
-        names: missedNames,
-      });
+    // failed to copy verbatim. Only WEEKLY_SUMMARY is required to
+    // mention top users by name — GRANT_APPLICATION / MEDIA_PR /
+    // MEMBER_NEWSLETTER deliberately omit individual names, so a
+    // "missed name" there is by-design, not a regression. Gating the
+    // warn log by variant prevents false-positive alerts from those
+    // designs. Numeric fields (top_user_points etc.) are intentionally
+    // NOT logged here because their substring matches false-positive
+    // too easily (e.g. "21000" appearing as a fragment of "210000")
+    // to be a useful signal — the raw counters still flow into
+    // `coverageJson` for offline analysis.
+    if (report.variant === GqlReportVariant.WeeklySummary) {
+      const missedNames = coverage.top_user_names.filter((u) => !u.mentioned).map((u) => u.name);
+      if (missedNames.length > 0) {
+        logger.warn("report.coverage.top_user_names_missed", {
+          event: "report.coverage.top_user_names_missed",
+          reportId: report.id,
+          variant: report.variant,
+          names: missedNames,
+        });
+      }
     }
 
     let judgeTemplate;
@@ -563,9 +567,7 @@ export default class ReportUseCase {
     // either, so this branch is unreachable in practice but keeps the
     // call contract honest for future variants.
     const judgeCriteria =
-      report.variant === GqlReportVariant.WeeklySummary
-        ? WEEKLY_SUMMARY_JUDGE_CRITERIA
-        : undefined;
+      report.variant === GqlReportVariant.WeeklySummary ? WEEKLY_SUMMARY_JUDGE_CRITERIA : undefined;
 
     let judgeResult;
     try {
@@ -988,11 +990,7 @@ export default class ReportUseCase {
       cursor: args.cursor ?? undefined,
       first,
     });
-    return ReportPresenter.adminReportSummaryConnection(
-      result.items,
-      result.totalCount,
-      first,
-    );
+    return ReportPresenter.adminReportSummaryConnection(result.items, result.totalCount, first);
   }
 
   // =========================================================================
@@ -1026,12 +1024,7 @@ function clampInt(value: number, min: number, max: number, name: string): number
  * legacy `browseReports`) keep their current behaviour to avoid
  * widening this PR's scope into a domain-wide refactor.
  */
-function validateIntInRange(
-  value: number,
-  min: number,
-  max: number,
-  name: string,
-): number {
+function validateIntInRange(value: number, min: number, max: number, name: string): number {
   if (!Number.isInteger(value) || value < min || value > max) {
     throw new ValidationError(
       `${name} must be an integer between ${min} and ${max}, got ${value}`,

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -9,7 +9,7 @@ import ReportJudgeService, {
 } from "@/application/domain/report/template/judgeService";
 import ReportTemplateSelector from "@/application/domain/report/template/selector";
 import ReportPresenter from "@/application/domain/report/presenter";
-import { WeeklyReportPayload } from "@/application/domain/report/types";
+import { WeeklyReportPayload, ReportVariant } from "@/application/domain/report/types";
 import {
   addDays,
   daysBetweenJst,
@@ -24,7 +24,6 @@ import {
   GqlReportsConnection,
   GqlReport,
   GqlReportTemplate,
-  GqlReportVariant,
   GqlUpdateReportTemplatePayload,
   GqlApproveReportPayload,
   GqlPublishReportPayload,
@@ -517,7 +516,7 @@ export default class ReportUseCase {
     // too easily (e.g. "21000" appearing as a fragment of "210000")
     // to be a useful signal — the raw counters still flow into
     // `coverageJson` for offline analysis.
-    if (report.variant === GqlReportVariant.WeeklySummary) {
+    if (report.variant === ReportVariant.WeeklySummary) {
       const missedNames = coverage.top_user_names.filter((u) => !u.mentioned).map((u) => u.name);
       if (missedNames.length > 0) {
         logger.warn("report.coverage.top_user_names_missed", {
@@ -567,7 +566,7 @@ export default class ReportUseCase {
     // either, so this branch is unreachable in practice but keeps the
     // call contract honest for future variants.
     const judgeCriteria =
-      report.variant === GqlReportVariant.WeeklySummary ? WEEKLY_SUMMARY_JUDGE_CRITERIA : undefined;
+      report.variant === ReportVariant.WeeklySummary ? WEEKLY_SUMMARY_JUDGE_CRITERIA : undefined;
 
     let judgeResult;
     try {

--- a/src/infrastructure/prisma/seeds/reportTemplates.ts
+++ b/src/infrastructure/prisma/seeds/reportTemplates.ts
@@ -47,6 +47,12 @@ highlight_comments のコメントを読むとき、以下の3点だけを読み
 
 フレーム外の解釈（なぜそうなったか・コミュニティの文化論・背景の推測）はしない。
 活動認定と感謝の贈り合いを区別する。活動認定は運営からの公式な認定。
+
+### highlight_comments の重複引用を避ける
+出力の中で、同じ取引（同じ transaction_id）のコメントを2回以上引用しない。
+複数のセクションでコメントを引用する構成でも、各 transaction_id は出力全体で最大1回まで。
+payload の highlight_comments に同じ transaction_id が複数行で含まれていた場合も、
+出力に出すのは1回だけにする。
 `.trim();
 
 // This seed manages SYSTEM-scope rows only (the upsert lookup is


### PR DESCRIPTION
## Summary

ロードマップの「直近 [A] / [B]」を3コミットで投入。月曜バッチ前にマージ可能な確定不具合のみ。`[C] PR-D`(継続性表現修正)はバッチ実出力を見てから別PRで判断。

- **[A]** `scripts/ci/run-golden-cases.ts` の judgeService import パスを `template/judgeService` に修正。これがないと `ci:report-golden` が起動失敗
- **[B-1]** `coverage.top_user_names_missed` の warn ログを `WEEKLY_SUMMARY` に限定。GRANT_APPLICATION / MEDIA_PR / MEMBER_NEWSLETTER は名前を出さない設計なので「miss」が by-design ノイズになっていた
- **[B-2]** 全 GENERATION テンプレ共通の `COMMON_RULES` に「同一 transaction_id を出力で2回以上引用しない」ルールを追加。payload 側に同じ tx が複数行入っていた場合も出力では1回まで

`coverageJson` は変えていない(全 variant で従来通りの boolean が記録される)。Phase 2 のオフライン解析シグナルは保持。

## Test plan

- [x] `pnpm exec tsc --noEmit` — 変更3ファイルに新規エラーなし(既存の typed-SQL 関連エラーは live DB 必要・本PR範囲外)
- [x] `pnpm exec jest src/__tests__/unit/report/coverage.test.ts src/__tests__/unit/report/usecase.test.ts` — 33 tests passed
- [x] `pnpm exec eslint` 既存ルール違反なし
- [x] Prettier reformat 適用済み
- [ ] マージ後 `ci:report-golden` が起動することを確認(現在は import エラーで起動不能なので、このPRでブロッカー解消)
- [ ] 月曜バッチ後、GRANT_APPLICATION / MEDIA_PR / MEMBER_NEWSLETTER の `report.coverage.top_user_names_missed` ログがゼロ件になっていることを確認
- [ ] 月曜バッチの highlight_comments 引用が同一 tx 重複していないことを目視確認

https://claude.ai/code/session_018MJcM8wfRw8GhzdRWYKY19

---
_Generated by [Claude Code](https://claude.ai/code/session_018MJcM8wfRw8GhzdRWYKY19)_