### PR TITLE
phase1(presentation): DID/VC 公開ルート (.well-known / users / inclusion-proof) 配線

### DIFF
--- a/src/__tests__/unit/presentation/router/did.test.ts
+++ b/src/__tests__/unit/presentation/router/did.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Unit tests for `src/presentation/router/did.ts` (§5.4 public routes).
+ *
+ * Covers the three endpoints shipped in this PR:
+ *   - GET /.well-known/did.json          → 200 + minimal issuer document
+ *   - GET /users/:userId/did.json        → 200 (CONFIRMED / DEACTIVATE)
+ *                                          → 404 (no anchor)
+ *                                          → 400 (malformed userId)
+ *                                          → 500 (resolver throws)
+ *   - GET /vc/:vcId/inclusion-proof      → 501 not_implemented
+ *                                          → 400 (empty vcId — guarded by
+ *                                            Express's own routing, but we
+ *                                            still assert the shape on
+ *                                            valid input)
+ *
+ * The `DidDocumentResolver` is stubbed via `container.register` so the
+ * tests never touch Prisma. Each route is exercised through a real
+ * Express app via supertest to catch routing-level regressions
+ * (path params, JSON content-type, status codes).
+ */
+
+import "reflect-metadata";
+
+import express from "express";
+import request from "supertest";
+import { container } from "tsyringe";
+
+import didRouter from "@/presentation/router/did";
+import type {
+  DidDocumentResolver,
+  DidDocumentWithProof,
+} from "@/infrastructure/libs/did/didDocumentResolver";
+
+const USER_ID = "u_alice";
+const USER_DID = "did:web:api.civicship.app:users:u_alice";
+const TX_HASH = "a".repeat(64);
+const DOC_HASH = "b".repeat(64);
+
+function buildApp() {
+  const app = express();
+  app.use("/", didRouter);
+  return app;
+}
+
+function buildConfirmedDoc(): DidDocumentWithProof {
+  return {
+    "@context": ["https://www.w3.org/ns/did/v1"],
+    id: USER_DID,
+    proof: {
+      type: "DataIntegrityProof",
+      cryptosuite: "civicship-merkle-anchor-2026",
+      anchorChain: "cardano:mainnet",
+      anchorTxHash: TX_HASH,
+      opIndexInTx: 0,
+      docHash: DOC_HASH,
+      anchorStatus: "confirmed",
+      anchoredAt: "2026-01-15T12:00:00.000Z",
+      verificationUrl: `https://cardanoscan.io/transaction/${TX_HASH}`,
+    },
+  };
+}
+
+function buildTombstoneDoc(): DidDocumentWithProof {
+  return {
+    "@context": ["https://www.w3.org/ns/did/v1"],
+    id: USER_DID,
+    deactivated: true,
+    proof: {
+      type: "DataIntegrityProof",
+      cryptosuite: "civicship-merkle-anchor-2026",
+      anchorChain: "cardano:mainnet",
+      anchorTxHash: TX_HASH,
+      opIndexInTx: 1,
+      docHash: DOC_HASH,
+      anchorStatus: "confirmed",
+      anchoredAt: "2026-01-20T12:00:00.000Z",
+      verificationUrl: `https://cardanoscan.io/transaction/${TX_HASH}`,
+    },
+  };
+}
+
+function registerResolverMock(buildDidDocument: jest.Mock): void {
+  const mock: Partial<DidDocumentResolver> = { buildDidDocument };
+  container.register("DidDocumentResolver", { useValue: mock as DidDocumentResolver });
+}
+
+describe("router/did (§5.4)", () => {
+  beforeEach(() => {
+    container.clearInstances();
+  });
+
+  describe("GET /.well-known/did.json", () => {
+    it("returns 200 and a minimal issuer DID Document", async () => {
+      const res = await request(buildApp()).get("/.well-known/did.json");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        "@context": ["https://www.w3.org/ns/did/v1"],
+        id: "did:web:api.civicship.app",
+      });
+    });
+
+    it("does not require the resolver (works without DI registration)", async () => {
+      // No `registerResolverMock` call — the issuer endpoint must not
+      // resolve anything from the container.
+      const res = await request(buildApp()).get("/.well-known/did.json");
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("GET /users/:userId/did.json", () => {
+    it("returns 200 with the document when the resolver yields a CONFIRMED anchor", async () => {
+      const buildDidDocument = jest.fn().mockResolvedValue(buildConfirmedDoc());
+      registerResolverMock(buildDidDocument);
+
+      const res = await request(buildApp()).get(`/users/${USER_ID}/did.json`);
+
+      expect(res.status).toBe(200);
+      expect(buildDidDocument).toHaveBeenCalledWith(USER_ID);
+      expect(res.body).toMatchObject({
+        id: USER_DID,
+        proof: { anchorStatus: "confirmed", anchorTxHash: TX_HASH },
+      });
+    });
+
+    it("returns 200 with a Tombstone document for DEACTIVATE op (§E)", async () => {
+      const buildDidDocument = jest.fn().mockResolvedValue(buildTombstoneDoc());
+      registerResolverMock(buildDidDocument);
+
+      const res = await request(buildApp()).get(`/users/${USER_ID}/did.json`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ id: USER_DID, deactivated: true });
+    });
+
+    it("returns 404 when the resolver yields null (no anchor row)", async () => {
+      const buildDidDocument = jest.fn().mockResolvedValue(null);
+      registerResolverMock(buildDidDocument);
+
+      const res = await request(buildApp()).get(`/users/${USER_ID}/did.json`);
+
+      expect(res.status).toBe(404);
+      expect(res.body).toMatchObject({ error: "did_not_found" });
+    });
+
+    it("returns 400 when the userId fails the §9.2 regex", async () => {
+      const buildDidDocument = jest.fn();
+      registerResolverMock(buildDidDocument);
+
+      const res = await request(buildApp()).get("/users/Bad%20User/did.json");
+
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({ error: "invalid_user_id" });
+      expect(buildDidDocument).not.toHaveBeenCalled();
+    });
+
+    it("returns 500 when the resolver throws", async () => {
+      const buildDidDocument = jest.fn().mockRejectedValue(new Error("boom"));
+      registerResolverMock(buildDidDocument);
+
+      const res = await request(buildApp()).get(`/users/${USER_ID}/did.json`);
+
+      expect(res.status).toBe(500);
+      expect(res.body).toMatchObject({ error: "internal_error" });
+    });
+  });
+
+  describe("GET /vc/:vcId/inclusion-proof", () => {
+    it("returns 501 not_implemented for any vcId until the batch worker lands", async () => {
+      const res = await request(buildApp()).get("/vc/vc_123/inclusion-proof");
+
+      expect(res.status).toBe(501);
+      expect(res.body).toMatchObject({
+        error: "not_implemented",
+        message: expect.stringContaining("Phase 1 step 7"),
+      });
+    });
+  });
+});

--- a/src/__tests__/unit/presentation/router/did.test.ts
+++ b/src/__tests__/unit/presentation/router/did.test.ts
@@ -161,7 +161,7 @@ describe("router/did (§5.4)", () => {
       const res = await request(buildApp()).get(`/users/${USER_ID}/did.json`);
 
       expect(res.status).toBe(500);
-      expect(res.body).toMatchObject({ error: "internal_error" });
+      expect(res.body).toMatchObject({ error: "Internal Server Error" });
     });
   });
 

