### PR TITLE
docs(security): clarify pnpm bypass entry expiration tracking

### DIFF
--- a/docs/handbook/SECURITY.md
+++ b/docs/handbook/SECURITY.md
@@ -602,6 +602,10 @@ unpublish されるので、3 日待つだけで window の大半を回避でき
    恒久的な exclude は supply chain hardening を骨抜きにするので避ける。
 3. 月次棚卸しで残存 entry を確認 (`.trivyignore` の expires policy と同じ運用)。
 
+`package.json` は JSON のためファイル内にコメントを書けず、`.trivyignore` の
+ような inline `expires:` を持てない。この制約のため、bypass の理由・期限は
+PR description / commit message への併記で代替する運用としている。
+
 ### 既知の副作用
 
 - Dependabot / 手動 bump PR で **publish 直後の version** が指定されると、


### PR DESCRIPTION
## Summary
- `package.json` は JSON のため inline コメントが書けず、`.trivyignore` のような `expires:` をファイル内に持てない制約を SECURITY.md に明記
- bypass の理由・期限を PR description / commit message への併記で代替する運用であることを補足

## Context
gemini-code-assist のレビュー指摘 (`minimumReleaseAgeExclude` の運用ルールが `.trivyignore` の運用とどう違うか) への対応。将来の管理者が混乱しないよう、JSON 形式の制約を明示しておく。

なお同レビューに含まれていた chalk/debug hijack の日付修正提案 (2025-09 → 2025-01) は誤り（実際の事案は 2025-09 で原文が正しい）のため、こちらは取り込んでいない。

## Test plan
- [x] `docs/handbook/SECURITY.md` を目視確認

https://claude.ai/code/session_01PYmVdNoNcWMSMaEmf6q8x2

---
_Generated by [Claude Code](https://claude.ai/code/session_01PYmVdNoNcWMSMaEmf6q8x2)_