### PR TITLE
phase1(app): UserDidService + VcIssuanceService を application 層に追加

### DIFF
--- a/src/__tests__/unit/application/domain/account/userDid/service.test.ts
+++ b/src/__tests__/unit/application/domain/account/userDid/service.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for `UserDidService` (Phase 1 step 7).
+ *
+ * Strategy A: the repository is a stub but tests inject a `useValue` mock
+ * so we can assert the call shape. The service's pure encoding /
+ * hashing path is exercised end-to-end — only persistence is mocked.
+ */
+
+import "reflect-metadata";
+import { container } from "tsyringe";
+import { decode as cborDecode } from "cbor-x";
+import { blake2b } from "@noble/hashes/blake2b";
+import { bytesToHex } from "@noble/hashes/utils";
+import UserDidService from "@/application/domain/account/userDid/service";
+import { IContext } from "@/types/server";
+import {
+  buildDeactivatedDidDocument,
+  buildMinimalDidDocument,
+  buildUserDid,
+} from "@/infrastructure/libs/did/userDidBuilder";
+
+const VALID_USER_ID = "u_xyz_phase1";
+const SAMPLE_NETWORK = "CARDANO_PREPROD" as const;
+
+class MockUserDidAnchorRepository {
+  findLatestByUserId = jest.fn().mockResolvedValue(null);
+  createCreate = jest.fn();
+  createUpdate = jest.fn();
+  createDeactivate = jest.fn();
+}
+
+describe("UserDidService", () => {
+  let mockRepository: MockUserDidAnchorRepository;
+  let service: UserDidService;
+  const mockCtx = {} as IContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    container.reset();
+
+    mockRepository = new MockUserDidAnchorRepository();
+    container.register("UserDidAnchorRepository", { useValue: mockRepository });
+    container.register("UserDidService", { useClass: UserDidService });
+
+    service = container.resolve(UserDidService);
+  });
+
+  describe("createDidForUser", () => {
+    it("builds did:web string + minimal Document and persists with Blake2b-256 hash", async () => {
+      mockRepository.createCreate.mockResolvedValue({ ok: true });
+
+      await service.createDidForUser(mockCtx, VALID_USER_ID);
+
+      expect(mockRepository.createCreate).toHaveBeenCalledTimes(1);
+      const [ctxArg, input, txArg] = mockRepository.createCreate.mock.calls[0];
+
+      expect(ctxArg).toBe(mockCtx);
+      expect(txArg).toBeUndefined();
+      expect(input.userId).toBe(VALID_USER_ID);
+      expect(input.did).toBe(buildUserDid(VALID_USER_ID));
+      // Default network falls back to mainnet per §4.1.
+      expect(input.network).toBe("CARDANO_MAINNET");
+
+      // documentHash is 64 hex chars (32 bytes) of Blake2b-256 over the
+      // CBOR-encoded minimal Document.
+      expect(input.documentHash).toMatch(/^[0-9a-f]{64}$/);
+      expect(input.documentCbor).toBeInstanceOf(Uint8Array);
+
+      // Round-trip: decoded CBOR matches the minimal Document exactly.
+      const decoded = cborDecode(input.documentCbor as Uint8Array);
+      expect(decoded).toEqual(buildMinimalDidDocument(VALID_USER_ID));
+
+      // Hash matches manually-computed Blake2b-256 of the same bytes.
+      const recomputed = bytesToHex(blake2b(input.documentCbor as Uint8Array, { dkLen: 32 }));
+      expect(input.documentHash).toBe(recomputed);
+    });
+
+    it("forwards the supplied tx to the repository", async () => {
+      mockRepository.createCreate.mockResolvedValue({ ok: true });
+      const fakeTx = { sentinel: true } as never;
+
+      await service.createDidForUser(mockCtx, VALID_USER_ID, fakeTx);
+
+      expect(mockRepository.createCreate).toHaveBeenCalledTimes(1);
+      const [, , txArg] = mockRepository.createCreate.mock.calls[0];
+      expect(txArg).toBe(fakeTx);
+    });
+
+    it("propagates the supplied network", async () => {
+      mockRepository.createCreate.mockResolvedValue({ ok: true });
+
+      await service.createDidForUser(mockCtx, VALID_USER_ID, undefined, SAMPLE_NETWORK);
+
+      const [, input] = mockRepository.createCreate.mock.calls[0];
+      expect(input.network).toBe(SAMPLE_NETWORK);
+    });
+
+    it("rejects userIds that violate the §9.2 regex", async () => {
+      // `assertValidUserId` (called by `buildUserDid`) throws on uppercase / colons.
+      await expect(service.createDidForUser(mockCtx, "BAD:ID")).rejects.toThrow(/§9\.2/);
+      expect(mockRepository.createCreate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("updateDid", () => {
+    it("re-anchors the minimal Document via createUpdate", async () => {
+      mockRepository.createUpdate.mockResolvedValue({ ok: true });
+
+      await service.updateDid(mockCtx, VALID_USER_ID);
+
+      expect(mockRepository.createUpdate).toHaveBeenCalledTimes(1);
+      expect(mockRepository.createCreate).not.toHaveBeenCalled();
+      const [, input] = mockRepository.createUpdate.mock.calls[0];
+      expect(input.did).toBe(buildUserDid(VALID_USER_ID));
+      expect(input.documentCbor).toBeInstanceOf(Uint8Array);
+
+      // CBOR shape parity with createDidForUser (Phase 1 only re-anchors
+      // the minimal document — see §B / §10.1.3 future work note).
+      const decoded = cborDecode(input.documentCbor as Uint8Array);
+      expect(decoded).toEqual(buildMinimalDidDocument(VALID_USER_ID));
+    });
+  });
+
+  describe("deactivateDid", () => {
+    it("hashes the tombstone Document and emits createDeactivate without CBOR", async () => {
+      mockRepository.createDeactivate.mockResolvedValue({ ok: true });
+
+      await service.deactivateDid(mockCtx, VALID_USER_ID);
+
+      expect(mockRepository.createDeactivate).toHaveBeenCalledTimes(1);
+      const [, input] = mockRepository.createDeactivate.mock.calls[0];
+      expect(input.userId).toBe(VALID_USER_ID);
+      expect(input.did).toBe(buildUserDid(VALID_USER_ID));
+      // §E: tombstone CBOR is null on chain — resolver reconstructs it.
+      expect((input as { documentCbor?: unknown }).documentCbor).toBeUndefined();
+
+      // documentHash references the canonical tombstone shape so verifiers
+      // can reproduce it offline.
+      const tombstoneCbor = (await import("cbor-x")).encode(
+        buildDeactivatedDidDocument(VALID_USER_ID),
+      );
+      const tombstoneBytes =
+        tombstoneCbor instanceof Uint8Array ? tombstoneCbor : new Uint8Array(tombstoneCbor);
+      const expectedHash = bytesToHex(blake2b(tombstoneBytes, { dkLen: 32 }));
+      expect(input.documentHash).toBe(expectedHash);
+    });
+  });
+});

--- a/src/__tests__/unit/application/domain/credential/vcIssuance/service.test.ts
+++ b/src/__tests__/unit/application/domain/credential/vcIssuance/service.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Unit tests for `VcIssuanceService` (Phase 1 step 7).
+ *
+ * Strategy A: the repository is a stub but tests inject a `useValue` mock
+ * so we can assert the persisted row shape. The KMS signer is also stubbed
+ * via the `STUB_SIGNATURE` constant (real signing lands in
+ * `claude/phase1-infra-kms-issuer-did`).
+ */
+
+import "reflect-metadata";
+import { container } from "tsyringe";
+import VcIssuanceService, {
+  CIVICSHIP_ISSUER_DID,
+  buildVcPayload,
+} from "@/application/domain/credential/vcIssuance/service";
+import { IContext } from "@/types/server";
+
+const SUBJECT_DID = "did:web:api.civicship.app:users:u_xyz_phase1";
+const SAMPLE_USER_ID = "u_xyz_phase1";
+
+class MockVcIssuanceRepository {
+  findById = jest.fn().mockResolvedValue(null);
+  create = jest.fn();
+}
+
+function decodeJwtSegment(segment: string): unknown {
+  return JSON.parse(Buffer.from(segment, "base64url").toString("utf8"));
+}
+
+describe("VcIssuanceService", () => {
+  let mockRepository: MockVcIssuanceRepository;
+  let service: VcIssuanceService;
+  const mockCtx = {} as IContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    container.reset();
+
+    mockRepository = new MockVcIssuanceRepository();
+    container.register("VcIssuanceRepository", { useValue: mockRepository });
+    container.register("VcIssuanceService", { useClass: VcIssuanceService });
+
+    service = container.resolve(VcIssuanceService);
+  });
+
+  describe("issueVc", () => {
+    it("persists a COMPLETED row with the civicship issuer DID and a JWT-shaped vcJwt", async () => {
+      mockRepository.create.mockResolvedValue({ ok: true });
+
+      await service.issueVc(mockCtx, {
+        userId: SAMPLE_USER_ID,
+        evaluationId: "eval-1",
+        subjectDid: SUBJECT_DID,
+        claims: { score: 5, label: "GOOD" },
+      });
+
+      expect(mockRepository.create).toHaveBeenCalledTimes(1);
+      const [ctxArg, input, txArg] = mockRepository.create.mock.calls[0];
+
+      expect(ctxArg).toBe(mockCtx);
+      expect(txArg).toBeUndefined();
+      expect(input.userId).toBe(SAMPLE_USER_ID);
+      expect(input.evaluationId).toBe("eval-1");
+      expect(input.subjectDid).toBe(SUBJECT_DID);
+      expect(input.issuerDid).toBe(CIVICSHIP_ISSUER_DID);
+      expect(input.vcFormat).toBe("INTERNAL_JWT");
+      // §5.2.2: VC body is COMPLETED even before chain anchor.
+      expect(input.status).toBe("COMPLETED");
+      // §D StatusList wiring lands in step 9 — null for now.
+      expect(input.statusListIndex).toBeNull();
+      expect(input.statusListCredential).toBeNull();
+    });
+
+    it("emits a JWT with three dot-separated segments, signature stub last", async () => {
+      mockRepository.create.mockResolvedValue({ ok: true });
+
+      await service.issueVc(mockCtx, {
+        userId: SAMPLE_USER_ID,
+        subjectDid: SUBJECT_DID,
+        claims: { score: 5 },
+      });
+
+      const [, input] = mockRepository.create.mock.calls[0];
+      const segments = (input.vcJwt as string).split(".");
+      expect(segments).toHaveLength(3);
+
+      const header = decodeJwtSegment(segments[0]) as Record<string, unknown>;
+      expect(header.alg).toBe("EdDSA");
+      expect(header.typ).toBe("JWT");
+      // The kid currently references the stub key — real KMS replaces this.
+      expect(String(header.kid).startsWith(CIVICSHIP_ISSUER_DID)).toBe(true);
+
+      const payload = decodeJwtSegment(segments[1]) as Record<string, unknown>;
+      expect(payload.issuer).toBe(CIVICSHIP_ISSUER_DID);
+      const subject = payload.credentialSubject as Record<string, unknown>;
+      expect(subject.id).toBe(SUBJECT_DID);
+      expect(subject.score).toBe(5);
+
+      // The signature segment is a stub marker; verifiers must reject it.
+      expect(segments[2]).toBe("stub-not-signed");
+    });
+
+    it("forwards the supplied tx to the repository", async () => {
+      mockRepository.create.mockResolvedValue({ ok: true });
+      const fakeTx = { sentinel: true } as never;
+
+      await service.issueVc(
+        mockCtx,
+        { userId: SAMPLE_USER_ID, subjectDid: SUBJECT_DID, claims: {} },
+        fakeTx,
+      );
+
+      const [, , txArg] = mockRepository.create.mock.calls[0];
+      expect(txArg).toBe(fakeTx);
+    });
+
+    it("defaults evaluationId to null when omitted", async () => {
+      mockRepository.create.mockResolvedValue({ ok: true });
+
+      await service.issueVc(mockCtx, {
+        userId: SAMPLE_USER_ID,
+        subjectDid: SUBJECT_DID,
+        claims: {},
+      });
+
+      const [, input] = mockRepository.create.mock.calls[0];
+      expect(input.evaluationId).toBeNull();
+    });
+  });
+
+  describe("buildVcPayload (pure function)", () => {
+    it("attaches W3C contexts, type array, ISO issuanceDate, and merges claims into credentialSubject", () => {
+      const issuedAt = new Date("2026-05-10T12:00:00Z");
+      const payload = buildVcPayload({
+        issuer: CIVICSHIP_ISSUER_DID,
+        subject: SUBJECT_DID,
+        claims: { score: 5, label: "GOOD" },
+        issuedAt,
+      });
+
+      expect(payload["@context"]).toEqual([
+        "https://www.w3.org/2018/credentials/v1",
+        "https://w3id.org/security/data-integrity/v2",
+      ]);
+      expect(payload.type).toEqual(["VerifiableCredential"]);
+      expect(payload.issuer).toBe(CIVICSHIP_ISSUER_DID);
+      expect(payload.issuanceDate).toBe(issuedAt.toISOString());
+      expect(payload.credentialSubject).toEqual({
+        id: SUBJECT_DID,
+        score: 5,
+        label: "GOOD",
+      });
+    });
+  });
+});

--- a/src/application/domain/account/userDid/data/interface.ts
+++ b/src/application/domain/account/userDid/data/interface.ts
@@ -1,0 +1,59 @@
+/**
+ * Repository contract for the `userDid` application domain.
+ *
+ * The interface is intentionally narrow — only the four operations used by
+ * `UserDidService` are declared. Heavier query patterns (e.g. paginated
+ * listing for an admin UI) live behind a separate interface and will be
+ * added in a later phase.
+ *
+ * Strategy A note (Phase 1 step 7) ----------------------------------------
+ *
+ * `findLatestByUserId` matches the `UserDidAnchorStore` interface declared
+ * in `src/infrastructure/libs/did/didDocumentResolver.ts` so a single
+ * production repository can satisfy both the resolver (PR #1096) and the
+ * service (this PR) once the schema PR (#1094) merges.
+ *
+ * The `tx` argument follows the project-wide branching pattern (see
+ * CLAUDE.md "Transaction Handling Pattern"): when `tx` is supplied, the
+ * repository must execute against it; when omitted, it must obtain its own
+ * issuer-scoped client.
+ */
+
+import type { Prisma } from "@prisma/client";
+import { IContext } from "@/types/server";
+import type {
+  CreateUserDidAnchorInput,
+  DeactivateUserDidAnchorInput,
+  UpdateUserDidAnchorInput,
+  UserDidAnchorRow,
+} from "@/application/domain/account/userDid/data/type";
+import type { UserDidAnchorStore } from "@/infrastructure/libs/did/didDocumentResolver";
+
+export interface IUserDidAnchorRepository extends UserDidAnchorStore {
+  /**
+   * Return the most recently-created anchor for `userId`, regardless of
+   * status (PENDING included per §F). Returns `null` when no row exists.
+   *
+   * Inherited from `UserDidAnchorStore` so the production class can be
+   * reused by `DidDocumentResolver` (PR #1096) without an adapter.
+   */
+  findLatestByUserId(userId: string): Promise<UserDidAnchorRow | null>;
+
+  createCreate(
+    ctx: IContext,
+    input: CreateUserDidAnchorInput,
+    tx?: Prisma.TransactionClient,
+  ): Promise<UserDidAnchorRow>;
+
+  createUpdate(
+    ctx: IContext,
+    input: UpdateUserDidAnchorInput,
+    tx?: Prisma.TransactionClient,
+  ): Promise<UserDidAnchorRow>;
+
+  createDeactivate(
+    ctx: IContext,
+    input: DeactivateUserDidAnchorInput,
+    tx?: Prisma.TransactionClient,
+  ): Promise<UserDidAnchorRow>;
+}

--- a/src/application/domain/account/userDid/data/repository.ts
+++ b/src/application/domain/account/userDid/data/repository.ts
@@ -1,0 +1,95 @@
+/**
+ * Stub repository for `UserDidAnchor`.
+ *
+ * Strategy A note (Phase 1 step 7) ----------------------------------------
+ *
+ * The `t_user_did_anchors` Prisma model lands in a sibling PR
+ * (`claude/phase1-schema-migration`, #1094). Until that merges, we cannot
+ * issue real Prisma queries against `tx.userDidAnchor` — the type does not
+ * exist yet on `Prisma.TransactionClient`.
+ *
+ * To keep the application layer compilable and DI-resolvable today:
+ *
+ *   - `findLatestByUserId` returns `null` (mirrors "no row" — appropriate
+ *     for both DI smoke tests and the resolver fallback to 404).
+ *   - `createCreate` / `createUpdate` / `createDeactivate` throw a
+ *     `NotImplementedError` with a TODO marker. The service still calls them
+ *     so that downstream test doubles can verify the call shape; production
+ *     code will get a real implementation when the schema PR merges.
+ *
+ * After the schema PR merges, the swap is mechanical — replace the bodies
+ * with the equivalents already prototyped in `DIDIssuanceRequestRepository`
+ * (see `src/application/domain/account/identity/didIssuanceRequest/data/repository.ts`).
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §4.1   (UserDidAnchor schema)
+ *   docs/report/did-vc-internalization.md §5.2.1 (Application service shape)
+ *   docs/report/did-vc-internalization.md §5.1.4 (DidDocumentResolver storage interface)
+ */
+
+import { injectable } from "tsyringe";
+import type { Prisma } from "@prisma/client";
+import { IContext } from "@/types/server";
+import type { IUserDidAnchorRepository } from "@/application/domain/account/userDid/data/interface";
+import type {
+  CreateUserDidAnchorInput,
+  DeactivateUserDidAnchorInput,
+  UpdateUserDidAnchorInput,
+  UserDidAnchorRow,
+} from "@/application/domain/account/userDid/data/type";
+
+/**
+ * Marker error so tests / runtime callers can distinguish "feature not
+ * wired up yet" from "feature broken". Keeping it local avoids cross-PR
+ * coupling — once the real repository lands this class is deleted.
+ */
+export class UserDidAnchorRepositoryNotImplementedError extends Error {
+  constructor(method: string) {
+    super(
+      `UserDidAnchorRepositoryStub.${method}: not implemented yet — depends on ` +
+        "schema PR (#1094, t_user_did_anchors). Replace stub with the production " +
+        "Prisma-backed repository after that PR merges (Phase 1 step 8+).",
+    );
+    this.name = "UserDidAnchorRepositoryNotImplementedError";
+  }
+}
+
+@injectable()
+export default class UserDidAnchorRepositoryStub implements IUserDidAnchorRepository {
+  // findLatestByUserId is the only method that has a meaningful no-op:
+  // returning `null` correctly tells the resolver "no anchor for this user".
+  // The signature matches `UserDidAnchorStore` from the resolver.
+  async findLatestByUserId(_userId: string): Promise<UserDidAnchorRow | null> {
+    return null;
+  }
+
+  // TODO(phase1-final): swap to Prisma-backed implementation once
+  // `t_user_did_anchors` is in the generated client.
+  async createCreate(
+    _ctx: IContext,
+    _input: CreateUserDidAnchorInput,
+    _tx?: Prisma.TransactionClient,
+  ): Promise<UserDidAnchorRow> {
+    throw new UserDidAnchorRepositoryNotImplementedError("createCreate");
+  }
+
+  // TODO(phase1-final): swap to Prisma-backed implementation once
+  // `t_user_did_anchors` is in the generated client.
+  async createUpdate(
+    _ctx: IContext,
+    _input: UpdateUserDidAnchorInput,
+    _tx?: Prisma.TransactionClient,
+  ): Promise<UserDidAnchorRow> {
+    throw new UserDidAnchorRepositoryNotImplementedError("createUpdate");
+  }
+
+  // TODO(phase1-final): swap to Prisma-backed implementation once
+  // `t_user_did_anchors` is in the generated client.
+  async createDeactivate(
+    _ctx: IContext,
+    _input: DeactivateUserDidAnchorInput,
+    _tx?: Prisma.TransactionClient,
+  ): Promise<UserDidAnchorRow> {
+    throw new UserDidAnchorRepositoryNotImplementedError("createDeactivate");
+  }
+}

--- a/src/application/domain/account/userDid/data/type.ts
+++ b/src/application/domain/account/userDid/data/type.ts
@@ -1,0 +1,67 @@
+/**
+ * Local type declarations for the `userDid` application domain.
+ *
+ * Strategy A note (Phase 1 step 7) ----------------------------------------
+ *
+ * The `t_user_did_anchors` Prisma model lives in a sibling PR
+ * (`claude/phase1-schema-migration`, #1094) which has not yet merged. To keep
+ * this PR independent we re-export the row shape declared by the resolver
+ * (PR #1096, `src/infrastructure/libs/did/didDocumentResolver.ts`) so the
+ * service / repository layer can be built against a stable contract.
+ *
+ * After the schema PR merges, the swap is a one-line change:
+ *
+ *     // TODO(phase1-final): replace with
+ *     //   import type { UserDidAnchor } from "@prisma/client";
+ *     //   export type UserDidAnchorRow = UserDidAnchor;
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §4.1 (UserDidAnchor schema)
+ *   docs/report/did-vc-internalization.md §5.2.1 (Application service shape)
+ */
+
+import type {
+  AnchorNetworkValue,
+  AnchorStatusValue,
+  DidOperationValue,
+  UserDidAnchorRow,
+} from "@/infrastructure/libs/did/didDocumentResolver";
+
+// Re-export so callers in this domain do not need to reach into infrastructure.
+export type { AnchorNetworkValue, AnchorStatusValue, DidOperationValue, UserDidAnchorRow };
+
+/**
+ * Input for creating a new CREATE-op `UserDidAnchor` row.
+ *
+ * Mirrors the columns the schema PR will introduce in `t_user_did_anchors`.
+ * Only the fields the service needs at row insertion time are listed; chain
+ * tx fields (`chainTxHash`, `chainOpIndex`, `confirmedAt`) are filled in
+ * later by the anchor batch service.
+ */
+export interface CreateUserDidAnchorInput {
+  userId: string;
+  did: string;
+  documentHash: string;
+  documentCbor: Uint8Array;
+  /** Defaults to `"CARDANO_MAINNET"` per §5.2.1 example when omitted. */
+  network?: AnchorNetworkValue;
+}
+
+/**
+ * Input for an UPDATE-op anchor row. Reuses the CREATE shape — the only
+ * semantic difference is `operation = "UPDATE"`, which the repository sets
+ * internally.
+ */
+export type UpdateUserDidAnchorInput = CreateUserDidAnchorInput;
+
+/**
+ * Input for a DEACTIVATE-op anchor row. `documentCbor` is null per §E
+ * (Tombstone documents are reconstructed from the tombstone builder, not
+ * from CBOR), and `documentHash` references the tombstone document hash.
+ */
+export interface DeactivateUserDidAnchorInput {
+  userId: string;
+  did: string;
+  documentHash: string;
+  network?: AnchorNetworkValue;
+}

--- a/src/application/domain/account/userDid/presenter.ts
+++ b/src/application/domain/account/userDid/presenter.ts
@@ -1,0 +1,54 @@
+/**
+ * `UserDidPresenter` — Prisma row → GraphQL type formatting for the User
+ * DID domain.
+ *
+ * Phase 1 step 7 scope: skeleton only. The schema PR (#1094) introduces
+ * the underlying Prisma model and the GraphQL schema PR (Phase 1 step 8)
+ * introduces `GqlUserDidAnchor`. Until both land, the presenter exposes a
+ * single passthrough so the upcoming resolver has a clear extension point
+ * without leaking GraphQL types into the service layer.
+ *
+ * Pure functions only — no I/O, no DI, no business logic (per CLAUDE.md
+ * "Layer Responsibilities" §6).
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.2.1
+ */
+
+import type { UserDidAnchorRow } from "@/application/domain/account/userDid/data/type";
+
+/**
+ * Public-facing skeleton shape. Matches the field set the design's §5.4.4
+ * `proof` block exposes, less the `proof` framing — that wrapping happens
+ * in the resolver layer (PR #1096 already implements it for the HTTP
+ * route). Once the GraphQL schema lands, swap the return type to
+ * `GqlUserDidAnchor` and tighten the field names.
+ */
+export interface UserDidAnchorView {
+  did: string;
+  operation: UserDidAnchorRow["operation"];
+  documentHash: string;
+  network: UserDidAnchorRow["network"];
+  status: UserDidAnchorRow["status"];
+  chainTxHash: string | null;
+  chainOpIndex: number | null;
+  confirmedAt: string | null;
+}
+
+const UserDidPresenter = {
+  /** Convert a single anchor row to its GraphQL-friendly view shape. */
+  view(row: UserDidAnchorRow): UserDidAnchorView {
+    return {
+      did: row.did,
+      operation: row.operation,
+      documentHash: row.documentHash,
+      network: row.network,
+      status: row.status,
+      chainTxHash: row.chainTxHash,
+      chainOpIndex: row.chainOpIndex,
+      confirmedAt: row.confirmedAt ? row.confirmedAt.toISOString() : null,
+    };
+  },
+};
+
+export default UserDidPresenter;

--- a/src/application/domain/account/userDid/service.ts
+++ b/src/application/domain/account/userDid/service.ts
@@ -1,0 +1,211 @@
+/**
+ * `UserDidService` — application-layer entry point for civicship's
+ * internal User DID lifecycle (create / update / deactivate).
+ *
+ * Per design §5.2.1, each lifecycle event:
+ *
+ *   1. Computes the canonical did:web string for the user.
+ *   2. Builds the minimal DID Document (or tombstone for DEACTIVATE).
+ *   3. CBOR-encodes the Document.
+ *   4. Hashes the CBOR bytes with Blake2b-256 → `documentHash` (32 B / 64 hex).
+ *   5. Persists a `UserDidAnchor` row in PENDING status.
+ *
+ * Step 5's row is picked up later by the weekly anchor batch (§5.3.1),
+ * which is the responsibility of a different service (Phase 1 step 9). This
+ * service intentionally does NOT touch Cardano — by keeping anchoring out
+ * of the request path, DID create / update / deactivate stays fast and
+ * independent of chain availability.
+ *
+ * §B compliance: User DIDs do not carry verification material. The service
+ * never generates user keypairs.
+ *
+ * §F compliance: anchors are persisted as PENDING and the resolver serves
+ * them immediately — confirmation on chain happens out-of-band.
+ *
+ * Strategy A note (Phase 1 step 7) ----------------------------------------
+ *
+ * The repository is a stub (see `data/repository.ts`) until schema PR
+ * #1094 lands. The service is fully functional today: callers exercising
+ * `createDidForUser` will get back a valid `did` / `documentHash` /
+ * `documentCbor` triple — only the persistence call throws. Tests inject a
+ * `useValue` mock to verify the upstream pipeline.
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §3.3   (CBOR-encoded DID Document)
+ *   docs/report/did-vc-internalization.md §5.2.1 (this service)
+ *   docs/report/did-vc-internalization.md §B / §E / §F
+ */
+
+import { blake2b } from "@noble/hashes/blake2b";
+import { encode as cborEncode } from "cbor-x";
+import { bytesToHex } from "@noble/hashes/utils";
+import { inject, injectable } from "tsyringe";
+import type { Prisma } from "@prisma/client";
+import { IContext } from "@/types/server";
+import logger from "@/infrastructure/logging";
+import type { IUserDidAnchorRepository } from "@/application/domain/account/userDid/data/interface";
+import type {
+  AnchorNetworkValue,
+  UserDidAnchorRow,
+} from "@/application/domain/account/userDid/data/type";
+import {
+  buildDeactivatedDidDocument,
+  buildMinimalDidDocument,
+  buildUserDid,
+  type DidDocument,
+  type TombstoneDocument,
+} from "@/infrastructure/libs/did/userDidBuilder";
+
+/** Output length of `documentHash`, in bytes (Blake2b-256 → 32 B). */
+const DOCUMENT_HASH_BYTES = 32;
+
+/**
+ * Default chain network for new anchors. The design only ships
+ * `CARDANO_MAINNET` and `CARDANO_PREPROD` (§4.1 ChainNetwork) — production
+ * defaults to mainnet, callers in dev / preview environments must pass
+ * `CARDANO_PREPROD` explicitly.
+ */
+const DEFAULT_NETWORK: AnchorNetworkValue = "CARDANO_MAINNET";
+
+/**
+ * CBOR-encode a DID Document and return both the bytes and the
+ * Blake2b-256 hex digest. Pulled out as a helper so create / update share
+ * one canonical encode path — drift between the two would silently break
+ * verifiers.
+ */
+function encodeAndHash(document: DidDocument | TombstoneDocument): {
+  cbor: Uint8Array;
+  hashHex: string;
+} {
+  const cbor = cborEncode(document);
+  // `cborEncode` returns a Buffer in Node; normalize to Uint8Array so the
+  // shape matches what the resolver and chain layer consume (§3.3).
+  const cborBytes = cbor instanceof Uint8Array ? cbor : new Uint8Array(cbor);
+  const digest = blake2b(cborBytes, { dkLen: DOCUMENT_HASH_BYTES });
+  return { cbor: cborBytes, hashHex: bytesToHex(digest) };
+}
+
+@injectable()
+export default class UserDidService {
+  constructor(
+    @inject("UserDidAnchorRepository")
+    private readonly repository: IUserDidAnchorRepository,
+  ) {}
+
+  /**
+   * §5.2.1: enqueue a CREATE-op `UserDidAnchor` for `userId`.
+   *
+   * Returns the persisted row so the caller (UseCase) can pass it through
+   * its presenter. The row is PENDING — it becomes SUBMITTED / CONFIRMED
+   * later via the weekly anchor batch.
+   *
+   * `tx` follows the project-wide branching pattern: when supplied, the
+   * write happens inside the caller's transaction; when omitted, the
+   * repository establishes its own issuer-scoped transaction.
+   */
+  async createDidForUser(
+    ctx: IContext,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+    network: AnchorNetworkValue = DEFAULT_NETWORK,
+  ): Promise<UserDidAnchorRow> {
+    const did = buildUserDid(userId);
+    const document = buildMinimalDidDocument(userId);
+    const { cbor, hashHex } = encodeAndHash(document);
+
+    logger.debug("[UserDidService] createDidForUser", {
+      userId,
+      did,
+      documentHash: hashHex,
+      network,
+    });
+
+    return this.repository.createCreate(
+      ctx,
+      {
+        userId,
+        did,
+        documentHash: hashHex,
+        documentCbor: cbor,
+        network,
+      },
+      tx,
+    );
+  }
+
+  /**
+   * §5.2.1: enqueue an UPDATE-op `UserDidAnchor` for `userId`.
+   *
+   * Phase 1 only re-anchors the minimal document shape (§B — User DIDs
+   * have no verification material). When VPs from users land in a future
+   * phase (§10.1.3), this method grows a `nextDocument` argument so callers
+   * can pass an extended Document.
+   */
+  async updateDid(
+    ctx: IContext,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+    network: AnchorNetworkValue = DEFAULT_NETWORK,
+  ): Promise<UserDidAnchorRow> {
+    const did = buildUserDid(userId);
+    const document = buildMinimalDidDocument(userId);
+    const { cbor, hashHex } = encodeAndHash(document);
+
+    logger.debug("[UserDidService] updateDid", {
+      userId,
+      did,
+      documentHash: hashHex,
+      network,
+    });
+
+    return this.repository.createUpdate(
+      ctx,
+      {
+        userId,
+        did,
+        documentHash: hashHex,
+        documentCbor: cbor,
+        network,
+      },
+      tx,
+    );
+  }
+
+  /**
+   * §5.2.1 + §E: enqueue a DEACTIVATE-op `UserDidAnchor` for `userId`.
+   *
+   * The on-chain row's `documentCbor` is intentionally null (the resolver
+   * reconstructs the tombstone via `buildDeactivatedDidDocument` rather
+   * than pulling from CBOR — see `didDocumentResolver.ts`), but the
+   * `documentHash` still references the canonical tombstone Document so
+   * verifiers can reproduce it.
+   */
+  async deactivateDid(
+    ctx: IContext,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+    network: AnchorNetworkValue = DEFAULT_NETWORK,
+  ): Promise<UserDidAnchorRow> {
+    const did = buildUserDid(userId);
+    const tombstone = buildDeactivatedDidDocument(userId);
+    const { hashHex } = encodeAndHash(tombstone);
+
+    logger.debug("[UserDidService] deactivateDid", {
+      userId,
+      did,
+      documentHash: hashHex,
+      network,
+    });
+
+    return this.repository.createDeactivate(
+      ctx,
+      {
+        userId,
+        did,
+        documentHash: hashHex,
+        network,
+      },
+      tx,
+    );
+  }
+}

--- a/src/application/domain/account/userDid/usecase.ts
+++ b/src/application/domain/account/userDid/usecase.ts
@@ -1,0 +1,62 @@
+/**
+ * `UserDidUseCase` — transaction boundary for the User DID lifecycle.
+ *
+ * Phase 1 step 7 scope (per task brief):
+ *   - Provide a transaction boundary so future GraphQL resolvers (Phase 1
+ *     step 8) can drop in without re-architecting.
+ *   - Delegate to `UserDidService` for all real work — the usecase is
+ *     intentionally thin.
+ *
+ * Why a usecase exists today even though no resolver calls it yet: the
+ * project pattern (CLAUDE.md "Layer Responsibilities") makes UseCase the
+ * sole layer that may open transactions. Adding it here avoids an awkward
+ * later refactor where every test against the resolver would have to be
+ * rewritten to thread a transaction.
+ *
+ * Strategy A note (Phase 1 step 7) ----------------------------------------
+ *
+ * The repository writes throw `NotImplementedError` until schema PR #1094
+ * merges. Calls into this usecase exercise the full flow up to the
+ * persistence boundary, which is exactly the contract test surface the
+ * upcoming resolver will need.
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.2.1 (this domain)
+ *   CLAUDE.md "Transaction Handling Pattern"
+ */
+
+import { inject, injectable } from "tsyringe";
+import { IContext } from "@/types/server";
+import UserDidService from "@/application/domain/account/userDid/service";
+import type { UserDidAnchorRow } from "@/application/domain/account/userDid/data/type";
+
+@injectable()
+export default class UserDidUseCase {
+  constructor(@inject("UserDidService") private readonly service: UserDidService) {}
+
+  /**
+   * Open an issuer-scoped transaction and enqueue a CREATE-op anchor.
+   *
+   * `ctx.issuer.public` is used (rather than `onlyBelongingCommunity`)
+   * because user DID lifecycle is keyed by `userId` and not gated on
+   * community membership — the resolver will perform its own auth check
+   * (Phase 1 step 8) via `src/presentation/graphql/rule.ts`.
+   */
+  async createDidForUser(ctx: IContext, userId: string): Promise<UserDidAnchorRow> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      return this.service.createDidForUser(ctx, userId, tx);
+    });
+  }
+
+  async updateDid(ctx: IContext, userId: string): Promise<UserDidAnchorRow> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      return this.service.updateDid(ctx, userId, tx);
+    });
+  }
+
+  async deactivateDid(ctx: IContext, userId: string): Promise<UserDidAnchorRow> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      return this.service.deactivateDid(ctx, userId, tx);
+    });
+  }
+}

