### PR TITLE
chore(deps): bump axios + @apollo/server to fix 5 HIGH CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",
-    "@apollo/server": "^4.12.0",
+    "@apollo/server": "^4.13.0",
     "@dotenvx/dotenvx": "^1.41.0",
     "@escape.tech/graphql-armor": "^3.1.3",
     "@escape.tech/graphql-armor-types": "^0.7.0",
@@ -165,7 +165,7 @@
     "@prisma/client": "^6.6.0",
     "@prisma/instrumentation": "^6.19.0",
     "@types/graphql-upload": "^17.0.0",
-    "axios": "1.15.0",
+    "axios": "1.15.2",
     "busboy": "^1.6.0",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,14 +32,14 @@ importers:
         specifier: ^0.90.0
         version: 0.90.0
       '@apollo/server':
-        specifier: ^4.12.0
-        version: 4.12.2(graphql@16.10.0)
+        specifier: ^4.13.0
+        version: 4.13.0(graphql@16.10.0)
       '@dotenvx/dotenvx':
         specifier: ^1.41.0
         version: 1.47.3
       '@escape.tech/graphql-armor':
         specifier: ^3.1.3
-        version: 3.1.6(@apollo/server@4.12.2(graphql@16.10.0))(@envelop/core@5.3.0)(@escape.tech/graphql-armor-types@0.7.0)
+        version: 3.1.6(@apollo/server@4.13.0(graphql@16.10.0))(@envelop/core@5.3.0)(@escape.tech/graphql-armor-types@0.7.0)
       '@escape.tech/graphql-armor-types':
         specifier: ^0.7.0
         version: 0.7.0
@@ -57,7 +57,7 @@ importers:
         version: 7.16.0
       '@graphql-authz/apollo-server-plugin':
         specifier: ^3.1.3
-        version: 3.1.3(@apollo/server@4.12.2(graphql@16.10.0))(@graphql-authz/core@1.3.2(graphql@16.10.0))(graphql@16.10.0)
+        version: 3.1.3(@apollo/server@4.13.0(graphql@16.10.0))(@graphql-authz/core@1.3.2(graphql@16.10.0))(graphql@16.10.0)
       '@graphql-authz/core':
         specifier: ^1.3.2
         version: 1.3.2(graphql@16.10.0)
@@ -125,8 +125,8 @@ importers:
         specifier: ^17.0.0
         version: 17.0.0
       axios:
-        specifier: 1.15.0
-        version: 1.15.0
+        specifier: 1.15.2
+        version: 1.15.2
       busboy:
         specifier: ^1.6.0
         version: 1.6.0
@@ -391,8 +391,8 @@ packages:
     peerDependencies:
       graphql: 14.x || 15.x || 16.x
 
-  '@apollo/server@4.12.2':
-    resolution: {integrity: sha512-jKRlf+sBMMdKYrjMoiWKne42Eb6paBfDOr08KJnUaeaiyWFj+/040FjVPQI7YGLfdwnYIsl1NUUqS2UdgezJDg==}
+  '@apollo/server@4.13.0':
+    resolution: {integrity: sha512-t4GzaRiYIcPwYy40db6QjZzgvTr9ztDKBddykUXmBb2SVjswMKXbkaJ5nPeHqmT3awr9PAaZdCZdZhRj55I/8A==}
     engines: {node: '>=14.16.0'}
     deprecated: Apollo Server v4 is end-of-life since January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v5 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.
     peerDependencies:
@@ -3865,8 +3865,8 @@ packages:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
     engines: {node: '>= 6.0.0'}
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.15.2:
+    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
 
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
@@ -8458,6 +8458,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@11.1.0:
@@ -8466,19 +8467,22 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.0:
     resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uvu@0.5.6:
@@ -8806,7 +8810,7 @@ snapshots:
       '@apollo/utils.logger': 2.0.1
       graphql: 16.10.0
 
-  '@apollo/server@4.12.2(graphql@16.10.0)':
+  '@apollo/server@4.13.0(graphql@16.10.0)':
     dependencies:
       '@apollo/cache-control-types': 1.0.3(graphql@16.10.0)
       '@apollo/server-gateway-interface': 1.1.1(graphql@16.10.0)
@@ -8823,6 +8827,7 @@ snapshots:
       '@types/express-serve-static-core': 4.19.6
       '@types/node-fetch': 2.6.12
       async-retry: 1.3.3
+      content-type: 1.0.5
       cors: 2.8.5
       express: 4.21.2
       graphql: 16.10.0
@@ -10550,7 +10555,7 @@ snapshots:
     dependencies:
       graphql: 16.10.0
 
-  '@escape.tech/graphql-armor@3.1.6(@apollo/server@4.12.2(graphql@16.10.0))(@envelop/core@5.3.0)(@escape.tech/graphql-armor-types@0.7.0)':
+  '@escape.tech/graphql-armor@3.1.6(@apollo/server@4.13.0(graphql@16.10.0))(@envelop/core@5.3.0)(@escape.tech/graphql-armor-types@0.7.0)':
     dependencies:
       '@escape.tech/graphql-armor-block-field-suggestions': 3.0.1
       '@escape.tech/graphql-armor-cost-limit': 2.4.3
@@ -10560,7 +10565,7 @@ snapshots:
       '@escape.tech/graphql-armor-max-tokens': 2.5.1
       graphql: 16.10.0
     optionalDependencies:
