### PR TITLE
chore(security): add vulnerability disclosure policy + OpenSSF Scorecard workflow

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -12,7 +12,9 @@ civicship-api のセキュリティ脆弱性を発見した場合の報告手順
 セキュリティ脆弱性は **必ず非公開チャネル** で報告してください。
 
 - 推奨: GitHub の **Private Vulnerability Reporting** 機能から報告
-  - <https://github.com/Hopin-inc/civicship-api/security/advisories/new>
+  - 本リポジトリの **Security タブ → Report a vulnerability** ボタンから
+    advisory を作成してください (本ファイル `SECURITY.md` を GitHub が認識
+    すると自動でリンクが表示されます)
   - GitHub アカウントがあれば誰でも利用可能。レポート / 議論 / fix の調整 / CVE 採番までを 1 つの advisory 内で完結できます。
 
 公開 issue / pull request / discussion 等で **脆弱性の詳細を開示しないでください**。

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,60 @@
+# Security Policy
+
+civicship-api のセキュリティ脆弱性を発見した場合の報告手順をまとめています。
+
+> **Note**
+> 本ファイルは外部報告者向けの開示ポリシー (Vulnerability Disclosure Policy) です。
+> 内部設計 (Auth flow / RLS / supply chain hardening 等) のドキュメントは
+> [`docs/handbook/SECURITY.md`](../docs/handbook/SECURITY.md) を参照してください。
+
+## Reporting a Vulnerability
+
+セキュリティ脆弱性は **必ず非公開チャネル** で報告してください。
+
+- 推奨: GitHub の **Private Vulnerability Reporting** 機能から報告
+  - <https://github.com/Hopin-inc/civicship-api/security/advisories/new>
+  - GitHub アカウントがあれば誰でも利用可能。レポート / 議論 / fix の調整 / CVE 採番までを 1 つの advisory 内で完結できます。
+
+公開 issue / pull request / discussion 等で **脆弱性の詳細を開示しないでください**。
+他の利用者が脆弱性に晒される時間を最小化するため、修正リリースまでは
+private advisory 上でのみ議論します。
+
+### 報告に含めてほしい情報
+
+- 影響範囲 (どのコンポーネント / バージョン / endpoint か)
+- 再現手順 (PoC があると望ましい)
+- 想定される impact (機密情報露出 / 権限昇格 / DoS 等)
+- 報告者の連絡先 (GitHub handle で OK)
+
+日本語 / 英語のいずれでも対応します。
+
+## What to Expect
+
+- **受領通知**: 5 営業日以内に advisory 上で acknowledge します
+- **初期トリアージ**: 受領後 10 営業日以内に severity / 影響範囲の見立てを返します
+- **修正方針**: severity に応じて優先度を決め、修正 PR を private advisory 内で開発
+- **公開**: 修正リリース後、advisory を public にして CVE / GHSA ID を発行 (希望者は credit に追加)
+
+確定 SLA は提示できませんが、上記タイムラインを目安として運用しています。
+
+## Out of Scope
+
+以下は本ポリシーの対象外です:
+
+- **第三者依存ライブラリの既知 CVE** — Dependabot / Trivy / `pnpm audit` / GitHub
+  Advisory Database で継続監視しており、upstream の patch 待ち / 不到達 path 判定で
+  時限 ignore する運用です (`docs/handbook/SECURITY.md` の "Container Image Scanning"
+  / "npm Supply Chain Hardening" セクション参照)。
+  個別の dep CVE 報告ではなく、upstream に直接 issue を上げてください。
+- **物理アクセス / ソーシャルエンジニアリング** が前提となる攻撃
+- **本サービスのドメイン外** (フロントエンド / 関連リポジトリ) — それぞれのリポの
+  SECURITY.md を参照
+- **Brute force / rate-limit / DoS** — インフラ層 (Cloud Run / Cloud Armor) で
+  対処しており、本リポでの脆弱性とは扱いません
+
+## Coordinated Disclosure
+
+本プロジェクトは responsible / coordinated disclosure を歓迎します。
+報告者の協力により利用者の安全が保たれることを尊重し、修正完了前の早期公開や
+SLA 超過時の独自開示は避けてください。長期化が懸念される場合は private advisory
+上で開示時期を相談してください。

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,94 @@
+name: OpenSSF Scorecard supply-chain analysis
+
+# OpenSSF Scorecard は repo の supply chain 健全性を ~20 項目で自動採点する
+# (https://github.com/ossf/scorecard)。public repo は score / 各項目の sarif を
+# Security タブ + scorecard.dev の badge に publish できるため、外部からの
+# 信頼性指標 + 内部の継続改善トリガーとして運用する。
+#
+# トリガー:
+#   - branch_protection_rule: branch protection 変更時に再スコア
+#   - schedule (週次): 採点 drift の検知
+#   - push (default branch のみ): 直近のコード変更を反映
+#
+# 結果は (1) Security タブ (sarif), (2) artifact (json), (3) scorecard.dev
+# (publish_results: true) の 3 経路で確認できる。
+
+on:
+  branch_protection_rule:
+  schedule:
+    # CodeQL (Mon 21:00 UTC) と 1 時間ずらしてランナーの輻輳を避ける。
+    # 火曜 07:00 JST 相当。
+    - cron: '0 22 * * 1'
+  push:
+    branches:
+      # default branch に push されたタイミング (= PR merge 直後) に再採点。
+      # 本 repo の development フローは develop 起点 (`ci.yml` の push trigger
+      # も `[master]` だが Scorecard は default branch のスコアを評価するため
+      # 別途 develop 側でも採点する)。
+      - master
+      - develop
+
+# Scorecard の各 check は read 権限で十分なので job 単位で job-level に
+# 必要な write を付与する形にする (workflow-level は最小)。
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      # SARIF を Security タブに upload するため。
+      security-events: write
+      # publish_results: true で OIDC 経由で scorecard.dev に署名付き publish するため。
+      id-token: write
+      contents: read
+      # branch protection / dangerous-workflow 等の check が actions API を読む。
+      actions: read
+
+    steps:
+      # 他 workflow と同様に audit mode + disable-sudo で start。Scorecard 自体
+      # が dangerous-workflow check で harden-runner の有無を見ているため、
+      # 入れておくと自分のスコアにも返ってくる。
+      - name: Harden runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+          disable-sudo: true
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # Scorecard の Token-Permissions / Pinned-Dependencies 等の検査は
+          # full history を要求しないが、persist-credentials: false にして
+          # 後続 step が誤って GITHUB_TOKEN を漏らすリスクを下げる
+          # (Scorecard 自体は OIDC で publish するため checkout の token は不要)。
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        with:
+          results_file: scorecard-results.sarif
+          results_format: sarif
+          # public repo なので publish_results: true で scorecard.dev に
+          # OIDC 署名付きで publish。badge / 公開 dashboard が利用可能になる。
+          # private repo に変わった場合はここを false にすること。
+          publish_results: true
+
+      # 解析の生 json/sarif を artifact として 5 日保持。debugging 用 + score
+      # 推移を比較したい場合に手で download できるようにしておく。
+      - name: Upload artifact
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: scorecard-results
+          path: scorecard-results.sarif
+          retention-days: 5
+
+      # Security タブ (Code Scanning) に上げて、各 check が low/medium/high で
+      # surface されるようにする。trivy / codeql と同居するため category 必須。
+      - name: Upload to Security tab
+        uses: github/codeql-action/upload-sarif@4f3212b61783c3c68e8309a0f18a699764811cda # v3.27.1
+        with:
+          sarif_file: scorecard-results.sarif
+          category: scorecard