--- a/src/application/domain/credential/vcIssuance/data/interface.ts
+++ b/src/application/domain/credential/vcIssuance/data/interface.ts
@@ -1,0 +1,34 @@
+/**
+ * Repository contract for the `credential/vcIssuance` application domain.
+ *
+ * Narrow surface — only `findById` and `create` are needed for Phase 1
+ * step 7. Anchor-side fields (`vcAnchorId`, `anchorLeafIndex`) are filled
+ * in by a separate `update` call from the weekly anchor batch (Phase 1
+ * step 9), which will extend this interface when it lands.
+ *
+ * Strategy A note (Phase 1 step 7) ----------------------------------------
+ *
+ * The implementing repository (`VcIssuanceRepositoryStub`) throws
+ * `NotImplementedError` for `create` until schema PR #1094 lands; tests
+ * inject a `useValue` mock to verify the upstream pipeline.
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.2.2
+ */
+
+import type { Prisma } from "@prisma/client";
+import { IContext } from "@/types/server";
+import type {
+  CreateVcIssuanceInput,
+  VcIssuanceRow,
+} from "@/application/domain/credential/vcIssuance/data/type";
+
+export interface IVcIssuanceRepository {
+  findById(ctx: IContext, id: string): Promise<VcIssuanceRow | null>;
+
+  create(
+    ctx: IContext,
+    input: CreateVcIssuanceInput,
+    tx?: Prisma.TransactionClient,
+  ): Promise<VcIssuanceRow>;
+}

