### PR TITLE
perf(ci): cache Prisma generated client to skip db:generate (~135s/run)

### DIFF
--- a/.github/actions/setup-civicship/action.yml
+++ b/.github/actions/setup-civicship/action.yml
@@ -60,6 +60,46 @@ runs:
       shell: bash
       run: pnpm install --frozen-lockfile --prefer-offline
 
+    # `db:generate` は cold で ~27s、warm でも ~13s かかる重い step。CI 1 run
+    # あたり build job + test matrix (×4) で計 5 回呼ばれるため、累積で
+    # ~135s/run の負荷。schema が変わらない PR (= 大半) では完全に無駄。
+    #
+    # 出力 (Prisma client + TypedSQL types) は schema + sql/*.sql + prisma
+    # version さえ同じなら deterministic。したがって出力を cache し、key
+    # 一致時は db:generate 全体を skip できる (ELIFECYCLE 11 → 0s)。
+    #
+    # cache 対象は pnpm 仮想ストア配下に限定。実機検証 (PR description 参照)
+    # で以下が判明:
+    #   - 出力本体は `node_modules/.pnpm/@prisma+client@<HASH>/.../node_modules/`
+    #     配下にあり、ディレクトリ名は lockfile resolution で決まる。
+    #     glob `@prisma+client@*` で吸収 (key の lockfile hash で整合)
+    #   - `pnpm install --frozen-lockfile --prefer-offline` は既存
+    #     `.prisma/` を保持するので install 後の restore で OK
+    #   - db:generate が回す他 4 generator (erd / dbml / fabbrica / json-types)
+    #     の出力は git tracked (docs/ERD.md, docs/schema.dbml,
+    #     src/.../factories/__generated__/) なので checkout で復元される。
+    #     skip しても問題なし
+    #
+    # cache key は **強い key 単体**で運用 (`restore-keys` を意図的に置かない):
+    #   - `.tsbuildinfo` cache の cross-branch fallback で stale を食う事故
+    #     (#943 関連) が前例。同じ轍を踏まない
+    #   - hash inputs: schema.prisma + sql/*.sql + pnpm-lock.yaml
+    #     (= prisma binary version + 全 generator deps を捕捉)
+    #   - cache miss 時は今と同じ挙動 (regen 走る) なので速度退行ゼロ
+    #
+    # 緊急 invalidation が必要になったら key prefix を `prisma-v1-` →
+    # `prisma-v2-` に bump するだけで全 entry を無効化できる
+    # (actions/cache 標準挙動、追加実装不要)。
+    - name: Restore Prisma generated client cache
+      id: prisma-cache
+      if: ${{ inputs.database-url != '' }}
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      with:
+        path: |
+          node_modules/.pnpm/@prisma+client@*/node_modules/.prisma
+          node_modules/.pnpm/@prisma+client@*/node_modules/@prisma/client
+        key: prisma-v1-${{ runner.os }}-${{ hashFiles('src/infrastructure/prisma/schema.prisma', 'src/infrastructure/prisma/sql/**/*.sql', 'pnpm-lock.yaml') }}
+
     - name: Apply Prisma migrations (db:deploy)
       if: ${{ inputs.apply-migrations == 'true' && inputs.database-url != '' }}
       shell: bash
@@ -68,7 +108,9 @@ runs:
       run: pnpm db:deploy
 
     - name: Generate Prisma client (db:generate, with TypedSQL)
-      if: ${{ inputs.database-url != '' }}
+      # cache hit 時は skip (~27s/job × 5 jobs = ~135s 削減)。
+      # schema/sql/lockfile が変わったら key 不一致で cache miss → 再生成。
+      if: ${{ inputs.database-url != '' && steps.prisma-cache.outputs.cache-hit != 'true' }}
       shell: bash
       env:
         DATABASE_URL: ${{ inputs.database-url }}

--- a/.github/actions/setup-civicship/action.yml
+++ b/.github/actions/setup-civicship/action.yml
@@ -85,6 +85,11 @@ runs:
     #     (#943 関連) が前例。同じ轍を踏まない
     #   - hash inputs: schema.prisma + sql/*.sql + pnpm-lock.yaml
     #     (= prisma binary version + 全 generator deps を捕捉)
+    #   - 加えて `runner.os` + `inputs.node-version` も key に含める
+    #     (PR #1075 review 反映)。Prisma 出力は厳密には Node major 非依存
+    #     (N-API) で lockfile hash が @prisma/client version を捕捉する
+    #     ため冗長気味だが、`inputs.node-version` を変えた時に確実に
+    #     invalidate されるよう defense-in-depth として明示。
     #   - cache miss 時は今と同じ挙動 (regen 走る) なので速度退行ゼロ
     #
     # 緊急 invalidation が必要になったら key prefix を `prisma-v1-` →
@@ -98,7 +103,7 @@ runs:
         path: |
           node_modules/.pnpm/@prisma+client@*/node_modules/.prisma
           node_modules/.pnpm/@prisma+client@*/node_modules/@prisma/client