--- a/docs/handbook/SECURITY.md
+++ b/docs/handbook/SECURITY.md
@@ -2,6 +2,12 @@
 
 This document describes civicship-api's security architecture, authentication flow, authorization system, and security best practices.
 
+> **Reporting a security vulnerability?**
+> 本ドキュメントは内部設計書です。脆弱性を発見した場合は
+> [`/.github/SECURITY.md`](../../.github/SECURITY.md) (Vulnerability Disclosure
+> Policy) を参照し、GitHub の Private Vulnerability Reporting で非公開に報告してください。
+> 公開 issue / PR で詳細を開示しないでください。
+
 ## Security Architecture Overview
 
 civicship-api employs a four-tier security architecture:


### PR DESCRIPTION
## Summary

public repo 前提で 2 層追加:

1. **外部報告者向けの脆弱性開示ポリシー** (`.github/SECURITY.md`)
2. **OpenSSF Scorecard による継続的 supply chain 採点** (`.github/workflows/scorecard.yml`)

## 何を入れるか

### 1. `.github/SECURITY.md` (Vulnerability Disclosure Policy)

GitHub の Private Vulnerability Reporting に誘導する公開ポリシー。
GitHub が `.github/SECURITY.md` を認識すると Security タブに
"Reporting a Vulnerability" リンクが自動表示されます。