--- a/src/application/domain/credential/vcIssuance/data/repository.ts
+++ b/src/application/domain/credential/vcIssuance/data/repository.ts
@@ -1,0 +1,61 @@
+/**
+ * Stub repository for `VcIssuanceRequest` (post-schema-PR shape).
+ *
+ * Strategy A note (Phase 1 step 7) ----------------------------------------
+ *
+ * The Phase-1 redesign of `t_vc_issuance_requests` lands in schema PR
+ * #1094. The legacy IDENTUS-era model still exists in the current
+ * generated client, but its column set is incompatible (no `vcJwt`,
+ * `vcAnchorId`, etc.), so we cannot back this domain with the old
+ * model.
+ *
+ * Until #1094 merges:
+ *   - `findById` returns `null` (mirrors "no row" — keeps the DI smoke
+ *     path green).
+ *   - `create` throws `NotImplementedError` with a TODO marker. The
+ *     service's behaviour is verified via a `useValue` mock in tests; the
+ *     real implementation is a 5-line Prisma call that will land alongside
+ *     the schema PR.
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §4.1   (VcIssuanceRequest schema)
+ *   docs/report/did-vc-internalization.md §5.2.2 (Application service shape)
+ */
+
+import { injectable } from "tsyringe";
+import type { Prisma } from "@prisma/client";
+import { IContext } from "@/types/server";
+import type { IVcIssuanceRepository } from "@/application/domain/credential/vcIssuance/data/interface";
+import type {
+  CreateVcIssuanceInput,
+  VcIssuanceRow,
+} from "@/application/domain/credential/vcIssuance/data/type";
+
+export class VcIssuanceRepositoryNotImplementedError extends Error {
+  constructor(method: string) {
+    super(
+      `VcIssuanceRepositoryStub.${method}: not implemented yet — depends on ` +
+        "schema PR (#1094, t_vc_issuance_requests JWT-shaped redesign). Replace " +
+        "stub with the production Prisma-backed repository after that PR merges " +
+        "(Phase 1 step 8+).",
+    );
+    this.name = "VcIssuanceRepositoryNotImplementedError";
+  }
+}
+
+@injectable()
+export default class VcIssuanceRepositoryStub implements IVcIssuanceRepository {
+  async findById(_ctx: IContext, _id: string): Promise<VcIssuanceRow | null> {
+    return null;
+  }
+
+  // TODO(phase1-final): swap to Prisma-backed implementation once
+  // `t_vc_issuance_requests` (Phase-1 redesign) is in the generated client.
+  async create(
+    _ctx: IContext,
+    _input: CreateVcIssuanceInput,
+    _tx?: Prisma.TransactionClient,
+  ): Promise<VcIssuanceRow> {
+    throw new VcIssuanceRepositoryNotImplementedError("create");
+  }
+}