--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -107,6 +107,8 @@ import TicketClaimLinkUseCase from "@/application/domain/reward/ticketClaimLink/
 import TicketClaimLinkConverter from "@/application/domain/reward/ticketClaimLink/data/converter";
 import { TicketIssuerUseCase } from "@/application/domain/reward/ticketIssuer/usecase";
 import { DIDVCServerClient } from "@/infrastructure/libs/did";
+import { DidDocumentResolver } from "@/infrastructure/libs/did/didDocumentResolver";
+import { UserDidAnchorStoreStub } from "@/infrastructure/libs/did/userDidAnchorStoreStub";
 import { DIDIssuanceService } from "@/application/domain/account/identity/didIssuanceRequest/service";
 import { VCIssuanceRequestService } from "@/application/domain/experience/evaluation/vcIssuanceRequest/service";
 import { VCIssuanceRequestRepository } from "@/application/domain/experience/evaluation/vcIssuanceRequest/data/repository";
@@ -230,6 +232,13 @@ export function registerProductionDependencies() {
   container.register("DIDVCServerClient", { useClass: DIDVCServerClient });
   container.register("DIDIssuanceService", { useClass: DIDIssuanceService });
   container.register("DIDIssuanceRequestRepository", { useClass: DIDIssuanceRequestRepository });
+
+  // Phase 1 internalized DID/VC stack (§5.1.4 / §5.4).
+  // TODO(phase1-final): replace UserDidAnchorStoreStub with a Prisma-backed
+  // UserDidAnchorRepository once the schema PR (#1094) merges and the
+  // application service PR wires UserDidDocumentService.
+  container.register("UserDidAnchorStore", { useClass: UserDidAnchorStoreStub });
+  container.register("DidDocumentResolver", { useClass: DidDocumentResolver });
 
   container.register("VCIssuanceRequestUseCase", { useClass: VCIssuanceRequestUseCase });
   container.register("VCIssuanceRequestConverter", { useClass: VCIssuanceRequestConverter });

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { createApolloServer } from "@/presentation/graphql/server";
 import logger from "@/infrastructure/logging";
 import { authHandler } from "@/presentation/middleware/auth";
 import lineRouter from "@/presentation/router/line";
+import didRouter from "@/presentation/router/did";
 import { batchProcess } from "@/batch";
 import express from "express";
 import { corsHandler } from "@/presentation/middleware/cors";
@@ -75,6 +76,11 @@ async function startServer() {
     authHandler(apolloServer),
   );
   app.use("/line", lineRouter);
+  // Phase 1 DID/VC public routes (§5.4):
+  //   /.well-known/did.json
+  //   /users/:userId/did.json
+  //   /vc/:vcId/inclusion-proof
+  app.use("/", didRouter);
 
   app.get("/health", (req, res) => {
     res.status(200).json({ status: "healthy", service: "internal-api" });
@@ -83,22 +89,29 @@ async function startServer() {
   // Error handler — must be registered after all routes.
   // Distinguishes client errors (4xx) from server errors (5xx) so that
   // malformed multipart requests return 400 instead of 500.
-  app.use((err: Error & { status?: number; expose?: boolean }, req: express.Request, res: express.Response, _next: express.NextFunction) => {
-    const status = typeof err.status === "number" ? err.status : 500;
-    if (status < 500) {
-      logger.warn("Client error:", {
-        status,
-        message: err.message,
-        url: req.originalUrl,
-      });
-    } else {
-      logger.error("Unhandled Express Error:", {
-        message: err.message,
-        stack: err.stack,
-      });
-    }
-    res.status(status).json({ error: err.expose ? err.message : "Internal Server Error" });
-  });
+  app.use(
+    (
+      err: Error & { status?: number; expose?: boolean },
+      req: express.Request,
+      res: express.Response,
+      _next: express.NextFunction,
+    ) => {
+      const status = typeof err.status === "number" ? err.status : 500;
+      if (status < 500) {
+        logger.warn("Client error:", {
+          status,
+          message: err.message,
+          url: req.originalUrl,
+        });
+      } else {
+        logger.error("Unhandled Express Error:", {
+          message: err.message,
+          stack: err.stack,
+        });
+      }
+      res.status(status).json({ error: err.expose ? err.message : "Internal Server Error" });
+    },
+  );
 
   step("Middleware registered");
 

--- a/src/infrastructure/libs/did/userDidAnchorStoreStub.ts
+++ b/src/infrastructure/libs/did/userDidAnchorStoreStub.ts
@@ -1,0 +1,37 @@
+/**
+ * TODO(phase1-final): replace with Prisma-backed UserDidAnchorRepository.
+ *
+ * Stub implementation of `UserDidAnchorStore` used until the
+ * `t_user_did_anchors` Prisma model lands (Phase 1 schema PR #1094) and
+ * the proper repository/service stack is wired (Phase 1 application
+ * service PR).
+ *
+ * Behavior: `findLatestByUserId` always resolves to `null`, so callers
+ * such as `DidDocumentResolver` see "no anchor record exists for this
+ * user" — the HTTP layer (`/users/:userId/did.json`) maps that to 404,
+ * which is the correct interim behavior because no user has an anchor
+ * yet (the batch worker that creates them lands in Phase 1 step 7).
+ *
+ * This file is intentionally minimal: it carries no Prisma dependency,
+ * no DI of repositories, no schema knowledge. Once the schema PR
+ * merges, replace this whole file with a Prisma-backed implementation
+ * (and update `provider.ts` to register that class instead).
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.1.4 (DidDocumentResolver)
+ *   docs/report/did-vc-internalization.md §5.4 (public routes)
+ *   docs/report/did-vc-internalization.md §4.1 (UserDidAnchor schema)
+ */
+
+import { injectable } from "tsyringe";
+import type {
+  UserDidAnchorRow,
+  UserDidAnchorStore,
+} from "@/infrastructure/libs/did/didDocumentResolver";
+
+@injectable()
+export class UserDidAnchorStoreStub implements UserDidAnchorStore {
+  async findLatestByUserId(_userId: string): Promise<UserDidAnchorRow | null> {
+    return null;
+  }
+}

--- a/src/infrastructure/libs/did/userDidBuilder.ts
+++ b/src/infrastructure/libs/did/userDidBuilder.ts
@@ -80,6 +80,18 @@ export function assertValidUserId(userId: string): string {
   return userId;
 }
 
+/**
+ * Boolean variant of `assertValidUserId` for code paths that need a
+ * non-throwing check (e.g. the `/users/:userId/did.json` route returning
+ * HTTP 400 instead of throwing). Centralises the validation rule so it
+ * stays in sync with `assertValidUserId` / `buildUserDid`.
+ */
+export function isValidUserId(userId: unknown): userId is string {
+  if (typeof userId !== "string") return false;
+  if (userId.length < USER_ID_MIN || userId.length > USER_ID_MAX) return false;
+  return USER_ID_REGEX.test(userId);
+}
+
 /** Build the canonical did:web string for a civicship user. */
 export function buildUserDid(userId: string): string {
   assertValidUserId(userId);

--- a/src/presentation/router/did.ts
+++ b/src/presentation/router/did.ts
@@ -1,0 +1,141 @@
+/**
+ * Public DID/VC routes (§5.4).
+ *
+ * Exposes three endpoints:
+ *
+ *   GET /.well-known/did.json
+ *     Returns the civicship.app issuer DID Document. This PR ships a
+ *     minimal static `{ "@context", id }` body — the full document
+ *     (with KMS-backed verificationMethod + service entries) is built
+ *     by `IssuerDidBuilder` in a sibling PR (claude/phase1-infra-kms-issuer-did).
+ *     We deliberately do NOT import that builder here so this PR builds
+ *     standalone; once the builder lands the resolver will switch.
+ *
+ *   GET /users/:userId/did.json
+ *     Returns the User DID Document for `userId`. Delegates to
+ *     `DidDocumentResolver.buildDidDocument(userId)` (#1096). Maps:
+ *       - `null` (no anchor row at all)               → 404
+ *       - DEACTIVATE op (Tombstone with deactivated)  → 200 (§E)
+ *       - everything else (CREATE/UPDATE)             → 200
+ *     The resolver itself handles PENDING / SUBMITTED / CONFIRMED proof
+ *     state (§F), so we do not need extra branching here.
+ *
+ *   GET /vc/:vcId/inclusion-proof
+ *     Stubbed 501 Not Implemented for this PR. The real handler depends
+ *     on the batch worker (Phase 1 step 7) that produces Merkle inclusion
+ *     proofs for VCs once their batch is anchored. Returning 501 — rather
+ *     than 404 — communicates "endpoint exists but not yet implemented"
+ *     and lets clients retry later without changing URL.
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.4   (public routes)
+ *   docs/report/did-vc-internalization.md §5.4.4 (UserDidDocumentService)
+ *   docs/report/did-vc-internalization.md §B / §E / §F
+ */
+
+import express, { Request, Response } from "express";
+import { container } from "tsyringe";
+import {
+  DidDocumentResolver,
+  type DidDocumentWithProof,
+} from "@/infrastructure/libs/did/didDocumentResolver";
+import { USER_ID_REGEX, buildUserDid } from "@/infrastructure/libs/did/userDidBuilder";
+import logger from "@/infrastructure/logging";
+
+const router = express.Router();
+
+// ---------------------------------------------------------------------------
+// Issuer DID Document — /.well-known/did.json
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the minimal issuer DID Document for civicship.app.
+ *
+ * This is the static stand-in until `IssuerDidBuilder` (sibling PR
+ * claude/phase1-infra-kms-issuer-did) provides the full document with
+ * KMS-derived verificationMethod entries.
+ *
+ * The shape matches what every DID-aware verifier expects at minimum:
+ *   `@context` + `id`. Adding fields later is backward-compatible.
+ */
+function buildIssuerDidDocument(): { "@context": readonly string[]; id: string } {
+  return {
+    "@context": ["https://www.w3.org/ns/did/v1"],
+    id: "did:web:api.civicship.app",
+  };
+}
+
+router.get("/.well-known/did.json", (_req: Request, res: Response) => {
+  res.status(200).json(buildIssuerDidDocument());
+});
+
+// ---------------------------------------------------------------------------
+// User DID Document — /users/:userId/did.json
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate `userId` against the same regex used by `buildUserDid` (§9.2)
+ * BEFORE reaching the resolver, so malformed IDs return 400 — never
+ * leaking through to a database query that would always miss anyway.
+ */
+function isValidUserId(userId: string): boolean {
+  return (
+    typeof userId === "string" &&
+    userId.length > 0 &&
+    userId.length <= 64 &&
+    USER_ID_REGEX.test(userId)
+  );
+}
+
+router.get("/users/:userId/did.json", async (req: Request, res: Response) => {
+  const { userId } = req.params;
+
+  if (!isValidUserId(userId)) {
+    return res.status(400).json({
+      error: "invalid_user_id",
+      message: `userId must match ${USER_ID_REGEX} (design §9.2)`,
+    });
+  }
+
+  try {
+    const resolver = container.resolve<DidDocumentResolver>("DidDocumentResolver");
+    const doc: DidDocumentWithProof | null = await resolver.buildDidDocument(userId);
+
+    if (doc === null) {
+      return res.status(404).json({
+        error: "did_not_found",
+        message: `No DID Document anchored for user ${buildUserDid(userId)}`,
+      });
+    }
+
+    return res.status(200).json(doc);
+  } catch (err) {
+    logger.error("[router/did] failed to build user DID Document", {
+      userId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return res.status(500).json({ error: "internal_error" });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// VC Inclusion Proof — /vc/:vcId/inclusion-proof
+// ---------------------------------------------------------------------------
+
+router.get("/vc/:vcId/inclusion-proof", (req: Request, res: Response) => {
+  const { vcId } = req.params;
+
+  if (typeof vcId !== "string" || vcId.length === 0) {
+    return res.status(400).json({
+      error: "invalid_vc_id",
+      message: "vcId is required",
+    });
+  }
+
+  return res.status(501).json({
+    error: "not_implemented",
+    message: "VC inclusion-proof endpoint will land in Phase 1 step 7 (batch worker)",
+  });
+});
+
+export default router;

--- a/src/presentation/router/did.ts
+++ b/src/presentation/router/did.ts
@@ -39,7 +39,11 @@ import {
   DidDocumentResolver,
   type DidDocumentWithProof,
 } from "@/infrastructure/libs/did/didDocumentResolver";
-import { USER_ID_REGEX, buildUserDid } from "@/infrastructure/libs/did/userDidBuilder";
+import {
+  USER_ID_REGEX,
+  buildUserDid,
+  isValidUserId,
+} from "@/infrastructure/libs/did/userDidBuilder";
 import logger from "@/infrastructure/logging";
 
 const router = express.Router();
@@ -73,23 +77,12 @@ router.get("/.well-known/did.json", (_req: Request, res: Response) => {
 // User DID Document — /users/:userId/did.json
 // ---------------------------------------------------------------------------
 
-/**
- * Validate `userId` against the same regex used by `buildUserDid` (§9.2)
- * BEFORE reaching the resolver, so malformed IDs return 400 — never
- * leaking through to a database query that would always miss anyway.
- */
-function isValidUserId(userId: string): boolean {
-  return (
-    typeof userId === "string" &&
-    userId.length > 0 &&
-    userId.length <= 64 &&
-    USER_ID_REGEX.test(userId)
-  );
-}
-
 router.get("/users/:userId/did.json", async (req: Request, res: Response) => {
   const { userId } = req.params;
 
+  // Re-uses the same predicate as `buildUserDid` / `assertValidUserId`
+  // (`@/infrastructure/libs/did/userDidBuilder`) so the §9.2 regex / length
+  // bounds live in exactly one place.
   if (!isValidUserId(userId)) {
     return res.status(400).json({
       error: "invalid_user_id",
@@ -110,11 +103,15 @@ router.get("/users/:userId/did.json", async (req: Request, res: Response) => {
 
     return res.status(200).json(doc);
   } catch (err) {
+    // Mirror `src/index.ts` global error handler: log message + stack and
+    // surface the same `{ error: "Internal Server Error" }` shape so HTTP
+    // clients see a consistent 5xx contract across the API.
     logger.error("[router/did] failed to build user DID Document", {
       userId,
-      err: err instanceof Error ? err.message : String(err),
+      message: err instanceof Error ? err.message : String(err),
+      stack: err instanceof Error ? err.stack : undefined,
     });
-    return res.status(500).json({ error: "internal_error" });
+    return res.status(500).json({ error: "Internal Server Error" });
   }
 });
 


### PR DESCRIPTION
## 概要

設計書 `docs/report/did-vc-internalization.md` §5.4 で規定された 3 本のパブリック HTTP ルートを Express router として実装し、`src/index.ts` から配線した。本 PR の範囲は **HTTP routing と presentation 層のみ**で、application service は呼ばず `DidDocumentResolver` (#1096 で実装済) を直接 inject する暫定形。`UserDidDocumentService` 経由への切替は次の application service PR で行う。

stacked PR チェーン:
- `develop` ← `claude/did-vc-internalization-review-eptzS` (#1082) ← `claude/phase1-infra-crypto` (#1093) ← `claude/phase1-infra-blockfrost-resolver` (#1096) ← **本 PR**

## 追加 / 変更ファイル

| File | Status | 概要 |
| --- | --- | --- |
| `src/presentation/router/did.ts` | new | 3 ルートを束ねる Express Router |
| `src/infrastructure/libs/did/userDidAnchorStoreStub.ts` | new | `UserDidAnchorStore` の暫定 stub (常に `null` を返す) |
| `src/__tests__/unit/presentation/router/did.test.ts` | new | supertest ベース、200 / 404 / 400 / 500 / 501 をカバー |
| `src/application/provider.ts` | modify | `UserDidAnchorStore` / `DidDocumentResolver` を DI 登録 |
| `src/index.ts` | modify | `app.use('/', didRouter)` で配線 |

## ルート定義

| Path | Status | 振る舞い |
| --- | --- | --- |
| `GET /.well-known/did.json` | 200 | civicship.app issuer DID Document の最小静的 body (`{ "@context", id: "did:web:api.civicship.app" }`)。フル Document (KMS-backed verificationMethod 等) は sibling PR `claude/phase1-infra-kms-issuer-did` の `IssuerDidBuilder` 完成後に差し替え。 |
| `GET /users/:userId/did.json` | 200 / 404 / 400 / 500 | `DidDocumentResolver.buildDidDocument(userId)` に委譲。null → 404 / 通常 → 200 / Tombstone (§E) → 200 / userId が §9.2 regex 違反 → 400 / resolver が throw → 500。PENDING / SUBMITTED / CONFIRMED の proof state 切替 (§F) は resolver 側で閉じているため presentation 層は分岐しない。 |
| `GET /vc/:vcId/inclusion-proof` | 501 | 暫定 501 Not Implemented。Merkle inclusion-proof は Phase 1 step 7 (batch worker) 完成後に本実装。404 でなく 501 にすることで「endpoint は存在するが未実装」のセマンティクスを伝える。 |

## DI 登録

```ts
// Phase 1 internalized DID/VC stack (§5.1.4 / §5.4).
// TODO(phase1-final): replace UserDidAnchorStoreStub with a Prisma-backed
// UserDidAnchorRepository once the schema PR (#1094) merges and the
// application service PR wires UserDidDocumentService.
container.register("UserDidAnchorStore", { useClass: UserDidAnchorStoreStub });
container.register("DidDocumentResolver", { useClass: DidDocumentResolver });
```

## 暫定 stub の TODO

- `UserDidAnchorStoreStub` は `findLatestByUserId` が常に `null` を返す。本 PR 単独で `/users/:userId/did.json` は安全に 404 を返す。
- `t_user_did_anchors` Prisma model が未 merge (Schema PR #1094) のため、merge 後に `UserDidAnchorRepository` (Prisma backed) に差し替え予定。
- TODO は以下 2 箇所に明記済み:
  - `src/infrastructure/libs/did/userDidAnchorStoreStub.ts` ファイル冒頭
  - `src/application/provider.ts` の DI 登録ブロックコメント (`TODO(phase1-final): ...`)

## テスト結果

```
$ pnpm test --testPathPattern 'presentation/router/did'
PASS src/__tests__/unit/presentation/router/did.test.ts (14.804 s)
  router/did (§5.4)
    GET /.well-known/did.json
      ✓ returns 200 and a minimal issuer DID Document
      ✓ does not require the resolver (works without DI registration)
    GET /users/:userId/did.json
      ✓ returns 200 with the document when the resolver yields a CONFIRMED anchor
      ✓ returns 200 with a Tombstone document for DEACTIVATE op (§E)
      ✓ returns 404 when the resolver yields null (no anchor row)
      ✓ returns 400 when the userId fails the §9.2 regex
      ✓ returns 500 when the resolver throws
    GET /vc/:vcId/inclusion-proof
      ✓ returns 501 not_implemented for any vcId until the batch worker lands

Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total
```

ビルド / lint:
- `pnpm exec eslint src/presentation/router/ ...` clean
- `pnpm build` 新規エラー 0 件 (baseline 5 件: `@prisma/client/sql` typedSql 由来、本 PR 範囲外)
- prettier 適用済み

## SonarCloud 注意点

#1096 で踏んだ rule に該当する書き方は採用していない:
- Promise executor は本 PR では使用せず
- テストでの直書き `new` は `registerResolverMock` 関数経由で隠蔽し、`new SomeClass()` 直書きは無し

## 次の Phase 1 step

1. application service レイヤ (`UserDidDocumentService` + `UserDidAnchorRepository`) — Schema PR #1094 merge 後
2. batch worker — Merkle batch から VC inclusion-proof を生成し本ルートを 200 化
3. KMS-backed `IssuerDidBuilder` への `/.well-known/did.json` 切替

## Test plan

- [x] `pnpm test --testPathPattern 'presentation/router/did'` 全 8 ケース pass
- [x] `pnpm exec eslint src/presentation/router/` clean
- [x] `pnpm build` 新規エラー 0 件 (baseline 維持)
- [x] prettier 適用済み

https://claude.ai/code/session_019MKzV6DsfsHA6dLJ99chU8

---
_Generated by [Claude Code](https://claude.ai/code/session_019MKzV6DsfsHA6dLJ99chU8)_