### PR TITLE
phase1(app+presentation): IssuerDidService 結合 + /.well-known/did.json 本実装化

### DIFF
--- a/src/__tests__/unit/application/domain/credential/issuerDid/service.test.ts
+++ b/src/__tests__/unit/application/domain/credential/issuerDid/service.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Unit tests for `IssuerDidService` (§5.4.3).
+ *
+ * Covers:
+ *   - `getActiveIssuerDid()`        → constant, sync, no I/O
+ *   - `getActiveIssuerDidDocument()`
+ *       - active key present → builds full Document via IssuerDidBuilder
+ *       - active key absent  → returns null (router-side fallback)
+ *       - public-key cache TTL → second call within TTL skips KMS
+ *       - public-key cache TTL → second call after TTL refetches KMS
+ *       - distinct resource names cached independently
+ *   - `signWithActiveKey()`
+ *       - active key present → delegates to KmsSigner.signEd25519
+ *       - active key absent  → throws (no fallback for signing)
+ *
+ * Repository and KmsSigner are stubbed via plain object literals so the
+ * tests never touch Prisma or GCP KMS. Time is injected via the optional
+ * `now` constructor argument so TTL assertions are deterministic.
+ */
+
+import "reflect-metadata";
+
+import IssuerDidService, {
+  PUBLIC_KEY_TTL_MS,
+} from "@/application/domain/credential/issuerDid/service";
+import type { IIssuerDidKeyRepository } from "@/application/domain/credential/issuerDid/data/interface";
+import type { IssuerDidKeyRow } from "@/application/domain/credential/issuerDid/data/type";
+import type { KmsSigner } from "@/infrastructure/libs/kms/kmsSigner";
+
+const KMS_KEY_RESOURCE =
+  "projects/civicship-prd/locations/global/keyRings/civicship/cryptoKeys/civicship-issuer-vc/cryptoKeyVersions/1";
+const KMS_KEY_RESOURCE_V2 =
+  "projects/civicship-prd/locations/global/keyRings/civicship/cryptoKeys/civicship-issuer-vc/cryptoKeyVersions/2";
+
+// 32-byte all-zero public key — valid Ed25519 length, easy to assert.
+const ZERO_PUBKEY = new Uint8Array(32);
+// Distinct second key for cache-isolation tests; raw bytes 0x01..0x20.
+const ALT_PUBKEY = new Uint8Array(32);
+for (let i = 0; i < 32; i++) ALT_PUBKEY[i] = i + 1;
+
+function makeRow(overrides: Partial<IssuerDidKeyRow> = {}): IssuerDidKeyRow {
+  return {
+    id: "key_test_1",
+    kmsKeyResourceName: KMS_KEY_RESOURCE,
+    activatedAt: new Date("2026-01-01T00:00:00Z"),
+    deactivatedAt: null,
+    ...overrides,
+  };
+}
+
+interface RepoStub extends IIssuerDidKeyRepository {
+  findActiveKey: jest.Mock;
+  listActiveKeys: jest.Mock;
+}
+
+interface SignerStub {
+  signEd25519: jest.Mock;
+  getPublicKey: jest.Mock;
+}
+
+function makeRepo(activeRow: IssuerDidKeyRow | null): RepoStub {
+  return {
+    findActiveKey: jest.fn().mockResolvedValue(activeRow),
+    listActiveKeys: jest.fn().mockResolvedValue(activeRow ? [activeRow] : []),
+  };
+}
+
+function makeSigner(): SignerStub {
+  return {
+    signEd25519: jest.fn().mockResolvedValue(new Uint8Array(64)),
+    getPublicKey: jest.fn().mockResolvedValue(ZERO_PUBKEY),
+  };
+}
+
+/**
+ * Construct an `IssuerDidService` directly with stubs. We avoid going
+ * through `container.resolve` here so the tests pin *exactly* the
+ * dependencies under test — DI smoke-testing belongs in a separate
+ * provider-level test, not at the service granularity.
+ */
+function buildService(opts: {
+  repo: IIssuerDidKeyRepository;
+  signer: SignerStub;
+  now?: () => number;
+}): IssuerDidService {
+  return new IssuerDidService(opts.repo, opts.signer as unknown as KmsSigner, opts.now);
+}
+
+describe("IssuerDidService", () => {
+  describe("getActiveIssuerDid", () => {
+    it("returns the canonical did:web:api.civicship.app constant", () => {
+      const svc = buildService({ repo: makeRepo(null), signer: makeSigner() });
+      expect(svc.getActiveIssuerDid()).toBe("did:web:api.civicship.app");
+    });
+
+    it("does not touch the repository or KMS", () => {
+      const repo = makeRepo(makeRow());
+      const signer = makeSigner();
+      const svc = buildService({ repo, signer });
+
+      svc.getActiveIssuerDid();
+
+      expect(repo.findActiveKey).not.toHaveBeenCalled();
+      expect(signer.getPublicKey).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getActiveIssuerDidDocument — active key present", () => {
+    it("returns a full Issuer DID Document built via IssuerDidBuilder", async () => {
+      const repo = makeRepo(makeRow());
+      const signer = makeSigner();
+      const svc = buildService({ repo, signer });
+
+      const doc = await svc.getActiveIssuerDidDocument();
+
+      expect(doc).not.toBeNull();
+      expect(doc!.id).toBe("did:web:api.civicship.app");
+      // Fragment derives from cryptoKeyVersions/<n> (§5.1.2).
+      expect(doc!.verificationMethod[0].id).toBe("did:web:api.civicship.app#key-1");
+      expect(doc!.verificationMethod[0].type).toBe("Multikey");
+      expect(doc!.verificationMethod[0].controller).toBe("did:web:api.civicship.app");
+      // Multibase prefix `z` for base58btc (W3C Multikey).
+      expect(doc!.verificationMethod[0].publicKeyMultibase.startsWith("z")).toBe(true);
+      expect(doc!.assertionMethod[0]).toBe("did:web:api.civicship.app#key-1");
+    });
+
+    it("calls KmsSigner.getPublicKey with the active row's resource name", async () => {
+      const repo = makeRepo(makeRow());
+      const signer = makeSigner();
+      const svc = buildService({ repo, signer });
+
+      await svc.getActiveIssuerDidDocument();
+
+      expect(signer.getPublicKey).toHaveBeenCalledWith(KMS_KEY_RESOURCE);
+    });
+  });
+
+  describe("getActiveIssuerDidDocument — active key absent", () => {
+    it("returns null without invoking KMS", async () => {
+      const repo = makeRepo(null);
+      const signer = makeSigner();
+      const svc = buildService({ repo, signer });
+
+      const doc = await svc.getActiveIssuerDidDocument();
+
+      expect(doc).toBeNull();
+      expect(signer.getPublicKey).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getActiveIssuerDidDocument — public-key cache TTL", () => {
+    it("does not call KMS twice within the TTL window", async () => {
+      const repo = makeRepo(makeRow());
+      const signer = makeSigner();
+      // Frozen clock: every call sees the same `now`.
+      const svc = buildService({ repo, signer, now: () => 1_000_000 });
+
+      await svc.getActiveIssuerDidDocument();
+      await svc.getActiveIssuerDidDocument();
+
+      expect(signer.getPublicKey).toHaveBeenCalledTimes(1);
+    });
+
+    it("refetches the public key after the TTL elapses", async () => {
+      const repo = makeRepo(makeRow());
+      const signer = makeSigner();
+      let now = 1_000_000;
+      const svc = buildService({ repo, signer, now: () => now });
+
+      await svc.getActiveIssuerDidDocument();
+      // Advance just past the TTL boundary.
+      now += PUBLIC_KEY_TTL_MS + 1;
+      await svc.getActiveIssuerDidDocument();
+
+      expect(signer.getPublicKey).toHaveBeenCalledTimes(2);
+    });
+
+    it("caches independently per KMS resource name (§G overlap)", async () => {
+      // Repo flips the active row between calls — simulates a §G rotation
+      // where the active key advances mid-session.
+      const rowV1 = makeRow({ kmsKeyResourceName: KMS_KEY_RESOURCE });
+      const rowV2 = makeRow({ kmsKeyResourceName: KMS_KEY_RESOURCE_V2, id: "key_test_2" });
+      const repo: RepoStub = {
+        findActiveKey: jest
+          .fn()
+          .mockResolvedValueOnce(rowV1)
+          .mockResolvedValueOnce(rowV2)
+          .mockResolvedValueOnce(rowV1),
+        listActiveKeys: jest.fn().mockResolvedValue([rowV1, rowV2]),
+      };
+      const signer: SignerStub = {
+        signEd25519: jest.fn(),
+        // First two calls return distinct keys; the third call (post-cache)
+        // should never reach this mock because v1 is cached from call #1.
+        getPublicKey: jest
+          .fn()
+          .mockResolvedValueOnce(ZERO_PUBKEY)
+          .mockResolvedValueOnce(ALT_PUBKEY)
+          .mockRejectedValueOnce(new Error("should not reach KMS for cached v1")),
+      };
+      const svc = buildService({ repo, signer, now: () => 1_000_000 });
+
+      await svc.getActiveIssuerDidDocument(); // v1 → KMS hit, cached
+      await svc.getActiveIssuerDidDocument(); // v2 → KMS hit (different cache key)
+      await svc.getActiveIssuerDidDocument(); // v1 again → cache hit, no KMS
+
+      expect(signer.getPublicKey).toHaveBeenCalledTimes(2);
+      expect(signer.getPublicKey).toHaveBeenNthCalledWith(1, KMS_KEY_RESOURCE);
+      expect(signer.getPublicKey).toHaveBeenNthCalledWith(2, KMS_KEY_RESOURCE_V2);
+    });
+  });
+
+  describe("signWithActiveKey", () => {
+    it("delegates to KmsSigner.signEd25519 with the active resource name", async () => {
+      const repo = makeRepo(makeRow());
+      const signer = makeSigner();
+      const expectedSig = new Uint8Array(64);
+      expectedSig[0] = 0xab;
+      signer.signEd25519.mockResolvedValueOnce(expectedSig);
+      const svc = buildService({ repo, signer });
+
+      const payload = new Uint8Array([1, 2, 3]);
+      const sig = await svc.signWithActiveKey(payload);
+
+      expect(signer.signEd25519).toHaveBeenCalledWith(KMS_KEY_RESOURCE, payload);
+      expect(sig).toBe(expectedSig);
+    });
+
+    it("throws when no active key is registered (no fallback for signing)", async () => {
+      const repo = makeRepo(null);
+      const signer = makeSigner();
+      const svc = buildService({ repo, signer });
+
+      await expect(svc.signWithActiveKey(new Uint8Array([1]))).rejects.toThrow(
+        /no active issuer key registered/i,
+      );
+      expect(signer.signEd25519).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/__tests__/unit/presentation/router/did.test.ts
+++ b/src/__tests__/unit/presentation/router/did.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Unit tests for `src/presentation/router/did.ts` (§5.4 public routes).
+ *
+ * Covers the three endpoints shipped in this PR:
+ *   - GET /.well-known/did.json          → 200 + minimal issuer document
+ *   - GET /users/:userId/did.json        → 200 (CONFIRMED / DEACTIVATE)
+ *                                          → 404 (no anchor)
+ *                                          → 400 (malformed userId)
+ *                                          → 500 (resolver throws)
+ *   - GET /vc/:vcId/inclusion-proof      → 501 not_implemented
+ *                                          → 400 (empty vcId — guarded by
+ *                                            Express's own routing, but we
+ *                                            still assert the shape on
+ *                                            valid input)
+ *
+ * The `DidDocumentResolver` is stubbed via `container.register` so the
+ * tests never touch Prisma. Each route is exercised through a real
+ * Express app via supertest to catch routing-level regressions
+ * (path params, JSON content-type, status codes).
+ */
+
+import "reflect-metadata";
+
+import express from "express";
+import request from "supertest";
+import { container } from "tsyringe";
+
+import didRouter from "@/presentation/router/did";
+import type {
+  DidDocumentResolver,
+  DidDocumentWithProof,
+} from "@/infrastructure/libs/did/didDocumentResolver";
+
+const USER_ID = "u_alice";
+const USER_DID = "did:web:api.civicship.app:users:u_alice";
+const TX_HASH = "a".repeat(64);
+const DOC_HASH = "b".repeat(64);
+
+function buildApp() {
+  const app = express();
+  app.use("/", didRouter);
+  return app;
+}
+
+function buildConfirmedDoc(): DidDocumentWithProof {
+  return {
+    "@context": ["https://www.w3.org/ns/did/v1"],
+    id: USER_DID,
+    proof: {
+      type: "DataIntegrityProof",
+      cryptosuite: "civicship-merkle-anchor-2026",
+      anchorChain: "cardano:mainnet",
+      anchorTxHash: TX_HASH,
+      opIndexInTx: 0,
+      docHash: DOC_HASH,
+      anchorStatus: "confirmed",
+      anchoredAt: "2026-01-15T12:00:00.000Z",
+      verificationUrl: `https://cardanoscan.io/transaction/${TX_HASH}`,
+    },
+  };
+}
+
+function buildTombstoneDoc(): DidDocumentWithProof {
+  return {
+    "@context": ["https://www.w3.org/ns/did/v1"],
+    id: USER_DID,
+    deactivated: true,
+    proof: {
+      type: "DataIntegrityProof",
+      cryptosuite: "civicship-merkle-anchor-2026",
+      anchorChain: "cardano:mainnet",
+      anchorTxHash: TX_HASH,
+      opIndexInTx: 1,
+      docHash: DOC_HASH,
+      anchorStatus: "confirmed",
+      anchoredAt: "2026-01-20T12:00:00.000Z",
+      verificationUrl: `https://cardanoscan.io/transaction/${TX_HASH}`,
+    },
+  };
+}
+
+function registerResolverMock(buildDidDocument: jest.Mock): void {
+  const mock: Partial<DidDocumentResolver> = { buildDidDocument };
+  container.register("DidDocumentResolver", { useValue: mock as DidDocumentResolver });
+}
+
+describe("router/did (§5.4)", () => {
+  beforeEach(() => {
+    container.clearInstances();
+  });
+
+  describe("GET /.well-known/did.json", () => {
+    it("returns 200 and a minimal issuer DID Document", async () => {
+      const res = await request(buildApp()).get("/.well-known/did.json");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        "@context": ["https://www.w3.org/ns/did/v1"],
+        id: "did:web:api.civicship.app",
+      });
+    });
+
+    it("does not require the resolver (works without DI registration)", async () => {
+      // No `registerResolverMock` call — the issuer endpoint must not
+      // resolve anything from the container.
+      const res = await request(buildApp()).get("/.well-known/did.json");
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("GET /users/:userId/did.json", () => {
+    it("returns 200 with the document when the resolver yields a CONFIRMED anchor", async () => {
+      const buildDidDocument = jest.fn().mockResolvedValue(buildConfirmedDoc());
+      registerResolverMock(buildDidDocument);
+
+      const res = await request(buildApp()).get(`/users/${USER_ID}/did.json`);
+
+      expect(res.status).toBe(200);
+      expect(buildDidDocument).toHaveBeenCalledWith(USER_ID);
+      expect(res.body).toMatchObject({
+        id: USER_DID,
+        proof: { anchorStatus: "confirmed", anchorTxHash: TX_HASH },
+      });
+    });
+
+    it("returns 200 with a Tombstone document for DEACTIVATE op (§E)", async () => {
+      const buildDidDocument = jest.fn().mockResolvedValue(buildTombstoneDoc());
+      registerResolverMock(buildDidDocument);
+
+      const res = await request(buildApp()).get(`/users/${USER_ID}/did.json`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ id: USER_DID, deactivated: true });
+    });
+
+    it("returns 404 when the resolver yields null (no anchor row)", async () => {
+      const buildDidDocument = jest.fn().mockResolvedValue(null);
+      registerResolverMock(buildDidDocument);
+
+      const res = await request(buildApp()).get(`/users/${USER_ID}/did.json`);
+
+      expect(res.status).toBe(404);
+      expect(res.body).toMatchObject({ error: "did_not_found" });
+    });
+
+    it("returns 400 when the userId fails the §9.2 regex", async () => {
+      const buildDidDocument = jest.fn();
+      registerResolverMock(buildDidDocument);
+
+      const res = await request(buildApp()).get("/users/Bad%20User/did.json");
+
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({ error: "invalid_user_id" });
+      expect(buildDidDocument).not.toHaveBeenCalled();
+    });
+
+    it("returns 500 when the resolver throws", async () => {
+      const buildDidDocument = jest.fn().mockRejectedValue(new Error("boom"));
+      registerResolverMock(buildDidDocument);
+
+      const res = await request(buildApp()).get(`/users/${USER_ID}/did.json`);
+
+      expect(res.status).toBe(500);
+      expect(res.body).toMatchObject({ error: "internal_error" });
+    });
+  });
+
+  describe("GET /vc/:vcId/inclusion-proof", () => {
+    it("returns 501 not_implemented for any vcId until the batch worker lands", async () => {
+      const res = await request(buildApp()).get("/vc/vc_123/inclusion-proof");
+
+      expect(res.status).toBe(501);
+      expect(res.body).toMatchObject({
+        error: "not_implemented",
+        message: expect.stringContaining("Phase 1 step 7"),
+      });
+    });
+  });
+});

--- a/src/__tests__/unit/presentation/router/did.test.ts
+++ b/src/__tests__/unit/presentation/router/did.test.ts
@@ -1,8 +1,11 @@
 /**
  * Unit tests for `src/presentation/router/did.ts` (§5.4 public routes).
  *
- * Covers the three endpoints shipped in this PR:
- *   - GET /.well-known/did.json          → 200 + minimal issuer document
+ * Covers the three endpoints:
+ *   - GET /.well-known/did.json
+ *       → 200 + full Issuer DID Document when `IssuerDidUseCase` yields one
+ *       → 200 + minimal static fallback when the use case yields `null`
+ *       → 500 when the use case throws
  *   - GET /users/:userId/did.json        → 200 (CONFIRMED / DEACTIVATE)
  *                                          → 404 (no anchor)
  *                                          → 400 (malformed userId)
@@ -13,10 +16,10 @@
  *                                            still assert the shape on
  *                                            valid input)
  *
- * The `DidDocumentResolver` is stubbed via `container.register` so the
- * tests never touch Prisma. Each route is exercised through a real
- * Express app via supertest to catch routing-level regressions
- * (path params, JSON content-type, status codes).
+ * The `DidDocumentResolver` and `IssuerDidUseCase` are both stubbed via
+ * `container.register` so the tests never touch Prisma or KMS. Each route
+ * is exercised through a real Express app via supertest to catch
+ * routing-level regressions (path params, JSON content-type, status codes).
  */
 
 import "reflect-metadata";
@@ -26,6 +29,8 @@ import request from "supertest";
 import { container } from "tsyringe";
 
 import didRouter from "@/presentation/router/did";
+import type IssuerDidUseCase from "@/application/domain/credential/issuerDid/usecase";
+import type { IssuerDidDocument } from "@/infrastructure/libs/did/issuerDidBuilder";
 import type {
   DidDocumentResolver,
   DidDocumentWithProof,
@@ -84,13 +89,57 @@ function registerResolverMock(buildDidDocument: jest.Mock): void {
   container.register("DidDocumentResolver", { useValue: mock as DidDocumentResolver });
 }
 
+function registerIssuerDidUseCaseMock(getActiveIssuerDidDocument: jest.Mock): void {
+  const mock: Partial<IssuerDidUseCase> = { getActiveIssuerDidDocument };
+  container.register("IssuerDidUseCase", { useValue: mock as IssuerDidUseCase });
+}
+
+function buildFullIssuerDoc(): IssuerDidDocument {
+  return {
+    "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/multikey/v1"],
+    id: "did:web:api.civicship.app",
+    verificationMethod: [
+      {
+        id: "did:web:api.civicship.app#key-1",
+        type: "Multikey",
+        controller: "did:web:api.civicship.app",
+        publicKeyMultibase: "z6MkfullmockedmultibaseTESTONLY",
+      },
+    ],
+    assertionMethod: ["did:web:api.civicship.app#key-1"],
+    authentication: ["did:web:api.civicship.app#key-1"],
+    service: [
+      {
+        id: "did:web:api.civicship.app#issued-credentials",
+        type: "CivicshipIssuedCredentials",
+        serviceEndpoint: { credentialTypes: ["civicship-attendance-credential-2026"] },
+      },
+    ],
+  };
+}
+
 describe("router/did (§5.4)", () => {
   beforeEach(() => {
     container.clearInstances();
   });
 
   describe("GET /.well-known/did.json", () => {
-    it("returns 200 and a minimal issuer DID Document", async () => {
+    it("returns 200 with the full Issuer DID Document when the use case yields one", async () => {
+      const fullDoc = buildFullIssuerDoc();
+      const getActiveIssuerDidDocument = jest.fn().mockResolvedValue(fullDoc);
+      registerIssuerDidUseCaseMock(getActiveIssuerDidDocument);
+
+      const res = await request(buildApp()).get("/.well-known/did.json");
+
+      expect(res.status).toBe(200);
+      expect(getActiveIssuerDidDocument).toHaveBeenCalledTimes(1);
+      expect(res.body).toEqual(fullDoc);
+    });
+
+    it("falls back to the minimal static Document when the use case yields null", async () => {
+      const getActiveIssuerDidDocument = jest.fn().mockResolvedValue(null);
+      registerIssuerDidUseCaseMock(getActiveIssuerDidDocument);
+
       const res = await request(buildApp()).get("/.well-known/did.json");
 
       expect(res.status).toBe(200);
@@ -100,11 +149,16 @@ describe("router/did (§5.4)", () => {
       });
     });
 
-    it("does not require the resolver (works without DI registration)", async () => {
-      // No `registerResolverMock` call — the issuer endpoint must not
-      // resolve anything from the container.
+    it("returns 500 when the use case throws (genuine misconfiguration, no silent fallback)", async () => {
+      const getActiveIssuerDidDocument = jest
+        .fn()
+        .mockRejectedValue(new Error("KMS PERMISSION_DENIED"));
+      registerIssuerDidUseCaseMock(getActiveIssuerDidDocument);
+
       const res = await request(buildApp()).get("/.well-known/did.json");
-      expect(res.status).toBe(200);
+
+      expect(res.status).toBe(500);
+      expect(res.body).toEqual({ error: "Internal Server Error" });
     });
   });
 

--- a/src/__tests__/unit/presentation/router/did.test.ts
+++ b/src/__tests__/unit/presentation/router/did.test.ts
@@ -161,7 +161,7 @@ describe("router/did (§5.4)", () => {
       const res = await request(buildApp()).get(`/users/${USER_ID}/did.json`);
 
       expect(res.status).toBe(500);
-      expect(res.body).toMatchObject({ error: "internal_error" });
+      expect(res.body).toMatchObject({ error: "Internal Server Error" });
     });
   });
 

--- a/src/application/domain/credential/issuerDid/data/interface.ts
+++ b/src/application/domain/credential/issuerDid/data/interface.ts
@@ -1,0 +1,56 @@
+/**
+ * Repository contract for the `issuerDid` application domain.
+ *
+ * Narrow on purpose — `IssuerDidService` (§5.4.3) only needs to ask "what
+ * KMS key should I be signing with right now?" and "list every key the §G
+ * overlap window says is still trusted". Heavier admin queries (paginated
+ * audit trail, historical lookups by activation date) live behind a
+ * separate interface and will be added when key rotation tooling lands.
+ *
+ * Strategy A note (Phase 1 step 8) ----------------------------------------
+ *
+ * The Prisma model `IssuerDidKey` is not yet in the schema (§4 redesign in
+ * progress). The repository implementation in this PR is a Strategy A stub
+ * — `findActiveKey()` returns `null` so the router falls through to the
+ * minimal static Document. `listActiveKeys()` returns `[]` for the same
+ * reason. Both methods become real Prisma queries once the schema PR adds
+ * `t_issuer_did_keys`; the interface itself is forward-compatible with
+ * that swap.
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.4.3 (IssuerDidService)
+ *   docs/report/did-vc-internalization.md §G    (key rotation overlap)
+ */
+
+import type { IssuerDidKeyRow } from "@/application/domain/credential/issuerDid/data/type";
+
+export interface IIssuerDidKeyRepository {
+  /**
+   * Return the single currently-active key (`deactivatedAt IS NULL`).
+   *
+   * The contract returns `null` (not throws) when no active key is
+   * registered: this is the bootstrap state on a freshly-deployed
+   * environment, and the router must degrade gracefully to the minimal
+   * static Document rather than 503.
+   *
+   * If multiple rows have `deactivatedAt = NULL` (mid-rotation §G overlap),
+   * the production implementation must return the row most recently
+   * activated; `IssuerDidService.signWithActiveKey` always uses this
+   * single row, while `getActiveIssuerDidDocument` will (in Phase 2)
+   * combine it with `listActiveKeys()` to publish both keys.
+   */
+  findActiveKey(): Promise<IssuerDidKeyRow | null>;
+
+  /**
+   * Return every key in the §G overlap window — all rows where
+   * `deactivatedAt IS NULL` plus those whose `deactivatedAt` is within
+   * the published verification grace period. Ordered by `activatedAt ASC`
+   * so the DID Document `verificationMethod` ordering is stable across
+   * re-renders.
+   *
+   * Returns `[]` (not null) when no keys are registered. Callers building
+   * a DID Document use the empty array to drive the same fallback as
+   * `findActiveKey() === null`.
+   */
+  listActiveKeys(): Promise<IssuerDidKeyRow[]>;
+}

--- a/src/application/domain/credential/issuerDid/data/repository.ts
+++ b/src/application/domain/credential/issuerDid/data/repository.ts
@@ -1,0 +1,79 @@
+/**
+ * Stub repository for `IssuerDidKey` (Strategy A, Phase 1 step 8).
+ *
+ * The Prisma model `IssuerDidKey` (`t_issuer_did_keys`) has NOT yet been
+ * added to `schema.prisma` — the schema migration scope (#1094) shipped
+ * `UserDidAnchor`, `VcAnchor`, `TransactionAnchor`, and
+ * `StatusListCredential`, but the Issuer DID key registry was deferred
+ * pending §G (key rotation) tooling design.
+ *
+ * Until the schema PR adds the table, the repository implementation
+ * returns:
+ *
+ *   - `findActiveKey()` → `null` (no row at all)
+ *   - `listActiveKeys()` → `[]`  (no rows at all)
+ *
+ * This is intentionally identical to "freshly-deployed bootstrap state":
+ * `IssuerDidService` and the `/.well-known/did.json` route both treat a
+ * `null` active key as the trigger to fall back to a minimal static
+ * Document, which preserves dev/staging UX (clients still get a 200 with
+ * a syntactically-valid `did:web` Document body).
+ *
+ * Once the schema PR merges, the swap is mechanical:
+ *
+ *   1. Replace the bodies with `tx.issuerDidKey.findFirst({ where: { deactivatedAt: null } })`
+ *      and `tx.issuerDidKey.findMany({ where: { ... }, orderBy: { activatedAt: "asc" } })`.
+ *   2. Use `ctx.issuer.public(ctx, tx => ...)` for RLS — the Issuer DID
+ *      table is platform-global so `public` is appropriate (no community
+ *      scope).
+ *   3. Delete `IssuerDidKeyRepositoryNotImplementedError` (kept for
+ *      consistency with the other Phase 1 stub repositories).
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.4.3 (IssuerDidService)
+ *   docs/report/did-vc-internalization.md §G    (key rotation overlap)
+ *   src/application/domain/account/userDid/data/repository.ts (sibling stub)
+ */
+
+import { injectable } from "tsyringe";
+
+import type { IIssuerDidKeyRepository } from "@/application/domain/credential/issuerDid/data/interface";
+import type { IssuerDidKeyRow } from "@/application/domain/credential/issuerDid/data/type";
+
+/**
+ * Marker error for future write methods (`activateKeyVersion`,
+ * `deactivateKeyVersion`) that intentionally do not exist yet. Mirrors
+ * `UserDidAnchorRepositoryNotImplementedError` so a single grep finds
+ * every Phase 1 stub site.
+ *
+ * Kept exported so an admin runbook script that probes for write support
+ * can `instanceof`-check the error and produce a clear "feature not yet
+ * shipped" message rather than a generic 500.
+ */
+export class IssuerDidKeyRepositoryNotImplementedError extends Error {
+  constructor(method: string) {
+    super(
+      `IssuerDidKeyRepositoryStub.${method}: not implemented yet — depends on ` +
+        "schema PR adding t_issuer_did_keys. Replace stub with the production " +
+        "Prisma-backed repository when that table lands (Phase 1 step 8+).",
+    );
+    this.name = "IssuerDidKeyRepositoryNotImplementedError";
+  }
+}
+
+@injectable()
+export default class IssuerDidKeyRepositoryStub implements IIssuerDidKeyRepository {
+  // Returning `null` is the *correct* bootstrap signal — see file-header
+  // comment. `IssuerDidService.getActiveIssuerDidDocument()` propagates
+  // null upward and the router maps it to the minimal static Document.
+  async findActiveKey(): Promise<IssuerDidKeyRow | null> {
+    return null;
+  }
+
+  // Returning `[]` matches the empty-table state. Callers building a
+  // DID Document `verificationMethod[]` array will see no keys and fall
+  // back to the minimal static Document via the same null-check path.
+  async listActiveKeys(): Promise<IssuerDidKeyRow[]> {
+    return [];
+  }
+}

--- a/src/application/domain/credential/issuerDid/data/type.ts
+++ b/src/application/domain/credential/issuerDid/data/type.ts
@@ -1,0 +1,63 @@
+/**
+ * Domain types for the `issuerDid` application domain (§5.4.3 / §G).
+ *
+ * The platform has exactly one Issuer DID (`did:web:api.civicship.app`). The
+ * persistence layer tracks one row per **KMS key version** so that key
+ * rotation (§G overlap shape) is auditable: each row remembers the KMS
+ * resource name, when it was activated, and — if rotated out — when it was
+ * deactivated. The `did:web` Document served at `/.well-known/did.json`
+ * exposes every still-active key as a separate `verificationMethod`.
+ *
+ * Strategy A note (Phase 1 step 8) ----------------------------------------
+ *
+ * The Prisma model `IssuerDidKey` is NOT in the schema yet. Until the
+ * schema PR adds the table, the repository implementation returns `null`
+ * from `findActiveKey()` so the router falls back to the minimal static
+ * Document (which preserves dev/staging UX). The shape of `IssuerDidKeyRow`
+ * below mirrors the planned columns one-for-one so the swap is mechanical.
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.1.1 (KMS resource naming)
+ *   docs/report/did-vc-internalization.md §5.1.2 (Issuer DID Document shape)
+ *   docs/report/did-vc-internalization.md §5.4.3 (IssuerDidService)
+ *   docs/report/did-vc-internalization.md §G    (key rotation)
+ */
+
+/**
+ * Single row in the (planned) `t_issuer_did_keys` table. Each row binds a
+ * KMS Ed25519 key version to the civicship Issuer DID.
+ */
+export interface IssuerDidKeyRow {
+  /** Stable identifier — cuid in the planned schema. */
+  id: string;
+
+  /**
+   * Full KMS resource name including `cryptoKeyVersions/N`. Used by
+   * `KmsSigner` directly and by `IssuerDidBuilder` to derive the DID
+   * Document `verificationMethod` fragment (`#key-N`).
+   */
+  kmsKeyResourceName: string;
+
+  /**
+   * Wall-clock activation. Together with `deactivatedAt`, this is the
+   * authoritative record of when this key was eligible to sign.
+   */
+  activatedAt: Date;
+
+  /**
+   * `null` while the key is still active. When set, marks the end of the
+   * §G overlap window for this key — verifiers who look up VCs signed
+   * during the overlap can still resolve the public key from chain anchors,
+   * but new signatures must use the next active key.
+   */
+  deactivatedAt: Date | null;
+}
+
+/**
+ * Input shape for activating a key version (admin / rotation runbook).
+ * Kept here so future repository methods (`activateKeyVersion`) have a
+ * single typed contract; not consumed in Phase 1 step 8 itself.
+ */
+export interface ActivateIssuerDidKeyInput {
+  kmsKeyResourceName: string;
+}

--- a/src/application/domain/credential/issuerDid/presenter.ts
+++ b/src/application/domain/credential/issuerDid/presenter.ts
@@ -1,0 +1,37 @@
+/**
+ * `IssuerDidPresenter` — pure transform from internal types to the wire
+ * shape served at `/.well-known/did.json`.
+ *
+ * Today the wire shape *is* the internal type (`IssuerDidDocument` is
+ * already the W3C JSON-LD form built by `IssuerDidBuilder`). The presenter
+ * therefore looks like an identity function — but it exists so that:
+ *
+ *   1. The architectural pattern (UseCase always invokes a presenter
+ *      before returning) holds uniformly across domains.
+ *   2. Future per-route adjustments (e.g. stripping a `@deactivated` field
+ *      we add for admin GraphQL but should not appear on the public route)
+ *      have a stable injection point that doesn't churn the use case.
+ *   3. Tests can import the presenter alone to assert the wire contract
+ *      without the service / KMS layers.
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.1.2 (DID Document shape)
+ *   CLAUDE.md "Layer Responsibilities" (Presenter — pure functions only)
+ */
+
+import type { IssuerDidDocument } from "@/infrastructure/libs/did/issuerDidBuilder";
+
+const IssuerDidPresenter = {
+  /**
+   * Identity transform. Re-emits the same object reference; callers that
+   * mutate the response would corrupt the cached builder output, so we
+   * deliberately do NOT clone. The DID Document is logically immutable
+   * once built (single-shot read), and `IssuerDidBuilder` returns a fresh
+   * object on every call.
+   */
+  toDocumentResponse(document: IssuerDidDocument): IssuerDidDocument {
+    return document;
+  },
+};
+
+export default IssuerDidPresenter;

--- a/src/application/domain/credential/issuerDid/presenter.ts
+++ b/src/application/domain/credential/issuerDid/presenter.ts
@@ -28,6 +28,22 @@ const IssuerDidPresenter = {
    * deliberately do NOT clone. The DID Document is logically immutable
    * once built (single-shot read), and `IssuerDidBuilder` returns a fresh
    * object on every call.
+   *
+   * **Immutability contract**: the value returned by this presenter MUST
+   * be treated as read-only by callers. Mutating it (in-place edits to
+   * `verificationMethod`, `@context`, etc.) would corrupt downstream
+   * serialisation, leak request-scoped data into other callers if a
+   * future Phase 2 change adds caching of the built Document, and break
+   * the §5.1.2 wire-shape contract verifiers depend on. The Express
+   * handler at `src/presentation/router/did.ts` only `res.json()`s the
+   * value — it never mutates — and any new caller added here must follow
+   * the same discipline. We do not call `Object.freeze` because (a) the
+   * cost of a deep freeze on every request is wasteful when the only
+   * caller today is read-only, and (b) `Object.freeze` is shallow, which
+   * would give a false sense of safety against the realistic risk
+   * (mutations of nested arrays like `verificationMethod`). If a future
+   * Phase 2 change introduces a Document cache, prefer building a fresh
+   * object per request rather than retroactively freezing.
    */
   toDocumentResponse(document: IssuerDidDocument): IssuerDidDocument {
     return document;

--- a/src/application/domain/credential/issuerDid/service.ts
+++ b/src/application/domain/credential/issuerDid/service.ts
@@ -32,6 +32,20 @@
  *     translates that to the minimal static Document so dev/staging
  *     environments remain operable before the first key is provisioned.
  *
+ * §G key-rotation scope (Phase 1 vs Phase 2):
+ *
+ *   Phase 1 (this PR) intentionally operates in **single-active-key** mode.
+ *   `getActiveIssuerDidDocument()` calls `findActiveKey()` once and emits a
+ *   DID Document carrying exactly one `verificationMethod`. The repository
+ *   interface already declares `listActiveKeys()` (see `data/interface.ts`)
+ *   — that method is reserved for Phase 2 §G overlap-window support, where
+ *   the Document will publish *both* the outgoing and incoming keys for the
+ *   duration of the rotation grace period so verifiers can validate proofs
+ *   signed by either key. Phase 1 deliberately does not consume
+ *   `listActiveKeys()`; rotation in Phase 1 is a hard cut-over (single
+ *   activate-then-deactivate transaction) and the §G overlap window is
+ *   tracked in the design doc as Phase 2 work.
+ *
  * TTL cache rationale:
  *
  *   The KMS public key for a given resource name is **immutable** — once a
@@ -88,6 +102,18 @@ export default class IssuerDidService {
    * rotation that activates a *new* resource name doesn't evict the still-
    * valid entry for the old one — both keys may be needed during the
    * overlap window.
+   *
+   * Memory-growth note: this Map lives for the process lifetime and entries
+   * are never explicitly evicted (only TTL-skipped on read). Unbounded
+   * growth is acceptable in Phase 1 because key rotations are rare events
+   * (target ≤ 1 / quarter per §G) — the steady-state cardinality is 1 and
+   * the worst case during an overlap window is 2. If rotation cadence ever
+   * accelerates (e.g. compromise-driven re-keys), or if this cache is
+   * reused for non-issuer keys, switch to an LRU with a small bound (≤ 16
+   * entries) — every entry is ~80 bytes so memory pressure is theoretical
+   * not practical.
+   * TODO(Phase 2): replace with an LRU once §G overlap is implemented and
+   * `listActiveKeys()` becomes the primary read path.
    */
   private readonly publicKeyCache = new Map<string, CachedPublicKey>();
 
@@ -167,8 +193,11 @@ export default class IssuerDidService {
     if (activeKey === null) {
       throw new Error(
         "IssuerDidService.signWithActiveKey: no active issuer key registered. " +
-          "Run the rotation runbook to activate a KMS key version before " +
-          "enabling internal VC issuance (design §G).",
+          "Activate a KMS key version before enabling internal VC issuance — " +
+          "see runbook at docs/runbooks/issuer-did-key-rotation.md " +
+          "(design §G). NOTE: the runbook itself ships in a separate PR; " +
+          "until it lands, follow the activation sequence outlined in " +
+          "docs/report/did-vc-internalization.md §5.4.3 / §G.",
       );
     }
     return this.kms.signEd25519(activeKey.kmsKeyResourceName, payload);

--- a/src/application/domain/credential/issuerDid/service.ts
+++ b/src/application/domain/credential/issuerDid/service.ts
@@ -1,0 +1,225 @@
+/**
+ * `IssuerDidService` — application-layer entry point for the civicship
+ * platform Issuer DID (`did:web:api.civicship.app`, §5.4.3).
+ *
+ * Responsibilities:
+ *
+ *   1. Resolve the **canonical Issuer DID** (a hard-coded constant — there is
+ *      exactly one, bound to the API host).
+ *   2. Build the **Issuer DID Document** that `/.well-known/did.json` serves:
+ *      DB lookup of the active KMS key version → KMS public-key fetch (with
+ *      a TTL cache) → delegate to `IssuerDidBuilder.buildIssuerDidDocument`.
+ *   3. Provide a **signing primitive** (`signWithActiveKey`) so other
+ *      services (Phase 1 step 9 `VcIssuanceService`, anchor batch worker)
+ *      can sign payloads without learning the key resource name.
+ *
+ * Boundary discipline:
+ *
+ *   - Does NOT cache the *DID Document object* itself — only the public key
+ *     bytes. The DID Document is small and the cost of re-running
+ *     `IssuerDidBuilder.buildIssuerDidDocument` is dwarfed by the KMS round-
+ *     trip. Caching the document directly would also leak any future
+ *     per-request mutations (e.g. embedding a `verificationRelationship`
+ *     selected by header).
+ *
+ *   - Does NOT manage transactions — `findActiveKey()` is a single read
+ *     against `t_issuer_did_keys`, which has no community scope. Callers
+ *     that issue VCs DO open transactions, but the issuer-key read is
+ *     deliberately outside those (it's a global lookup table).
+ *
+ *   - Does NOT decide what to do when no active key exists. Returning
+ *     `null` from `getActiveIssuerDidDocument` is intentional — the router
+ *     translates that to the minimal static Document so dev/staging
+ *     environments remain operable before the first key is provisioned.
+ *
+ * TTL cache rationale:
+ *
+ *   The KMS public key for a given resource name is **immutable** — once a
+ *   `cryptoKeyVersions/N` is created, its public key never changes. The
+ *   only reason we use a TTL (rather than caching forever) is to bound the
+ *   blast radius of a stale-cache bug: if the KMS resource name on a row
+ *   somehow refers to the wrong version, a 1-hour TTL caps how long a bad
+ *   `verificationMethod` can ride out in the DID Document. Real rotation
+ *   advances the key resource name (a different cache key entirely), so
+ *   the TTL never gates rotation throughput.
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.4.3 (this service)
+ *   docs/report/did-vc-internalization.md §5.1.1 (KMS resource naming)
+ *   docs/report/did-vc-internalization.md §5.1.2 (Issuer DID Document shape)
+ *   docs/report/did-vc-internalization.md §G    (key rotation overlap)
+ */
+
+import { inject, injectable } from "tsyringe";
+
+import logger from "@/infrastructure/logging";
+import type { IIssuerDidKeyRepository } from "@/application/domain/credential/issuerDid/data/interface";
+import {
+  CIVICSHIP_ISSUER_DID,
+  buildIssuerDidDocument,
+  type IssuerDidDocument,
+} from "@/infrastructure/libs/did/issuerDidBuilder";
+import { KmsSigner } from "@/infrastructure/libs/kms/kmsSigner";
+
+/**
+ * Public-key cache TTL. 1 hour — see file-header rationale. Exposed as a
+ * module-level const (rather than a constructor arg) because tests reach
+ * for `IssuerDidService.PUBLIC_KEY_TTL_MS` to assert TTL behaviour without
+ * having to pass the value through DI.
+ */
+const PUBLIC_KEY_TTL_MS = 60 * 60 * 1000;
+
+/**
+ * Cached entry for a single KMS key resource name.
+ *
+ * `publicKeyHex` is the lowercase 64-char hex string the
+ * `IssuerDidBuilder` expects. Stored pre-encoded so cache hits don't
+ * re-run the bytes-to-hex loop.
+ */
+interface CachedPublicKey {
+  publicKeyHex: string;
+  expiresAt: number;
+}
+
+@injectable()
+export default class IssuerDidService {
+  /**
+   * Per-resource-name cache. Map (rather than a single entry) so a §G
+   * rotation that activates a *new* resource name doesn't evict the still-
+   * valid entry for the old one — both keys may be needed during the
+   * overlap window.
+   */
+  private readonly publicKeyCache = new Map<string, CachedPublicKey>();
+
+  /**
+   * Optional clock injection for tests. Production passes `undefined` and
+   * we use `Date.now`. Tests pass a controlled clock so TTL tests don't
+   * race the real wall clock.
+   */
+  private readonly now: () => number;
+
+  constructor(
+    @inject("IssuerDidKeyRepository")
+    private readonly repository: IIssuerDidKeyRepository,
+    @inject("KmsSigner")
+    private readonly kms: KmsSigner,
+    /**
+     * Optional time source. Defaulted in the body so tsyringe doesn't try
+     * to resolve a `now` token from the container.
+     */
+    now?: () => number,
+  ) {
+    this.now = now ?? Date.now;
+  }
+
+  /**
+   * The canonical Issuer DID. Argument-less because civicship has exactly
+   * one, hard-coded to the API host. Synchronous so call-sites that need
+   * the DID for log lines / metrics / GraphQL fields don't have to await.
+   */
+  getActiveIssuerDid(): string {
+    return CIVICSHIP_ISSUER_DID;
+  }
+
+  /**
+   * Build the Issuer DID Document for `/.well-known/did.json`.
+   *
+   * Returns `null` when no active key is registered (bootstrap state).
+   * The router maps null to the minimal static Document; never returns
+   * 503 for this case — dev/staging UX matters and a syntactically-valid
+   * `did:web` body is harmless until the first VC is issued.
+   *
+   * Throws (and surfaces a 500) when a KMS lookup fails — that is a
+   * genuine misconfiguration (wrong resource name, expired ADC, etc.) and
+   * the operator needs the error rather than a degraded fallback.
+   */
+  async getActiveIssuerDidDocument(): Promise<IssuerDidDocument | null> {
+    const activeKey = await this.repository.findActiveKey();
+    if (activeKey === null) {
+      // Bootstrap state — file-header comment in `data/repository.ts`
+      // explains why `null` is the right signal. Logged at debug level
+      // because in dev/staging this is the steady state until the first
+      // key is provisioned; warn-level would spam logs.
+      logger.debug("[IssuerDidService] no active issuer key — falling through to static stub");
+      return null;
+    }
+
+    const publicKeyHex = await this.fetchPublicKeyHex(activeKey.kmsKeyResourceName);
+
+    return buildIssuerDidDocument({
+      kmsKeyResourceName: activeKey.kmsKeyResourceName,
+      publicKeyEd25519Hex: publicKeyHex,
+    });
+  }
+
+  /**
+   * Sign `payload` with the currently-active KMS key.
+   *
+   * Used by `VcIssuanceService` (Phase 1 step 9) and the anchor batch
+   * worker. Throws when no active key is registered: signing has no
+   * meaningful fallback (you cannot emit an unsigned VC), so callers MUST
+   * have provisioned a key before invoking signing flows. In practice the
+   * deployment runbook will register the first key before any feature
+   * flag flips internal VC issuance on.
+   */
+  async signWithActiveKey(payload: Uint8Array): Promise<Uint8Array> {
+    const activeKey = await this.repository.findActiveKey();
+    if (activeKey === null) {
+      throw new Error(
+        "IssuerDidService.signWithActiveKey: no active issuer key registered. " +
+          "Run the rotation runbook to activate a KMS key version before " +
+          "enabling internal VC issuance (design §G).",
+      );
+    }
+    return this.kms.signEd25519(activeKey.kmsKeyResourceName, payload);
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  /**
+   * Fetch the raw public key for `keyResourceName` and return it as a
+   * lowercase hex string. Memoized for `PUBLIC_KEY_TTL_MS`.
+   *
+   * Public keys for a pinned KMS `cryptoKeyVersions/N` are immutable, so
+   * stale-read risk is bounded; see file-header for full rationale.
+   */
+  private async fetchPublicKeyHex(keyResourceName: string): Promise<string> {
+    const cached = this.publicKeyCache.get(keyResourceName);
+    if (cached && cached.expiresAt > this.now()) {
+      return cached.publicKeyHex;
+    }
+
+    const rawBytes = await this.kms.getPublicKey(keyResourceName);
+    const publicKeyHex = bytesToHex(rawBytes);
+
+    this.publicKeyCache.set(keyResourceName, {
+      publicKeyHex,
+      expiresAt: this.now() + PUBLIC_KEY_TTL_MS,
+    });
+
+    return publicKeyHex;
+  }
+}
+
+/**
+ * Encode raw bytes as a lowercase hex string (no `0x` prefix).
+ *
+ * Hand-rolled rather than `Buffer.from(bytes).toString("hex")` so the
+ * dependency is on Node's built-in number formatting only — keeps the
+ * service file portable to Edge / Workers runtimes if we ever need to
+ * inline-test it outside Node.
+ */
+function bytesToHex(bytes: Uint8Array): string {
+  let out = "";
+  for (let i = 0; i < bytes.length; i++) {
+    const b = bytes[i];
+    out += (b >>> 4).toString(16);
+    out += (b & 0x0f).toString(16);
+  }
+  return out;
+}
+
+// Exported for tests — see file-header re: TTL cache.
+export { PUBLIC_KEY_TTL_MS };

--- a/src/application/domain/credential/issuerDid/usecase.ts
+++ b/src/application/domain/credential/issuerDid/usecase.ts
@@ -1,0 +1,51 @@
+/**
+ * `IssuerDidUseCase` — orchestration entry point for the Issuer DID flows.
+ *
+ * Phase 1 step 8 ships exactly one flow: serving the
+ * `/.well-known/did.json` body. The route handler (`presentation/router/did.ts`)
+ * historically reached straight into `IssuerDidService`, which works but
+ * places presentation-layer code one architectural step too close to the
+ * service. The use case wraps the service so that:
+ *
+ *   - future GraphQL admin queries (e.g. `issuerDidDocument` in the admin
+ *     panel) can reuse exactly the same orchestration layer;
+ *   - the presenter (below) is invoked uniformly regardless of caller.
+ *
+ * The use case does NOT manage transactions — `findActiveKey()` is a
+ * single read with no community scope, so opening a transaction would add
+ * latency without correctness benefit.
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.4.3 (IssuerDidService)
+ *   CLAUDE.md "Layer Responsibilities" (UseCase ↔ Service ↔ Repository)
+ */
+
+import { inject, injectable } from "tsyringe";
+
+import IssuerDidService from "@/application/domain/credential/issuerDid/service";
+import IssuerDidPresenter from "@/application/domain/credential/issuerDid/presenter";
+import type { IssuerDidDocument } from "@/infrastructure/libs/did/issuerDidBuilder";
+
+@injectable()
+export default class IssuerDidUseCase {
+  constructor(
+    @inject("IssuerDidService")
+    private readonly service: IssuerDidService,
+  ) {}
+
+  /**
+   * Resolve the JSON body for `/.well-known/did.json`.
+   *
+   * Returns `null` (not a payload) when no active key is registered, to
+   * preserve the router's "fall back to minimal static stub" path. The
+   * presenter is invoked only on the happy path so callers cannot
+   * accidentally bypass it.
+   */
+  async getActiveIssuerDidDocument(): Promise<IssuerDidDocument | null> {
+    const document = await this.service.getActiveIssuerDidDocument();
+    if (document === null) {
+      return null;
+    }
+    return IssuerDidPresenter.toDocumentResponse(document);
+  }
+}

--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -160,6 +160,12 @@ import VcIssuanceUseCase from "@/application/domain/credential/vcIssuance/usecas
 import VcIssuanceRepositoryStub from "@/application/domain/credential/vcIssuance/data/repository";
 import VcIssuanceResolver from "@/application/domain/credential/vcIssuance/controller/resolver";
 
+// 🪪 Issuer DID (§5.4.3 internal DID Document service, Phase 1 step 8)
+import IssuerDidService from "@/application/domain/credential/issuerDid/service";
+import IssuerDidUseCase from "@/application/domain/credential/issuerDid/usecase";
+import IssuerDidKeyRepositoryStub from "@/application/domain/credential/issuerDid/data/repository";
+import { KmsSigner } from "@/infrastructure/libs/kms/kmsSigner";
+
 export function registerProductionDependencies() {
   // ------------------------------
   // 🏗️ Infrastructure
@@ -284,6 +290,21 @@ export function registerProductionDependencies() {
   container.register("VcIssuanceService", { useClass: VcIssuanceService });
   container.register("VcIssuanceUseCase", { useClass: VcIssuanceUseCase });
   container.register("VcIssuanceResolver", { useClass: VcIssuanceResolver });
+
+  // 🪪 Issuer DID (§5.4.3 internal DID Document service) — Strategy A stub
+  // repository. Drives `/.well-known/did.json` via `IssuerDidUseCase`. The
+  // stub returns `null` for `findActiveKey` until the schema PR adds the
+  // `t_issuer_did_keys` table; the router then falls back to a minimal
+  // static Document, preserving dev/staging UX.
+  //
+  // `KmsSigner` is registered here (not in a dedicated infra section) so
+  // it sits adjacent to its single application-layer consumer for the
+  // lifetime of Phase 1; future consumers (anchor batch worker) can lift
+  // it into a shared "Cryptography" group once they land.
+  container.registerSingleton("KmsSigner", KmsSigner);
+  container.register("IssuerDidKeyRepository", { useClass: IssuerDidKeyRepositoryStub });
+  container.register("IssuerDidService", { useClass: IssuerDidService });
+  container.register("IssuerDidUseCase", { useClass: IssuerDidUseCase });
 
   // ------------------------------
   // 📰 Content

--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -107,6 +107,8 @@ import TicketClaimLinkUseCase from "@/application/domain/reward/ticketClaimLink/
 import TicketClaimLinkConverter from "@/application/domain/reward/ticketClaimLink/data/converter";
 import { TicketIssuerUseCase } from "@/application/domain/reward/ticketIssuer/usecase";
 import { DIDVCServerClient } from "@/infrastructure/libs/did";
+import { DidDocumentResolver } from "@/infrastructure/libs/did/didDocumentResolver";
+import { UserDidAnchorStoreStub } from "@/infrastructure/libs/did/userDidAnchorStoreStub";
 import { DIDIssuanceService } from "@/application/domain/account/identity/didIssuanceRequest/service";
 import { VCIssuanceRequestService } from "@/application/domain/experience/evaluation/vcIssuanceRequest/service";
 import { VCIssuanceRequestRepository } from "@/application/domain/experience/evaluation/vcIssuanceRequest/data/repository";
@@ -251,6 +253,13 @@ export function registerProductionDependencies() {
   container.register("DIDVCServerClient", { useClass: DIDVCServerClient });
   container.register("DIDIssuanceService", { useClass: DIDIssuanceService });
   container.register("DIDIssuanceRequestRepository", { useClass: DIDIssuanceRequestRepository });
+
+  // Phase 1 internalized DID/VC stack (§5.1.4 / §5.4).
+  // TODO(phase1-final): replace UserDidAnchorStoreStub with a Prisma-backed
+  // UserDidAnchorRepository once the schema PR (#1094) merges and the
+  // application service PR wires UserDidDocumentService.
+  container.register("UserDidAnchorStore", { useClass: UserDidAnchorStoreStub });
+  container.register("DidDocumentResolver", { useClass: DidDocumentResolver });
 
   container.register("VCIssuanceRequestUseCase", { useClass: VCIssuanceRequestUseCase });
   container.register("VCIssuanceRequestConverter", { useClass: VCIssuanceRequestConverter });

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import logger from "@/infrastructure/logging";
 import { authHandler } from "@/presentation/middleware/auth";
 import lineRouter from "@/presentation/router/line";
 import anchorBatchRouter from "@/presentation/router/admin/anchorBatch";
+import didRouter from "@/presentation/router/did";
 import { batchProcess } from "@/batch";
 import express from "express";
 import { corsHandler } from "@/presentation/middleware/cors";
@@ -77,6 +78,11 @@ async function startServer() {
   );
   app.use("/line", lineRouter);
   app.use("/admin/anchor-batch", anchorBatchRouter);
+  // Phase 1 DID/VC public routes (§5.4):
+  //   /.well-known/did.json
+  //   /users/:userId/did.json
+  //   /vc/:vcId/inclusion-proof
+  app.use("/", didRouter);
 
   app.get("/health", (req, res) => {
     res.status(200).json({ status: "healthy", service: "internal-api" });

--- a/src/infrastructure/libs/did/userDidAnchorStoreStub.ts
+++ b/src/infrastructure/libs/did/userDidAnchorStoreStub.ts
@@ -1,0 +1,37 @@
+/**
+ * TODO(phase1-final): replace with Prisma-backed UserDidAnchorRepository.
+ *
+ * Stub implementation of `UserDidAnchorStore` used until the
+ * `t_user_did_anchors` Prisma model lands (Phase 1 schema PR #1094) and
+ * the proper repository/service stack is wired (Phase 1 application
+ * service PR).
+ *
+ * Behavior: `findLatestByUserId` always resolves to `null`, so callers
+ * such as `DidDocumentResolver` see "no anchor record exists for this
+ * user" — the HTTP layer (`/users/:userId/did.json`) maps that to 404,
+ * which is the correct interim behavior because no user has an anchor
+ * yet (the batch worker that creates them lands in Phase 1 step 7).
+ *
+ * This file is intentionally minimal: it carries no Prisma dependency,
+ * no DI of repositories, no schema knowledge. Once the schema PR
+ * merges, replace this whole file with a Prisma-backed implementation
+ * (and update `provider.ts` to register that class instead).
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.1.4 (DidDocumentResolver)
+ *   docs/report/did-vc-internalization.md §5.4 (public routes)
+ *   docs/report/did-vc-internalization.md §4.1 (UserDidAnchor schema)
+ */
+
+import { injectable } from "tsyringe";
+import type {
+  UserDidAnchorRow,
+  UserDidAnchorStore,
+} from "@/infrastructure/libs/did/didDocumentResolver";
+
+@injectable()
+export class UserDidAnchorStoreStub implements UserDidAnchorStore {
+  async findLatestByUserId(_userId: string): Promise<UserDidAnchorRow | null> {
+    return null;
+  }
+}

--- a/src/infrastructure/libs/did/userDidBuilder.ts
+++ b/src/infrastructure/libs/did/userDidBuilder.ts
@@ -80,6 +80,18 @@ export function assertValidUserId(userId: string): string {
   return userId;
 }
 
+/**
+ * Boolean variant of `assertValidUserId` for code paths that need a
+ * non-throwing check (e.g. the `/users/:userId/did.json` route returning
+ * HTTP 400 instead of throwing). Centralises the validation rule so it
+ * stays in sync with `assertValidUserId` / `buildUserDid`.
+ */
+export function isValidUserId(userId: unknown): userId is string {
+  if (typeof userId !== "string") return false;
+  if (userId.length < USER_ID_MIN || userId.length > USER_ID_MAX) return false;
+  return USER_ID_REGEX.test(userId);
+}
+
 /** Build the canonical did:web string for a civicship user. */
 export function buildUserDid(userId: string): string {
   assertValidUserId(userId);

--- a/src/presentation/router/did.ts
+++ b/src/presentation/router/did.ts
@@ -94,6 +94,14 @@ router.get("/.well-known/did.json", async (_req: Request, res: Response) => {
       message: err instanceof Error ? err.message : String(err),
       stack: err instanceof Error ? err.stack : undefined,
     });
+    // TODO(verifier-DX): consider returning a more specific error code
+    // alongside the existing shape so verifier clients can branch on it
+    // without parsing the message string — e.g.
+    //   { error: "issuer_did_document_unavailable", message: "..." }
+    // This PR keeps `{ error: "Internal Server Error" }` to stay aligned
+    // with the global 5xx contract used elsewhere in the API; switching
+    // shapes is deferred until we audit every 5xx site for consistency
+    // (separate PR).
     return res.status(500).json({ error: "Internal Server Error" });
   }
 });

--- a/src/presentation/router/did.ts
+++ b/src/presentation/router/did.ts
@@ -1,0 +1,141 @@
+/**
+ * Public DID/VC routes (§5.4).
+ *
+ * Exposes three endpoints:
+ *
+ *   GET /.well-known/did.json
+ *     Returns the civicship.app issuer DID Document. This PR ships a
+ *     minimal static `{ "@context", id }` body — the full document
+ *     (with KMS-backed verificationMethod + service entries) is built
+ *     by `IssuerDidBuilder` in a sibling PR (claude/phase1-infra-kms-issuer-did).
+ *     We deliberately do NOT import that builder here so this PR builds
+ *     standalone; once the builder lands the resolver will switch.
+ *
+ *   GET /users/:userId/did.json
+ *     Returns the User DID Document for `userId`. Delegates to
+ *     `DidDocumentResolver.buildDidDocument(userId)` (#1096). Maps:
+ *       - `null` (no anchor row at all)               → 404
+ *       - DEACTIVATE op (Tombstone with deactivated)  → 200 (§E)
+ *       - everything else (CREATE/UPDATE)             → 200
+ *     The resolver itself handles PENDING / SUBMITTED / CONFIRMED proof
+ *     state (§F), so we do not need extra branching here.
+ *
+ *   GET /vc/:vcId/inclusion-proof
+ *     Stubbed 501 Not Implemented for this PR. The real handler depends
+ *     on the batch worker (Phase 1 step 7) that produces Merkle inclusion
+ *     proofs for VCs once their batch is anchored. Returning 501 — rather
+ *     than 404 — communicates "endpoint exists but not yet implemented"
+ *     and lets clients retry later without changing URL.
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.4   (public routes)
+ *   docs/report/did-vc-internalization.md §5.4.4 (UserDidDocumentService)
+ *   docs/report/did-vc-internalization.md §B / §E / §F
+ */
+
+import express, { Request, Response } from "express";
+import { container } from "tsyringe";
+import {
+  DidDocumentResolver,
+  type DidDocumentWithProof,
+} from "@/infrastructure/libs/did/didDocumentResolver";
+import { USER_ID_REGEX, buildUserDid } from "@/infrastructure/libs/did/userDidBuilder";
+import logger from "@/infrastructure/logging";
+
+const router = express.Router();
+
+// ---------------------------------------------------------------------------
+// Issuer DID Document — /.well-known/did.json
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the minimal issuer DID Document for civicship.app.
+ *
+ * This is the static stand-in until `IssuerDidBuilder` (sibling PR
+ * claude/phase1-infra-kms-issuer-did) provides the full document with
+ * KMS-derived verificationMethod entries.
+ *
+ * The shape matches what every DID-aware verifier expects at minimum:
+ *   `@context` + `id`. Adding fields later is backward-compatible.
+ */
+function buildIssuerDidDocument(): { "@context": readonly string[]; id: string } {
+  return {
+    "@context": ["https://www.w3.org/ns/did/v1"],
+    id: "did:web:api.civicship.app",
+  };
+}
+
+router.get("/.well-known/did.json", (_req: Request, res: Response) => {
+  res.status(200).json(buildIssuerDidDocument());
+});
+
+// ---------------------------------------------------------------------------
+// User DID Document — /users/:userId/did.json
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate `userId` against the same regex used by `buildUserDid` (§9.2)
+ * BEFORE reaching the resolver, so malformed IDs return 400 — never
+ * leaking through to a database query that would always miss anyway.
+ */
+function isValidUserId(userId: string): boolean {
+  return (
+    typeof userId === "string" &&
+    userId.length > 0 &&
+    userId.length <= 64 &&
+    USER_ID_REGEX.test(userId)
+  );
+}
+
+router.get("/users/:userId/did.json", async (req: Request, res: Response) => {
+  const { userId } = req.params;
+
+  if (!isValidUserId(userId)) {
+    return res.status(400).json({
+      error: "invalid_user_id",
+      message: `userId must match ${USER_ID_REGEX} (design §9.2)`,
+    });
+  }
+
+  try {
+    const resolver = container.resolve<DidDocumentResolver>("DidDocumentResolver");
+    const doc: DidDocumentWithProof | null = await resolver.buildDidDocument(userId);
+
+    if (doc === null) {
+      return res.status(404).json({
+        error: "did_not_found",
+        message: `No DID Document anchored for user ${buildUserDid(userId)}`,
+      });
+    }
+
+    return res.status(200).json(doc);
+  } catch (err) {
+    logger.error("[router/did] failed to build user DID Document", {
+      userId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return res.status(500).json({ error: "internal_error" });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// VC Inclusion Proof — /vc/:vcId/inclusion-proof
+// ---------------------------------------------------------------------------
+
+router.get("/vc/:vcId/inclusion-proof", (req: Request, res: Response) => {
+  const { vcId } = req.params;
+
+  if (typeof vcId !== "string" || vcId.length === 0) {
+    return res.status(400).json({
+      error: "invalid_vc_id",
+      message: "vcId is required",
+    });
+  }
+
+  return res.status(501).json({
+    error: "not_implemented",
+    message: "VC inclusion-proof endpoint will land in Phase 1 step 7 (batch worker)",
+  });
+});
+
+export default router;

--- a/src/presentation/router/did.ts
+++ b/src/presentation/router/did.ts
@@ -4,12 +4,12 @@
  * Exposes three endpoints:
  *
  *   GET /.well-known/did.json
- *     Returns the civicship.app issuer DID Document. This PR ships a
- *     minimal static `{ "@context", id }` body — the full document
- *     (with KMS-backed verificationMethod + service entries) is built
- *     by `IssuerDidBuilder` in a sibling PR (claude/phase1-infra-kms-issuer-did).
- *     We deliberately do NOT import that builder here so this PR builds
- *     standalone; once the builder lands the resolver will switch.
+ *     Returns the civicship.app Issuer DID Document. Phase 1 step 8
+ *     wires this through `IssuerDidUseCase` so the response carries the
+ *     active KMS-backed `verificationMethod` whenever a key has been
+ *     activated. Until then the use case returns `null` and we fall back
+ *     to the minimal static `{ "@context", id }` body — preserving the
+ *     dev/staging UX that existed before the use case landed.
  *
  *   GET /users/:userId/did.json
  *     Returns the User DID Document for `userId`. Delegates to
@@ -29,12 +29,14 @@
  *
  * Design references:
  *   docs/report/did-vc-internalization.md §5.4   (public routes)
+ *   docs/report/did-vc-internalization.md §5.4.3 (IssuerDidService)
  *   docs/report/did-vc-internalization.md §5.4.4 (UserDidDocumentService)
  *   docs/report/did-vc-internalization.md §B / §E / §F
  */
 
 import express, { Request, Response } from "express";
 import { container } from "tsyringe";
+import IssuerDidUseCase from "@/application/domain/credential/issuerDid/usecase";
 import {
   DidDocumentResolver,
   type DidDocumentWithProof,
@@ -53,24 +55,47 @@ const router = express.Router();
 // ---------------------------------------------------------------------------
 
 /**
- * Build the minimal issuer DID Document for civicship.app.
+ * Minimal static fallback Document.
  *
- * This is the static stand-in until `IssuerDidBuilder` (sibling PR
- * claude/phase1-infra-kms-issuer-did) provides the full document with
- * KMS-derived verificationMethod entries.
+ * Served when `IssuerDidUseCase.getActiveIssuerDidDocument()` returns
+ * `null` — i.e. no active KMS key is registered yet (bootstrap state on
+ * dev/staging). The shape is the smallest body every DID-aware verifier
+ * accepts (`@context` + `id`); the absence of `verificationMethod` is
+ * intentional and matches the spec's "no proofs yet" mode.
  *
- * The shape matches what every DID-aware verifier expects at minimum:
- *   `@context` + `id`. Adding fields later is backward-compatible.
+ * Adding fields later is backward-compatible. Switching to the use case
+ * happens automatically as soon as the first key is activated.
  */
-function buildIssuerDidDocument(): { "@context": readonly string[]; id: string } {
-  return {
-    "@context": ["https://www.w3.org/ns/did/v1"],
-    id: "did:web:api.civicship.app",
-  };
-}
+const STATIC_FALLBACK_DOCUMENT = Object.freeze({
+  "@context": ["https://www.w3.org/ns/did/v1"],
+  id: "did:web:api.civicship.app",
+});
 
-router.get("/.well-known/did.json", (_req: Request, res: Response) => {
-  res.status(200).json(buildIssuerDidDocument());
+router.get("/.well-known/did.json", async (_req: Request, res: Response) => {
+  try {
+    const useCase = container.resolve<IssuerDidUseCase>("IssuerDidUseCase");
+    const document = await useCase.getActiveIssuerDidDocument();
+
+    if (document === null) {
+      // Bootstrap fallback — see `STATIC_FALLBACK_DOCUMENT` rationale.
+      // Logged at debug level only; this is the expected steady state on
+      // a freshly-deployed environment until the first key is provisioned.
+      logger.debug("[router/did] no active issuer key — serving static fallback");
+      return res.status(200).json(STATIC_FALLBACK_DOCUMENT);
+    }
+
+    return res.status(200).json(document);
+  } catch (err) {
+    // Genuine misconfiguration (bad KMS resource name, expired ADC, etc.).
+    // Do NOT silently fall back to the static stub here — that would hide
+    // the configuration error from operators and mislead verifiers into
+    // accepting a Document that is missing the active verificationMethod.
+    logger.error("[router/did] failed to build issuer DID Document", {
+      message: err instanceof Error ? err.message : String(err),
+      stack: err instanceof Error ? err.stack : undefined,
+    });
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/src/presentation/router/did.ts
+++ b/src/presentation/router/did.ts
@@ -39,7 +39,11 @@ import {
   DidDocumentResolver,
   type DidDocumentWithProof,
 } from "@/infrastructure/libs/did/didDocumentResolver";
-import { USER_ID_REGEX, buildUserDid } from "@/infrastructure/libs/did/userDidBuilder";
+import {
+  USER_ID_REGEX,
+  buildUserDid,
+  isValidUserId,
+} from "@/infrastructure/libs/did/userDidBuilder";
 import logger from "@/infrastructure/logging";
 
 const router = express.Router();
@@ -73,23 +77,12 @@ router.get("/.well-known/did.json", (_req: Request, res: Response) => {
 // User DID Document — /users/:userId/did.json
 // ---------------------------------------------------------------------------
 
-/**
- * Validate `userId` against the same regex used by `buildUserDid` (§9.2)
- * BEFORE reaching the resolver, so malformed IDs return 400 — never
- * leaking through to a database query that would always miss anyway.
- */
-function isValidUserId(userId: string): boolean {
-  return (
-    typeof userId === "string" &&
-    userId.length > 0 &&
-    userId.length <= 64 &&
-    USER_ID_REGEX.test(userId)
-  );
-}
-
 router.get("/users/:userId/did.json", async (req: Request, res: Response) => {
   const { userId } = req.params;
 
+  // Re-uses the same predicate as `buildUserDid` / `assertValidUserId`
+  // (`@/infrastructure/libs/did/userDidBuilder`) so the §9.2 regex / length
+  // bounds live in exactly one place.
   if (!isValidUserId(userId)) {
     return res.status(400).json({
       error: "invalid_user_id",
@@ -110,11 +103,15 @@ router.get("/users/:userId/did.json", async (req: Request, res: Response) => {
 
     return res.status(200).json(doc);
   } catch (err) {
+    // Mirror `src/index.ts` global error handler: log message + stack and
+    // surface the same `{ error: "Internal Server Error" }` shape so HTTP
+    // clients see a consistent 5xx contract across the API.
     logger.error("[router/did] failed to build user DID Document", {
       userId,
-      err: err instanceof Error ? err.message : String(err),
+      message: err instanceof Error ? err.message : String(err),
+      stack: err instanceof Error ? err.stack : undefined,
     });
-    return res.status(500).json({ error: "internal_error" });
+    return res.status(500).json({ error: "Internal Server Error" });
   }
 });
 


### PR DESCRIPTION
## 概要

DID/VC 内製化 Phase 1 step 8 (E)。`IssuerDidService` を application 層に新設し、`/.well-known/did.json` を Phase 1 step 7 の最小静的スタブから IssuerDidUseCase 経由の本実装に切り替えました。
設計書 §5.4.3 (IssuerDidService) / §5.1.2 (Issuer DID Document) / §G (key rotation) に準拠しています。

## 追加・変更ファイル

### 新規 application ドメイン: `src/application/domain/credential/issuerDid/`

DDD 標準パターン (CLAUDE.md の "Standard Domain Pattern") に準拠:

- `data/type.ts` - `IssuerDidKeyRow` (planned `t_issuer_did_keys` の 1:1 mirror)
- `data/interface.ts` - `IIssuerDidKeyRepository` (`findActiveKey` / `listActiveKeys`)
- `data/repository.ts` - `IssuerDidKeyRepositoryStub` (Strategy A スタブ — `findActiveKey` は `null`、`listActiveKeys` は `[]` を返す)
- `service.ts` - `IssuerDidService`
  - `getActiveIssuerDid()` → ハードコード定数を同期返却
  - `getActiveIssuerDidDocument()` → DB から active key 取得 → KMS で公開鍵 fetch (TTL 1h cache) → `IssuerDidBuilder.buildIssuerDidDocument` に委譲
  - `signWithActiveKey(payload)` → active key を取得し `KmsSigner.signEd25519` に委譲。active key 不在時は throw (signing にフォールバックなし)
- `usecase.ts` - `IssuerDidUseCase` (presenter を必ず通す薄い wrapper)
- `presenter.ts` - 現状は identity 変換だが、admin GraphQL 等の将来追加用の安定 injection point として明示的に配置

### 既存ファイルの編集

- `src/application/provider.ts`
  - `IssuerDidKeyRepository` / `IssuerDidService` / `IssuerDidUseCase` / `KmsSigner` を DI 登録
- `src/presentation/router/did.ts`
  - `/.well-known/did.json` を `IssuerDidUseCase.getActiveIssuerDidDocument()` 経由に切替
  - `null` 返却 → 最小静的 Document fallback (200)
  - throw → 5xx 形式 (`{ error: "Internal Server Error" }`) で 500

### テスト

- `src/__tests__/unit/application/domain/credential/issuerDid/service.test.ts` (新規, 12 ケース)
- `src/__tests__/unit/presentation/router/did.test.ts` (更新、3 ケース書き換え)

## DI 登録

| トークン | 実装 | スコープ |
| --- | --- | --- |
| `KmsSigner` | `KmsSigner` | singleton |
| `IssuerDidKeyRepository` | `IssuerDidKeyRepositoryStub` | default |
| `IssuerDidService` | `IssuerDidService` | default |
| `IssuerDidUseCase` | `IssuerDidUseCase` | default |

## 公開鍵 TTL キャッシュ

- `Map<kmsKeyResourceName, { publicKeyHex, expiresAt }>` をサービス内に保持
- TTL は `PUBLIC_KEY_TTL_MS = 60 * 60 * 1000` (1h)
- KMS の `cryptoKeyVersions/N` の公開鍵自体は不変なので「TTL は永続化しないため」ではなく「stale-cache バグの blast radius を 1h に制限する」目的
- §G key rotation で resource name が変わる場合はキャッシュキー自体が異なるため、回転と TTL は独立

## active key 不在時の fallback 動作

- service: `findActiveKey()` が `null` を返した場合、`getActiveIssuerDidDocument()` も `null` を返す (例外を投げない)
- usecase: `null` を素通しで返す (presenter は呼ばない)
- router: `null` を受けたら `STATIC_FALLBACK_DOCUMENT` (`{ "@context": [...], id: "did:web:api.civicship.app" }`) を 200 で返す
- これにより dev/staging で初期 KMS key 未投入時でも 503 にならず、200 + 構文上正当な did:web Document を返せる

KMS 等での throw (resource name 不正、ADC 期限切れ等) は fallback せず、operator にエラーを surface するため 500。

## テスト結果

```
$ pnpm test --testPathPattern '(application/domain/credential/issuerDid|presentation/router/did)' --runInBand

Test Suites: 2 passed, 2 total
Tests:       19 passed, 19 total
```

ビルド: 既存 baseline 5 件 (mv refresh の生 SQL バインディング) のみ、新規エラーゼロ
ESLint: clean
Prettier: 適用済

## 設計書からの逸脱・決定事項

1. **`IssuerDidKey` の Prisma model がまだ schema に存在しない**
   - 設計書 §5.4.3 では DB から active key を引く前提だが、#1094 (schema) には `UserDidAnchor` / `VcAnchor` / `TransactionAnchor` / `StatusListCredential` の 4 model のみで `IssuerDidKey` は未追加
   - CLAUDE.md の "schema は触らない" 制約に従い、Phase 1 step 7 で確立されている Strategy A スタブ pattern (`UserDidAnchorRepositoryStub` / `VcIssuanceRepositoryStub`) と同じ方針を採用
   - `IssuerDidKeyRepositoryStub` は `findActiveKey` で `null`、`listActiveKeys` で `[]` を返し、router は最小静的 Document に fallback
   - schema PR で `t_issuer_did_keys` が追加された段階で repository 実装の差し替えのみで完結する設計

2. **DI に `KmsSigner` を追加**
   - 仕様書には「`KmsSigner` を DI 登録」とのみあったため、application layer の DID/VC グループに併設
   - 将来 anchor batch worker 等の追加 consumer が増えた段階で「Cryptography」サブセクションに昇格させる方針をコメントで明記

3. **Presenter は identity 変換**
   - 現状 internal type と wire shape が一致するため identity だが、UseCase が必ず Presenter を通す pattern を維持するために明示的に配置 (将来 admin GraphQL で `@deactivated` 等を増やす際の差し込み点)

4. **TTL キャッシュは Document object ではなく公開鍵 bytes のみ**
   - `IssuerDidBuilder.buildIssuerDidDocument` 自体は十分軽量
   - Document を直接 cache すると将来の per-request mutation (`verificationRelationship` 選択等) を破壊するため避けた

## ベース branch についての注記

`claude/did-vc-internalization-review-eptzS` には #1099 まで取り込まれていますが、本実装が前提とする #1097 (presentation routes) と #1098 (app services) はまだ未マージです。本 PR では検証のため、これら 2 つを simulate するためのマージコミット (`a3b02486`, `1e7db03c`) を含めています。#1097 / #1098 がマージされれば diff から消えます。

## 次の Phase 1 step

- step 9: VcIssuanceService の stub 署名を `IssuerDidService.signWithActiveKey()` 経由に切替 (本 PR で signing primitive は揃った)
- step 10: anchor batch worker の追加 (`KmsSigner` を共有 DI として再利用)
- schema PR の続きで `t_issuer_did_keys` を追加し、`IssuerDidKeyRepositoryStub` を Prisma backed に差し替え

https://claude.ai/code/session_019MKzV6DsfsHA6dLJ99chU8

---
_Generated by [Claude Code](https://claude.ai/code/session_019MKzV6DsfsHA6dLJ99chU8)_