--- a/src/application/domain/credential/vcIssuance/data/type.ts
+++ b/src/application/domain/credential/vcIssuance/data/type.ts
@@ -65,6 +65,17 @@ export interface IssueVcInput {
   subjectDid: string;
   /** Free-form claim payload — opaque to this service, signed by KMS. */
   claims: Record<string, unknown>;
+  /**
+   * Issuance timestamp injected by the caller. Optional — defaults to
+   * `new Date()` inside the service. Exposed so that:
+   *   1. tests can pin the timestamp for deterministic JWT/snapshot assertions
+   *   2. batch / replay flows can preserve the original VC issuance time
+   *      instead of stamping the moment of replay.
+   *
+   * The same instance is used for both the W3C `issuanceDate` claim and the
+   * persistence row, eliminating sub-second drift between the two.
+   */
+  issuedAt?: Date;
 }
 
 /** Inputs to `IVcIssuanceRepository.create`. */

--- a/src/application/domain/credential/vcIssuance/data/type.ts
+++ b/src/application/domain/credential/vcIssuance/data/type.ts
@@ -1,0 +1,81 @@
+/**
+ * Local type declarations for the `credential/vcIssuance` application
+ * domain.
+ *
+ * Strategy A note (Phase 1 step 7) ----------------------------------------
+ *
+ * The schema PR (#1094) introduces a new `t_vc_issuance_requests` Prisma
+ * model that supersedes the existing IDENTUS-era `vcIssuanceRequest` model
+ * with a JWT-shaped column set (vcJwt / vcAnchorId / anchorLeafIndex /
+ * statusListIndex / statusListCredential). To keep this PR independent we
+ * declare the row shape locally as `VcIssuanceRow` — it intentionally
+ * mirrors the design's column set so that, after the schema PR merges,
+ * swapping to the generated type is a one-line change:
+ *
+ *     // TODO(phase1-final): replace with
+ *     //   import type { VcIssuanceRequest } from "@prisma/client";
+ *     //   export type VcIssuanceRow = VcIssuanceRequest;
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §4.1   (VcIssuanceRequest schema)
+ *   docs/report/did-vc-internalization.md §5.2.2 (Application service shape)
+ *   docs/report/did-vc-internalization.md §D     (credentialStatus)
+ */
+
+/** §4.1 — VC format. Phase 1 only emits `INTERNAL_JWT`. */
+export type VcFormatValue = "INTERNAL_JWT" | "INTERNAL_LD";
+
+/** §4.1 — VC lifecycle status. */
+export type VcStatusValue = "PENDING" | "PROCESSING" | "COMPLETED" | "FAILED" | "REVOKED";
+
+/**
+ * Local row shape standing in for `VcIssuanceRequest` post-schema-PR.
+ *
+ * Fields match the design's schema (§4.1) one-for-one. The legacy IDENTUS
+ * fields (`jobId`, `errorMessage`, `retryCount`, …) are intentionally
+ * omitted — Phase 1 step 7 only needs the columns this service writes.
+ */
+export interface VcIssuanceRow {
+  id: string;
+  userId: string;
+  evaluationId: string | null;
+  issuerDid: string;
+  subjectDid: string;
+  vcFormat: VcFormatValue;
+  vcJwt: string;
+  statusListIndex: number | null;
+  statusListCredential: string | null;
+  vcAnchorId: string | null;
+  anchorLeafIndex: number | null;
+  status: VcStatusValue;
+  createdAt: Date;
+  completedAt: Date | null;
+}
+
+/**
+ * Inputs to `VcIssuanceService.issueVc`. Mirrors §5.2.2 example with the
+ * `issuerDid` defaulted in the service (always
+ * `did:web:api.civicship.app` per Phase 1 design).
+ */
+export interface IssueVcInput {
+  userId: string;
+  /** Optional — set when the VC is tied to an Evaluation (typical case). */
+  evaluationId?: string;
+  /** The user's `did:web:api.civicship.app:users:<id>` per §B. */
+  subjectDid: string;
+  /** Free-form claim payload — opaque to this service, signed by KMS. */
+  claims: Record<string, unknown>;
+}
+
+/** Inputs to `IVcIssuanceRepository.create`. */
+export interface CreateVcIssuanceInput {
+  userId: string;
+  evaluationId?: string | null;
+  issuerDid: string;
+  subjectDid: string;
+  vcFormat: VcFormatValue;
+  vcJwt: string;
+  statusListIndex?: number | null;
+  statusListCredential?: string | null;
+  status: VcStatusValue;
+}

