### PR TITLE
feat(membership): add prior-activity columns + CSV bulk-import tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,5 +152,8 @@ credentials/
 # sciprt result
 .generated/
 
+# Probe / export script artifacts
+tmp/
+
 # NMKR generated files
 /src/infrastructure/libs/nmkr/types/*.d.ts

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -104,6 +104,13 @@ ASSIGNED ASSIGNED
     
 
 
+        MemberPriorActivitySource {
+            SELF_REPORTED SELF_REPORTED
+ADMIN_CONFIRMED ADMIN_CONFIRMED
+        }
+    
+
+
         ParticipationType {
             HOSTED HOSTED
 PARTICIPATED PARTICIPATED
@@ -546,6 +553,10 @@ OTHER OTHER
     String community_id 
     String headline "❓"
     String bio "❓"
+    DateTime prior_active_from "❓"
+    String prior_activity_note "❓"
+    MemberPriorActivitySource prior_activity_source "❓"
+    String prior_activity_recorded_by "❓"
     MembershipStatus status 
     MembershipStatusReason reason 
     Role role 
@@ -1177,6 +1188,7 @@ OTHER OTHER
     "t_vc_issuance_requests" }o--|| t_users : "user"
     "t_memberships" }o--|| t_users : "user"
     "t_memberships" }o--|| t_communities : "community"
+    "t_memberships" |o--|o "MemberPriorActivitySource" : "enum:prior_activity_source"
     "t_memberships" |o--|| "MembershipStatus" : "enum:status"
     "t_memberships" |o--|| "MembershipStatusReason" : "enum:reason"
     "t_memberships" |o--|| "Role" : "enum:role"

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -104,9 +104,9 @@ ASSIGNED ASSIGNED
     
 
 
-        MemberPriorActivitySource {
-            SELF_REPORTED SELF_REPORTED
-ADMIN_CONFIRMED ADMIN_CONFIRMED
+        MemberPriorActivityClass {
+            PRE_CIVICSHIP_ACTIVE PRE_CIVICSHIP_ACTIVE
+POST_CIVICSHIP_ENGAGED POST_CIVICSHIP_ENGAGED
         }
     
 
@@ -553,9 +553,8 @@ OTHER OTHER
     String community_id 
     String headline "❓"
     String bio "❓"
-    DateTime prior_active_from "❓"
+    MemberPriorActivityClass prior_activity_class "❓"
     String prior_activity_note "❓"
-    MemberPriorActivitySource prior_activity_source "❓"
     String prior_activity_recorded_by "❓"
     MembershipStatus status 
     MembershipStatusReason reason 
@@ -1188,7 +1187,7 @@ OTHER OTHER
     "t_vc_issuance_requests" }o--|| t_users : "user"
     "t_memberships" }o--|| t_users : "user"
     "t_memberships" }o--|| t_communities : "community"
-    "t_memberships" |o--|o "MemberPriorActivitySource" : "enum:prior_activity_source"
+    "t_memberships" |o--|o "MemberPriorActivityClass" : "enum:prior_activity_class"
     "t_memberships" |o--|| "MembershipStatus" : "enum:status"
     "t_memberships" |o--|| "MembershipStatusReason" : "enum:reason"
     "t_memberships" |o--|| "Role" : "enum:role"

--- a/docs/schema.dbml
+++ b/docs/schema.dbml
@@ -299,6 +299,10 @@ Table t_memberships {
   community t_communities [not null]
   headline String
   bio String
+  priorActiveFrom DateTime
+  priorActivityNote String
+  priorActivitySource MemberPriorActivitySource
+  priorActivityRecordedBy String
   status MembershipStatus [not null]
   reason MembershipStatusReason [not null]
   role Role [not null, default: 'MEMBER']
@@ -1168,6 +1172,11 @@ Enum MembershipStatusReason {
   WITHDRAWN
   REMOVED
   ASSIGNED
+}
+
+Enum MemberPriorActivitySource {
+  SELF_REPORTED
+  ADMIN_CONFIRMED
 }
 
 Enum ParticipationType {

--- a/docs/schema.dbml
+++ b/docs/schema.dbml
@@ -299,9 +299,8 @@ Table t_memberships {
   community t_communities [not null]
   headline String
   bio String
-  priorActiveFrom DateTime
+  priorActivityClass MemberPriorActivityClass
   priorActivityNote String
-  priorActivitySource MemberPriorActivitySource
   priorActivityRecordedBy String
   status MembershipStatus [not null]
   reason MembershipStatusReason [not null]
@@ -1174,9 +1173,9 @@ Enum MembershipStatusReason {
   ASSIGNED
 }
 
-Enum MemberPriorActivitySource {
-  SELF_REPORTED
-  ADMIN_CONFIRMED
+Enum MemberPriorActivityClass {
+  PRE_CIVICSHIP_ACTIVE
+  POST_CIVICSHIP_ENGAGED
 }
 
 Enum ParticipationType {

--- a/scripts/export-members.ts
+++ b/scripts/export-members.ts
@@ -6,7 +6,7 @@ import { prismaClient } from "@/infrastructure/prisma/client";
 
 /**
  * Export JOINED memberships to CSV so a community manager can fill in
- * `priorActiveFrom` / `priorActivityNote` in a spreadsheet and feed
+ * `priorActivityClass` / `priorActivityNote` in a spreadsheet and feed
  * the file back through `scripts/import-prior-activity.ts`.
  *
  * Usage:
@@ -23,7 +23,7 @@ import { prismaClient } from "@/infrastructure/prisma/client";
  * Only JOINED memberships are exported — PENDING / LEFT rows are not
  * actionable for a "civicship 導入前から動いていたか" question.
  *
- * Existing `priorActive*` values are preserved in the export so a
+ * Existing `priorActivity*` values are preserved in the export so a
  * manager re-running the workflow against an already-populated
  * community sees their prior entries and only fills in the gaps.
  */
@@ -65,7 +65,7 @@ function parseArgs(): CliArgs {
 /**
  * RFC 4180 minimal quoter. Wraps the value in quotes only when it
  * contains a delimiter (`,`), a quote, or a newline; doubles embedded
- * quotes. Avoids a CSV library dependency for an 8-column writer.
+ * quotes. Avoids a CSV library dependency for a 7-column writer.
  */
 function csvField(value: string | null | undefined): string {
   if (value === null || value === undefined) return "";
@@ -77,9 +77,8 @@ function csvField(value: string | null | undefined): string {
 }
 
 /**
- * Render a Date as `YYYY-MM-DD` in UTC. The export is meant to be
- * edited in a spreadsheet and re-imported, so calendar precision is
- * sufficient — the import script parses the same shape back.
+ * Render a Date as `YYYY-MM-DD` in UTC. Only used for `joinedAt`
+ * (system-recorded) — there is no editable date column in the export.
  */
 function formatDate(d: Date | null | undefined): string {
   if (!d) return "";
@@ -92,9 +91,8 @@ const HEADER = [
   "communityId",
   "communityName",
   "joinedAt",
-  "priorActiveFrom",
+  "priorActivityClass",
   "priorActivityNote",
-  "priorActivitySource",
 ] as const;
 
 interface MembershipRow {
@@ -103,9 +101,8 @@ interface MembershipRow {
   communityId: string;
   communityName: string;
   joinedAt: Date;
-  priorActiveFrom: Date | null;
+  priorActivityClass: string | null;
   priorActivityNote: string | null;
-  priorActivitySource: string | null;
 }
 
 async function fetchMemberships(communityIds: string[] | null): Promise<MembershipRow[]> {
@@ -118,9 +115,8 @@ async function fetchMemberships(communityIds: string[] | null): Promise<Membersh
       userId: true,
       communityId: true,
       createdAt: true,
-      priorActiveFrom: true,
+      priorActivityClass: true,
       priorActivityNote: true,
-      priorActivitySource: true,
       user: { select: { name: true } },
       community: { select: { name: true } },
     },
@@ -132,9 +128,8 @@ async function fetchMemberships(communityIds: string[] | null): Promise<Membersh
     communityId: r.communityId,
     communityName: r.community?.name ?? "",
     joinedAt: r.createdAt,
-    priorActiveFrom: r.priorActiveFrom,
+    priorActivityClass: r.priorActivityClass,
     priorActivityNote: r.priorActivityNote,
-    priorActivitySource: r.priorActivitySource,
   }));
 }
 