-        key: prisma-v1-${{ runner.os }}-${{ hashFiles('src/infrastructure/prisma/schema.prisma', 'src/infrastructure/prisma/sql/**/*.sql', 'pnpm-lock.yaml') }}
+        key: prisma-v1-${{ runner.os }}-node${{ inputs.node-version }}-${{ hashFiles('src/infrastructure/prisma/schema.prisma', 'src/infrastructure/prisma/sql/**/*.sql', 'pnpm-lock.yaml') }}
 
     - name: Apply Prisma migrations (db:deploy)
       if: ${{ inputs.apply-migrations == 'true' && inputs.database-url != '' }}


### PR DESCRIPTION
## Summary

`pnpm db:generate` を CI で cache し、schema 不変の PR では skip することで **~135 秒/run** 短縮する。`setup-civicship` composite action 内に `actions/cache` を追加し、key 一致時は `db:generate` step 自体を skip する条件を入れる。

## なぜ

`db:generate` は build job + test matrix (×4) で計 5 回呼ばれており、cold で各 ~27 秒。schema が変わらない PR (= 大半) では完全に無駄。

## 実機検証 (本ローカル環境で実施)

| 項目 | 結果 |
|---|---|
| cold `db:generate` | **26.9s** |
| warm `db:generate` (同 schema) | 12.6s |
| 出力サイズ (cache 対象) | 63MB |
| `pnpm install --frozen-lockfile --prefer-offline` が既存 `.prisma/` を保持 | ✅ |
| snapshot → 削除 → restore → typecheck で functional | ✅ |

→ CI 1 run あたり累積 ~135 秒。cache hit でほぼゼロに圧縮。

## 当初計画から変更が必要だった 3 点 (実機検証で発覚)

### 1. cache target は pnpm 仮想ストア配下

普通の `node_modules/.prisma/` ではなく、pnpm が生成する hash 付きの仮想ストア下:

```
node_modules/.pnpm/@prisma+client@6.11.1_prisma@6.11.1_typescript@5.8.3__typescript@5.8.3/node_modules/.prisma/
node_modules/.pnpm/@prisma+client@6.11.1_prisma@6.11.1_typescript@5.8.3__typescript@5.8.3/node_modules/@prisma/client/
```

→ glob `node_modules/.pnpm/@prisma+client@*/node_modules/...` で hash 部分を吸収。key 側に `pnpm-lock.yaml` を含めるので整合。

### 2. db:generate が回す 5 generators のうち、prisma-client + TypedSQL 以外は **git tracked**

```
prisma-client-js          → .prisma/                (cache 必要)
prisma-erd-generator      → docs/ERD.md             ✅ git tracked
prisma-dbml-generator     → docs/schema.dbml        ✅ git tracked
@quramy/prisma-fabbrica   → src/.../__generated__/  ✅ git tracked
prisma-json-types-gen     → .prisma/ 内             (cache 同梱)
```

→ checkout で復元されるので skip しても影響なし。cache 範囲が想定より単純化。

### 3. cache 配置は `pnpm install` の **後**

install が `.pnpm/@prisma+client@<HASH>/node_modules/` のディレクトリ構造を先に作る必要があるので、`install → cache restore → (skip) db:generate` の順。実機検証で `pnpm install --frozen-lockfile --prefer-offline` が既存 `.prisma/` を保持することを確認済み。

## key 設計 (`.tsbuildinfo` cache 前例 = `9a4bea6` の教訓を反映)

- **強い key 単体**で運用 (`restore-keys` を意図的に置かない) — cross-branch fallback で stale を食う事故を再発させない
- hash inputs:
  - `src/infrastructure/prisma/schema.prisma`
  - `src/infrastructure/prisma/sql/**/*.sql`
  - `pnpm-lock.yaml` (prisma binary version + 全 generator deps を捕捉)
- prefix `prisma-v1-` を付与し、緊急時の手動 invalidation (`v1` → `v2` で全無効化) に備える

## 効果と退行

- **効果**: cache hit 時 ~27s × 5 jobs = **~130s 削減** (schema 不変な大半の PR で発火)
- **退行**: cache miss 時は今と同じ挙動 (regen 走る) → **速度退行ゼロ**
- **失敗モード**: stale cache を引いた場合は typecheck / test で即 visible (silent corruption なし)
- **緊急回避**: cache key prefix の version bump で全 invalidate (追加実装不要、actions/cache 標準挙動)

## Test plan

- [ ] CI green (lint / build / test / trivy / dependency-review)
- [ ] 初回 run は cache **miss** → 全 5 jobs で `db:generate` 走る (今と同じ)
- [ ] 2 回目以降の同 schema run は cache **hit** → `db:generate` step が skip され、build/test job 全体時間が短縮 (~30s 短縮を期待)
- [ ] schema を編集した PR で cache **miss** → 再生成 → 動作変化なし

https://claude.ai/code/session_01YKp4foiiVqxLCDv7D7LjT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKp4foiiVqxLCDv7D7LjT8)_