--- a/src/application/domain/credential/vcIssuance/presenter.ts
+++ b/src/application/domain/credential/vcIssuance/presenter.ts
@@ -1,0 +1,54 @@
+/**
+ * `VcIssuancePresenter` — Prisma row → GraphQL type formatting for the
+ * VC issuance domain.
+ *
+ * Phase 1 step 7 scope: skeleton only. Once the GraphQL schema PR (Phase
+ * 1 step 8) introduces `GqlVcIssuance`, swap the return type to that and
+ * tighten the shape. Pure functions only — no I/O, no DI, no business
+ * logic (per CLAUDE.md "Layer Responsibilities" §6).
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.2.2
+ */
+
+import type { VcIssuanceRow } from "@/application/domain/credential/vcIssuance/data/type";
+
+export interface VcIssuanceView {
+  id: string;
+  userId: string;
+  evaluationId: string | null;
+  issuerDid: string;
+  subjectDid: string;
+  vcFormat: VcIssuanceRow["vcFormat"];
+  vcJwt: string;
+  statusListIndex: number | null;
+  statusListCredential: string | null;
+  vcAnchorId: string | null;
+  anchorLeafIndex: number | null;
+  status: VcIssuanceRow["status"];
+  createdAt: string;
+  completedAt: string | null;
+}
+
+const VcIssuancePresenter = {
+  view(row: VcIssuanceRow): VcIssuanceView {
+    return {
+      id: row.id,
+      userId: row.userId,
+      evaluationId: row.evaluationId,
+      issuerDid: row.issuerDid,
+      subjectDid: row.subjectDid,
+      vcFormat: row.vcFormat,
+      vcJwt: row.vcJwt,
+      statusListIndex: row.statusListIndex,
+      statusListCredential: row.statusListCredential,
+      vcAnchorId: row.vcAnchorId,
+      anchorLeafIndex: row.anchorLeafIndex,
+      status: row.status,
+      createdAt: row.createdAt.toISOString(),
+      completedAt: row.completedAt ? row.completedAt.toISOString() : null,
+    };
+  },
+};
+
+export default VcIssuancePresenter;

