### PR TITLE
chore(security): layered npm supply chain defense (dep-review + audit --prod + cleanup duplicate config)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,38 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # `dependency-review-action` は PR diff (base..head) で **新規追加された**
+  # npm 依存に既知 CVE / 不適合 license が含まれていないかを GitHub の
+  # advisory DB に問い合わせて gate する。`pnpm audit` (build job 内、
+  # advisory) が lockfile 全体を継続監視するのに対し、こちらは
+  # **PR で増えた diff だけ** を高い severity で blocking する役割分担。
+  # push (master) や手動 dispatch では動かないため `if: github.event_name`
+  # で gating する。aggregator (`ci` job) は `skipped` を success 扱い
+  # にしているので push 時は無害に skip される。
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      # comment-summary-in-pr で失敗時に PR コメントを起こすため write が必要。
+      pull-requests: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+          disable-sudo: true
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure
+
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -137,10 +169,20 @@ jobs:
       # change independently of code changes; gating CI on transitive
       # vulnerabilities yields a flaky required check). The full audit output
       # is preserved in the step log for triage.
+      # `pnpm audit` は npm advisory DB ベースで lockfile 全体 (transitive 含む)
+      # を継続監視する。Trivy は image レイヤ (OS / Debian package) しか
+      # 見ないので、両者で守備範囲が異なる:
+      #   - Trivy: Debian package / Node ランタイムの CVE
+      #   - pnpm audit: package.json + 推移的依存の npm advisory
+      # `--prod` で devDependencies (jest / eslint plugin 等) を除外し、
+      # 本番デプロイに乗らない dev tool の CVE ノイズを advisory から外す。
+      # CI runner 上では dev tool もコード実行されるが、production 影響を
+      # 切り分けて見たい運用に倒している (dev tool CVE は手動 pnpm audit /
+      # Dependabot の生 PR で別途確認可能)。
       - name: Audit (non-blocking, surfaces findings as warnings)
         run: |
-          if ! pnpm audit --audit-level=high; then
-            echo "::warning::pnpm audit found high-severity vulnerabilities (non-blocking — see step log for details)"
+          if ! pnpm audit --audit-level=high --prod; then
+            echo "::warning::pnpm audit found high-severity vulnerabilities in production deps (non-blocking — see step log for details)"
           fi
 
       # Surface destructive Prisma migration DDL (DROP TABLE / DROP COLUMN /
@@ -605,7 +647,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [lint, build, trivy, test]
+    needs: [dependency-review, lint, build, trivy, test]
     if: always()
     permissions:
       contents: read
@@ -614,11 +656,12 @@ jobs:
     steps:
       - name: Verify all required jobs passed
         run: |
+          dep_review='${{ needs.dependency-review.result }}'
           lint='${{ needs.lint.result }}'
           build='${{ needs.build.result }}'
           trivy='${{ needs.trivy.result }}'
           test='${{ needs.test.result }}'
-          echo "lint=$lint build=$build trivy=$trivy test=$test"
+          echo "dep_review=$dep_review lint=$lint build=$build trivy=$trivy test=$test"
           # CRITICAL を blocking 化したので trivy も required ジョブに昇格。
           # trivy job 内部で「scan = exit 0、最後に Surface step が件数 > 0 で
           # exit 1」という構造を取っているので、`failure` は CRITICAL 検出
@@ -626,7 +669,9 @@ jobs:
           # 必要になったら trivy job 側で step output を立てて aggregator で
           # 分岐する形に拡張する (現時点では「とにかく落ちたら deploy 不可」
           # という挙動で十分)。
-          for j in "$lint" "$build" "$trivy" "$test"; do
+          # dependency-review は push (master) 時に if-skip するので
+          # `skipped` を success と等価扱いする (case 句で吸収)。
+          for j in "$dep_review" "$lint" "$build" "$trivy" "$test"; do
             case "$j" in
               success|skipped) ;;
               *) echo "::error::required job failed: $j"; exit 1 ;;

--- a/docs/handbook/SECURITY.md
+++ b/docs/handbook/SECURITY.md
@@ -556,19 +556,91 @@ Cosign keyless 署名は将来的に検討するが、現状は GitHub Actions O
 build provenance を保持する形で十分とする (cosign 署名追加時は
 `sigstore/cosign-installer` + `cosign sign --yes` を deploy workflow に追加)。
 
