### PR TITLE
refactor(authz): require x-community-id header for admin in community rules

### DIFF
--- a/src/application/domain/transaction/usecase.ts
+++ b/src/application/domain/transaction/usecase.ts
@@ -236,16 +236,21 @@ export default class TransactionUseCase {
     // mode flag: prefer owner-mode when the caller actually owns the
     // current community AND the txn was emitted from that community's
     // wallet, otherwise fall back to self-mode (caller is the creator).
+    // SYS_ADMIN bypasses the wallet/creator checks entirely — admins are
+    // a cross-community operations role and the IsCommunityOwner rule
+    // already forced them to declare the operating community via the
+    // x-community-id header.
     const ctxCommunityId = ctx.communityId;
-    const isOwnerOfCtxCommunity =
-      ctx.isAdmin ||
-      (!!ctxCommunityId &&
-        ctx.currentUser?.memberships?.some(
-          (m) => m.communityId === ctxCommunityId && m.role === Role.OWNER,
-        ) === true);
     const isCreator = existing.createdBy === currentUserId;
+    const isOwnerOfCtxCommunity =
+      !!ctxCommunityId &&
+      ctx.currentUser?.memberships?.some(
+        (m) => m.communityId === ctxCommunityId && m.role === Role.OWNER,
+      ) === true;
 
-    if (isOwnerOfCtxCommunity && ctxCommunityId) {
+    if (ctx.isAdmin) {
+      // admin はスコープ制限なし
+    } else if (isOwnerOfCtxCommunity && ctxCommunityId) {
       const communityWallet = await this.walletService.findCommunityWalletOrThrow(
         ctx,
         ctxCommunityId,

--- a/src/presentation/graphql/rules/index.ts
+++ b/src/presentation/graphql/rules/index.ts
@@ -79,13 +79,15 @@ const IsSelf = preExecRule({
 const IsCommunityOwner = preExecRule({
   error: new AuthorizationError("User must be community owner"),
 })((context: IContext) => {
-  if (context.isAdmin) return true;
-
   // Scope is resolved from the `x-community-id` header — the auth
   // middleware injects it from the authenticated session, so it's the
   // only trusted source. Args (`permission` / `communityPermission`)
   // are deprecated and ignored to keep the authz check and the
-  // operation aligned on the same community.
+  // operation aligned on the same community. The header is required
+  // for admins too: every downstream usecase calls
+  // `getCommunityIdFromCtx(ctx)` which throws on a missing header,
+  // and forcing admins to declare the operating community keeps the
+  // audit trail honest.
   const communityId = context.communityId;
   if (!communityId) {
     logger.warn("IsCommunityOwner authorization FAILED", {
@@ -94,6 +96,8 @@ const IsCommunityOwner = preExecRule({
     });
     return false;
   }
+
+  if (context.isAdmin) return true;
 
   const allowed = isCommunityOwner(context, communityId);
 
@@ -113,8 +117,6 @@ const IsCommunityOwner = preExecRule({
 const IsCommunityManager = preExecRule({
   error: new AuthorizationError("User must be community manager or owner"),
 })((context: IContext) => {
-  if (context.isAdmin) return true;
-
   const communityId = context.communityId;
   if (!communityId) {
     logger.warn("IsCommunityManager authorization FAILED", {
@@ -123,6 +125,8 @@ const IsCommunityManager = preExecRule({
     });
     return false;
   }
+
+  if (context.isAdmin) return true;
 
   const allowed = isCommunityManager(context, communityId);
 
@@ -142,8 +146,6 @@ const IsCommunityManager = preExecRule({
 const IsCommunityMember = preExecRule({
   error: new AuthorizationError("User must be a community member"),
 })((context: IContext) => {
-  if (context.isAdmin) return true;
-
   const communityId = context.communityId;
   if (!communityId) {
     logger.warn("IsCommunityMember authorization FAILED", {
@@ -152,6 +154,8 @@ const IsCommunityMember = preExecRule({
     });
     return false;
   }
+
+  if (context.isAdmin) return true;
 
   const allowed = isCommunityMember(context, communityId);
 


### PR DESCRIPTION
## Summary

PR レビュー（gemini-code-assist）で指摘された **「ルールは admin を素通しするのに、UseCase 側で `getCommunityIdFromCtx(ctx)` がヘッダー必須でスローする」** という不整合を解消します。

### 変更点

- **`src/presentation/graphql/rules/index.ts`**: `IsCommunityOwner` / `IsCommunityManager` / `IsCommunityMember` の admin 早期リターンを `ctx.communityId` 存在チェックの **後** に移動。admin にも `x-community-id` ヘッダーを必須にし、認可レイヤーと UseCase 層のスコープ前提を一致させる。`IsAdmin`（cross-community 用）は header 不要のまま。
- **`src/application/domain/transaction/usecase.ts`** (`userUpdateTransactionMetadata`): SYS_ADMIN は wallet / creator チェックを無条件で通過。admin はクロスコミュニティ運用ロールであり、上記ルール変更で操作対象コミュニティの宣言は強制済み。

### 設計上の意図

- ヘッダーが唯一の信頼できるスコープ源（auth ミドルウェアが認証セッションから注入）。admin にも宣言を強制することで監査ログが「どのコミュニティとして操作したか」を必ず保持する。
- ルール段階で `ctx.communityId` 必須にしたので、`getCommunityIdFromCtx(ctx)` 経由で UseCase 側がスローする経路は実質発生しない（ルールが先に弾く）。

## Test plan

- [ ] `pnpm test src/__tests__/auth/mutation.onlyCommunityOwner.test.ts` — 既存テストは `communityId: "community-1"` を ctx にセット済みのため影響なし
- [ ] `pnpm test` 全体 grep
- [ ] admin ユーザーでヘッダー無しリクエスト → `IsCommunityOwner` 系の operation で 403
- [ ] admin ユーザーでヘッダーありリクエスト → 自分が作成していないトランザクションのメタデータも更新可能

https://claude.ai/code/session_01WcPnirzfV5hKVWQwH6gHVA

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcPnirzfV5hKVWQwH6gHVA)_