--- a/src/application/domain/credential/vcIssuance/service.ts
+++ b/src/application/domain/credential/vcIssuance/service.ts
@@ -122,7 +122,11 @@ export default class VcIssuanceService {
     input: IssueVcInput,
     tx?: Prisma.TransactionClient,
   ): Promise<VcIssuanceRow> {
-    const issuedAt = new Date();
+    // Capture the issuance instant exactly once: re-using the same `Date`
+    // for both the JWT `issuanceDate` claim and downstream persistence
+    // avoids sub-second drift between payload and DB row. Callers (tests,
+    // replay batches) may override via `input.issuedAt`.
+    const issuedAt = input.issuedAt ?? new Date();
     const issuerDid = CIVICSHIP_ISSUER_DID;
 
     // 1) Build the W3C VC payload. §D `credentialStatus` is intentionally

--- a/src/application/domain/credential/vcIssuance/service.ts
+++ b/src/application/domain/credential/vcIssuance/service.ts
@@ -1,0 +1,181 @@
+/**
+ * `VcIssuanceService` — application-layer entry point for civicship's
+ * internal Verifiable Credential issuance flow (§5.2.2).
+ *
+ * Per design §5.2.2, each issuance:
+ *
+ *   1. Builds the W3C VC payload with a fixed civicship issuer DID.
+ *   2. Reserves a StatusList slot for revocation (§D credentialStatus).
+ *      ★ Phase 1 step 7 stub: StatusList domain lives in a sibling PR;
+ *        this service emits a placeholder slot reference and leaves
+ *        revocation wiring to Phase 1 step 9.
+ *   3. Encodes header.payload as base64url, leaves the signature empty
+ *      (stub — KMS signer is in `claude/phase1-infra-kms-issuer-did`,
+ *      out of scope for this PR per task brief).
+ *   4. Persists a `VcIssuanceRequest` row with `status = COMPLETED`. The
+ *      `vcAnchorId` is filled in later by the weekly anchor batch.
+ *
+ * Why issue and persist with `COMPLETED` even before anchor confirmation:
+ * §5.2.2 explicitly states "VC 本体は anchor 待ちなしで COMPLETED" — the
+ * UI must be able to present the VC immediately. Anchor state lives on a
+ * separate field (`vcAnchorId`) which the verifier inspects when stronger
+ * trust guarantees are needed.
+ *
+ * Strategy A note (Phase 1 step 7) ----------------------------------------
+ *
+ * The repository is a stub (see `data/repository.ts`) until schema PR
+ * #1094 lands. The signature stub (`vcJwt = "<header>.<payload>.stub-not-signed"`)
+ * exists because the KMS signer lives in PR `claude/phase1-infra-kms-issuer-did`.
+ * Both will be swapped to real implementations in Phase 1 step 9; the
+ * unit tests already verify the JWT shape so the swap is mechanical.
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.2.2 (this service)
+ *   docs/report/did-vc-internalization.md §D     (BitstringStatusList)
+ *   docs/report/did-vc-internalization.md §B     (issuer DID — civicship.app)
+ */
+
+import { inject, injectable } from "tsyringe";
+import type { Prisma } from "@prisma/client";
+import { IContext } from "@/types/server";
+import logger from "@/infrastructure/logging";
+import type { IVcIssuanceRepository } from "@/application/domain/credential/vcIssuance/data/interface";
+import type {
+  IssueVcInput,
+  VcIssuanceRow,
+} from "@/application/domain/credential/vcIssuance/data/type";
+
+/**
+ * Civicship platform issuer DID. Hardcoded per §B / §5.2.2 — civicship is
+ * a platform-issued credential model so there is exactly one issuer.
+ *
+ * TODO(phase1-final): replace with `IssuerDidService.getActiveIssuerDid()`
+ * once the KMS issuer DID PR (`claude/phase1-infra-kms-issuer-did`) lands.
+ */
+export const CIVICSHIP_ISSUER_DID = "did:web:api.civicship.app";
+
+/**
+ * Phase 1 step 7 placeholder for the JWT signature. Real signing lives in
+ * a sibling PR (`claude/phase1-infra-kms-issuer-did`) — we emit a
+ * deterministic non-base64url marker so:
+ *
+ *   1. Tests can assert "this is a stub VC" without false positives.
+ *   2. Verifiers will reject it (it's not a valid base64url signature).
+ *   3. The grep target is unique enough to find every stub site once
+ *      KMS lands.
+ */
+const STUB_SIGNATURE = "stub-not-signed";
+
+/**
+ * Build the unsigned VC payload (§5.2.2 `buildVcPayload`).
+ *
+ * Pure function so the JWT shape is testable without touching the service.
+ * Returns the payload object that becomes the JWT's middle segment.
+ */
+export function buildVcPayload(input: {
+  issuer: string;
+  subject: string;
+  claims: Record<string, unknown>;
+  issuedAt: Date;
+}): Record<string, unknown> {
+  return {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://w3id.org/security/data-integrity/v2",
+    ],
+    type: ["VerifiableCredential"],
+    issuer: input.issuer,
+    issuanceDate: input.issuedAt.toISOString(),
+    credentialSubject: {
+      id: input.subject,
+      ...input.claims,
+    },
+  };
+}
+
+/**
+ * Encode an arbitrary JSON-serializable object as base64url. Used for both
+ * the JWT header and payload segments.
+ *
+ * Spec note: base64url is base64 with `+` → `-`, `/` → `_`, and trailing
+ * `=` removed (RFC 4648 §5). `Buffer.toString("base64url")` does this
+ * natively in Node ≥14.18.
+ */
+function base64urlEncodeJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
+}
+
+@injectable()
+export default class VcIssuanceService {
+  constructor(
+    @inject("VcIssuanceRepository")
+    private readonly repository: IVcIssuanceRepository,
+  ) {}
+
+  /**
+   * §5.2.2: build a VC for the supplied claims, sign-stub it, and persist
+   * the resulting row. Anchor wiring (vcAnchorId / anchorLeafIndex) is
+   * left to the weekly batch.
+   */
+  async issueVc(
+    ctx: IContext,
+    input: IssueVcInput,
+    tx?: Prisma.TransactionClient,
+  ): Promise<VcIssuanceRow> {
+    const issuedAt = new Date();
+    const issuerDid = CIVICSHIP_ISSUER_DID;
+
+    // 1) Build the W3C VC payload. §D `credentialStatus` is intentionally
+    //    NOT embedded here — the StatusList domain lands in Phase 1 step 9
+    //    and will inject the slot via a follow-up service call. Tests
+    //    verify the payload shape independently.
+    const vcPayload = buildVcPayload({
+      issuer: issuerDid,
+      subject: input.subjectDid,
+      claims: input.claims,
+      issuedAt,
+    });
+
+    // 2) Build a JWT-shape envelope. KMS-backed signing lands in
+    //    `claude/phase1-infra-kms-issuer-did`; until then the signature
+    //    segment is a deterministic stub marker (see `STUB_SIGNATURE`).
+    const header = base64urlEncodeJson({
+      alg: "EdDSA",
+      typ: "JWT",
+      // `kid` will reference the active KMS key id once it lands.
+      kid: `${issuerDid}#stub`,
+    });
+    const payload = base64urlEncodeJson(vcPayload);
+    const vcJwt = `${header}.${payload}.${STUB_SIGNATURE}`;
+
+    logger.debug("[VcIssuanceService] issueVc", {
+      userId: input.userId,
+      subjectDid: input.subjectDid,
+      issuerDid,
+      vcFormat: "INTERNAL_JWT",
+      // Don't log the full JWT — it includes the (stub) signature segment
+      // and would create noise once real signatures arrive.
+      jwtLength: vcJwt.length,
+    });
+
+    return this.repository.create(
+      ctx,
+      {
+        userId: input.userId,
+        evaluationId: input.evaluationId ?? null,
+        issuerDid,
+        subjectDid: input.subjectDid,
+        vcFormat: "INTERNAL_JWT",
+        vcJwt,
+        // §D StatusList slot is reserved by a sibling service in Phase 1
+        // step 9; for now, leave both fields null and let the upgrade path
+        // patch them in.
+        statusListIndex: null,
+        statusListCredential: null,
+        // §5.2.2: VC body is COMPLETED even before chain anchor.
+        status: "COMPLETED",
+      },
+      tx,
+    );
+  }
+}

