### PR TITLE
fix(ci): aggregator concurrency-cancel race causing 5 PRs in a row to report false failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -648,7 +648,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: [dependency-review, lint, build, trivy, test]
-    if: always()
+    # `if: !cancelled()` で以下を両立:
+    #   - 通常 fail / skipped (= push 時の dependency-review) でも
+    #     アグリゲータを走らせ status を必ず報告する (`success()` 単独だと
+    #     needs failure で skip され、required check が pending で固まる)
+    #   - **PR の concurrency cancel を superseded run に伝播**: 旧
+    #     `if: always()` は `always()` の仕様 (cancellation を override する)
+    #     で cancel された run でもアグリゲータが走り、`cancelled` の needs
+    #     result を case 句が拾えず exit 1 → required check が `failure`
+    #     報告。後続 commit の run が成功しても UI 上に過去 fail が残り、
+    #     admin override 強制 merge が必要になる。これで 5 PR
+    #     (#1063 / #1066 / #1071 / #1073 / #1075) 連続で踏んだのを修正。
+    #   - `!cancelled()` は workflow 全体の cancellation 時に false を
+    #     返してアグリゲータごと skip させる (status: skipped)。branch
+    #     protection は最新 commit の status を見るので、superseded run の
+    #     skip は merge 可否に影響しない。
+    if: ${{ !cancelled() }}
     permissions:
       contents: read
       # PR への coverage コメント投稿に必要 (marocchino/sticky-pull-request-comment)。


### PR DESCRIPTION
## Summary

`ci` aggregator が直近 5 PR (#1063 / #1066 / #1071 / #1073 / #1075) 連続で `failure` を報告していた根因を特定。本 PR の変更とは無関係な **concurrency cancellation の race** が原因で、`if: always()` を `if: ${{ !cancelled() }}` に置換するだけで解消する。

## 根因

`ci.yml` の構成:

```yaml
concurrency:
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
...
ci:
  if: always()    # ← ★ 問題箇所
  ...
  steps:
    - name: Verify all required jobs passed
      run: |
        for j in "$dep_review" "$lint" ...; do
          case "$j" in
            success|skipped) ;;
            *) exit 1 ;;
          esac
        done
```

[GitHub Actions docs の `always()` 仕様](https://docs.github.com/en/actions/learn-github-actions/expressions#always):
> Always evaluates to true. **Even if cancellation of a workflow is requested, that workflow will continue to run.**

つまり PR で **2nd commit が push** されると:

1. `concurrency` が先行 run を cancel
2. needs (test / build / trivy 等) の一部が `cancelled` 状態に
3. `if: always()` のせいでアグリゲータが cancellation を **override** して走る
4. case 句は `success|skipped` のみ accept → `cancelled` で `*)` 句に落ち `exit 1`
5. conclusion: `failure` で required check に報告される

## 5 PR の整合確認

| PR | commits | 1st commit aggregator | 2nd commit aggregator |
|---|---|---|---|
| #1063 | 2 | failure ❌ | success ✅ |
| #1066 | multiple | failure ❌ | success ✅ |
| #1071 | 2 | failure ❌ | success ✅ |
| #1073 | 1 (force-push?) | failure ❌ | success ✅ |
| #1075 | 2 | failure ❌ | success ✅ |

すべて 2nd commit を push して 1st を supersede するタイミングと、failed `ci` の発火タイミングが完全一致。本仮説と整合する。

## 修正

```diff
- if: always()
+ if: ${{ !cancelled() }}
```

| 条件式 | workflow キャンセル時 | needs failure 時 (通常) | needs success 時 |
|---|---|---|---|
| `always()` (旧) | 走る → cancelled deps で **fail 誤報告** | 走る → fail 報告 ✅ | 走る → success ✅ |
| `!cancelled()` (新) | **skip** ✅ | 走る → fail 報告 ✅ | 走る → success ✅ |

副作用なし:
- 通常の fail / skipped (= push 時の `dependency-review`) は今まで通り集約される
- branch protection は **最新 commit の aggregator status** を見るので、superseded run が `skipped` でも merge 可否に影響しない (= 過去 run の fail ノイズが消える)

## 検証

- YAML syntax check pass
- 修正は 1 行 + 解説コメントのみで、ロジック変更なし
- 本 PR 自体に **追加 commit を 1 つ push** すれば、修正前なら 1st commit のアグリゲータが failure になっていた現象が、修正後は skipped になることで動作確認できる (本 PR を最初の検証ケースにできる)

## Test plan

- [ ] CI green (現行 behavior は通常 path で不変なので普通に通るはず)
- [ ] merge 後、次に **複数 commit を push する PR** で 1st commit のアグリゲータが `skipped` (旧 `failure`) で表示される
- [ ] その PR の 2nd commit のアグリゲータは従来通り `success`
- [ ] branch protection は最新 commit を見るので merge は可能なまま

https://claude.ai/code/session_01YKp4foiiVqxLCDv7D7LjT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKp4foiiVqxLCDv7D7LjT8)_