### PR TITLE
fix(liff): drop &quot;undefined&quot; from LINE error messages on network failures

### DIFF
--- a/src/application/domain/account/auth/liff/service.ts
+++ b/src/application/domain/account/auth/liff/service.ts
@@ -39,10 +39,10 @@ export class LIFFService {
     } catch (error) {
       if (axios.isAxiosError(error)) {
         const err = error.response?.data;
-        throw new Error(
-          `[LINE Token Verification] ${err?.error}: ${err?.error_description || error.message}`,
-          { cause: error },
-        );
+        const detail = err?.error
+          ? `${err.error}: ${err.error_description || error.message}`
+          : error.message;
+        throw new Error(`[LINE Token Verification] ${detail}`, { cause: error });
       }
       throw new Error(
         `[LINE Token Verification] ${error instanceof Error ? error.message : String(error)}`,
@@ -60,10 +60,10 @@ export class LIFFService {
     } catch (error) {
       if (axios.isAxiosError(error)) {
         const err = error.response?.data;
-        throw new Error(
-          `[LINE Profile Fetch] ${err?.error}: ${err?.error_description || error.message}`,
-          { cause: error },
-        );
+        const detail = err?.error
+          ? `${err.error}: ${err.error_description || error.message}`
+          : error.message;
+        throw new Error(`[LINE Profile Fetch] ${detail}`, { cause: error });
       }
       throw new Error(
         `[LINE Profile Fetch] ${error instanceof Error ? error.message : String(error)}`,

--- a/src/application/domain/account/auth/liff/service.ts
+++ b/src/application/domain/account/auth/liff/service.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 import { SignInProvider } from "@/consts/utils";
 import { auth } from "@/infrastructure/libs/firebase";
 import logger from "@/infrastructure/logging";
@@ -18,6 +18,14 @@ export interface LINETokenVerifyResponse {
 }
 
 export class LIFFService {
+  private static throwAxiosError(prefix: string, error: AxiosError): never {
+    const err = error.response?.data as { error?: string; error_description?: string } | undefined;
+    const detail = err?.error
+      ? `${err.error}: ${err.error_description || error.message}`
+      : error.message;
+    throw new Error(`[${prefix}] ${detail}`, { cause: error });
+  }
+
   static async verifyAccessToken(
     accessToken: string,
     channelId: string,
@@ -38,11 +46,7 @@ export class LIFFService {
       return data;
     } catch (error) {
       if (axios.isAxiosError(error)) {
-        const err = error.response?.data;
-        const detail = err?.error
-          ? `${err.error}: ${err.error_description || error.message}`
-          : error.message;
-        throw new Error(`[LINE Token Verification] ${detail}`, { cause: error });
+        LIFFService.throwAxiosError("LINE Token Verification", error);
       }
       throw new Error(
         `[LINE Token Verification] ${error instanceof Error ? error.message : String(error)}`,
@@ -59,11 +63,7 @@ export class LIFFService {
       return response.data as LINEProfile;
     } catch (error) {
       if (axios.isAxiosError(error)) {
-        const err = error.response?.data;
-        const detail = err?.error
-          ? `${err.error}: ${err.error_description || error.message}`
-          : error.message;
-        throw new Error(`[LINE Profile Fetch] ${detail}`, { cause: error });
+        LIFFService.throwAxiosError("LINE Profile Fetch", error);
       }
       throw new Error(
         `[LINE Profile Fetch] ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary

PR #1083 のレビューで gemini-code-assist が指摘してくれた、LIFFService のエラーメッセージレンダリング問題を修正。

## 問題

`liff/service.ts` の `verifyAccessToken` / `getProfile` の axios catch では、

```ts
const err = error.response?.data;
throw new Error(
  `[LINE Token Verification] ${err?.error}: ${err?.error_description || error.message}`,
  { cause: error },
);
```

axios が **完走して LINE が 4xx を返した時**は綺麗にレンダリングされる：

```
[LINE Token Verification] invalid_request: <description>
```

ただし **タイムアウト / ECONNRESET / DNS エラー**では `error.response` が undefined → `err?.error` が undefined → 文字列に `"undefined"` が混入：

```
[LINE Token Verification] undefined: timeout of 5000ms exceeded
                          ^^^^^^^^^
```

## 修正

レスポンスボディに `err.error` がある時だけ LINE 構造化エラーを頭に出して、無ければ素直に `error.message` だけ使う：

```ts
const err = error.response?.data;
const detail = err?.error
  ? `${err.error}: ${err.error_description || error.message}`
  : error.message;
throw new Error(`[LINE Token Verification] ${detail}`, { cause: error });
```

`verifyAccessToken` / `getProfile` 両方に同じ修正を適用。

## 影響範囲

- 例外メッセージの文字列レンダリングのみ。`{ cause: error }` 連鎖もそのまま維持
- throw 経路・呼び出し元の振る舞いは変わらず
- 1 ファイル / 8 行

## Test plan

- [x] `pnpm exec eslint src/application/domain/account/auth/liff/service.ts` 成功

https://claude.ai/code/session_016oudiJtj4X4cdgLK56AFY7

---
_Generated by [Claude Code](https://claude.ai/code/session_016oudiJtj4X4cdgLK56AFY7)_