--- a/src/application/domain/credential/vcIssuance/usecase.ts
+++ b/src/application/domain/credential/vcIssuance/usecase.ts
@@ -1,0 +1,35 @@
+/**
+ * `VcIssuanceUseCase` — transaction boundary for the VC issuance flow.
+ *
+ * Phase 1 step 7 scope (per task brief): provide a transaction boundary so
+ * future GraphQL resolvers (Phase 1 step 8) can drop in without re-architecting.
+ * Delegates to `VcIssuanceService` for all real work.
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.2.2
+ *   CLAUDE.md "Transaction Handling Pattern"
+ */
+
+import { inject, injectable } from "tsyringe";
+import { IContext } from "@/types/server";
+import VcIssuanceService from "@/application/domain/credential/vcIssuance/service";
+import type {
+  IssueVcInput,
+  VcIssuanceRow,
+} from "@/application/domain/credential/vcIssuance/data/type";
+
+@injectable()
+export default class VcIssuanceUseCase {
+  constructor(@inject("VcIssuanceService") private readonly service: VcIssuanceService) {}
+
+  /**
+   * Open an issuer-scoped transaction and issue a VC for the supplied
+   * claims. The resulting row is `COMPLETED` per §5.2.2 (anchor state is
+   * tracked separately on `vcAnchorId`).
+   */
+  async issueVc(ctx: IContext, input: IssueVcInput): Promise<VcIssuanceRow> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      return this.service.issueVc(ctx, input, tx);
+    });
+  }
+}

--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -137,6 +137,16 @@ import AnalyticsUseCase from "@/application/domain/analytics/usecase";
 import AnalyticsCommunityService from "@/application/domain/analytics/community/service";
 import AnalyticsCommunityUseCase from "@/application/domain/analytics/community/usecase";
 
