### PR TITLE
ci(scorecard): drop master from push trigger

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -21,11 +21,11 @@ on:
     - cron: '0 22 * * 1'
   push:
     branches:
-      # default branch に push されたタイミング (= PR merge 直後) に再採点。
-      # 本 repo の development フローは develop 起点 (`ci.yml` の push trigger
-      # も `[master]` だが Scorecard は default branch のスコアを評価するため
-      # 別途 develop 側でも採点する)。
-      - master
+      # Scorecard は default branch でしか動かない (それ以外を渡すと
+      # `Only the default branch <name> is supported` で job 全体が fail する)。
+      # 本 repo の default branch は develop なので develop のみ列挙する。
+      # master 側は default branch ではないため Scorecard の対象外で、
+      # cron + branch_protection_rule で十分カバーされる。
       - develop
 
 # Scorecard の各 check は read 権限で十分なので job 単位で job-level に


### PR DESCRIPTION
## Summary

- The OpenSSF Scorecard action fails with `Only the default branch develop is supported` whenever it's invoked from a non-default branch — it's a hard error, not a soft preference. Every push to `master` (e.g. the recent `c2f730b` merge) was therefore failing the job.
- Default branch here is `develop`, so the push trigger now lists only `develop`. Comment rewritten to document the constraint accurately so the next person doesn't re-add `master`.
- `master` coverage is still provided by the existing `schedule` (weekly) and `branch_protection_rule` triggers, which is sufficient for drift detection.

## Test plan

- [ ] Merge to `develop` and confirm the Scorecard workflow runs to completion (uploads SARIF, publishes to scorecard.dev).
- [ ] Merge `develop` → `master` and confirm the workflow does not run on the `master` push (expected: skipped, not failed).
- [ ] Confirm the weekly cron run still produces a Scorecard report after the next Monday 22:00 UTC tick.

https://claude.ai/code/session_01MNDhih7JoSCnNrvim4PagX

---
_Generated by [Claude Code](https://claude.ai/code/session_01MNDhih7JoSCnNrvim4PagX)_