### PR TITLE
ci(security): pass limit-severities-for-sarif so Trivy honors severity filter

### DIFF
--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -200,6 +200,18 @@ jobs:
       # docs/handbook/SECURITY.md "Severity Policy" を参照。
       # `ignore-unfixed: true` で fix の出ていない CVE は除外する (上流が
       # 直せない CVE で deploy が永久に止まらないようにする保険)。
+      # `limit-severities-for-sarif: true` は **必須**。trivy-action は
+      # `format: sarif` のときデフォルトで `severity` フィルタを **無視** して
+      # 全 severity を sarif に出力する仕様 (action log に
+      # "Building SARIF report with all severities" が出る)。これを有効化しないと
+      # `severity: CRITICAL` を指定しても HIGH/MEDIUM の CVE で `exit-code: '1'`
+      # が trip し、deploy が誤 block される (#1059 の merge 直後に観測。
+      # CI 側 (`ci.yml` の trivy job) は `format: json` で本 quirk の影響を
+      # 受けず CRITICAL: 0 のまま通っていたが、deploy 側だけ落ちる症状になった)。
+      # 本 flag を入れることで、severity フィルタが json/table と同じく sarif
+      # 出力にも適用され、exit-code 判定が本物の CRITICAL のみに限定される。
+      # HIGH (advisory) 側は exit-code: '0' で fail しないが、Security タブの
+      # category が混ざらないように同様に true に揃える。
       - name: Scan image (Trivy CRITICAL — blocking)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -209,6 +221,7 @@ jobs:
           ignore-unfixed: true
           format: sarif
           output: trivy-critical.sarif
+          limit-severities-for-sarif: true
 
       - name: Scan image (Trivy HIGH — advisory)
         # CRITICAL が落ちて job が fail した場合でも HIGH の sarif を生成し
@@ -222,6 +235,7 @@ jobs:
           ignore-unfixed: true
           format: sarif
           output: trivy-high.sarif
+          limit-severities-for-sarif: true
 
       # CRITICAL 件数を `::error::` annotation として workflow summary 最上部
       # に上げる (上の scan step が `exit-code: '1'` で既に fail させているが、

--- a/.github/workflows/_deploy-external-api.yml
+++ b/.github/workflows/_deploy-external-api.yml
@@ -145,6 +145,12 @@ jobs:
       # CRITICAL = blocking、HIGH = advisory。政策と blocking 解除手順は
       # _deploy-cloud-run.yml の同名 step コメント + docs/handbook/SECURITY.md
       # 参照。両 image (internal / external) で完全に同じ政策。
+      # `limit-severities-for-sarif: true` の根拠は `_deploy-cloud-run.yml` の
+      # 同名 step コメント参照。trivy-action の `format: sarif` モードは
+      # default で severity フィルタが無効化されるため、本 flag が無いと
+      # `severity: CRITICAL` を指定しても HIGH/MEDIUM で exit-code: '1' が
+      # trip し deploy が誤 block される。両 image (internal / external) で
+      # 完全に同じ政策。
       - name: Scan image (Trivy CRITICAL — blocking)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -154,6 +160,7 @@ jobs:
           ignore-unfixed: true
           format: sarif
           output: trivy-critical.sarif
+          limit-severities-for-sarif: true
 
       - name: Scan image (Trivy HIGH — advisory)
         if: always()
@@ -165,6 +172,7 @@ jobs:
           ignore-unfixed: true
           format: sarif
           output: trivy-high.sarif
+          limit-severities-for-sarif: true
 
       # CRITICAL = ::error:: annotation, HIGH = ::warning::.
       # 同 step の根拠は _deploy-cloud-run.yml 参照。

--- a/.github/workflows/trivy-daily.yml
+++ b/.github/workflows/trivy-daily.yml
@@ -135,6 +135,11 @@ jobs:
           format: json
           output: trivy-internal.json
 
+      # `limit-severities-for-sarif: true` の根拠は `_deploy-cloud-run.yml`
+      # の同名 step コメント参照。本 daily job は exit-code: '0' なので
+      # blocking 影響は無いが、本 flag が無いと Security タブの
+      # `trivy-critical` category に HIGH/MEDIUM 含む全 severity が混入し、
+      # category 名と中身が乖離するため必須。
       - name: Trivy scan internal image (sarif → Security tab)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -144,6 +149,7 @@ jobs:
           ignore-unfixed: true
           format: sarif
           output: trivy-internal.sarif
+          limit-severities-for-sarif: true
 
       - name: Trivy scan external image (json)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
@@ -164,6 +170,7 @@ jobs:
           ignore-unfixed: true
           format: sarif
           output: trivy-external.sarif
+          limit-severities-for-sarif: true
 
       - name: Upload SARIF to Security tab (internal)
         uses: github/codeql-action/upload-sarif@4f3212b61783c3c68e8309a0f18a699764811cda # v3.27.1


### PR DESCRIPTION
## Summary

#1059 で CRITICAL blocking に昇格させた直後、dev deploy (run_id `25537329183`) が
Trivy CRITICAL scan step で fail する事象が発生。原因は **trivy-action の SARIF
severity-filter quirk** で、`format: sarif` 時は `limit-severities-for-sarif: true`
を明示しないと `severity:` フィルタが**無視されて全 severity が sarif に出力される**
(action ログに `Building SARIF report with all severities` が出る)。結果:

- `severity: CRITICAL` 指定でも HIGH/MEDIUM の CVE で `exit-code: '1'` が trip
- Surface step は `CRITICAL: 38 / HIGH: 38` (= 同一全 severity dump) を出力
- CI 側 (`ci.yml` の trivy job) は `format: json` で影響を受けず CRITICAL: 0 で green
- 結果、CI は通るのに deploy だけ落ちる非対称な症状

## Fix

sarif を出力している全 trivy-action step に `limit-severities-for-sarif: true` を追加:

- `_deploy-cloud-run.yml`: CRITICAL (blocking) + HIGH (advisory)
- `_deploy-external-api.yml`: 同上
- `trivy-daily.yml`: internal/external sarif step (Security タブの category 名
  `trivy-critical` / `trivy-external-critical` と中身を整合させるため、advisory でも追加)

`ci.yml` の trivy job は `format: json` のため変更不要。

policy 自体 (CRITICAL=blocking / HIGH=advisory) は維持。これで deploy 側でも本物の
CRITICAL のみで exit-code が trip し、Security タブの severity 別 category も宣言通りに
分離される。

## Test plan

- [ ] CI green (lint / typecheck / test / trivy json scan)
- [ ] develop merge 後、次の dev deploy で `Surface Trivy CVE count` が `CRITICAL: 0`
      を出して deploy が pass する (現在 18 件残っている HIGH は advisory のまま warning)
- [ ] Security タブの `trivy-critical` category が CRITICAL のみに整理される (古い HIGH 混入分は
      sarif の置換でクリアされる想定)

https://claude.ai/code/session_01YKp4foiiVqxLCDv7D7LjT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKp4foiiVqxLCDv7D7LjT8)_