+// 🪪 User DID (§5.2 internal DID/VC, Phase 1 step 7 — Strategy A stubs)
+import UserDidService from "@/application/domain/account/userDid/service";
+import UserDidUseCase from "@/application/domain/account/userDid/usecase";
+import UserDidAnchorRepositoryStub from "@/application/domain/account/userDid/data/repository";
+
+// 🪪 VC Issuance (§5.2 internal DID/VC, Phase 1 step 7 — Strategy A stubs)
+import VcIssuanceService from "@/application/domain/credential/vcIssuance/service";
+import VcIssuanceUseCase from "@/application/domain/credential/vcIssuance/usecase";
+import VcIssuanceRepositoryStub from "@/application/domain/credential/vcIssuance/data/repository";
+
 export function registerProductionDependencies() {
   // ------------------------------
   // 🏗️ Infrastructure
@@ -235,6 +245,23 @@ export function registerProductionDependencies() {
   container.register("VCIssuanceRequestConverter", { useClass: VCIssuanceRequestConverter });
   container.register("VCIssuanceRequestService", { useClass: VCIssuanceRequestService });
   container.register("VCIssuanceRequestRepository", { useClass: VCIssuanceRequestRepository });
+
+  // 🪪 User DID (§5.2 internal DID/VC) — Strategy A stub repository.
+  // The stub satisfies `UserDidAnchorStore` (resolver, PR #1096) and the
+  // domain interface; Prisma-backed implementation lands after schema
+  // PR #1094 merges (Phase 1 step 8+).
+  container.register("UserDidAnchorRepository", { useClass: UserDidAnchorRepositoryStub });
+  // Alias used by `DidDocumentResolver` (PR #1096) — same instance.
+  container.register("UserDidAnchorStore", { useClass: UserDidAnchorRepositoryStub });
+  container.register("UserDidService", { useClass: UserDidService });
+  container.register("UserDidUseCase", { useClass: UserDidUseCase });
+
+  // 🪪 VC Issuance (§5.2 internal DID/VC) — Strategy A stub repository.
+  // Distinct from the legacy `VCIssuanceRequest*` registrations above:
+  // those wrap the IDENTUS-era model, this wraps the Phase-1 redesign.
+  container.register("VcIssuanceRepository", { useClass: VcIssuanceRepositoryStub });
+  container.register("VcIssuanceService", { useClass: VcIssuanceService });
+  container.register("VcIssuanceUseCase", { useClass: VcIssuanceUseCase });
 
   // ------------------------------
   // 📰 Content


### PR DESCRIPTION
## 概要

設計書 `docs/report/did-vc-internalization.md` §5.2 (application service 層) のうち、`UserDidService` と `VcIssuanceService` の core ロジックを application 層に追加する。Phase 1 step 7 のスコープ。

`develop` から見て stacked PR の中段に位置する:

```
develop
  └─ #1082 設計書 main
      ├─ #1094 Prisma schema (未 merge)
      ├─ #1093 infra crypto
      │   └─ #1096 Blockfrost / DidDocumentResolver  ← 本 PR の親
      │       └─ ★ 本 PR (claude/phase1-app-services)
      └─ #1095 TLS DNS / spec
```

## 戦略 A について

Schema PR (#1094) が未 merge のため、`UserDidAnchor` / `VcIssuanceRequest` の Prisma 型をまだ参照できない。本 PR では PR #1096 が既に export している `UserDidAnchorRow` / `UserDidAnchorStore` (in `src/infrastructure/libs/did/didDocumentResolver.ts`) を再利用し、`VcIssuanceRow` だけを domain 配下にローカル宣言した。

Repository は **stub** とし、schema PR merge 後に Prisma 直叩きへ差し替える前提:

- `findById` / `findLatestByUserId` → `null` 返却（DI smoke は通る、resolver は 404 を返す挙動と整合）
- `createCreate` / `createUpdate` / `createDeactivate` / `create` → `NotImplementedError` throw（呼び出し形は test mock で検証済）

両 stub クラスとも `TODO(phase1-final)` マーカー付きで、merge 後の置換は機械的に行える。

## 追加ファイル

### `src/application/domain/account/userDid/`

- `data/type.ts` — Strategy A による型再エクスポート + `CreateUserDidAnchorInput` 等
- `data/interface.ts` — `IUserDidAnchorRepository` (`UserDidAnchorStore` を継承し findLatest / createCreate / createUpdate / createDeactivate)
- `data/repository.ts` — `UserDidAnchorRepositoryStub` (上記 stub 動作)
- `service.ts` — `UserDidService.createDidForUser / updateDid / deactivateDid`
  - `userDidBuilder.buildUserDid()` で DID 文字列生成
  - `userDidBuilder.buildMinimalDidDocument() / buildDeactivatedDidDocument()` で Document 構築
  - `cbor-x` の `encode` で CBOR エンコード
  - `@noble/hashes/blake2b` で 32 byte ハッシュを取得し hex 化 → `documentHash`
  - `repository.createCreate` 等で PENDING 状態で永続化（実体は stub なので throw）
- `usecase.ts` — `UserDidUseCase` (transaction boundary、`ctx.issuer.public` 配下で service を呼ぶ)
- `presenter.ts` — `UserDidAnchorView` skeleton（GraphQL schema PR 待ちのため最小限）

### `src/application/domain/credential/vcIssuance/`

- `data/type.ts` — `VcIssuanceRow` / `IssueVcInput` / `CreateVcIssuanceInput`（Phase-1 redesign 後の `t_vc_issuance_requests` 列を反映）
- `data/interface.ts` — `IVcIssuanceRepository` (`findById` / `create`)
- `data/repository.ts` — `VcIssuanceRepositoryStub`
- `service.ts` — `VcIssuanceService.issueVc(ctx, input, tx?)`
  - Issuer DID は `did:web:api.civicship.app` をハードコード (`CIVICSHIP_ISSUER_DID` 定数)
  - W3C VC payload を `buildVcPayload` で構築（`@context` / `type` / `issuer` / `issuanceDate` / `credentialSubject`）
  - JWT shape: `header.payload.signature` を base64url で連結
  - **署名は本 PR では stub** — 署名セグメントを `"stub-not-signed"` 固定文字列にし、KMS 署名 PR (`claude/phase1-infra-kms-issuer-did`) merge 時に差し替える
  - StatusList (§D credentialStatus) も別 PR (Phase 1 step 9) のため `null` 設定
  - `status = COMPLETED` で永続化（§5.2.2「VC 本体は anchor 待ちなしで COMPLETED」）
- `usecase.ts` — `VcIssuanceUseCase`
- `presenter.ts` — `VcIssuanceView` skeleton

### `src/application/provider.ts`

DI 登録を追加:

- `UserDidAnchorRepository` → `UserDidAnchorRepositoryStub`
- `UserDidAnchorStore` (resolver alias) → 同 stub クラス（同一インスタンスで `DidDocumentResolver` も解決可能）
- `UserDidService` / `UserDidUseCase`
- `VcIssuanceRepository` → `VcIssuanceRepositoryStub`（既存 `VCIssuanceRequest*` registration とは別物。前者は IDENTUS-era、後者は Phase-1 redesign）
- `VcIssuanceService` / `VcIssuanceUseCase`

### Tests (`src/__tests__/unit/application/domain/`)

- `account/userDid/service.test.ts` (5 件)
  - CBOR round-trip / Blake2b-256 hash 一致
  - tx forwarding
  - network override 伝播
  - §9.2 regex 違反は throw
  - update / deactivate の経路も同様
- `credential/vcIssuance/service.test.ts` (6 件)
  - 永続化 row 形（issuer / vcFormat / status COMPLETED / statusList null）
  - JWT 3-segment 構造、header alg=EdDSA、payload に `credentialSubject`、signature が `"stub-not-signed"`
  - tx forwarding
  - `evaluationId` 省略時の `null` 化
  - `buildVcPayload` 純粋関数の W3C 構造

## stub の TODO

すべて `// TODO(phase1-final):` マーカー付き:

- `data/repository.ts` (両ドメイン) — Prisma 直叩きへの差し替え（schema PR #1094 merge 後）
- `service.ts` (vcIssuance) — `CIVICSHIP_ISSUER_DID` 定数を `IssuerDidService.getActiveIssuerDid()` 呼び出しへ差し替え（KMS PR merge 後）
- `service.ts` (vcIssuance) — `STUB_SIGNATURE` を実 KMS 署名へ差し替え

## テスト結果

```
Test Suites: 2 passed, 2 total
Tests:       11 passed, 11 total
Time:        17.6 s
```

`pnpm test --testPathPattern 'application/domain/(account/userDid|credential/vcIssuance)'` 全 pass。

## ビルド & lint

- `pnpm build`: 新規エラーゼロ。残留 5 件は親 PR から引き継いだ `@prisma/client/sql` の baseline (refreshMaterializedView 系)。本 PR で増減なし
- `pnpm exec eslint src/application/domain/{account/userDid,credential/vcIssuance}/`: clean
- `pnpm exec prettier --write` 適用済み

## 次の Phase 1 step

- step 8: GraphQL schema 定義（`schema/*.graphql`）と Resolver 実装。Schema PR (#1094) merge 後にローカル型宣言を `import type { UserDidAnchor, VcIssuanceRequest } from "@prisma/client"` へ置換
- step 9: anchor batch service (`application/domain/anchor/`) — PENDING な `UserDidAnchor` / `VcAnchor` / `TransactionAnchor` を週次バッチで Cardano に anchor。本 PR の stub repository を Prisma 実装に差し替え
- step 10: KMS 署名統合 — `claude/phase1-infra-kms-issuer-did` merge 後、`VcIssuanceService.issueVc` の `STUB_SIGNATURE` を実 KMS 署名に差し替え + StatusList wiring (§D)

https://claude.ai/code/session_019MKzV6DsfsHA6dLJ99chU8

---
_Generated by [Claude Code](https://claude.ai/code/session_019MKzV6DsfsHA6dLJ99chU8)_