含む内容:
- 推奨報告経路 (Private Vulnerability Reporting) と公開禁止の明記
- 報告に含めてほしい情報 (再現手順 / 影響範囲 / impact)
- 受領 5 営業日 / トリアージ 10 営業日 / 修正後 advisory 公開
- Out of scope (第三者 dep の既知 CVE は Trivy/Dependabot 経路、関連 repo、DoS など)
- Coordinated Disclosure ポリシー

内部設計書 `docs/handbook/SECURITY.md` との役割分担:
- 公開向け開示ポリシー = `.github/SECURITY.md` (本 PR で追加)
- 内部 architecture / hardening = `docs/handbook/SECURITY.md` (既存)

両者をクロスリンクし、誤って公開 issue に脆弱性詳細が出るのを防ぐ。

### 2. `.github/workflows/scorecard.yml` (OpenSSF Scorecard)

`ossf/scorecard-action@v2.4.3` を以下のトリガーで実行:

- **branch_protection_rule** 変更時 — protection 設定変更を即時再採点
- **schedule** 週次 (Mon 22:00 UTC, CodeQL と 1h ずらし) — drift 検知
- **push** to `master` / `develop` — PR merge 直後に再採点

結果は 3 経路で確認可能:

| 経路 | 内容 |
|---|---|
| Security タブ | 各 check (Token-Permissions / Pinned-Dependencies / Branch-Protection 等 ~20 項目) を sarif で可視化 |
| Artifact (5 日保持) | 生 sarif を debugging 用に download 可能 |
| scorecard.dev | OIDC 署名付き publish。public dashboard / badge 利用可能 |

`publish_results: true` は **public repo のみ** で利用可。private 化時は false に切り替えること (workflow にコメント記載)。

### Workflow 自身の Scorecard 健全性

scorecard-action を入れた workflow 自体が Dangerous-Workflow / Token-Permissions check で評価されるため、以下を満たす:

- `harden-runner` (audit + disable-sudo) を最初に実行
- `permissions: read-all` を workflow-level に置き、job-level で必要な write のみ昇格
- `actions/checkout` で `persist-credentials: false`
- すべての action を 40-char SHA で pin (リポ既存規約)

## 既存防御との関係

これまでの hardening (Trivy / Dependabot / dependency-review / pnpm
minimumReleaseAge / onlyBuiltDependencies / WIF / canary / harden-runner /
CodeQL security-extended) はそのままで、**(a) 受動的な報告チャネル** と
**(b) 能動的な scoring/可視化** を別軸として追加する形。

期待される初期スコア: 上記の hardening 群により **8/10 前後** が出るはず
(Branch-Protection / Signed-Releases 等の repo settings 由来 check は
本 PR の範囲外で別途調整余地あり)。

## Test plan

- [ ] CI green (lint / build / test / trivy / dependency-review)
- [ ] merge 後、Security タブに "Reporting a Vulnerability" リンクが表示される
- [ ] merge 後の最初の schedule 実行で Security タブの `scorecard` category に
      sarif が出る + scorecard.dev で score が公開される
- [ ] 出てきたスコアの low-priority check を見て、次の hardening PR の優先度を決める

https://claude.ai/code/session_01YKp4foiiVqxLCDv7D7LjT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKp4foiiVqxLCDv7D7LjT8)_