-## npm Supply Chain Hardening (`pnpm.minimumReleaseAge`)
+## npm Supply Chain Hardening
 
-`package.json` の `pnpm.minimumReleaseAge: 4320` (= **3 日**, 分単位) で、
+npm エコシステム由来の脅威 (既知 CVE / postinstall malware / runtime 混入型
+malware / typosquat 等) に対して、**重ね合わせ** で守る方針を取る。各層は
+別の検知ロジック / 起動タイミングを持ち、1 つが空振りしても他が拾う。
+
+### 防御レイヤ一覧
+
+| 層 | ツール / 設定 | 起動 | 役割 |
+|---|---|---|---|
+| (1) PR diff の追加 dep を gate | `actions/dependency-review-action` | PR 時 | 新規追加 dep に既知 CVE (HIGH+) / 不適合 license があれば fail |
+| (2) lockfile 全体の advisory | `pnpm audit --audit-level=high --prod` | CI build job | npm advisory DB ベースで lockfile 全体を継続監視 (warning only、production deps に scope) |
+| (3) image 全体の CVE scan | Trivy CRITICAL=blocking / HIGH=advisory | CI + deploy + daily | OS / Debian package / Node ランタイム |
+| (4) lifecycle script の execution gate | `pnpm-workspace.yaml` の `onlyBuiltDependencies` allowlist | install 時 | allowlist 外の dep の postinstall / preinstall を deny |
+| (5) publish 直後の release を install 拒否 | `pnpm-workspace.yaml` の `minimumReleaseAge: 4320` (= 3 日) | install 時 | 0-day マルウェア混入 release (chalk/debug 型 hijack) の attack window を短縮 |
+| (6) direct dep 自動 bump | Dependabot (cooldown 付き) | weekly | (1)〜(5) で検知された CVE / drift を自動修正 |
+
+(1)〜(3) は **既知 CVE 対策**、(4)〜(5) は **未知 / 0-day malware 対策**、
+(6) は **修正サイクルの自動化**。
+
+### (1) `dependency-review-action` (PR diff gate)
+
+GitHub 公式 action。`base..head` の `package.json` / `pnpm-lock.yaml` 差分を
+GitHub Advisory Database に問い合わせ、**新規追加された dep に HIGH+ CVE が
+含まれていれば PR を fail** させる。`pnpm audit` (advisory) との違いは:
+
+- audit: lockfile 全体を毎回チェック → drift で flaky
+- dep-review: PR で**増えた dep だけ** をチェック → 安定 / blocking 可能
+
+push (master) や手動 dispatch では skip され、aggregator (`ci`) は `skipped` を
+success と等価扱いする。
+
+### (2) `pnpm audit --audit-level=high --prod` (advisory)
+
+`ci.yml` の build job に組み込み済み。`--prod` で devDependencies (jest /
+eslint plugin 等、本番デプロイに乗らない dev tool) を除外し、production 影響を
+切り分けて見る運用に倒している。閾値超えは `::warning::` annotation で surface
+するのみで blocking はしない (lockfile-wide audit は drift で flaky になりがち
+なので gate には使わない、issue #979 と同じ方針)。
+
+### (3) Trivy
+
+詳細は本ドキュメント上部の "Container Image Scanning (Trivy)" 参照。
+image レイヤの CVE 検出を担い、(1)(2) と検出ソースが補完関係にある。
+
+### (4) `onlyBuiltDependencies` allowlist (lifecycle deny by default)
+
+pnpm 10 から `postinstall` / `preinstall` 等の lifecycle script は
+**デフォルトで無効化** され、`onlyBuiltDependencies` に明示 allowlist した
+package のみ走る。本リポジトリでは **`pnpm-workspace.yaml`** で許可 package を
+列挙する形で運用している (該当ファイル参照):
+
+```yaml
+# pnpm-workspace.yaml (抜粋)
+onlyBuiltDependencies:
+  - '@apollo/protobufjs'
+  - '@prisma/client'
+  - '@prisma/engines'
+  - esbuild
+  - prisma
+  - protobufjs
+  - puppeteer
+  - sharp
+  - vue-demi
+```
+
+それ以外の package の lifecycle script はすべて deny される (例: 新たに
+追加された malicious package が postinstall で外部にデータ送出する等の攻撃を
+install 時点で阻止する)。
+
+許可を新規追加する場合は:
+
+1. PR で `pnpm-workspace.yaml` を編集し、commit message に **追加の根拠**
+   (なぜ build script が必要か / 代替手段が無いか / その package を信頼する根拠)
+   を必ず書く
+2. CI レビューで明示的に承認する (現状リストの 9 package はいずれも
+   ビルドツール / native binary 系で必要性が明確、新規追加は同等の妥当性を要求)
+3. pnpm 10 では `pnpm approve-builds` で interactive に追加もできるが、
+   YAML 直編集 + PR の方が レビュー導線として推奨
+
+### (5) `minimumReleaseAge` (release age gate)
+
+`pnpm-workspace.yaml` の `minimumReleaseAge: 4320` (= **3 日**, 分単位) で、
 publish 後 3 日経過していない npm package version は install 対象から
 除外する。これは pnpm 10.16+ の supply chain hardening 機能。
-
-### 何を防ぐか / 防げないか
-
-| 脅威 | 防御 |
-|---|---|
-| 既知 CVE (古い lib) | Trivy / Dependabot / `pnpm.overrides` で対処 |
-| postinstall 型 malware | pnpm 10 default-deny + `onlyBuiltDependencies` allowlist (現状未定義 = 全 lifecycle script 無効) |
-| **publish 直後の runtime 混入型 malware** | **`minimumReleaseAge`** で attack window を短縮 |
 
 `pnpm audit` / Trivy は **既知 CVE** の検知が前提で、`chalk` / `debug` の hijack
 (2025-09) のように publish 直後で発見前の malware が混入したケースは原理的に
@@ -576,20 +648,20 @@ publish 後 3 日経過していない npm package version は install 対象か
 unpublish されるので、3 日待つだけで window の大半を回避できる
 (cf. ua-parser-js, event-stream, eslint-scope, chalk/debug の各事案)。
 
-### 緊急バイパス: `minimumReleaseAgeExclude`
+#### 緊急バイパス: `minimumReleaseAgeExclude`
 
 緊急 CVE で fresh patch を 3 日待たず即時取り込みたい場合は、
-`package.json` の `pnpm` block に `minimumReleaseAgeExclude` を追加して
+`pnpm-workspace.yaml` に `minimumReleaseAgeExclude` を追加して
 特定 package のみ release age 制限を bypass できる:
 
-```json
-"pnpm": {
-  "minimumReleaseAge": 4320,
-  "minimumReleaseAgeExclude": [
-    "axios"
-  ],
-  "overrides": { ... }
-}
+```yaml
+# pnpm-workspace.yaml (抜粋)
+minimumReleaseAge: 4320
+minimumReleaseAgeExclude:
+  - axios
+
+onlyBuiltDependencies:
+  - ...
 ```
 
 運用ルール:
@@ -602,11 +674,7 @@ unpublish されるので、3 日待つだけで window の大半を回避でき
    恒久的な exclude は supply chain hardening を骨抜きにするので避ける。
 3. 月次棚卸しで残存 entry を確認 (`.trivyignore` の expires policy と同じ運用)。
 
-`package.json` は JSON のためファイル内にコメントを書けず、`.trivyignore` の
-ような inline `expires:` を持てない。この制約のため、bypass の理由・期限は
-PR description / commit message への併記で代替する運用としている。
-
-### 既知の副作用
+#### 既知の副作用 (`minimumReleaseAge`)
 
 - Dependabot / 手動 bump PR で **publish 直後の version** が指定されると、
   install が解決失敗相当になることがある。3 日後に自然解消するため

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "typescript-eslint": "^8.58.1"
   },
   "pnpm": {
-    "minimumReleaseAge": 4320,
     "overrides": {
       "@escape.tech/graphql-armor-max-depth": "^2.4.2",
       "ajv": "^6.12.6",


### PR DESCRIPTION
## Summary

npm エコシステム由来の脅威を **多層** で塞ぐ supply chain hardening 3 点パック。
PR 時 / install 時 / build 時 の各タイミングで別系統の検知ロジックを動かし、
1 つが空振りしても他で拾えるようにする。

> **注**: 当初は `package.json` に `pnpm.onlyBuiltDependencies: []` を明示宣言する
> 案を含めていたが、レビュー (gemini-code-assist, security-high) で指摘された通り
> **`pnpm-workspace.yaml` に既に 9-package allowlist が存在** しており、空配列宣言は
> それを override して prisma / sharp / @prisma/client 等の build script を
> deny にする致命的な間違いだったため削除。workspace 側の allowlist を sole source
> of truth として維持する方針に修正した上で、ドキュメント側を実態反映に書き換えている。

## 何を入れるか

### 1. `actions/dependency-review-action` を `ci.yml` に追加

GitHub 公式 action。`base..head` の `package.json` / `pnpm-lock.yaml` 差分を
GitHub Advisory Database に問い合わせ、**新規追加された dep に HIGH+ CVE が
あれば PR を fail** させる。

- 既存 `pnpm audit` (lockfile 全体の advisory、warning only) との **役割分担**:
  PR で増えた dep だけを高 severity で blocking する。drift で flake にならない。
- `push` (master) や手動 dispatch では `if: github.event_name == 'pull_request'`
  で skip。aggregator (`ci`) は `skipped` を success 等価扱いなので master push でも無害。
- 失敗時のみ PR コメントで要約 (`comment-summary-in-pr: on-failure`)。

### 2. 既存 `pnpm audit` step に `--prod` を追加

devDependencies (jest / eslint plugin 等) の CVE をノイズから除外し、
production 影響に scope を絞った advisory に変える。dev tool CVE は CI runner 上では
コードが走るが本番デプロイには乗らないので、分けて見るのが妥当。

### 3. `package.json` から redundant な `pnpm.minimumReleaseAge: 4320` を削除

PR #1063 で `package.json` に追加していたが、調査の結果 **`pnpm-workspace.yaml` line 8 に
既に同値で存在** しており完全な duplicate だった (同値だったため挙動は不変)。
将来の値更新で片方の追従漏れを起こさないため、workspace 側を sole source of truth に統一。

### 4. `docs/handbook/SECURITY.md` の "npm Supply Chain Hardening" セクションを再構成

現状の 6 層防御の役割分担を表で明示。`onlyBuiltDependencies` の項では
**実態 (workspace.yaml の 9-package allowlist)** を反映し、追加時の運用ルール
(PR で根拠記載 + レビュー必須) を明記。bypass 手順も `pnpm-workspace.yaml` 編集 +
PR/commit message 併記に揃えた (#1067 の意図を継続)。

## 既存防御との関係

| 層 | ツール / 設定 | 役割 |
|---|---|---|
| (1) PR diff の追加 dep を gate | **`actions/dependency-review-action`** 🆕 | PR で増えた dep に HIGH+ CVE があれば fail |
| (2) lockfile 全体の advisory | **`pnpm audit --audit-level=high --prod`** 🆕 (`--prod` 追加) | warning only、production scope |
| (3) image の CVE scan | Trivy CRITICAL=blocking / HIGH=advisory | 既存 |
| (4) lifecycle script deny | `pnpm-workspace.yaml` の `onlyBuiltDependencies` allowlist (9 packages) | 既存 (本 PR で documentation 整備) |
| (5) publish 直後の release を install 拒否 | `pnpm-workspace.yaml` の `minimumReleaseAge: 4320` | 既存 (本 PR で package.json の duplicate を削除) |
| (6) direct dep 自動 bump | Dependabot (cooldown 付き) | 既存 |

## 検証

- `pnpm install` で sharp / prisma / @prisma/client の postinstall が走り、
  "Ignored build scripts" 警告が出ないことを確認
- `pnpm install --lockfile-only` が drift 無く成功
- YAML / JSON syntax check pass

## Test plan

- [ ] CI green (lint / build / test / trivy / dependency-review)
- [ ] dependency-review job が **PR 時のみ** 実行され、master push 時は skip される
      → aggregator が両ケースで pass
- [ ] 既存 `pnpm audit` step が `--prod` で動作 (build job log を確認)

https://claude.ai/code/session_01YKp4foiiVqxLCDv7D7LjT8