@@ -152,9 +147,8 @@ function buildCsv(rows: MembershipRow[]): string {
         csvField(r.communityId),
         csvField(r.communityName),
         csvField(formatDate(r.joinedAt)),
-        csvField(formatDate(r.priorActiveFrom)),
+        csvField(r.priorActivityClass),
         csvField(r.priorActivityNote),
-        csvField(r.priorActivitySource),
       ].join(","),
     );
   }

--- a/scripts/export-members.ts
+++ b/scripts/export-members.ts
@@ -1,0 +1,215 @@
+import "reflect-metadata";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { MembershipStatus } from "@prisma/client";
+import { prismaClient } from "@/infrastructure/prisma/client";
+
+/**
+ * Export JOINED memberships to CSV so a community manager can fill in
+ * `priorActiveFrom` / `priorActivityNote` in a spreadsheet and feed
+ * the file back through `scripts/import-prior-activity.ts`.
+ *
+ * Usage:
+ *   dotenvx run -f .env.local -- tsx scripts/export-members.ts \
+ *     --community=<id1>[,<id2>,...]
+ *   dotenvx run -f .env.local -- tsx scripts/export-members.ts
+ *
+ * `--community` accepts one ID or a CSV of IDs. When omitted, every
+ * community in the database is exported. One file per community is
+ * written to `tmp/members_export_<communityId>_<timestamp>.csv` so
+ * managers can hand each community its own sheet without leaking
+ * other communities' member lists.
+ *
+ * Only JOINED memberships are exported — PENDING / LEFT rows are not
+ * actionable for a "civicship 導入前から動いていたか" question.
+ *
+ * Existing `priorActive*` values are preserved in the export so a
+ * manager re-running the workflow against an already-populated
+ * community sees their prior entries and only fills in the gaps.
+ */
+
+const USAGE =
+  "Usage: tsx scripts/export-members.ts [--community=<id1>[,<id2>,...]] [--out-dir=<path>]";
+
+interface CliArgs {
+  communityIds: string[] | null;
+  outDir: string;
+}
+
+/**
+ * Throws on bad input rather than calling `process.exit` directly so
+ * the parser stays unit-testable and `main` owns the exit boundary —
+ * mirrors `scripts/probe-reports.ts:parseArgs`.
+ */
+function parseArgs(): CliArgs {
+  const map = new Map<string, string>();
+  for (const a of process.argv.slice(2)) {
+    const m = /^--([\w-]+)=(.+)$/.exec(a);
+    if (m) map.set(m[1], m[2]);
+  }
+  const communityArg = map.get("community");
+  let communityIds: string[] | null = null;
+  if (communityArg !== undefined) {
+    communityIds = communityArg
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    if (communityIds.length === 0) {
+      throw new Error("--community must contain at least one non-empty id");
+    }
+  }
+  const outDir = map.get("out-dir") ?? join(process.cwd(), "tmp");
+  return { communityIds, outDir };
+}
+
+/**
+ * RFC 4180 minimal quoter. Wraps the value in quotes only when it
+ * contains a delimiter (`,`), a quote, or a newline; doubles embedded
+ * quotes. Avoids a CSV library dependency for an 8-column writer.
+ */
+function csvField(value: string | null | undefined): string {
+  if (value === null || value === undefined) return "";
+  const s = String(value);
+  if (/[",\n\r]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+/**
+ * Render a Date as `YYYY-MM-DD` in UTC. The export is meant to be
+ * edited in a spreadsheet and re-imported, so calendar precision is
+ * sufficient — the import script parses the same shape back.
+ */
+function formatDate(d: Date | null | undefined): string {
+  if (!d) return "";
+  return d.toISOString().slice(0, 10);
+}
+
+const HEADER = [
+  "userId",
+  "name",
+  "communityId",
+  "communityName",
+  "joinedAt",
+  "priorActiveFrom",
+  "priorActivityNote",
+  "priorActivitySource",
+] as const;
+
+interface MembershipRow {
+  userId: string;
+  userName: string;
+  communityId: string;
+  communityName: string;
+  joinedAt: Date;
+  priorActiveFrom: Date | null;
+  priorActivityNote: string | null;
+  priorActivitySource: string | null;
+}
+
+async function fetchMemberships(communityIds: string[] | null): Promise<MembershipRow[]> {
+  const rows = await prismaClient.membership.findMany({
+    where: {
+      status: MembershipStatus.JOINED,
+      ...(communityIds ? { communityId: { in: communityIds } } : {}),
+    },
+    select: {
+      userId: true,
+      communityId: true,
+      createdAt: true,
+      priorActiveFrom: true,
+      priorActivityNote: true,
+      priorActivitySource: true,
+      user: { select: { name: true } },
+      community: { select: { name: true } },
+    },
+    orderBy: [{ communityId: "asc" }, { user: { name: "asc" } }, { userId: "asc" }],
+  });
+  return rows.map((r) => ({
+    userId: r.userId,
+    userName: r.user?.name ?? "",
+    communityId: r.communityId,
+    communityName: r.community?.name ?? "",
+    joinedAt: r.createdAt,
+    priorActiveFrom: r.priorActiveFrom,
+    priorActivityNote: r.priorActivityNote,
+    priorActivitySource: r.priorActivitySource,
+  }));
+}
+
+function sanitizeForFilename(id: string): string {
+  return id.replace(/[^A-Za-z0-9._-]/g, "_");
+}
+
+function buildCsv(rows: MembershipRow[]): string {
+  const lines = [HEADER.join(",")];
+  for (const r of rows) {
+    lines.push(
+      [
+        csvField(r.userId),
+        csvField(r.userName),
+        csvField(r.communityId),
+        csvField(r.communityName),
+        csvField(formatDate(r.joinedAt)),
+        csvField(formatDate(r.priorActiveFrom)),
+        csvField(r.priorActivityNote),
+        csvField(r.priorActivitySource),
+      ].join(","),
+    );
+  }
+  return lines.join("\n") + "\n";
+}
+
+async function main(): Promise<void> {
+  let args: CliArgs;
+  try {
+    args = parseArgs();
+  } catch (e) {
+    console.error((e as Error).message);
+    console.error(USAGE);
+    process.exit(1);
+  }
+
+  const allRows = await fetchMemberships(args.communityIds);
+
+  if (allRows.length === 0) {
+    const target = args.communityIds ? `[${args.communityIds.join(", ")}]` : "all communities";
+    console.error(`No JOINED memberships found for ${target}.`);
+    await prismaClient.$disconnect();
+    process.exit(1);
+  }
+
+  // Bucket by community so each manager gets a self-contained file.
+  const byCommunity = new Map<string, MembershipRow[]>();
+  for (const r of allRows) {
+    const list = byCommunity.get(r.communityId);
+    if (list) list.push(r);
+    else byCommunity.set(r.communityId, [r]);
+  }
+
+  mkdirSync(args.outDir, { recursive: true });
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+
+  const outputs: { communityId: string; path: string; rowCount: number }[] = [];
+  for (const [communityId, rows] of byCommunity) {
+    const filename = `members_export_${sanitizeForFilename(communityId)}_${timestamp}.csv`;
+    const path = join(args.outDir, filename);
+    writeFileSync(path, buildCsv(rows), "utf-8");
+    outputs.push({ communityId, path, rowCount: rows.length });
+  }
+
+  console.info("=== Export summary ===");
+  for (const o of outputs) {
+    console.info(`[${o.communityId}] rows=${o.rowCount} → ${o.path}`);
+  }
+  console.info(`Total: ${allRows.length} rows across ${outputs.length} community/communities`);
+
+  await prismaClient.$disconnect();
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error("Export crashed:", e);
+  prismaClient.$disconnect().finally(() => process.exit(2));
+});

--- a/scripts/import-prior-activity.ts
+++ b/scripts/import-prior-activity.ts
@@ -2,14 +2,15 @@ import "reflect-metadata";
 import { createReadStream } from "node:fs";
 import { resolve as resolvePath } from "node:path";
 import { pipeline } from "node:stream/promises";
-import { MemberPriorActivitySource } from "@prisma/client";
+import { MemberPriorActivityClass } from "@prisma/client";
 import csvParser from "csv-parser";
 import { prismaClient } from "@/infrastructure/prisma/client";
 
 /**
- * Bulk-load `priorActiveFrom` / `priorActivityNote` / `priorActivitySource`
- * onto existing memberships from a CSV produced by
- * `scripts/export-members.ts`.
+ * Bulk-load `priorActivityClass` / `priorActivityNote` onto existing
+ * memberships from a CSV produced by `scripts/export-members.ts`.
+ * `priorActivityRecordedBy` is set from the `--recorded-by` argument
+ * on every updated row.
  *
  * Usage:
  *   dotenvx run -f .env.local -- tsx scripts/import-prior-activity.ts \
@@ -24,16 +25,17 @@ import { prismaClient } from "@/infrastructure/prisma/client";
  * — by convention, only sysadmin / Hopin operators should be running
  * this against prd.
  *
- * Source semantics: a row's `priorActivitySource` column is preserved
- * verbatim when it is one of the known enum values; a blank / missing
- * value defaults to `ADMIN_CONFIRMED` because the operator running
- * this import is implicitly the one verifying the data. Unknown
- * values fail the row loudly rather than silently coercing.
+ * Class semantics: the `priorActivityClass` column must be one of
+ * `PRE_CIVICSHIP_ACTIVE` (古参) or `POST_CIVICSHIP_ENGAGED` (新規).
+ * A blank cell skips the row (nothing to write). Anything else fails
+ * the row loudly rather than silently coercing.
  *
- * Skip rules:
- *   - `priorActiveFrom` blank → row skipped (nothing to write).
- *   - `userId` or `communityId` blank → row skipped with an error.
- *   - membership not found in DB → row skipped with an error.
+ * Skip / error rules:
+ *   - `priorActivityClass` blank → row skipped (no write).
+ *   - `priorActivityClass` not a known enum → row errored.
+ *   - `userId` or `communityId` blank → row errored.
+ *   - `priorActivityNote` > 500 chars → row errored (column is VARCHAR(500)).
+ *   - membership not found in DB → row errored.
  *
  * `--dry-run` runs every validation and prints the per-row outcome
  * but rolls back at the end of the transaction, so the operator can
@@ -74,14 +76,13 @@ function parseArgs(): CliArgs {
 interface CsvRow {
   userId: string;
   communityId: string;
-  priorActiveFrom: string;
+  priorActivityClass: string;
   priorActivityNote: string;
-  priorActivitySource: string;
 }
 
 /**
  * Stream-parse the CSV via `csv-parser`. The export side emits a
- * fixed 8-column header; downstream we only consume the 5 columns
+ * fixed 7-column header; downstream we only consume the 4 columns
  * the import actually writes (extras are ignored, which keeps the
  * import tolerant of operators adding an "owner notes" column or
  * similar in their spreadsheet).
@@ -108,9 +109,8 @@ async function readCsv(path: string): Promise<CsvRow[]> {
     rows.push({
       userId: (raw.userId ?? "").trim(),
       communityId: (raw.communityId ?? "").trim(),
-      priorActiveFrom: (raw.priorActiveFrom ?? "").trim(),
+      priorActivityClass: (raw.priorActivityClass ?? "").trim(),
       priorActivityNote: (raw.priorActivityNote ?? "").trim(),
-      priorActivitySource: (raw.priorActivitySource ?? "").trim(),
     });
   });
   await pipeline(createReadStream(path), parser);
@@ -118,28 +118,19 @@ async function readCsv(path: string): Promise<CsvRow[]> {
 }
 
 /**
- * Parse a date in `YYYY-MM-DD` shape (the format the export writes)
- * to a `Date` at UTC midnight. Anything else returns null so the row
- * is skipped with an error rather than silently mis-recorded.
- *
- * The round-trip check (`d.toISOString().slice(0,10) !== s`) catches
- * calendar-invalid inputs that Date silently rolls forward — e.g.
- * `2023-02-31` would otherwise land as `2023-03-03` and corrupt the
- * audit trail. We refuse those rows instead.
+ * Coerce the CSV cell to a `MemberPriorActivityClass` enum value.
+ * Returns "BLANK" when the cell is empty (caller skips the row) and
+ * "INVALID" when it is non-empty but does not match any enum member
+ * (caller errors the row). Strings come from `csv-parser` already
+ * trimmed in `readCsv`, so we do not re-trim here.
  */
-function parsePriorActiveFrom(s: string): Date | null {
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return null;
-  const d = new Date(`${s}T00:00:00Z`);
-  if (Number.isNaN(d.getTime())) return null;
-  if (d.toISOString().slice(0, 10) !== s) return null;
-  return d;
-}
-
-function parseSource(s: string): MemberPriorActivitySource | "INVALID" | "DEFAULT" {
-  if (s === "") return "DEFAULT";
-  if (s === MemberPriorActivitySource.SELF_REPORTED) return MemberPriorActivitySource.SELF_REPORTED;
-  if (s === MemberPriorActivitySource.ADMIN_CONFIRMED) {
-    return MemberPriorActivitySource.ADMIN_CONFIRMED;
+function parseClass(s: string): MemberPriorActivityClass | "INVALID" | "BLANK" {
+  if (s === "") return "BLANK";
+  if (s === MemberPriorActivityClass.PRE_CIVICSHIP_ACTIVE) {
+    return MemberPriorActivityClass.PRE_CIVICSHIP_ACTIVE;
+  }
+  if (s === MemberPriorActivityClass.POST_CIVICSHIP_ENGAGED) {
+    return MemberPriorActivityClass.POST_CIVICSHIP_ENGAGED;
   }
   return "INVALID";
 }
@@ -202,37 +193,25 @@ async function main(): Promise<void> {
             });
             continue;
           }
-          if (!r.priorActiveFrom) {
+          const classParsed = parseClass(r.priorActivityClass);
+          if (classParsed === "BLANK") {
             outcomes.push({
               userId: r.userId,
               communityId: r.communityId,
               status: "skipped",
-              reason: "priorActiveFrom blank",
+              reason: "priorActivityClass blank",
             });
             continue;
           }
-          const activeFrom = parsePriorActiveFrom(r.priorActiveFrom);
-          if (!activeFrom) {
+          if (classParsed === "INVALID") {
             outcomes.push({
               userId: r.userId,
               communityId: r.communityId,
               status: "error",
-              reason: `priorActiveFrom not parseable: "${r.priorActiveFrom}"`,
+              reason: `priorActivityClass not a known enum: "${r.priorActivityClass}"`,
             });
             continue;
           }
-          const sourceParsed = parseSource(r.priorActivitySource);
-          if (sourceParsed === "INVALID") {
-            outcomes.push({
-              userId: r.userId,
-              communityId: r.communityId,
-              status: "error",
-              reason: `priorActivitySource not a known enum: "${r.priorActivitySource}"`,
-            });
-            continue;
-          }
-          const source =
-            sourceParsed === "DEFAULT" ? MemberPriorActivitySource.ADMIN_CONFIRMED : sourceParsed;
 
           // Pre-check the note against the column's VARCHAR(500) bound
           // before queuing the update. Without this, a single oversize
@@ -271,12 +250,11 @@ async function main(): Promise<void> {
               userId_communityId: { userId: r.userId, communityId: r.communityId },
             },
             data: {
-              priorActiveFrom: activeFrom,
+              priorActivityClass: classParsed,
               // Empty note is normalized to NULL so a manager clearing a
               // cell in the spreadsheet round-trips back to "no note"
               // instead of an empty-string row that's surprising to query.
               priorActivityNote: r.priorActivityNote === "" ? null : r.priorActivityNote,
-              priorActivitySource: source,
               priorActivityRecordedBy: args.recordedBy,
             },
           });

--- a/scripts/import-prior-activity.ts
+++ b/scripts/import-prior-activity.ts
@@ -90,6 +90,16 @@ interface CsvRow {
  * file source (ENOENT / permission) or the parser surfaces as a
  * rejected promise. Attaching `.on("error", reject)` only on the
  * parser would silently drop source-side failures.
+ *
+ * Memory note: the parsed rows are buffered into one in-memory array
+ * before the import transaction runs. This is intentional — the import
+ * must succeed-or-rollback as a single transaction (so a partial CSV
+ * never leaves the community half-imported), and per-row pre-checks
+ * are easier to reason about against a fully-materialised list.
+ * Sizing assumption: this script is admin tooling for community
+ * onboarding (a few hundred rows per community at the high end).
+ * If CSV sizes grow into the tens of thousands the right shape is
+ * chunked transactions over a streaming parser, not a bigger array.
  */
 async function readCsv(path: string): Promise<CsvRow[]> {
   const rows: CsvRow[] = [];
@@ -111,11 +121,17 @@ async function readCsv(path: string): Promise<CsvRow[]> {
  * Parse a date in `YYYY-MM-DD` shape (the format the export writes)
  * to a `Date` at UTC midnight. Anything else returns null so the row
  * is skipped with an error rather than silently mis-recorded.
+ *
+ * The round-trip check (`d.toISOString().slice(0,10) !== s`) catches
+ * calendar-invalid inputs that Date silently rolls forward — e.g.
+ * `2023-02-31` would otherwise land as `2023-03-03` and corrupt the
+ * audit trail. We refuse those rows instead.
  */
 function parsePriorActiveFrom(s: string): Date | null {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return null;
   const d = new Date(`${s}T00:00:00Z`);
   if (Number.isNaN(d.getTime())) return null;
+  if (d.toISOString().slice(0, 10) !== s) return null;
   return d;
 }
 
@@ -166,95 +182,121 @@ async function main(): Promise<void> {
   // Wrap every row in one transaction so dry-run can roll back as a
   // group, and so a partial failure on commit mode aborts cleanly
   // instead of leaving the community in a half-imported state.
+  //
+  // Prisma's interactive-transaction default timeout is 5s, which is
+  // tight once an operator runs this against a backfill of a few
+  // hundred members over a slow connection. Raise both `timeout`
+  // (overall budget) and `maxWait` (queue wait before the tx slot
+  // opens) to one minute — well above any realistic admin batch and
+  // still bounded so a runaway script does not pin a connection.
   await prismaClient
-    .$transaction(async (tx) => {
-      for (const r of rows) {
-        if (!r.userId || !r.communityId) {
-          outcomes.push({
-            userId: r.userId,
-            communityId: r.communityId,
-            status: "error",
-            reason: "userId or communityId is blank",
-          });
-          continue;
-        }
-        if (!r.priorActiveFrom) {
-          outcomes.push({
-            userId: r.userId,
-            communityId: r.communityId,
-            status: "skipped",
-            reason: "priorActiveFrom blank",
-          });
-          continue;
-        }
-        const activeFrom = parsePriorActiveFrom(r.priorActiveFrom);
-        if (!activeFrom) {
-          outcomes.push({
-            userId: r.userId,
-            communityId: r.communityId,
-            status: "error",
-            reason: `priorActiveFrom not parseable: "${r.priorActiveFrom}"`,
-          });
-          continue;
-        }
-        const sourceParsed = parseSource(r.priorActivitySource);
-        if (sourceParsed === "INVALID") {
-          outcomes.push({
-            userId: r.userId,
-            communityId: r.communityId,
-            status: "error",
-            reason: `priorActivitySource not a known enum: "${r.priorActivitySource}"`,
-          });
-          continue;
-        }
-        const source =
-          sourceParsed === "DEFAULT" ? MemberPriorActivitySource.ADMIN_CONFIRMED : sourceParsed;
+    .$transaction(
+      async (tx) => {
+        for (const r of rows) {
+          if (!r.userId || !r.communityId) {
+            outcomes.push({
+              userId: r.userId,
+              communityId: r.communityId,
+              status: "error",
+              reason: "userId or communityId is blank",
+            });
+            continue;
+          }
+          if (!r.priorActiveFrom) {
+            outcomes.push({
+              userId: r.userId,
+              communityId: r.communityId,
+              status: "skipped",
+              reason: "priorActiveFrom blank",
+            });
+            continue;
+          }
+          const activeFrom = parsePriorActiveFrom(r.priorActiveFrom);
+          if (!activeFrom) {
+            outcomes.push({
+              userId: r.userId,
+              communityId: r.communityId,
+              status: "error",
+              reason: `priorActiveFrom not parseable: "${r.priorActiveFrom}"`,
+            });
+            continue;
+          }
+          const sourceParsed = parseSource(r.priorActivitySource);
+          if (sourceParsed === "INVALID") {
+            outcomes.push({
+              userId: r.userId,
+              communityId: r.communityId,
+              status: "error",
+              reason: `priorActivitySource not a known enum: "${r.priorActivitySource}"`,
+            });
+            continue;
+          }
+          const source =
+            sourceParsed === "DEFAULT" ? MemberPriorActivitySource.ADMIN_CONFIRMED : sourceParsed;
 
-        const existing = await tx.membership.findUnique({
-          where: {
-            userId_communityId: { userId: r.userId, communityId: r.communityId },
-          },
-          select: { userId: true },
-        });
-        if (!existing) {
+          // Pre-check the note against the column's VARCHAR(500) bound
+          // before queuing the update. Without this, a single oversize
+          // cell would surface as a Prisma `P2000` mid-transaction and
+          // roll the entire batch back, hiding which row was at fault.
+          // Reporting it row-by-row lets the operator fix that one cell
+          // and re-run.
+          if (r.priorActivityNote.length > 500) {
+            outcomes.push({
+              userId: r.userId,
+              communityId: r.communityId,
+              status: "error",
+              reason: `priorActivityNote too long (${r.priorActivityNote.length} > 500)`,
+            });
+            continue;
+          }
+
+          const existing = await tx.membership.findUnique({
+            where: {
+              userId_communityId: { userId: r.userId, communityId: r.communityId },
+            },
+            select: { userId: true },
+          });
+          if (!existing) {
+            outcomes.push({
+              userId: r.userId,
+              communityId: r.communityId,
+              status: "error",
+              reason: "membership not found (re-export from this community first)",
+            });
+            continue;
+          }
+
+          await tx.membership.update({
+            where: {
+              userId_communityId: { userId: r.userId, communityId: r.communityId },
+            },
+            data: {
+              priorActiveFrom: activeFrom,
+              // Empty note is normalized to NULL so a manager clearing a
+              // cell in the spreadsheet round-trips back to "no note"
+              // instead of an empty-string row that's surprising to query.
+              priorActivityNote: r.priorActivityNote === "" ? null : r.priorActivityNote,
+              priorActivitySource: source,
+              priorActivityRecordedBy: args.recordedBy,
+            },
+          });
           outcomes.push({
             userId: r.userId,
             communityId: r.communityId,
-            status: "error",
-            reason: "membership not found (re-export from this community first)",
+            status: "updated",
           });
-          continue;
         }
 
-        await tx.membership.update({
-          where: {
-            userId_communityId: { userId: r.userId, communityId: r.communityId },
-          },
-          data: {
-            priorActiveFrom: activeFrom,
-            // Empty note is normalized to NULL so a manager clearing a
-            // cell in the spreadsheet round-trips back to "no note"
-            // instead of an empty-string row that's surprising to query.
-            priorActivityNote: r.priorActivityNote === "" ? null : r.priorActivityNote,
-            priorActivitySource: source,
-            priorActivityRecordedBy: args.recordedBy,
-          },
-        });
-        outcomes.push({
-          userId: r.userId,
-          communityId: r.communityId,
-          status: "updated",
-        });
-      }
-
-      if (args.dryRun) {
-        // Throw inside the transaction callback so Prisma rolls back
-        // every update we just queued. The catch in the surrounding
-        // try/finally below swallows this specific marker and reports
-        // the dry-run summary on the way out.
-        throw new DryRunRollback();
-      }
-    })
+        if (args.dryRun) {
+          // Throw inside the transaction callback so Prisma rolls back
+          // every update we just queued. The catch in the surrounding
+          // try/finally below swallows this specific marker and reports
+          // the dry-run summary on the way out.
+          throw new DryRunRollback();
+        }
+      },
+      { timeout: 60_000, maxWait: 60_000 },
+    )
     .catch((e: unknown) => {
       if (e instanceof DryRunRollback) return;
       throw e;

--- a/scripts/import-prior-activity.ts
+++ b/scripts/import-prior-activity.ts
@@ -1,6 +1,7 @@
 import "reflect-metadata";
 import { createReadStream } from "node:fs";
 import { resolve as resolvePath } from "node:path";
+import { pipeline } from "node:stream/promises";
 import { MemberPriorActivitySource } from "@prisma/client";
 import csvParser from "csv-parser";
 import { prismaClient } from "@/infrastructure/prisma/client";
@@ -84,24 +85,26 @@ interface CsvRow {
  * the import actually writes (extras are ignored, which keeps the
  * import tolerant of operators adding an "owner notes" column or
  * similar in their spreadsheet).
+ *
+ * Uses `node:stream/promises` `pipeline` so an error on EITHER the
+ * file source (ENOENT / permission) or the parser surfaces as a
+ * rejected promise. Attaching `.on("error", reject)` only on the
+ * parser would silently drop source-side failures.
  */
 async function readCsv(path: string): Promise<CsvRow[]> {
-  return new Promise((resolve, reject) => {
-    const rows: CsvRow[] = [];
-    createReadStream(path)
-      .pipe(csvParser())
-      .on("data", (raw: Record<string, string | undefined>) => {
-        rows.push({
-          userId: (raw.userId ?? "").trim(),
-          communityId: (raw.communityId ?? "").trim(),
-          priorActiveFrom: (raw.priorActiveFrom ?? "").trim(),
-          priorActivityNote: (raw.priorActivityNote ?? "").trim(),
-          priorActivitySource: (raw.priorActivitySource ?? "").trim(),
-        });
-      })
-      .on("end", () => resolve(rows))
-      .on("error", reject);
+  const rows: CsvRow[] = [];
+  const parser = csvParser();
+  parser.on("data", (raw: Record<string, string | undefined>) => {
+    rows.push({
+      userId: (raw.userId ?? "").trim(),
+      communityId: (raw.communityId ?? "").trim(),
+      priorActiveFrom: (raw.priorActiveFrom ?? "").trim(),
+      priorActivityNote: (raw.priorActivityNote ?? "").trim(),
+      priorActivitySource: (raw.priorActivitySource ?? "").trim(),
+    });
   });
+  await pipeline(createReadStream(path), parser);
+  return rows;
 }
 
 /**

--- a/scripts/import-prior-activity.ts
+++ b/scripts/import-prior-activity.ts
@@ -1,0 +1,296 @@
+import "reflect-metadata";
+import { createReadStream } from "node:fs";
+import { resolve as resolvePath } from "node:path";
+import { MemberPriorActivitySource } from "@prisma/client";
+import csvParser from "csv-parser";
+import { prismaClient } from "@/infrastructure/prisma/client";
+
+/**
+ * Bulk-load `priorActiveFrom` / `priorActivityNote` / `priorActivitySource`
+ * onto existing memberships from a CSV produced by
+ * `scripts/export-members.ts`.
+ *
+ * Usage:
+ *   dotenvx run -f .env.local -- tsx scripts/import-prior-activity.ts \
+ *     --file=tmp/members_export_<communityId>_<timestamp>.csv \
+ *     --recorded-by=<adminUserId> [--dry-run]
+ *
+ * Trust model: this script bypasses GraphQL authorization and writes
+ * directly via the Prisma client. It is admin-only tooling intended
+ * for an operator running it from a dev / ops shell with the right
+ * `.env`. The `--recorded-by` user id is checked to exist in
+ * `t_users`, but no manager-of-the-target-community check is enforced
+ * — by convention, only sysadmin / Hopin operators should be running
+ * this against prd.
+ *
+ * Source semantics: a row's `priorActivitySource` column is preserved
+ * verbatim when it is one of the known enum values; a blank / missing
+ * value defaults to `ADMIN_CONFIRMED` because the operator running
+ * this import is implicitly the one verifying the data. Unknown
+ * values fail the row loudly rather than silently coercing.
+ *
+ * Skip rules:
+ *   - `priorActiveFrom` blank → row skipped (nothing to write).
+ *   - `userId` or `communityId` blank → row skipped with an error.
+ *   - membership not found in DB → row skipped with an error.
+ *
+ * `--dry-run` runs every validation and prints the per-row outcome
+ * but rolls back at the end of the transaction, so the operator can
+ * verify the diff before committing.
+ */
+
+const USAGE =
+  "Usage: tsx scripts/import-prior-activity.ts --file=<csvPath> --recorded-by=<userId> [--dry-run]";
+
+interface CliArgs {
+  filePath: string;
+  recordedBy: string;
+  dryRun: boolean;
+}
+
+function parseArgs(): CliArgs {
+  const map = new Map<string, string>();
+  let dryRun = false;
+  for (const a of process.argv.slice(2)) {
+    if (a === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    const m = /^--([\w-]+)=(.+)$/.exec(a);
+    if (m) map.set(m[1], m[2]);
+  }
+  const filePath = map.get("file");
+  if (!filePath) {
+    throw new Error("--file=<csvPath> is required");
+  }
+  const recordedBy = map.get("recorded-by");
+  if (!recordedBy) {
+    throw new Error("--recorded-by=<userId> is required");
+  }
+  return { filePath: resolvePath(filePath), recordedBy, dryRun };
+}
+
+interface CsvRow {
+  userId: string;
+  communityId: string;
+  priorActiveFrom: string;
+  priorActivityNote: string;
+  priorActivitySource: string;
+}
+
+/**
+ * Stream-parse the CSV via `csv-parser`. The export side emits a
+ * fixed 8-column header; downstream we only consume the 5 columns
+ * the import actually writes (extras are ignored, which keeps the
+ * import tolerant of operators adding an "owner notes" column or
+ * similar in their spreadsheet).
+ */
+async function readCsv(path: string): Promise<CsvRow[]> {
+  return new Promise((resolve, reject) => {
+    const rows: CsvRow[] = [];
+    createReadStream(path)
+      .pipe(csvParser())
+      .on("data", (raw: Record<string, string | undefined>) => {
+        rows.push({
+          userId: (raw.userId ?? "").trim(),
+          communityId: (raw.communityId ?? "").trim(),
+          priorActiveFrom: (raw.priorActiveFrom ?? "").trim(),
+          priorActivityNote: (raw.priorActivityNote ?? "").trim(),
+          priorActivitySource: (raw.priorActivitySource ?? "").trim(),
+        });
+      })
+      .on("end", () => resolve(rows))
+      .on("error", reject);
+  });
+}
+
+/**
+ * Parse a date in `YYYY-MM-DD` shape (the format the export writes)
+ * to a `Date` at UTC midnight. Anything else returns null so the row
+ * is skipped with an error rather than silently mis-recorded.
+ */
+function parsePriorActiveFrom(s: string): Date | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return null;
+  const d = new Date(`${s}T00:00:00Z`);
+  if (Number.isNaN(d.getTime())) return null;
+  return d;
+}
+
+function parseSource(s: string): MemberPriorActivitySource | "INVALID" | "DEFAULT" {
+  if (s === "") return "DEFAULT";
+  if (s === MemberPriorActivitySource.SELF_REPORTED) return MemberPriorActivitySource.SELF_REPORTED;
+  if (s === MemberPriorActivitySource.ADMIN_CONFIRMED) {
+    return MemberPriorActivitySource.ADMIN_CONFIRMED;
+  }
+  return "INVALID";
+}
+
+interface RowOutcome {
+  userId: string;
+  communityId: string;
+  status: "updated" | "skipped" | "error";
+  reason?: string;
+}
+
+async function main(): Promise<void> {
+  let args: CliArgs;
+  try {
+    args = parseArgs();
+  } catch (e) {
+    console.error((e as Error).message);
+    console.error(USAGE);
+    process.exit(1);
+  }
+
+  const recorder = await prismaClient.user.findUnique({
+    where: { id: args.recordedBy },
+    select: { id: true, name: true },
+  });
+  if (!recorder) {
+    console.error(`--recorded-by=${args.recordedBy} does not match any user.`);
+    await prismaClient.$disconnect();
+    process.exit(1);
+  }
+  console.info(`Recorder: ${recorder.id} (${recorder.name ?? "<no name>"})`);
+
+  const rows = await readCsv(args.filePath);
+  console.info(`Read ${rows.length} rows from ${args.filePath}`);
+  console.info(args.dryRun ? "Mode: DRY RUN (no writes will be committed)" : "Mode: COMMIT");
+  console.info("");
+
+  const outcomes: RowOutcome[] = [];
+
+  // Wrap every row in one transaction so dry-run can roll back as a
+  // group, and so a partial failure on commit mode aborts cleanly
+  // instead of leaving the community in a half-imported state.
+  await prismaClient
+    .$transaction(async (tx) => {
+      for (const r of rows) {
+        if (!r.userId || !r.communityId) {
+          outcomes.push({
+            userId: r.userId,
+            communityId: r.communityId,
+            status: "error",
+            reason: "userId or communityId is blank",
+          });
+          continue;
+        }
+        if (!r.priorActiveFrom) {
+          outcomes.push({
+            userId: r.userId,
+            communityId: r.communityId,
+            status: "skipped",
+            reason: "priorActiveFrom blank",
+          });
+          continue;
+        }
+        const activeFrom = parsePriorActiveFrom(r.priorActiveFrom);
+        if (!activeFrom) {
+          outcomes.push({
+            userId: r.userId,
+            communityId: r.communityId,
+            status: "error",
+            reason: `priorActiveFrom not parseable: "${r.priorActiveFrom}"`,
+          });
+          continue;
+        }
+        const sourceParsed = parseSource(r.priorActivitySource);
+        if (sourceParsed === "INVALID") {
+          outcomes.push({
+            userId: r.userId,
+            communityId: r.communityId,
+            status: "error",
+            reason: `priorActivitySource not a known enum: "${r.priorActivitySource}"`,
+          });
+          continue;
+        }
+        const source =
+          sourceParsed === "DEFAULT" ? MemberPriorActivitySource.ADMIN_CONFIRMED : sourceParsed;
+
+        const existing = await tx.membership.findUnique({
+          where: {
+            userId_communityId: { userId: r.userId, communityId: r.communityId },
+          },
+          select: { userId: true },
+        });
+        if (!existing) {
+          outcomes.push({
+            userId: r.userId,
+            communityId: r.communityId,
+            status: "error",
+            reason: "membership not found (re-export from this community first)",
+          });
+          continue;
+        }
+
+        await tx.membership.update({
+          where: {
+            userId_communityId: { userId: r.userId, communityId: r.communityId },
+          },
+          data: {
+            priorActiveFrom: activeFrom,
+            // Empty note is normalized to NULL so a manager clearing a
+            // cell in the spreadsheet round-trips back to "no note"
+            // instead of an empty-string row that's surprising to query.
+            priorActivityNote: r.priorActivityNote === "" ? null : r.priorActivityNote,
+            priorActivitySource: source,
+            priorActivityRecordedBy: args.recordedBy,
+          },
+        });
+        outcomes.push({
+          userId: r.userId,
+          communityId: r.communityId,
+          status: "updated",
+        });
+      }
+
+      if (args.dryRun) {
+        // Throw inside the transaction callback so Prisma rolls back
+        // every update we just queued. The catch in the surrounding
+        // try/finally below swallows this specific marker and reports
+        // the dry-run summary on the way out.
+        throw new DryRunRollback();
+      }
+    })
+    .catch((e: unknown) => {
+      if (e instanceof DryRunRollback) return;
+      throw e;
+    });
+
+  const counts = {
+    updated: outcomes.filter((o) => o.status === "updated").length,
+    skipped: outcomes.filter((o) => o.status === "skipped").length,
+    errored: outcomes.filter((o) => o.status === "error").length,
+  };
+
+  console.info("=== Per-row outcomes ===");
+  for (const o of outcomes) {
+    const reason = o.reason ? ` (${o.reason})` : "";
+    console.info(`  [${o.status}] ${o.userId} / ${o.communityId}${reason}`);
+  }
+  console.info("");
+  console.info("=== Summary ===");
+  console.info(`updated: ${counts.updated}`);
+  console.info(`skipped: ${counts.skipped}`);
+  console.info(`errored: ${counts.errored}`);
+  if (args.dryRun) {
+    console.info("(dry-run — no writes committed)");
+  }
+
+  await prismaClient.$disconnect();
+  // Exit non-zero when there were row-level errors so a wrapper /
+  // CI invocation can detect the failure without parsing stdout.
+  process.exit(counts.errored > 0 ? 1 : 0);
+}
+
+class DryRunRollback extends Error {
+  constructor() {
+    super("dry-run rollback");
+    this.name = "DryRunRollback";
+  }
+}
+
+main().catch((e) => {
+  console.error("Import crashed:", e);
+  prismaClient.$disconnect().finally(() => process.exit(2));
+});

--- a/src/infrastructure/prisma/factories/__generated__/index.ts
+++ b/src/infrastructure/prisma/factories/__generated__/index.ts
@@ -70,7 +70,7 @@ import type { Language } from "@prisma/client";
 import type { IdentityPlatform } from "@prisma/client";
 import type { DidIssuanceStatus } from "@prisma/client";
 import type { VcIssuanceStatus } from "@prisma/client";
-import type { MemberPriorActivitySource } from "@prisma/client";
+import type { MemberPriorActivityClass } from "@prisma/client";
 import type { MembershipStatus } from "@prisma/client";
 import type { MembershipStatusReason } from "@prisma/client";
 import type { Role } from "@prisma/client";
@@ -3838,9 +3838,8 @@ type MembershipopportunityHostedCountViewFactory = {
 type MembershipFactoryDefineInput = {
     headline?: string | null;
     bio?: string | null;
-    priorActiveFrom?: Date | null;
+    priorActivityClass?: MemberPriorActivityClass | null;
     priorActivityNote?: string | null;
-    priorActivitySource?: MemberPriorActivitySource | null;
     priorActivityRecordedBy?: string | null;
     status?: MembershipStatus;
     reason?: MembershipStatusReason;

--- a/src/infrastructure/prisma/factories/__generated__/index.ts
+++ b/src/infrastructure/prisma/factories/__generated__/index.ts
@@ -70,6 +70,7 @@ import type { Language } from "@prisma/client";
 import type { IdentityPlatform } from "@prisma/client";
 import type { DidIssuanceStatus } from "@prisma/client";
 import type { VcIssuanceStatus } from "@prisma/client";
+import type { MemberPriorActivitySource } from "@prisma/client";
 import type { MembershipStatus } from "@prisma/client";
 import type { MembershipStatusReason } from "@prisma/client";
 import type { Role } from "@prisma/client";
@@ -3837,6 +3838,10 @@ type MembershipopportunityHostedCountViewFactory = {
 type MembershipFactoryDefineInput = {
     headline?: string | null;
     bio?: string | null;
+    priorActiveFrom?: Date | null;
+    priorActivityNote?: string | null;
+    priorActivitySource?: MemberPriorActivitySource | null;
+    priorActivityRecordedBy?: string | null;
     status?: MembershipStatus;
     reason?: MembershipStatusReason;
     role?: Role;

--- a/src/infrastructure/prisma/migrations/20260507021757_add_membership_prior_activity/migration.sql
+++ b/src/infrastructure/prisma/migrations/20260507021757_add_membership_prior_activity/migration.sql
@@ -1,0 +1,8 @@
+-- CreateEnum
+CREATE TYPE "MemberPriorActivitySource" AS ENUM ('SELF_REPORTED', 'ADMIN_CONFIRMED');
+
+-- AlterTable
+ALTER TABLE "t_memberships" ADD COLUMN     "prior_active_from" TIMESTAMP(3),
+ADD COLUMN     "prior_activity_note" VARCHAR(500),
+ADD COLUMN     "prior_activity_recorded_by" TEXT,
+ADD COLUMN     "prior_activity_source" "MemberPriorActivitySource";

--- a/src/infrastructure/prisma/migrations/20260507021757_add_membership_prior_activity/migration.sql
+++ b/src/infrastructure/prisma/migrations/20260507021757_add_membership_prior_activity/migration.sql
@@ -1,8 +1,0 @@
--- CreateEnum
-CREATE TYPE "MemberPriorActivitySource" AS ENUM ('SELF_REPORTED', 'ADMIN_CONFIRMED');
-
--- AlterTable
-ALTER TABLE "t_memberships" ADD COLUMN     "prior_active_from" TIMESTAMP(3),
-ADD COLUMN     "prior_activity_note" VARCHAR(500),
-ADD COLUMN     "prior_activity_recorded_by" TEXT,
-ADD COLUMN     "prior_activity_source" "MemberPriorActivitySource";

--- a/src/infrastructure/prisma/migrations/20260507053838_add_membership_prior_activity/migration.sql
+++ b/src/infrastructure/prisma/migrations/20260507053838_add_membership_prior_activity/migration.sql
@@ -1,0 +1,7 @@
+-- CreateEnum
+CREATE TYPE "MemberPriorActivityClass" AS ENUM ('PRE_CIVICSHIP_ACTIVE', 'POST_CIVICSHIP_ENGAGED');
+
+-- AlterTable
+ALTER TABLE "t_memberships" ADD COLUMN     "prior_activity_class" "MemberPriorActivityClass",
+ADD COLUMN     "prior_activity_note" VARCHAR(500),
+ADD COLUMN     "prior_activity_recorded_by" TEXT;

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -545,6 +545,20 @@ model Membership {
   headline String?
   bio      String?
 
+  // Operator-recorded context for members who were active in the
+  // community before civicship was introduced. Used by GRANT_APPLICATION
+  // / sales-facing reports to distinguish "civicship 導入前から動いて
+  // いた古参" from members who joined after onboarding. All four
+  // columns are nullable: existing rows backfill to NULL, and the
+  // bulk-import workflow (scripts/import-prior-activity.ts) writes
+  // them in batches as managers fill in a CSV. Free-text `note` is
+  // capped to 500 chars so a runaway paste from a spreadsheet cell
+  // cannot bloat the row.
+  priorActiveFrom         DateTime?                  @map("prior_active_from")
+  priorActivityNote       String?                    @map("prior_activity_note") @db.VarChar(500)
+  priorActivitySource     MemberPriorActivitySource? @map("prior_activity_source")
+  priorActivityRecordedBy String?                    @map("prior_activity_recorded_by")
+
   status MembershipStatus
   reason MembershipStatusReason
   role   Role                   @default(MEMBER)
@@ -629,6 +643,15 @@ enum MembershipStatusReason {
   REMOVED
 
   ASSIGNED
+}
+
+/// Provenance for `Membership.priorActiveFrom`.
+/// SELF_REPORTED — the member supplied the date themselves.
+/// ADMIN_CONFIRMED — a community manager / owner verified it; in this
+/// case `priorActivityRecordedBy` carries the admin's user id for audit.
+enum MemberPriorActivitySource {
+  SELF_REPORTED
+  ADMIN_CONFIRMED
 }
 
 enum ParticipationType {

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -548,16 +548,23 @@ model Membership {
   // Operator-recorded context for members who were active in the
   // community before civicship was introduced. Used by GRANT_APPLICATION
   // / sales-facing reports to distinguish "civicship 導入前から動いて
-  // いた古参" from members who joined after onboarding. All four
+  // いた古参" from members who joined after onboarding. All three
   // columns are nullable: existing rows backfill to NULL, and the
   // bulk-import workflow (scripts/import-prior-activity.ts) writes
-  // them in batches as managers fill in a CSV. Free-text `note` is
-  // capped to 500 chars so a runaway paste from a spreadsheet cell
-  // cannot bloat the row.
-  priorActiveFrom         DateTime?                  @map("prior_active_from")
-  priorActivityNote       String?                    @map("prior_activity_note") @db.VarChar(500)
-  priorActivitySource     MemberPriorActivitySource? @map("prior_activity_source")
-  priorActivityRecordedBy String?                    @map("prior_activity_recorded_by")
+  // them in batches as managers fill in a CSV.
+  //
+  // We deliberately store a `priorActivityClass` enum rather than a
+  // `priorActiveFrom` date because community managers usually do not
+  // know precise start dates — forcing a date field would either get
+  // skipped or fabricated, both of which corrupt downstream
+  // aggregation. The "before / after civicship" boolean is what the
+  // report actually consumes; richer narrative ("2019 年から農業に
+  // 参加") lands in the free-text `note`. `note` is capped to 500
+  // chars so a runaway paste from a spreadsheet cell cannot bloat
+  // the row.
+  priorActivityClass      MemberPriorActivityClass? @map("prior_activity_class")
+  priorActivityNote       String?                   @map("prior_activity_note") @db.VarChar(500)
+  priorActivityRecordedBy String?                   @map("prior_activity_recorded_by")
 
   status MembershipStatus
   reason MembershipStatusReason
@@ -645,13 +652,15 @@ enum MembershipStatusReason {
   ASSIGNED
 }
 
-/// Provenance for `Membership.priorActiveFrom`.
-/// SELF_REPORTED — the member supplied the date themselves.
-/// ADMIN_CONFIRMED — a community manager / owner verified it; in this
-/// case `priorActivityRecordedBy` carries the admin's user id for audit.
-enum MemberPriorActivitySource {
-  SELF_REPORTED
-  ADMIN_CONFIRMED
+/// Coarse classification for a member's pre-civicship activity. NULL
+/// means the operator has not recorded a judgement yet.
+/// PRE_CIVICSHIP_ACTIVE — the member was already active in the
+/// community / region before civicship was introduced (古参).
+/// POST_CIVICSHIP_ENGAGED — the member became engaged in community
+/// activity through civicship itself (新規).
+enum MemberPriorActivityClass {
+  PRE_CIVICSHIP_ACTIVE
+  POST_CIVICSHIP_ENGAGED
 }
 
 enum ParticipationType {


### PR DESCRIPTION
## Summary

ロードマップ Phase 2 の **storage 層 + bulk-import tooling** を投入。GraphQL 層 (mutation / resolver / rule.ts) と report payload への反映は別 PR。

### コア変更

- **Membership 拡張(別テーブルなし)**: `priorActivityClass` (enum) / `priorActivityNote` (VARCHAR(500)) / `priorActivityRecordedBy` の **3 カラム**を追加。粒度が `(userId, communityId)` の 1:1 属性で別テーブル化する論理的根拠なし
- **`MemberPriorActivityClass` enum**: `PRE_CIVICSHIP_ACTIVE`(古参) / `POST_CIVICSHIP_ENGAGED`(新規)。NULL = 未入力
- **migration**: `20260507053838_add_membership_prior_activity` — 全カラム nullable・既存行は NULL に backfill・後方互換

### 設計判断: なぜ date ではなく enum か

最初のドラフトでは `priorActiveFrom: DateTime?` + `priorActivitySource` enum で管理者に「いつから」を入力させる設計だった。レビュー過程で実態を再考した結果、以下の理由で **enum class に書き換え**:

- 管理者は**正確な日付を知らないことが大多数**(「2015年か2016年くらい...」)。date 列は埋まらないか、`YYYY-04-01` みたいに機械的にでっちあげられる
- レポートが必要とする signal は実質**「導入前/後」の2値**。GRANT_APPLICATION の出力例「導入前から活動 ○名 / 導入後新規 ○名」が代表
- granular な narrative(「2019年から農業」)は `priorActivityNote` の自由記述で十分
- enum なら edge case 無し・`<` 比較不要・管理者UX が「2択+空欄」で済む
- `priorActivitySource` (`SELF_REPORTED`/`ADMIN_CONFIRMED`) も削除: admin-only 運用が前提なので code path が無いまま optionality だけ持つコストが見合わない

### CSV bulk-import tooling

portal UI を待たずに営業対象コミュニティへ class を一括登録できるよう、ペアの admin スクリプトを追加:

- **`scripts/export-members.ts`** — JOINED メンバーをコミュニティ単位で CSV 出力 (`tmp/members_export_<communityId>_<timestamp>.csv`)。既存値も含むので backfill が再開可能
- **`scripts/import-prior-activity.ts`** — CSV を `$transaction` 内で適用(timeout/maxWait = 60s)。`--dry-run` でロールバック試走。`priorActivityRecordedBy` は **CSV からではなく `--recorded-by` 引数から自動セット**(audit フィールドの偽造を防ぐ)
- 認可モデル: スクリプトは GraphQL auth をバイパスする admin-only ツール。`--recorded-by` の userId 存在チェックのみ実装、community-manager 検証は運用上の取り決め

### 既存実装への影響

- 既存 MV / retention 計算は **触っていない**(audit-log 的な薄い overlay として追加)
- 既存 GraphQL resolver / dataloader / presenter は無変更(後続 PR で拡張予定)

## Test plan

- [x] `pnpm exec tsc --noEmit` — 変更ファイルに新規エラーなし(既存 typed-SQL エラーのみ・本 PR 範囲外)
- [x] `pnpm db:migrate` でクリーン migration 生成 + `pnpm db:deploy` で全 138 件マイグレーションが成功
- [x] export script smoke-test: 2 メンバー × 1 コミュニティで CSV 生成確認
- [x] import script `--dry-run`: 正常enum値 / 不明enum値 / blank class / membership 不在 / 501文字note をすべて期待通り判定
- [x] import script commit mode: 2 行 update 成功 + DB に正しく書き込み確認 (`PRE_CIVICSHIP_ACTIVE` / `POST_CIVICSHIP_ENGAGED` / recorded_by)
- [x] round-trip: import 後の export で `priorActivityClass` / `priorActivityNote` が正しく出力されることを確認
- [x] 空の `priorActivityNote` が NULL に正規化されることを確認
- [x] 暦不正 / VARCHAR(500) 越え / file ENOENT が pipeline で正しく propagate (Gemini レビュー対応分)
- [ ] develop にマージ後、dev 環境で実コミュニティ相手に export → 軽い整形 → dry-run の運用試走

## Follow-ups (別 PR)

- `membershipSetPriorActivity` mutation + GraphQL schema 拡張 + 認可ルール (IsCommunityManager 以上)
- Membership presenter に新フィールドを追加
- Report payload に `user_segments` を追加 (GRANT_APPLICATION の「導入効果」セクションが消費)
- portal 側の Membership 編集 UI 拡張(class 2択 + note + クリアボタン)

## 改訂履歴

このPRは作業中に2度設計を見直してます:

1. **初版**: `priorActiveFrom: DateTime?` + `priorActivitySource` (`SELF_REPORTED`/`ADMIN_CONFIRMED`) の date+source 設計
2. **revise**: `priorActivityClass` enum に置き換え + source enum 削除(現在の形)

migration ファイルは合算して develop 相手の cumulative diff が「新シェイプを足す migration 一発」になるよう旧 migration を削除して再生成してます(まだマージされてないので revise 可能と判断)。

https://claude.ai/code/session_018MJcM8wfRw8GhzdRWYKY19