-      '@apollo/server': 4.12.2(graphql@16.10.0)
+      '@apollo/server': 4.13.0(graphql@16.10.0)
       '@envelop/core': 5.3.0
       '@escape.tech/graphql-armor-types': 0.7.0
 
@@ -10846,9 +10851,9 @@ snapshots:
       - encoding
       - supports-color
 
-  '@graphql-authz/apollo-server-plugin@3.1.3(@apollo/server@4.12.2(graphql@16.10.0))(@graphql-authz/core@1.3.2(graphql@16.10.0))(graphql@16.10.0)':
+  '@graphql-authz/apollo-server-plugin@3.1.3(@apollo/server@4.13.0(graphql@16.10.0))(@graphql-authz/core@1.3.2(graphql@16.10.0))(graphql@16.10.0)':
     dependencies:
-      '@apollo/server': 4.12.2(graphql@16.10.0)
+      '@apollo/server': 4.13.0(graphql@16.10.0)
       '@graphql-authz/core': 1.3.2(graphql@16.10.0)
       graphql: 16.10.0
 
@@ -11083,7 +11088,7 @@ snapshots:
       '@graphql-tools/utils': 8.9.0(graphql@16.10.0)
       dataloader: 2.1.0
       graphql: 16.10.0
-      tslib: 2.4.1
+      tslib: 2.8.1
       value-or-promise: 1.0.11
 
   '@graphql-tools/batch-execute@9.0.17(graphql@16.10.0)':
@@ -11329,7 +11334,7 @@ snapshots:
       '@ardatan/relay-compiler': 12.0.3(graphql@16.10.0)
       '@graphql-tools/utils': 10.8.6(graphql@16.10.0)
       graphql: 16.10.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     transitivePeerDependencies:
       - encoding
 
@@ -11814,7 +11819,7 @@ snapshots:
     dependencies:
       '@types/node': 22.16.3
     optionalDependencies:
-      axios: 1.15.0
+      axios: 1.15.2
     transitivePeerDependencies:
       - debug
 
@@ -13323,7 +13328,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.6':
     dependencies:
-      '@types/node': 22.16.3
+      '@types/node': 22.19.17
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.5
@@ -13860,7 +13865,7 @@ snapshots:
 
   aws-ssl-profiles@1.1.2: {}
 
-  axios@1.15.0:
+  axios@1.15.2:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
@@ -14800,7 +14805,7 @@ snapshots:
       '@dbml/core': 3.9.0
       '@oclif/core': 1.12.1
       '@oclif/plugin-help': 5.1.12
-      axios: 1.15.0
+      axios: 1.15.2
       chalk: 3.0.0
       dotenv: 8.6.0
       inquirer: 7.3.3
@@ -18456,7 +18461,7 @@ snapshots:
       asn1.js: 5.4.1
       asn1.js-rfc2560: 5.0.1(asn1.js@5.4.1)
       asn1.js-rfc5280: 3.0.0
-      axios: 1.15.0
+      axios: 1.15.2
       big-integer: 1.6.52
       bignumber.js: 9.3.0
       binascii: 0.0.2


### PR DESCRIPTION
## Summary

PR #1059 で CI に Trivy HIGH advisory scan を入れた結果、runtime image に **18 件の HIGH CVE** が検出されました。そのうち **直接依存パッケージ 2 つで合計 5 CVE** を 1 つの bump で解消できるので、まず先に潰します。

## 変更

| Pkg | 現在 | → | 新 | 解消 CVE |
|---|---|---|---|---|
| `axios` | 1.15.0 | → | 1.15.2 | CVE-2026-42033 / CVE-2026-42035 / CVE-2026-42043 (1.15.1 fix) + CVE-2026-42264 (1.15.2 fix) |
| `@apollo/server` | ^4.12.0 (resolved 4.12.2) | → | ^4.13.0 | CVE-2026-23897 |

両者とも minor / patch bump で semver 内、API 互換のはず。

## 残る 13 HIGH (本 PR 範囲外)

推移的依存なので親 bump or Dependabot 待ち。`pnpm.overrides` で強制 bump も可能だが、親が壊れるリスクと天秤。

| Pkg | 現在 | 推奨 | CVE 数 |
|---|---|---|---|
| `cross-spawn` | 7.0.3 | 7.0.5 | 1 |
| `glob` | 10.4.2 | 10.5.0 | 1 |
| `minimatch` | 9.0.5 | 9.0.6+ | 3 |
| `picomatch` | 2.3.1 / 4.0.2 | 4.0.4 | 1 |
| `tar` | 6.2.1 | 7.5.x | 6 |

## Test plan

- [x] `pnpm install --lockfile-only` で lockfile 再生成、変更は package.json + pnpm-lock.yaml のみ
- [ ] CI の `trivy` job で HIGH 件数が `18 → 13` に減ることを確認 (CRITICAL は引き続き 0 のまま)
- [ ] `build` / `test` matrix が green であることを確認 (axios / @apollo/server の API 互換確認)
- [ ] Code Scanning alerts (Security tab) で `trivy-high` カテゴリの該当 CVE が次の deploy run 後に解消されることを確認

## Note on follow-ups

残る 13 HIGH のうち `tar@6→7` は major bump で親 (puppeteer / prisma 等) が追従していないため、現実的には Dependabot で親が動いた時に連鎖解消するのを待つのが安全です。`pnpm.overrides` で強制したい場合は別 PR で慎重に検証することを推奨。

https://claude.ai/code/session_01YKp4foiiVqxLCDv7D7LjT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKp4foiiVqxLCDv7D7LjT8)_