### PR TITLE
fix(security): pin scorecard-action to peeled commit SHA (not tag object)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -66,8 +66,25 @@ jobs:
           # (Scorecard 自体は OIDC で publish するため checkout の token は不要)。
           persist-credentials: false
 
+      # `f49aabe0...` は v2.4.1 タグの **peeled commit SHA** (= refs/tags/v2.4.1^{}
+      # の commit object)。actions/starter-workflows の公式 scorecard starter
+      # も同 SHA を pin しており、scorecard.dev の verifier が allowlist
+      # しているのもこの commit SHA の系譜。
+      #
+      # ⚠️ 注意: `git ls-remote --tags` で v2.4.x の tag SHA を取ると、annotated
+      # tag の場合は **tag object SHA が先に返り**、peeled (^{}) な commit SHA
+      # と区別が付きにくい。tag object SHA を pin すると scorecard.dev の publish
+      # step が `imposter commit: ... does not belong to ossf/scorecard-action`
+      # で 400 を返して job 全体が fail する (initial deploy で実際に踏んだ)。
+      # 必ず `refs/tags/<ver>^{}` の peeled commit SHA を pin すること。
+      #
+      # version 上げる場合は (a) annotated tag の peeled commit SHA を取り、
+      # (b) actions/starter-workflows の scorecard.yml の現行推奨と整合する
+      # ことを確認してから差し替える。新 release 直後は scorecard.dev の
+      # verifier allowlist 反映が遅れ得るため、starter が推奨してない version
+      # への先行 bump は推奨しない。
       - name: Run analysis
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
         with:
           results_file: scorecard-results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary

PR #1071 で導入した `.github/workflows/scorecard.yml` が初回 `push` run で fail していた根因の修正。`ossf/scorecard-action` の pin を **tag object SHA** から **peeled commit SHA** に差し替える。

## 根因

scorecard-action を `99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3` で pin していたが、これは **annotated tag の object SHA** であり commit graph 上の commit ではない。scorecard.dev の publish webapp は受け取った workflow の SHA を ossf/scorecard-action のコミット履歴と照合するため、tag object SHA は「ここに無い commit」と判定されて以下を返す:

```
http response 400, status: 400 Bad Request,
error: workflow verification failed: imposter commit:
99c09fe975337306107572b4fdf4db224cf8e2f2 does not belong to
ossf/scorecard-action
```

scan 自体は成功 (score **6.1** が SARIF として正常に出力) していたが、publish step の検証エラーで job 全体が fail し Security タブの継続採点が機能していなかった。

`git ls-remote --tags` の結果を読み取る際、annotated tag は **tag object SHA が先に返り**、peeled (`refs/tags/<ver>^{}`) な commit SHA と区別が付きにくいことが原因のミス。本 PR で発生した混乱を将来繰り返さないよう、workflow にコメントで明示。

## 修正

```diff
- uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+ uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
```

`f49aabe0...` は `refs/tags/v2.4.1^{}` の peeled commit SHA。[`actions/starter-workflows` の公式 scorecard starter](https://github.com/actions/starter-workflows/blob/main/code-scanning/scorecard.yml) も同 SHA を現行推奨として pin しており、scorecard.dev verifier の allowlist にも入っている。

最新の v2.4.3 ではなく v2.4.1 を選んだ理由:
- 公式 starter が依然として v2.4.1 を維持している
- 新 release 直後は scorecard.dev の verifier allowlist 反映が遅れ得るため、starter が推奨してない version への先行 bump は危険

## 副産物: 初回 scan の score 6.1 内訳

publish 自体は失敗していたが scan ロジックは走っており、SARIF を decode すると以下の内訳が判明:

| Check | Score | 状態 |
|---|---|---|
| Dependency-Update-Tool | 10/10 | ✅ |
| Maintained | 10/10 | ✅ |
| Dangerous-Workflow | 10/10 | ✅ |
| Binary-Artifacts | 10/10 | ✅ |
| SAST | 10/10 | ✅ |
| License | 10/10 | ✅ |
| CI-Tests | 10/10 | ✅ |
| Pinned-Dependencies | 9/10 | 🔻 (rover.apollo.dev の curl\|sh 1 件) |
| Branch-Protection | 8/10 | 🔻 (2 reviewer + codeowners 化で 10) |
| Contributors | 6/10 | 🔻 (anthropic + hopin = 2 org) |
| Security-Policy | 4/10 | 🔻 (linked content 不足) |
| Code-Review | **0/10** | ❌ (大半の PR が approval 無し merge) |
| Token-Permissions | **0/10** | ❌ (deploy workflow に top-level / write 過大) |
| Vulnerabilities | **0/10** | ❌ (42 GHSA、Dependabot 経由で対応中) |
| CII-Best-Practices | 0/10 | (任意 badge) |
| Fuzzing | 0/10 | (任意) |
| Signed-Releases | N/A | (release が無い) |

→ 本 PR merge 後に publish が成功すれば scorecard.dev で badge 化可能。 0/10 の 3 項目 (Token-Permissions / Code-Review / Vulnerabilities) を次の改善 PR の優先度として確定できる。

## Test plan

- [ ] CI green
- [ ] merge 後の develop push で scorecard workflow が **success** で完走 (現状 1m で fail)
- [ ] scorecard.dev で repo の dashboard が公開され、score 6.1 前後が出る
- [ ] Security タブの `scorecard` category に SARIF が継続的に上がる

https://claude.ai/code/session_01YKp4foiiVqxLCDv7D7LjT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKp4foiiVqxLCDv7D7LjT8)_