### PR TITLE
phase1(graphql): UserDid + VcIssuance の Query/Mutation 実装

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -1243,6 +1243,20 @@ type AnalyticsWindowActivity {
   senderCountPrev: Int!
 }
 
+"""
+chain anchor のライフサイクル状態 (§4.1, §F)。
+- PENDING: DB 永続化済み、weekly anchor batch 未投入
+- SUBMITTED: Cardano tx 送信済み、未確定
+- CONFIRMED: tx finalized
+- FAILED: tx 失敗 / 再送対象
+"""
+enum AnchorStatus {
+  CONFIRMED
+  FAILED
+  PENDING
+  SUBMITTED
+}
+
 union ApproveReportPayload = ApproveReportSuccess
 
 type ApproveReportSuccess {
@@ -1371,6 +1385,12 @@ enum AuthZRules {
 }
 
 scalar BigInt
+
+"""chain network 識別子 (§4.1)。Phase 1 は Cardano のみサポート。"""
+enum ChainNetwork {
+  CARDANO_MAINNET
+  CARDANO_PREPROD
+}
 
 input CheckCommunityPermissionInput {
   communityId: ID!
@@ -1620,6 +1640,12 @@ type CommunityUpdateProfileSuccess {
   community: Community!
 }
 
+input CreateUserDidInput {
+  """対象 chain network。未指定時は CARDANO_MAINNET (§5.2.1)。"""
+  network: ChainNetwork
+  userId: ID!
+}
+
 type CurrentPointView {
   currentPoint: BigInt!
   walletId: String
@@ -1665,6 +1691,18 @@ enum DidIssuanceStatus {
   FAILED
   PENDING
   PROCESSING
+}
+
+"""
+DID lifecycle 操作種別 (§4.1)。
+- CREATE: 初回作成
+- UPDATE: 既存 DID Document の差し替え
+- DEACTIVATE: tombstone (§E)
+"""
+enum DidOperation {
+  CREATE
+  DEACTIVATE
+  UPDATE
 }
 
 interface Edge {
@@ -1919,6 +1957,20 @@ type IncentiveGrantsConnection {
   totalCount: Int!
 }
 
+input IssueVcInput {
+  """VC に乗せる claim 群。issuer 側で validation は行わず opaque に署名される。"""
+  claims: JSON!
+
+  """VC を Evaluation に紐づける場合の id。"""
+  evaluationId: ID
+
+  """ユーザーの did:web:api.civicship.app:users:<id> (§B)。"""
+  subjectDid: String!
+
+  """VC を保有するユーザー id。"""
+  userId: ID!
+}
+
 scalar JSON
 
 enum Language {
@@ -2076,10 +2128,29 @@ type Mutation {
   communityCreate(input: CommunityCreateInput!): CommunityCreatePayload
   communityDelete(id: ID!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): CommunityDeletePayload
   communityUpdateProfile(id: ID!, input: CommunityUpdateProfileInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): CommunityUpdateProfilePayload
+
+  """
+  ユーザー DID を新規作成する。CREATE-op の UserDidAnchor を PENDING で永続化する。
+  自分の userId のみ許可。`permission.userId` と `input.userId` が一致しなければならない。
+  """
+  createUserDid(input: CreateUserDidInput!, permission: CheckIsSelfPermissionInput!): UserDidAnchor!
+
+  """
+  ユーザー DID を deactivate する。DEACTIVATE-op の UserDidAnchor を PENDING で永続化する。
+  自分の userId のみ許可。
+  """
+  deactivateUserDid(permission: CheckIsSelfPermissionInput!, userId: ID!): UserDidAnchor!
   evaluationBulkCreate(input: EvaluationBulkCreateInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): EvaluationBulkCreatePayload
   generateReport(input: GenerateReportInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): GenerateReportPayload
   identityCheckPhoneUser(input: IdentityCheckPhoneUserInput!): IdentityCheckPhoneUserPayload!
   incentiveGrantRetry(input: IncentiveGrantRetryInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): IncentiveGrantRetryPayload
+
+  """
+  VC を発行する。civicship platform 専用 issuer による単一 issuer モデル (§B)。
+  Phase 1 では admin / system のみが直接呼び出せる。
+  本体は anchor 待ちなしで COMPLETED として永続化される (§5.2.2)。
+  """
+  issueVc(input: IssueVcInput!): VcIssuance!
   linkPhoneAuth(input: LinkPhoneAuthInput!, permission: CheckIsSelfPermissionInput!): LinkPhoneAuthPayload
   membershipAcceptMyInvitation(input: MembershipSetInvitationStatusInput!, permission: CheckIsSelfPermissionInput!): MembershipSetInvitationStatusPayload
   membershipAssignManager(input: MembershipSetRoleInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): MembershipSetRolePayload
@@ -2918,11 +2989,30 @@ type Query {
   transaction(id: ID!): Transaction
   transactions(cursor: String, filter: TransactionFilterInput, first: Int, sort: TransactionSortInput): TransactionsConnection!
   user(id: ID!): User
+
+  """
+  指定ユーザーの最新 UserDidAnchor を返却する。
+  存在しない場合は null。PENDING 状態でも返却される (§F)。
+  認証必須。
+  """
+  userDid(userId: ID!): UserDidAnchor
   users(cursor: String, filter: UserFilterInput, first: Int, sort: UserSortInput): UsersConnection!
   utilities(cursor: String, filter: UtilityFilterInput, first: Int, sort: UtilitySortInput): UtilitiesConnection!
   utility(id: ID!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): Utility
+
+  """
+  単一 VC issuance を id で取得。存在しない場合は null。
+  認証必須。
+  """
+  vcIssuance(id: ID!): VcIssuance
   vcIssuanceRequest(id: ID!): VcIssuanceRequest
   vcIssuanceRequests(cursor: String, filter: VcIssuanceRequestFilterInput, first: Int, sort: VcIssuanceRequestSortInput): VcIssuanceRequestsConnection!
+
+  """
+  指定ユーザーが保有する VC issuance 一覧を返却する。
+  認証必須。
+  """
+  vcIssuancesByUser(userId: ID!): [VcIssuance!]!
 
   """
   Verify transactions against the Cardano blockchain.
@@ -3767,6 +3857,24 @@ type UserDeletePayload {
   userId: ID
 }
 
+"""
+ユーザー DID の chain anchor 1 件を表す。
+PENDING 状態でも返却される（§F: PENDING も resolver で配信）。
+chainTxHash / chainOpIndex / confirmedAt は CONFIRMED で初めて埋まる。
+"""
+type UserDidAnchor {
+  chainOpIndex: Int
+  chainTxHash: String
+  confirmedAt: Datetime
+  createdAt: Datetime!
+  did: String!
+  documentHash: String!
+  id: ID!
+  network: ChainNetwork!
+  operation: DidOperation!
+  status: AnchorStatus!
+}
+
 type UserEdge implements Edge {
   cursor: String!
   node: User
@@ -3913,6 +4021,36 @@ enum ValueType {
   INT
 }
 
+"""
+VC のシリアライゼーション形式 (§4.1)。
+Phase 1 は INTERNAL_JWT のみ (§5.2.2)。
+IDENTUS_VC_PRISM は legacy 互換のため列挙のみ保持。
+"""
+enum VcFormat {
+  IDENTUS_VC_PRISM
+  INTERNAL_JWT
+}
+
+"""
+civicship が発行した内部 VC (§5.2.2)。
+本体は anchor 待ちなしで COMPLETED として配信される。
+chain anchor の状態は別フィールドで管理されており、検証側はそれを参照する。
+"""
+type VcIssuance {
+  createdAt: Datetime!
+  evaluationId: ID
+  id: ID!
+  issuerDid: String!
+  revokedAt: Datetime
+  status: VcIssuanceStatus!
+  statusListCredential: String
+  statusListIndex: Int
+  subjectDid: String!
+  userId: ID!
+  vcFormat: VcFormat!
+  vcJwt: String!
+}
+
 type VcIssuanceRequest {
   completedAt: Datetime
   createdAt: Datetime
@@ -3947,9 +4085,11 @@ type VcIssuanceRequestsConnection {
   totalCount: Int!
 }
 
+"""VC issuance のライフサイクル状態 (§4.1)。"""
 enum VcIssuanceStatus {
   COMPLETED
   FAILED
+  IN_PROGRESS
   PENDING
   PROCESSING
 }

--- a/src/__tests__/integration/userDid/userDid.test.ts
+++ b/src/__tests__/integration/userDid/userDid.test.ts
@@ -1,0 +1,256 @@
+/**
+ * UserDid GraphQL integration tests (§5.2.1 / Phase 1 step 8).
+ *
+ * Strategy A repositories are stubs (the Prisma model lands later), so
+ * these tests cover the full Apollo + AuthZ + Resolver path with the
+ * usecase mocked via tsyringe. They are the same shape as
+ * `__tests__/auth/mutation.onlySelf.test.ts` so Phase 1 step 8 wires
+ * cleanly into the existing auth coverage matrix.
+ */
+
+import "reflect-metadata";
+import { container } from "tsyringe";
+import { registerProductionDependencies } from "@/application/provider";
+import { createApolloTestServer } from "@/__tests__/helper/test-server";
+import request from "supertest";
+import path from "path";
+import { PrismaClientIssuer } from "@/infrastructure/prisma/client";
+
+jest.mock("@/presentation/graphql/scalar", () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock("@/presentation/graphql/schema/esmPath", () => ({
+  getESMDirname: jest.fn(() => path.resolve(__dirname, "../../../../src/presentation/graphql/schema")),
+}));
+
+jest.mock("@/application/domain/utils", () => ({
+  getCurrentUserId: jest.fn(() => "user-1"),
+}));
+
+const queries = {
+  userDid: /* GraphQL */ `
+    query ($userId: ID!) {
+      userDid(userId: $userId) {
+        id
+        did
+        operation
+        documentHash
+        network
+        status
+      }
+    }
+  `,
+  createUserDid: /* GraphQL */ `
+    mutation ($input: CreateUserDidInput!, $permission: CheckIsSelfPermissionInput!) {
+      createUserDid(input: $input, permission: $permission) {
+        id
+        did
+        operation
+        status
+      }
+    }
+  `,
+  deactivateUserDid: /* GraphQL */ `
+    mutation ($userId: ID!, $permission: CheckIsSelfPermissionInput!) {
+      deactivateUserDid(userId: $userId, permission: $permission) {
+        id
+        did
+        operation
+        status
+      }
+    }
+  `,
+};
+
+const fakeAnchor = {
+  __typename: "UserDidAnchor" as const,
+  id: "anchor-1",
+  did: "did:web:api.civicship.app:users:user-1",
+  operation: "CREATE",
+  documentHash: "0".repeat(64),
+  network: "CARDANO_MAINNET",
+  chainTxHash: null,
+  chainOpIndex: null,
+  status: "PENDING",
+  confirmedAt: null,
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+};
+
+let issuer: PrismaClientIssuer;
+
+const mockUserDidUseCase = {
+  viewUserDid: jest.fn(),
+  createUserDidForUser: jest.fn(),
+  deactivateUserDidForUser: jest.fn(),
+};
+
+describe("UserDid GraphQL", () => {
+  beforeAll(() => {
+    container.reset();
+    registerProductionDependencies();
+    issuer = container.resolve(PrismaClientIssuer);
+    container.register("UserDidUseCase", { useValue: mockUserDidUseCase });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("Query userDid", () => {
+    it("returns the anchor view when the usecase resolves a row", async () => {
+      mockUserDidUseCase.viewUserDid.mockResolvedValueOnce({
+        ...fakeAnchor,
+        operation: "CREATE",
+        status: "PENDING",
+      });
+
+      const app = await createApolloTestServer({
+        currentUser: { id: "user-1" },
+        issuer,
+      });
+      const res = await request(app)
+        .post("/graphql")
+        .send({ query: queries.userDid, variables: { userId: "user-1" } });
+
+      expect(res.body.errors).toBeUndefined();
+      expect(res.body.data.userDid).toMatchObject({
+        id: "anchor-1",
+        did: "did:web:api.civicship.app:users:user-1",
+        operation: "CREATE",
+        status: "PENDING",
+      });
+      expect(mockUserDidUseCase.viewUserDid).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns null when no anchor exists", async () => {
+      mockUserDidUseCase.viewUserDid.mockResolvedValueOnce(null);
+
+      const app = await createApolloTestServer({
+        currentUser: { id: "user-1" },
+        issuer,
+      });
+      const res = await request(app)
+        .post("/graphql")
+        .send({ query: queries.userDid, variables: { userId: "user-1" } });
+
+      expect(res.body.errors).toBeUndefined();
+      expect(res.body.data.userDid).toBeNull();
+    });
+
+    it("rejects unauthenticated requests with FORBIDDEN", async () => {
+      const app = await createApolloTestServer({ issuer });
+      const res = await request(app)
+        .post("/graphql")
+        .send({ query: queries.userDid, variables: { userId: "user-1" } });
+
+      const code = res.body.errors?.[0]?.code ?? res.body.errors?.[0]?.extensions?.code;
+      expect(code).toBe("FORBIDDEN");
+      expect(mockUserDidUseCase.viewUserDid).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Mutation createUserDid (IsSelf)", () => {
+    it("invokes the usecase when the caller acts on their own userId", async () => {
+      mockUserDidUseCase.createUserDidForUser.mockResolvedValueOnce({
+        ...fakeAnchor,
+        operation: "CREATE",
+        status: "PENDING",
+      });
+
+      const app = await createApolloTestServer({
+        currentUser: { id: "user-1" },
+        issuer,
+      });
+      const res = await request(app)
+        .post("/graphql")
+        .send({
+          query: queries.createUserDid,
+          variables: {
+            input: { userId: "user-1", network: "CARDANO_PREPROD" },
+            permission: { userId: "user-1" },
+          },
+        });
+
+      expect(res.body.errors).toBeUndefined();
+      expect(res.body.data.createUserDid.id).toBe("anchor-1");
+      expect(mockUserDidUseCase.createUserDidForUser).toHaveBeenCalledWith(
+        expect.anything(),
+        "user-1",
+        "CARDANO_PREPROD",
+      );
+    });
+
+    it("rejects when permission.userId differs from currentUser.id", async () => {
+      const app = await createApolloTestServer({
+        currentUser: { id: "user-1" },
+        issuer,
+      });
+      const res = await request(app)
+        .post("/graphql")
+        .send({
+          query: queries.createUserDid,
+          variables: {
+            input: { userId: "user-2" },
+            permission: { userId: "user-2" },
+          },
+        });
+
+      const code = res.body.errors?.[0]?.code ?? res.body.errors?.[0]?.extensions?.code;
+      expect(code).toBe("FORBIDDEN");
+      expect(mockUserDidUseCase.createUserDidForUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Mutation deactivateUserDid (IsSelf)", () => {
+    it("invokes the usecase for the caller's own DID", async () => {
+      mockUserDidUseCase.deactivateUserDidForUser.mockResolvedValueOnce({
+        ...fakeAnchor,
+        operation: "DEACTIVATE",
+        status: "PENDING",
+      });
+
+      const app = await createApolloTestServer({
+        currentUser: { id: "user-1" },
+        issuer,
+      });
+      const res = await request(app)
+        .post("/graphql")
+        .send({
+          query: queries.deactivateUserDid,
+          variables: {
+            userId: "user-1",
+            permission: { userId: "user-1" },
+          },
+        });
+
+      expect(res.body.errors).toBeUndefined();
+      expect(res.body.data.deactivateUserDid.operation).toBe("DEACTIVATE");
+      expect(mockUserDidUseCase.deactivateUserDidForUser).toHaveBeenCalledWith(
+        expect.anything(),
+        "user-1",
+      );
+    });
+
+    it("rejects when targeting a different user", async () => {
+      const app = await createApolloTestServer({
+        currentUser: { id: "user-1" },
+        issuer,
+      });
+      const res = await request(app)
+        .post("/graphql")
+        .send({
+          query: queries.deactivateUserDid,
+          variables: {
+            userId: "user-2",
+            permission: { userId: "user-2" },
+          },
+        });
+
+      const code = res.body.errors?.[0]?.code ?? res.body.errors?.[0]?.extensions?.code;
+      expect(code).toBe("FORBIDDEN");
+      expect(mockUserDidUseCase.deactivateUserDidForUser).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/__tests__/integration/vcIssuance/vcIssuance.test.ts
+++ b/src/__tests__/integration/vcIssuance/vcIssuance.test.ts
@@ -1,0 +1,230 @@
+/**
+ * VcIssuance GraphQL integration tests (§5.2.2 / Phase 1 step 8).
+ *
+ * Strategy A repository is a stub (the Prisma model lands later), so
+ * these tests cover the full Apollo + AuthZ + Resolver path with the
+ * usecase mocked via tsyringe.
+ */
+
+import "reflect-metadata";
+import { container } from "tsyringe";
+import { registerProductionDependencies } from "@/application/provider";
+import { createApolloTestServer } from "@/__tests__/helper/test-server";
+import request from "supertest";
+import path from "path";
+import { PrismaClientIssuer } from "@/infrastructure/prisma/client";
+
+jest.mock("@/presentation/graphql/scalar", () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock("@/presentation/graphql/schema/esmPath", () => ({
+  getESMDirname: jest.fn(() => path.resolve(__dirname, "../../../../src/presentation/graphql/schema")),
+}));
+
+jest.mock("@/application/domain/utils", () => ({
+  getCurrentUserId: jest.fn(() => "user-1"),
+}));
+
+const queries = {
+  vcIssuance: /* GraphQL */ `
+    query ($id: ID!) {
+      vcIssuance(id: $id) {
+        id
+        userId
+        issuerDid
+        subjectDid
+        vcFormat
+        status
+        vcJwt
+      }
+    }
+  `,
+  vcIssuancesByUser: /* GraphQL */ `
+    query ($userId: ID!) {
+      vcIssuancesByUser(userId: $userId) {
+        id
+        status
+      }
+    }
+  `,
+  issueVc: /* GraphQL */ `
+    mutation ($input: IssueVcInput!) {
+      issueVc(input: $input) {
+        id
+        status
+        vcFormat
+      }
+    }
+  `,
+};
+
+const fakeVc = {
+  __typename: "VcIssuance" as const,
+  id: "vc-1",
+  userId: "user-1",
+  evaluationId: null,
+  issuerDid: "did:web:api.civicship.app",
+  subjectDid: "did:web:api.civicship.app:users:user-1",
+  vcFormat: "INTERNAL_JWT",
+  vcJwt: "h.p.s",
+  status: "COMPLETED",
+  statusListIndex: null,
+  statusListCredential: null,
+  revokedAt: null,
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+};
+
+let issuer: PrismaClientIssuer;
+
+const mockVcIssuanceUseCase = {
+  viewVcIssuance: jest.fn(),
+  viewVcIssuancesByUser: jest.fn(),
+  issueVc: jest.fn(),
+};
+
+describe("VcIssuance GraphQL", () => {
+  beforeAll(() => {
+    container.reset();
+    registerProductionDependencies();
+    issuer = container.resolve(PrismaClientIssuer);
+    container.register("VcIssuanceUseCase", { useValue: mockVcIssuanceUseCase });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("Query vcIssuance (IsUser)", () => {
+    it("returns the VC when the usecase resolves a row", async () => {
+      mockVcIssuanceUseCase.viewVcIssuance.mockResolvedValueOnce(fakeVc);
+
+      const app = await createApolloTestServer({
+        currentUser: { id: "user-1" },
+        issuer,
+      });
+      const res = await request(app)
+        .post("/graphql")
+        .send({ query: queries.vcIssuance, variables: { id: "vc-1" } });
+
+      expect(res.body.errors).toBeUndefined();
+      expect(res.body.data.vcIssuance).toMatchObject({
+        id: "vc-1",
+        vcFormat: "INTERNAL_JWT",
+        status: "COMPLETED",
+      });
+      expect(mockVcIssuanceUseCase.viewVcIssuance).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns null when no VC exists", async () => {
+      mockVcIssuanceUseCase.viewVcIssuance.mockResolvedValueOnce(null);
+
+      const app = await createApolloTestServer({
+        currentUser: { id: "user-1" },
+        issuer,
+      });
+      const res = await request(app)
+        .post("/graphql")
+        .send({ query: queries.vcIssuance, variables: { id: "missing" } });
+
+      expect(res.body.errors).toBeUndefined();
+      expect(res.body.data.vcIssuance).toBeNull();
+    });
+
+    it("rejects unauthenticated callers", async () => {
+      const app = await createApolloTestServer({ issuer });
+      const res = await request(app)
+        .post("/graphql")
+        .send({ query: queries.vcIssuance, variables: { id: "vc-1" } });
+
+      const code = res.body.errors?.[0]?.code ?? res.body.errors?.[0]?.extensions?.code;
+      expect(code).toBe("FORBIDDEN");
+      expect(mockVcIssuanceUseCase.viewVcIssuance).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Query vcIssuancesByUser (IsUser)", () => {
+    it("returns the list when the usecase resolves rows", async () => {
+      mockVcIssuanceUseCase.viewVcIssuancesByUser.mockResolvedValueOnce([fakeVc]);
+
+      const app = await createApolloTestServer({
+        currentUser: { id: "user-1" },
+        issuer,
+      });
+      const res = await request(app)
+        .post("/graphql")
+        .send({ query: queries.vcIssuancesByUser, variables: { userId: "user-1" } });
+
+      expect(res.body.errors).toBeUndefined();
+      expect(res.body.data.vcIssuancesByUser).toHaveLength(1);
+      expect(res.body.data.vcIssuancesByUser[0].id).toBe("vc-1");
+    });
+
+    it("returns an empty array when no VCs exist", async () => {
+      mockVcIssuanceUseCase.viewVcIssuancesByUser.mockResolvedValueOnce([]);
+
+      const app = await createApolloTestServer({
+        currentUser: { id: "user-1" },
+        issuer,
+      });
+      const res = await request(app)
+        .post("/graphql")
+        .send({ query: queries.vcIssuancesByUser, variables: { userId: "user-1" } });
+
+      expect(res.body.errors).toBeUndefined();
+      expect(res.body.data.vcIssuancesByUser).toEqual([]);
+    });
+  });
+
+  describe("Mutation issueVc (IsAdmin)", () => {
+    it("invokes the usecase when the caller is admin", async () => {
+      mockVcIssuanceUseCase.issueVc.mockResolvedValueOnce(fakeVc);
+
+      const app = await createApolloTestServer({
+        isAdmin: true,
+        currentUser: { id: "admin-1", sysRole: "SYS_ADMIN" },
+        issuer,
+      });
+      const res = await request(app)
+        .post("/graphql")
+        .send({
+          query: queries.issueVc,
+          variables: {
+            input: {
+              userId: "user-1",
+              subjectDid: "did:web:api.civicship.app:users:user-1",
+              claims: { type: "EvaluationCredential" },
+            },
+          },
+        });
+
+      expect(res.body.errors).toBeUndefined();
+      expect(res.body.data.issueVc.id).toBe("vc-1");
+      expect(mockVcIssuanceUseCase.issueVc).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects when the caller is not admin", async () => {
+      const app = await createApolloTestServer({
+        currentUser: { id: "user-1", sysRole: "USER" },
+        issuer,
+      });
+      const res = await request(app)
+        .post("/graphql")
+        .send({
+          query: queries.issueVc,
+          variables: {
+            input: {
+              userId: "user-1",
+              subjectDid: "did:web:api.civicship.app:users:user-1",
+              claims: {},
+            },
+          },
+        });
+
+      const code = res.body.errors?.[0]?.code ?? res.body.errors?.[0]?.extensions?.code;
+      expect(code).toBe("FORBIDDEN");
+      expect(mockVcIssuanceUseCase.issueVc).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/__tests__/unit/application/domain/account/userDid/service.test.ts
+++ b/src/__tests__/unit/application/domain/account/userDid/service.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for `UserDidService` (Phase 1 step 7).
+ *
+ * Strategy A: the repository is a stub but tests inject a `useValue` mock
+ * so we can assert the call shape. The service's pure encoding /
+ * hashing path is exercised end-to-end — only persistence is mocked.
+ */
+
+import "reflect-metadata";
+import { container } from "tsyringe";
+import { decode as cborDecode } from "cbor-x";
+import { blake2b } from "@noble/hashes/blake2b";
+import { bytesToHex } from "@noble/hashes/utils";
+import UserDidService from "@/application/domain/account/userDid/service";
+import { IContext } from "@/types/server";
+import {
+  buildDeactivatedDidDocument,
+  buildMinimalDidDocument,
+  buildUserDid,
+} from "@/infrastructure/libs/did/userDidBuilder";
+
+const VALID_USER_ID = "u_xyz_phase1";
+const SAMPLE_NETWORK = "CARDANO_PREPROD" as const;
+
+class MockUserDidAnchorRepository {
+  findLatestByUserId = jest.fn().mockResolvedValue(null);
+  createCreate = jest.fn();
+  createUpdate = jest.fn();
+  createDeactivate = jest.fn();
+}
+
+describe("UserDidService", () => {
+  let mockRepository: MockUserDidAnchorRepository;
+  let service: UserDidService;
+  const mockCtx = {} as IContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    container.reset();
+
+    mockRepository = new MockUserDidAnchorRepository();
+    container.register("UserDidAnchorRepository", { useValue: mockRepository });
+    container.register("UserDidService", { useClass: UserDidService });
+
+    service = container.resolve(UserDidService);
+  });
+
+  describe("createDidForUser", () => {
+    it("builds did:web string + minimal Document and persists with Blake2b-256 hash", async () => {
+      mockRepository.createCreate.mockResolvedValue({ ok: true });
+
+      await service.createDidForUser(mockCtx, VALID_USER_ID);
+
+      expect(mockRepository.createCreate).toHaveBeenCalledTimes(1);
+      const [ctxArg, input, txArg] = mockRepository.createCreate.mock.calls[0];
+
+      expect(ctxArg).toBe(mockCtx);
+      expect(txArg).toBeUndefined();
+      expect(input.userId).toBe(VALID_USER_ID);
+      expect(input.did).toBe(buildUserDid(VALID_USER_ID));
+      // Default network falls back to mainnet per §4.1.
+      expect(input.network).toBe("CARDANO_MAINNET");
+
+      // documentHash is 64 hex chars (32 bytes) of Blake2b-256 over the
+      // CBOR-encoded minimal Document.
+      expect(input.documentHash).toMatch(/^[0-9a-f]{64}$/);
+      expect(input.documentCbor).toBeInstanceOf(Uint8Array);
+
+      // Round-trip: decoded CBOR matches the minimal Document exactly.
+      const decoded = cborDecode(input.documentCbor as Uint8Array);
+      expect(decoded).toEqual(buildMinimalDidDocument(VALID_USER_ID));
+
+      // Hash matches manually-computed Blake2b-256 of the same bytes.
+      const recomputed = bytesToHex(blake2b(input.documentCbor as Uint8Array, { dkLen: 32 }));
+      expect(input.documentHash).toBe(recomputed);
+    });
+
+    it("forwards the supplied tx to the repository", async () => {
+      mockRepository.createCreate.mockResolvedValue({ ok: true });
+      const fakeTx = { sentinel: true } as never;
+
+      await service.createDidForUser(mockCtx, VALID_USER_ID, fakeTx);
+
+      expect(mockRepository.createCreate).toHaveBeenCalledTimes(1);
+      const [, , txArg] = mockRepository.createCreate.mock.calls[0];
+      expect(txArg).toBe(fakeTx);
+    });
+
+    it("propagates the supplied network", async () => {
+      mockRepository.createCreate.mockResolvedValue({ ok: true });
+
+      await service.createDidForUser(mockCtx, VALID_USER_ID, undefined, SAMPLE_NETWORK);
+
+      const [, input] = mockRepository.createCreate.mock.calls[0];
+      expect(input.network).toBe(SAMPLE_NETWORK);
+    });
+
+    it("rejects userIds that violate the §9.2 regex", async () => {
+      // `assertValidUserId` (called by `buildUserDid`) throws on uppercase / colons.
+      await expect(service.createDidForUser(mockCtx, "BAD:ID")).rejects.toThrow(/§9\.2/);
+      expect(mockRepository.createCreate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("updateDid", () => {
+    it("re-anchors the minimal Document via createUpdate", async () => {
+      mockRepository.createUpdate.mockResolvedValue({ ok: true });
+
+      await service.updateDid(mockCtx, VALID_USER_ID);
+
+      expect(mockRepository.createUpdate).toHaveBeenCalledTimes(1);
+      expect(mockRepository.createCreate).not.toHaveBeenCalled();
+      const [, input] = mockRepository.createUpdate.mock.calls[0];
+      expect(input.did).toBe(buildUserDid(VALID_USER_ID));
+      expect(input.documentCbor).toBeInstanceOf(Uint8Array);
+
+      // CBOR shape parity with createDidForUser (Phase 1 only re-anchors
+      // the minimal document — see §B / §10.1.3 future work note).
+      const decoded = cborDecode(input.documentCbor as Uint8Array);
+      expect(decoded).toEqual(buildMinimalDidDocument(VALID_USER_ID));
+    });
+  });
+
+  describe("deactivateDid", () => {
+    it("hashes the tombstone Document and emits createDeactivate without CBOR", async () => {
+      mockRepository.createDeactivate.mockResolvedValue({ ok: true });
+
+      await service.deactivateDid(mockCtx, VALID_USER_ID);
+
+      expect(mockRepository.createDeactivate).toHaveBeenCalledTimes(1);
+      const [, input] = mockRepository.createDeactivate.mock.calls[0];
+      expect(input.userId).toBe(VALID_USER_ID);
+      expect(input.did).toBe(buildUserDid(VALID_USER_ID));
+      // §E: tombstone CBOR is null on chain — resolver reconstructs it.
+      expect((input as { documentCbor?: unknown }).documentCbor).toBeUndefined();
+
+      // documentHash references the canonical tombstone shape so verifiers
+      // can reproduce it offline.
+      const tombstoneCbor = (await import("cbor-x")).encode(
+        buildDeactivatedDidDocument(VALID_USER_ID),
+      );
+      const tombstoneBytes =
+        tombstoneCbor instanceof Uint8Array ? tombstoneCbor : new Uint8Array(tombstoneCbor);
+      const expectedHash = bytesToHex(blake2b(tombstoneBytes, { dkLen: 32 }));
+      expect(input.documentHash).toBe(expectedHash);
+    });
+  });
+});

--- a/src/__tests__/unit/application/domain/account/userDid/usecase.test.ts
+++ b/src/__tests__/unit/application/domain/account/userDid/usecase.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for `UserDidUseCase` authorization (review feedback for
+ * PR #1101).
+ *
+ * The schema's `@authz` rules only check "is the caller authenticated"
+ * (`IsUser`) and "does `permission.userId` match `currentUser.id`"
+ * (`IsSelf`); they do **not** bind `input.userId` (or `args.userId`) to
+ * the caller. The usecase therefore enforces an additional
+ * "self-or-admin" assertion. These tests exercise that boundary
+ * directly: the service is mocked so we can assert whether the call
+ * proceeded or was short-circuited / thrown.
+ */
+
+import "reflect-metadata";
+import { container } from "tsyringe";
+import UserDidUseCase from "@/application/domain/account/userDid/usecase";
+import UserDidService from "@/application/domain/account/userDid/service";
+import { AuthorizationError } from "@/errors/graphql";
+import type { IContext } from "@/types/server";
+
+const SELF_USER_ID = "user-self";
+const OTHER_USER_ID = "user-other";
+
+function makeIssuer() {
+  // The usecase only calls `ctx.issuer.public(ctx, cb)`. The fake forwards
+  // to the callback with a sentinel "tx" so the service mock can ignore
+  // it — we are not exercising Prisma here.
+  return {
+    public: jest.fn().mockImplementation(async (_ctx: IContext, cb: (tx: unknown) => unknown) =>
+      cb({ sentinel: "tx" }),
+    ),
+  };
+}
+
+function makeCtx(overrides: Partial<IContext> = {}): IContext {
+  return {
+    issuer: makeIssuer(),
+    loaders: {} as never,
+    communityId: "community-1",
+    currentUser: { id: SELF_USER_ID } as never,
+    isAdmin: false,
+    ...overrides,
+  } as IContext;
+}
+
+describe("UserDidUseCase (authz hardening for PR #1101)", () => {
+  let mockService: jest.Mocked<Pick<UserDidService, "findLatestForUser" | "createDidForUser" | "deactivateDid">>;
+  let usecase: UserDidUseCase;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    container.reset();
+
+    mockService = {
+      findLatestForUser: jest.fn(),
+      createDidForUser: jest.fn(),
+      deactivateDid: jest.fn(),
+    };
+
+    container.register("UserDidService", { useValue: mockService });
+    container.register("UserDidUseCase", { useClass: UserDidUseCase });
+
+    usecase = container.resolve(UserDidUseCase);
+  });
+
+  describe("viewUserDid (other-user guard — Major #1)", () => {
+    it("returns null without hitting the service when querying another user's DID", async () => {
+      const ctx = makeCtx();
+
+      const result = await usecase.viewUserDid(ctx, OTHER_USER_ID);
+
+      expect(result).toBeNull();
+      expect(mockService.findLatestForUser).not.toHaveBeenCalled();
+    });
+
+    it("loads the row when the caller is the target user", async () => {
+      mockService.findLatestForUser.mockResolvedValueOnce(null);
+      const ctx = makeCtx();
+
+      await usecase.viewUserDid(ctx, SELF_USER_ID);
+
+      expect(mockService.findLatestForUser).toHaveBeenCalledWith(ctx, SELF_USER_ID);
+    });
+
+    it("admins can read any user's DID", async () => {
+      mockService.findLatestForUser.mockResolvedValueOnce(null);
+      const ctx = makeCtx({ isAdmin: true, currentUser: { id: "admin-1" } as never });
+
+      await usecase.viewUserDid(ctx, OTHER_USER_ID);
+
+      expect(mockService.findLatestForUser).toHaveBeenCalledWith(ctx, OTHER_USER_ID);
+    });
+  });
+
+  describe("createUserDidForUser (input.userId binding — Major #2)", () => {
+    it("throws AuthorizationError when input.userId !== currentUser.id", async () => {
+      const ctx = makeCtx();
+
+      await expect(usecase.createUserDidForUser(ctx, OTHER_USER_ID)).rejects.toBeInstanceOf(
+        AuthorizationError,
+      );
+      expect(mockService.createDidForUser).not.toHaveBeenCalled();
+    });
+
+    it("invokes the service when input.userId === currentUser.id", async () => {
+      mockService.createDidForUser.mockResolvedValueOnce({
+        id: "anchor-1",
+        userId: SELF_USER_ID,
+        did: `did:web:api.civicship.app:users:${SELF_USER_ID}`,
+        operation: "CREATE",
+        documentHash: "0".repeat(64),
+        documentCbor: new Uint8Array(),
+        network: "CARDANO_MAINNET",
+        chainTxHash: null,
+        chainOpIndex: null,
+        status: "PENDING",
+        confirmedAt: null,
+        createdAt: new Date(),
+      } as never);
+      const ctx = makeCtx();
+
+      await usecase.createUserDidForUser(ctx, SELF_USER_ID);
+
+      expect(mockService.createDidForUser).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("deactivateUserDidForUser (userId binding)", () => {
+    it("throws AuthorizationError when userId !== currentUser.id", async () => {
+      const ctx = makeCtx();
+
+      await expect(usecase.deactivateUserDidForUser(ctx, OTHER_USER_ID)).rejects.toBeInstanceOf(
+        AuthorizationError,
+      );
+      expect(mockService.deactivateDid).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/__tests__/unit/application/domain/credential/vcIssuance/service.test.ts
+++ b/src/__tests__/unit/application/domain/credential/vcIssuance/service.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Unit tests for `VcIssuanceService` (Phase 1 step 7).
+ *
+ * Strategy A: the repository is a stub but tests inject a `useValue` mock
+ * so we can assert the persisted row shape. The KMS signer is also stubbed
+ * via the `STUB_SIGNATURE` constant (real signing lands in
+ * `claude/phase1-infra-kms-issuer-did`).
+ */
+
+import "reflect-metadata";
+import { container } from "tsyringe";
+import VcIssuanceService, {
+  CIVICSHIP_ISSUER_DID,
+  buildVcPayload,
+} from "@/application/domain/credential/vcIssuance/service";
+import { IContext } from "@/types/server";
+
+const SUBJECT_DID = "did:web:api.civicship.app:users:u_xyz_phase1";
+const SAMPLE_USER_ID = "u_xyz_phase1";
+
+class MockVcIssuanceRepository {
+  findById = jest.fn().mockResolvedValue(null);
+  create = jest.fn();
+}
+
+function decodeJwtSegment(segment: string): unknown {
+  return JSON.parse(Buffer.from(segment, "base64url").toString("utf8"));
+}
+
+describe("VcIssuanceService", () => {
+  let mockRepository: MockVcIssuanceRepository;
+  let service: VcIssuanceService;
+  const mockCtx = {} as IContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    container.reset();
+
+    mockRepository = new MockVcIssuanceRepository();
+    container.register("VcIssuanceRepository", { useValue: mockRepository });
+    container.register("VcIssuanceService", { useClass: VcIssuanceService });
+
+    service = container.resolve(VcIssuanceService);
+  });
+
+  describe("issueVc", () => {
+    it("persists a COMPLETED row with the civicship issuer DID and a JWT-shaped vcJwt", async () => {
+      mockRepository.create.mockResolvedValue({ ok: true });
+
+      await service.issueVc(mockCtx, {
+        userId: SAMPLE_USER_ID,
+        evaluationId: "eval-1",
+        subjectDid: SUBJECT_DID,
+        claims: { score: 5, label: "GOOD" },
+      });
+
+      expect(mockRepository.create).toHaveBeenCalledTimes(1);
+      const [ctxArg, input, txArg] = mockRepository.create.mock.calls[0];
+
+      expect(ctxArg).toBe(mockCtx);
+      expect(txArg).toBeUndefined();
+      expect(input.userId).toBe(SAMPLE_USER_ID);
+      expect(input.evaluationId).toBe("eval-1");
+      expect(input.subjectDid).toBe(SUBJECT_DID);
+      expect(input.issuerDid).toBe(CIVICSHIP_ISSUER_DID);
+      expect(input.vcFormat).toBe("INTERNAL_JWT");
+      // §5.2.2: VC body is COMPLETED even before chain anchor.
+      expect(input.status).toBe("COMPLETED");
+      // §D StatusList wiring lands in step 9 — null for now.
+      expect(input.statusListIndex).toBeNull();
+      expect(input.statusListCredential).toBeNull();
+    });
+
+    it("emits a JWT with three dot-separated segments, signature stub last", async () => {
+      mockRepository.create.mockResolvedValue({ ok: true });
+
+      await service.issueVc(mockCtx, {
+        userId: SAMPLE_USER_ID,
+        subjectDid: SUBJECT_DID,
+        claims: { score: 5 },
+      });
+
+      const [, input] = mockRepository.create.mock.calls[0];
+      const segments = (input.vcJwt as string).split(".");
+      expect(segments).toHaveLength(3);
+
+      const header = decodeJwtSegment(segments[0]) as Record<string, unknown>;
+      expect(header.alg).toBe("EdDSA");
+      expect(header.typ).toBe("JWT");
+      // The kid currently references the stub key — real KMS replaces this.
+      expect(String(header.kid).startsWith(CIVICSHIP_ISSUER_DID)).toBe(true);
+
+      const payload = decodeJwtSegment(segments[1]) as Record<string, unknown>;
+      expect(payload.issuer).toBe(CIVICSHIP_ISSUER_DID);
+      const subject = payload.credentialSubject as Record<string, unknown>;
+      expect(subject.id).toBe(SUBJECT_DID);
+      expect(subject.score).toBe(5);
+
+      // The signature segment is a stub marker; verifiers must reject it.
+      expect(segments[2]).toBe("stub-not-signed");
+    });
+
+    it("forwards the supplied tx to the repository", async () => {
+      mockRepository.create.mockResolvedValue({ ok: true });
+      const fakeTx = { sentinel: true } as never;
+
+      await service.issueVc(
+        mockCtx,
+        { userId: SAMPLE_USER_ID, subjectDid: SUBJECT_DID, claims: {} },
+        fakeTx,
+      );
+
+      const [, , txArg] = mockRepository.create.mock.calls[0];
+      expect(txArg).toBe(fakeTx);
+    });
+
+    it("defaults evaluationId to null when omitted", async () => {
+      mockRepository.create.mockResolvedValue({ ok: true });
+
+      await service.issueVc(mockCtx, {
+        userId: SAMPLE_USER_ID,
+        subjectDid: SUBJECT_DID,
+        claims: {},
+      });
+
+      const [, input] = mockRepository.create.mock.calls[0];
+      expect(input.evaluationId).toBeNull();
+    });
+  });
+
+  describe("buildVcPayload (pure function)", () => {
+    it("attaches W3C contexts, type array, ISO issuanceDate, and merges claims into credentialSubject", () => {
+      const issuedAt = new Date("2026-05-10T12:00:00Z");
+      const payload = buildVcPayload({
+        issuer: CIVICSHIP_ISSUER_DID,
+        subject: SUBJECT_DID,
+        claims: { score: 5, label: "GOOD" },
+        issuedAt,
+      });
+
+      expect(payload["@context"]).toEqual([
+        "https://www.w3.org/2018/credentials/v1",
+        "https://w3id.org/security/data-integrity/v2",
+      ]);
+      expect(payload.type).toEqual(["VerifiableCredential"]);
+      expect(payload.issuer).toBe(CIVICSHIP_ISSUER_DID);
+      expect(payload.issuanceDate).toBe(issuedAt.toISOString());
+      expect(payload.credentialSubject).toEqual({
+        id: SUBJECT_DID,
+        score: 5,
+        label: "GOOD",
+      });
+    });
+  });
+});

--- a/src/__tests__/unit/application/domain/credential/vcIssuance/usecase.test.ts
+++ b/src/__tests__/unit/application/domain/credential/vcIssuance/usecase.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for `VcIssuanceUseCase` authorization (review feedback for
+ * PR #1101).
+ *
+ * The schema gates reads on `IsUser` (logged-in) only, so the usecase
+ * layer enforces the "self-or-admin" rule. We also verify that the
+ * id-based `viewVcIssuance` query goes through `ctx.issuer.public` even
+ * for reads (Minor #5 — RLS consistency).
+ */
+
+import "reflect-metadata";
+import { container } from "tsyringe";
+import VcIssuanceUseCase from "@/application/domain/credential/vcIssuance/usecase";
+import VcIssuanceService from "@/application/domain/credential/vcIssuance/service";
+import { AuthorizationError } from "@/errors/graphql";
+import type { IContext } from "@/types/server";
+import type { VcIssuanceRow } from "@/application/domain/credential/vcIssuance/data/type";
+
+const SELF_USER_ID = "user-self";
+const OTHER_USER_ID = "user-other";
+
+function makeRow(overrides: Partial<VcIssuanceRow> = {}): VcIssuanceRow {
+  return {
+    id: "vc-1",
+    userId: SELF_USER_ID,
+    evaluationId: null,
+    issuerDid: "did:web:api.civicship.app",
+    subjectDid: `did:web:api.civicship.app:users:${SELF_USER_ID}`,
+    vcFormat: "INTERNAL_JWT",
+    vcJwt: "h.p.s",
+    statusListIndex: null,
+    statusListCredential: null,
+    vcAnchorId: null,
+    anchorLeafIndex: null,
+    status: "COMPLETED",
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    completedAt: null,
+    revokedAt: null,
+    ...overrides,
+  };
+}
+
+function makeIssuer() {
+  return {
+    public: jest.fn().mockImplementation(async (_ctx: IContext, cb: (tx: unknown) => unknown) =>
+      cb({ sentinel: "tx" }),
+    ),
+  };
+}
+
+function makeCtx(overrides: Partial<IContext> = {}): IContext {
+  return {
+    issuer: makeIssuer(),
+    loaders: {} as never,
+    communityId: "community-1",
+    currentUser: { id: SELF_USER_ID } as never,
+    isAdmin: false,
+    ...overrides,
+  } as IContext;
+}
+
+describe("VcIssuanceUseCase (authz hardening for PR #1101)", () => {
+  let mockService: jest.Mocked<
+    Pick<VcIssuanceService, "findVcById" | "findVcsByUserId" | "issueVc">
+  >;
+  let usecase: VcIssuanceUseCase;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    container.reset();
+
+    mockService = {
+      findVcById: jest.fn(),
+      findVcsByUserId: jest.fn(),
+      issueVc: jest.fn(),
+    };
+
+    container.register("VcIssuanceService", { useValue: mockService });
+    container.register("VcIssuanceUseCase", { useClass: VcIssuanceUseCase });
+
+    usecase = container.resolve(VcIssuanceUseCase);
+  });
+
+  describe("viewVcIssuance (ownership check — Major #3)", () => {
+    it("returns null when the row is owned by another user", async () => {
+      mockService.findVcById.mockResolvedValueOnce(makeRow({ userId: OTHER_USER_ID }));
+      const ctx = makeCtx();
+
+      const result = await usecase.viewVcIssuance(ctx, "vc-1");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns the presented row when the caller owns it", async () => {
+      mockService.findVcById.mockResolvedValueOnce(makeRow({ userId: SELF_USER_ID }));
+      const ctx = makeCtx();
+
+      const result = await usecase.viewVcIssuance(ctx, "vc-1");
+
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe("vc-1");
+    });
+
+    it("admins can read any user's VC", async () => {
+      mockService.findVcById.mockResolvedValueOnce(makeRow({ userId: OTHER_USER_ID }));
+      const ctx = makeCtx({ isAdmin: true, currentUser: { id: "admin-1" } as never });
+
+      const result = await usecase.viewVcIssuance(ctx, "vc-1");
+
+      expect(result).not.toBeNull();
+    });
+
+    it("returns null when no row matches the id", async () => {
+      mockService.findVcById.mockResolvedValueOnce(null);
+      const ctx = makeCtx();
+
+      const result = await usecase.viewVcIssuance(ctx, "missing");
+
+      expect(result).toBeNull();
+    });
+
+    it("wraps the read in ctx.issuer.public for RLS consistency (Minor #5)", async () => {
+      mockService.findVcById.mockResolvedValueOnce(null);
+      const ctx = makeCtx();
+
+      await usecase.viewVcIssuance(ctx, "vc-1");
+
+      // The fake `public` is invoked exactly once; the row lookup
+      // happens inside its callback.
+      expect((ctx.issuer.public as jest.Mock).mock.calls).toHaveLength(1);
+    });
+  });
+
+  describe("viewVcIssuancesByUser (caller binding — Major #4)", () => {
+    it("throws AuthorizationError when querying another user", async () => {
+      const ctx = makeCtx();
+
+      await expect(usecase.viewVcIssuancesByUser(ctx, OTHER_USER_ID)).rejects.toBeInstanceOf(
+        AuthorizationError,
+      );
+      expect(mockService.findVcsByUserId).not.toHaveBeenCalled();
+    });
+
+    it("returns the list when the caller asks about themselves", async () => {
+      mockService.findVcsByUserId.mockResolvedValueOnce([makeRow()]);
+      const ctx = makeCtx();
+
+      const result = await usecase.viewVcIssuancesByUser(ctx, SELF_USER_ID);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it("admins can list any user's VCs", async () => {
+      mockService.findVcsByUserId.mockResolvedValueOnce([makeRow({ userId: OTHER_USER_ID })]);
+      const ctx = makeCtx({ isAdmin: true, currentUser: { id: "admin-1" } as never });
+
+      const result = await usecase.viewVcIssuancesByUser(ctx, OTHER_USER_ID);
+
+      expect(result).toHaveLength(1);
+    });
+  });
+});

--- a/src/application/domain/account/userDid/controller/resolver.ts
+++ b/src/application/domain/account/userDid/controller/resolver.ts
@@ -1,0 +1,42 @@
+/**
+ * `UserDidResolver` — GraphQL Query / Mutation entry points for the
+ * `UserDidAnchor` type (§5.2.1 / Phase 1 step 8).
+ *
+ * Per CLAUDE.md "Layer Responsibilities", the resolver delegates to the
+ * usecase layer immediately and contains no business logic. Authorization
+ * is enforced by `@authz` directives in the schema files (`IsUser` for
+ * the read, `IsSelf` for the writes).
+ */
+
+import { inject, injectable } from "tsyringe";
+import { IContext } from "@/types/server";
+import UserDidUseCase from "@/application/domain/account/userDid/usecase";
+import type {
+  GqlMutationCreateUserDidArgs,
+  GqlMutationDeactivateUserDidArgs,
+  GqlQueryUserDidArgs,
+} from "@/types/graphql";
+
+@injectable()
+export default class UserDidResolver {
+  constructor(@inject("UserDidUseCase") private readonly userDidUseCase: UserDidUseCase) {}
+
+  Query = {
+    userDid: (_: unknown, args: GqlQueryUserDidArgs, ctx: IContext) => {
+      return this.userDidUseCase.viewUserDid(ctx, args.userId);
+    },
+  };
+
+  Mutation = {
+    createUserDid: (_: unknown, args: GqlMutationCreateUserDidArgs, ctx: IContext) => {
+      return this.userDidUseCase.createUserDidForUser(
+        ctx,
+        args.input.userId,
+        args.input.network ?? undefined,
+      );
+    },
+    deactivateUserDid: (_: unknown, args: GqlMutationDeactivateUserDidArgs, ctx: IContext) => {
+      return this.userDidUseCase.deactivateUserDidForUser(ctx, args.userId);
+    },
+  };
+}

--- a/src/application/domain/account/userDid/data/interface.ts
+++ b/src/application/domain/account/userDid/data/interface.ts
@@ -1,0 +1,59 @@
+/**
+ * Repository contract for the `userDid` application domain.
+ *
+ * The interface is intentionally narrow — only the four operations used by
+ * `UserDidService` are declared. Heavier query patterns (e.g. paginated
+ * listing for an admin UI) live behind a separate interface and will be
+ * added in a later phase.
+ *
+ * Strategy A note (Phase 1 step 7) ----------------------------------------
+ *
+ * `findLatestByUserId` matches the `UserDidAnchorStore` interface declared
+ * in `src/infrastructure/libs/did/didDocumentResolver.ts` so a single
+ * production repository can satisfy both the resolver (PR #1096) and the
+ * service (this PR) once the schema PR (#1094) merges.
+ *
+ * The `tx` argument follows the project-wide branching pattern (see
+ * CLAUDE.md "Transaction Handling Pattern"): when `tx` is supplied, the
+ * repository must execute against it; when omitted, it must obtain its own
+ * issuer-scoped client.
+ */
+
+import type { Prisma } from "@prisma/client";
+import { IContext } from "@/types/server";
+import type {
+  CreateUserDidAnchorInput,
+  DeactivateUserDidAnchorInput,
+  UpdateUserDidAnchorInput,
+  UserDidAnchorRow,
+} from "@/application/domain/account/userDid/data/type";
+import type { UserDidAnchorStore } from "@/infrastructure/libs/did/didDocumentResolver";
+
+export interface IUserDidAnchorRepository extends UserDidAnchorStore {
+  /**
+   * Return the most recently-created anchor for `userId`, regardless of
+   * status (PENDING included per §F). Returns `null` when no row exists.
+   *
+   * Inherited from `UserDidAnchorStore` so the production class can be
+   * reused by `DidDocumentResolver` (PR #1096) without an adapter.
+   */
+  findLatestByUserId(userId: string): Promise<UserDidAnchorRow | null>;
+
+  createCreate(
+    ctx: IContext,
+    input: CreateUserDidAnchorInput,
+    tx?: Prisma.TransactionClient,
+  ): Promise<UserDidAnchorRow>;
+
+  createUpdate(
+    ctx: IContext,
+    input: UpdateUserDidAnchorInput,
+    tx?: Prisma.TransactionClient,
+  ): Promise<UserDidAnchorRow>;
+
+  createDeactivate(
+    ctx: IContext,
+    input: DeactivateUserDidAnchorInput,
+    tx?: Prisma.TransactionClient,
+  ): Promise<UserDidAnchorRow>;
+}

--- a/src/application/domain/account/userDid/data/repository.ts
+++ b/src/application/domain/account/userDid/data/repository.ts
@@ -1,0 +1,95 @@
+/**
+ * Stub repository for `UserDidAnchor`.
+ *
+ * Strategy A note (Phase 1 step 7) ----------------------------------------
+ *
+ * The `t_user_did_anchors` Prisma model lands in a sibling PR
+ * (`claude/phase1-schema-migration`, #1094). Until that merges, we cannot
+ * issue real Prisma queries against `tx.userDidAnchor` — the type does not
+ * exist yet on `Prisma.TransactionClient`.
+ *
+ * To keep the application layer compilable and DI-resolvable today:
+ *
+ *   - `findLatestByUserId` returns `null` (mirrors "no row" — appropriate
+ *     for both DI smoke tests and the resolver fallback to 404).
+ *   - `createCreate` / `createUpdate` / `createDeactivate` throw a
+ *     `NotImplementedError` with a TODO marker. The service still calls them
+ *     so that downstream test doubles can verify the call shape; production
+ *     code will get a real implementation when the schema PR merges.
+ *
+ * After the schema PR merges, the swap is mechanical — replace the bodies
+ * with the equivalents already prototyped in `DIDIssuanceRequestRepository`
+ * (see `src/application/domain/account/identity/didIssuanceRequest/data/repository.ts`).
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §4.1   (UserDidAnchor schema)
+ *   docs/report/did-vc-internalization.md §5.2.1 (Application service shape)
+ *   docs/report/did-vc-internalization.md §5.1.4 (DidDocumentResolver storage interface)
+ */
+
+import { injectable } from "tsyringe";
+import type { Prisma } from "@prisma/client";
+import { IContext } from "@/types/server";
+import type { IUserDidAnchorRepository } from "@/application/domain/account/userDid/data/interface";
+import type {
+  CreateUserDidAnchorInput,
+  DeactivateUserDidAnchorInput,
+  UpdateUserDidAnchorInput,
+  UserDidAnchorRow,
+} from "@/application/domain/account/userDid/data/type";
+
+/**
+ * Marker error so tests / runtime callers can distinguish "feature not
+ * wired up yet" from "feature broken". Keeping it local avoids cross-PR
+ * coupling — once the real repository lands this class is deleted.
+ */
+export class UserDidAnchorRepositoryNotImplementedError extends Error {
+  constructor(method: string) {
+    super(
+      `UserDidAnchorRepositoryStub.${method}: not implemented yet — depends on ` +
+        "schema PR (#1094, t_user_did_anchors). Replace stub with the production " +
+        "Prisma-backed repository after that PR merges (Phase 1 step 8+).",
+    );
+    this.name = "UserDidAnchorRepositoryNotImplementedError";
+  }
+}
+
+@injectable()
+export default class UserDidAnchorRepositoryStub implements IUserDidAnchorRepository {
+  // findLatestByUserId is the only method that has a meaningful no-op:
+  // returning `null` correctly tells the resolver "no anchor for this user".
+  // The signature matches `UserDidAnchorStore` from the resolver.
+  async findLatestByUserId(_userId: string): Promise<UserDidAnchorRow | null> {
+    return null;
+  }
+
+  // TODO(phase1-final): swap to Prisma-backed implementation once
+  // `t_user_did_anchors` is in the generated client.
+  async createCreate(
+    _ctx: IContext,
+    _input: CreateUserDidAnchorInput,
+    _tx?: Prisma.TransactionClient,
+  ): Promise<UserDidAnchorRow> {
+    throw new UserDidAnchorRepositoryNotImplementedError("createCreate");
+  }
+
+  // TODO(phase1-final): swap to Prisma-backed implementation once
+  // `t_user_did_anchors` is in the generated client.
+  async createUpdate(
+    _ctx: IContext,
+    _input: UpdateUserDidAnchorInput,
+    _tx?: Prisma.TransactionClient,
+  ): Promise<UserDidAnchorRow> {
+    throw new UserDidAnchorRepositoryNotImplementedError("createUpdate");
+  }
+
+  // TODO(phase1-final): swap to Prisma-backed implementation once
+  // `t_user_did_anchors` is in the generated client.
+  async createDeactivate(
+    _ctx: IContext,
+    _input: DeactivateUserDidAnchorInput,
+    _tx?: Prisma.TransactionClient,
+  ): Promise<UserDidAnchorRow> {
+    throw new UserDidAnchorRepositoryNotImplementedError("createDeactivate");
+  }
+}

--- a/src/application/domain/account/userDid/data/type.ts
+++ b/src/application/domain/account/userDid/data/type.ts
@@ -24,11 +24,27 @@ import type {
   AnchorNetworkValue,
   AnchorStatusValue,
   DidOperationValue,
-  UserDidAnchorRow,
+  UserDidAnchorRow as InfraUserDidAnchorRow,
 } from "@/infrastructure/libs/did/didDocumentResolver";
 
 // Re-export so callers in this domain do not need to reach into infrastructure.
-export type { AnchorNetworkValue, AnchorStatusValue, DidOperationValue, UserDidAnchorRow };
+export type { AnchorNetworkValue, AnchorStatusValue, DidOperationValue };
+
+/**
+ * Domain-level row shape for `UserDidAnchor`.
+ *
+ * Strategy A note (Phase 1 step 8): the infrastructure-level
+ * `UserDidAnchorRow` (in `didDocumentResolver`) only declares fields the
+ * resolver needs. The GraphQL schema exposes `id`, `userId`, and `createdAt`
+ * too, so we widen the row here without touching the infra-side type. The
+ * cleanup PR (`claude/phase1-strategy-a-cleanup`) will replace this with
+ * the Prisma-generated `UserDidAnchor` model in one move.
+ */
+export interface UserDidAnchorRow extends InfraUserDidAnchorRow {
+  id: string;
+  userId: string;
+  createdAt: Date;
+}
 
 /**
  * Input for creating a new CREATE-op `UserDidAnchor` row.

--- a/src/application/domain/account/userDid/data/type.ts
+++ b/src/application/domain/account/userDid/data/type.ts
@@ -1,0 +1,67 @@
+/**
+ * Local type declarations for the `userDid` application domain.
+ *
+ * Strategy A note (Phase 1 step 7) ----------------------------------------
+ *
+ * The `t_user_did_anchors` Prisma model lives in a sibling PR
+ * (`claude/phase1-schema-migration`, #1094) which has not yet merged. To keep
+ * this PR independent we re-export the row shape declared by the resolver
+ * (PR #1096, `src/infrastructure/libs/did/didDocumentResolver.ts`) so the
+ * service / repository layer can be built against a stable contract.
+ *
+ * After the schema PR merges, the swap is a one-line change:
+ *
+ *     // TODO(phase1-final): replace with
+ *     //   import type { UserDidAnchor } from "@prisma/client";
+ *     //   export type UserDidAnchorRow = UserDidAnchor;
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §4.1 (UserDidAnchor schema)
+ *   docs/report/did-vc-internalization.md §5.2.1 (Application service shape)
+ */
+
+import type {
+  AnchorNetworkValue,
+  AnchorStatusValue,
+  DidOperationValue,
+  UserDidAnchorRow,
+} from "@/infrastructure/libs/did/didDocumentResolver";
+
+// Re-export so callers in this domain do not need to reach into infrastructure.
+export type { AnchorNetworkValue, AnchorStatusValue, DidOperationValue, UserDidAnchorRow };
+
+/**
+ * Input for creating a new CREATE-op `UserDidAnchor` row.
+ *
+ * Mirrors the columns the schema PR will introduce in `t_user_did_anchors`.
+ * Only the fields the service needs at row insertion time are listed; chain
+ * tx fields (`chainTxHash`, `chainOpIndex`, `confirmedAt`) are filled in
+ * later by the anchor batch service.
+ */
+export interface CreateUserDidAnchorInput {
+  userId: string;
+  did: string;
+  documentHash: string;
+  documentCbor: Uint8Array;
+  /** Defaults to `"CARDANO_MAINNET"` per §5.2.1 example when omitted. */
+  network?: AnchorNetworkValue;
+}
+
+/**
+ * Input for an UPDATE-op anchor row. Reuses the CREATE shape — the only
+ * semantic difference is `operation = "UPDATE"`, which the repository sets
+ * internally.
+ */
+export type UpdateUserDidAnchorInput = CreateUserDidAnchorInput;
+
+/**
+ * Input for a DEACTIVATE-op anchor row. `documentCbor` is null per §E
+ * (Tombstone documents are reconstructed from the tombstone builder, not
+ * from CBOR), and `documentHash` references the tombstone document hash.
+ */
+export interface DeactivateUserDidAnchorInput {
+  userId: string;
+  did: string;
+  documentHash: string;
+  network?: AnchorNetworkValue;
+}

--- a/src/application/domain/account/userDid/presenter.ts
+++ b/src/application/domain/account/userDid/presenter.ts
@@ -1,0 +1,54 @@
+/**
+ * `UserDidPresenter` — Prisma row → GraphQL type formatting for the User
+ * DID domain.
+ *
+ * Phase 1 step 7 scope: skeleton only. The schema PR (#1094) introduces
+ * the underlying Prisma model and the GraphQL schema PR (Phase 1 step 8)
+ * introduces `GqlUserDidAnchor`. Until both land, the presenter exposes a
+ * single passthrough so the upcoming resolver has a clear extension point
+ * without leaking GraphQL types into the service layer.
+ *
+ * Pure functions only — no I/O, no DI, no business logic (per CLAUDE.md
+ * "Layer Responsibilities" §6).
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.2.1
+ */
+
+import type { UserDidAnchorRow } from "@/application/domain/account/userDid/data/type";
+
+/**
+ * Public-facing skeleton shape. Matches the field set the design's §5.4.4
+ * `proof` block exposes, less the `proof` framing — that wrapping happens
+ * in the resolver layer (PR #1096 already implements it for the HTTP
+ * route). Once the GraphQL schema lands, swap the return type to
+ * `GqlUserDidAnchor` and tighten the field names.
+ */
+export interface UserDidAnchorView {
+  did: string;
+  operation: UserDidAnchorRow["operation"];
+  documentHash: string;
+  network: UserDidAnchorRow["network"];
+  status: UserDidAnchorRow["status"];
+  chainTxHash: string | null;
+  chainOpIndex: number | null;
+  confirmedAt: string | null;
+}
+
+const UserDidPresenter = {
+  /** Convert a single anchor row to its GraphQL-friendly view shape. */
+  view(row: UserDidAnchorRow): UserDidAnchorView {
+    return {
+      did: row.did,
+      operation: row.operation,
+      documentHash: row.documentHash,
+      network: row.network,
+      status: row.status,
+      chainTxHash: row.chainTxHash,
+      chainOpIndex: row.chainOpIndex,
+      confirmedAt: row.confirmedAt ? row.confirmedAt.toISOString() : null,
+    };
+  },
+};
+
+export default UserDidPresenter;

--- a/src/application/domain/account/userDid/presenter.ts
+++ b/src/application/domain/account/userDid/presenter.ts
@@ -2,51 +2,45 @@
  * `UserDidPresenter` — Prisma row → GraphQL type formatting for the User
  * DID domain.
  *
- * Phase 1 step 7 scope: skeleton only. The schema PR (#1094) introduces
- * the underlying Prisma model and the GraphQL schema PR (Phase 1 step 8)
- * introduces `GqlUserDidAnchor`. Until both land, the presenter exposes a
- * single passthrough so the upcoming resolver has a clear extension point
- * without leaking GraphQL types into the service layer.
+ * Phase 1 step 8 scope: GraphQL schema (`UserDidAnchor`) lands in this PR,
+ * so the presenter now produces `GqlUserDidAnchor`. Strategy A still
+ * applies: the input row is the local `UserDidAnchorRow`, which the
+ * cleanup PR (`claude/phase1-strategy-a-cleanup`) will replace with the
+ * Prisma-generated `UserDidAnchor` model in one move. Field names line up
+ * one-for-one so the swap is mechanical.
  *
  * Pure functions only — no I/O, no DI, no business logic (per CLAUDE.md
  * "Layer Responsibilities" §6).
  *
  * Design references:
  *   docs/report/did-vc-internalization.md §5.2.1
+ *   docs/report/did-vc-internalization.md §4.1 (UserDidAnchor schema)
  */
 
+import type { GqlUserDidAnchor } from "@/types/graphql";
 import type { UserDidAnchorRow } from "@/application/domain/account/userDid/data/type";
 
-/**
- * Public-facing skeleton shape. Matches the field set the design's §5.4.4
- * `proof` block exposes, less the `proof` framing — that wrapping happens
- * in the resolver layer (PR #1096 already implements it for the HTTP
- * route). Once the GraphQL schema lands, swap the return type to
- * `GqlUserDidAnchor` and tighten the field names.
- */
-export interface UserDidAnchorView {
-  did: string;
-  operation: UserDidAnchorRow["operation"];
-  documentHash: string;
-  network: UserDidAnchorRow["network"];
-  status: UserDidAnchorRow["status"];
-  chainTxHash: string | null;
-  chainOpIndex: number | null;
-  confirmedAt: string | null;
-}
-
 const UserDidPresenter = {
-  /** Convert a single anchor row to its GraphQL-friendly view shape. */
-  view(row: UserDidAnchorRow): UserDidAnchorView {
+  /**
+   * Convert a single anchor row to its GraphQL type.
+   *
+   * The local row's `operation` / `status` / `network` are already
+   * exact-string unions matching the GraphQL enum string values, so the
+   * conversion is a structural projection — no runtime mapping needed.
+   */
+  view(row: UserDidAnchorRow): GqlUserDidAnchor {
     return {
+      __typename: "UserDidAnchor",
+      id: row.id,
       did: row.did,
       operation: row.operation,
       documentHash: row.documentHash,
       network: row.network,
-      status: row.status,
       chainTxHash: row.chainTxHash,
       chainOpIndex: row.chainOpIndex,
-      confirmedAt: row.confirmedAt ? row.confirmedAt.toISOString() : null,
+      status: row.status,
+      confirmedAt: row.confirmedAt,
+      createdAt: row.createdAt,
     };
   },
 };

--- a/src/application/domain/account/userDid/schema/mutation.graphql
+++ b/src/application/domain/account/userDid/schema/mutation.graphql
@@ -1,0 +1,31 @@
+# ------------------------------
+# UserDid Mutation Definitions (§5.2.1)
+# ------------------------------
+extend type Mutation {
+  """
+  ユーザー DID を新規作成する。CREATE-op の UserDidAnchor を PENDING で永続化する。
+  自分の userId のみ許可。`permission.userId` と `input.userId` が一致しなければならない。
+  """
+  createUserDid(
+    input: CreateUserDidInput!
+    permission: CheckIsSelfPermissionInput!
+  ): UserDidAnchor! @authz(rules: [IsSelf])
+
+  """
+  ユーザー DID を deactivate する。DEACTIVATE-op の UserDidAnchor を PENDING で永続化する。
+  自分の userId のみ許可。
+  """
+  deactivateUserDid(userId: ID!, permission: CheckIsSelfPermissionInput!): UserDidAnchor!
+    @authz(rules: [IsSelf])
+}
+
+# ------------------------------
+# UserDid Input Definitions
+# ------------------------------
+input CreateUserDidInput {
+  userId: ID!
+  """
+  対象 chain network。未指定時は CARDANO_MAINNET (§5.2.1)。
+  """
+  network: ChainNetwork
+}

--- a/src/application/domain/account/userDid/schema/query.graphql
+++ b/src/application/domain/account/userDid/schema/query.graphql
@@ -1,0 +1,11 @@
+# ------------------------------
+# UserDid Query Definitions (§5.2.1)
+# ------------------------------
+extend type Query {
+  """
+  指定ユーザーの最新 UserDidAnchor を返却する。
+  存在しない場合は null。PENDING 状態でも返却される (§F)。
+  認証必須。
+  """
+  userDid(userId: ID!): UserDidAnchor @authz(rules: [IsUser])
+}

--- a/src/application/domain/account/userDid/schema/type.graphql
+++ b/src/application/domain/account/userDid/schema/type.graphql
@@ -1,0 +1,54 @@
+# ------------------------------
+# UserDidAnchor Type Definitions (§5.2.1)
+# ------------------------------
+"""
+ユーザー DID の chain anchor 1 件を表す。
+PENDING 状態でも返却される（§F: PENDING も resolver で配信）。
+chainTxHash / chainOpIndex / confirmedAt は CONFIRMED で初めて埋まる。
+"""
+type UserDidAnchor {
+  id: ID!
+  did: String!
+  operation: DidOperation!
+  documentHash: String!
+  network: ChainNetwork!
+  chainTxHash: String
+  chainOpIndex: Int
+  status: AnchorStatus!
+  confirmedAt: Datetime
+  createdAt: Datetime!
+}
+
+"""
+DID lifecycle 操作種別 (§4.1)。
+- CREATE: 初回作成
+- UPDATE: 既存 DID Document の差し替え
+- DEACTIVATE: tombstone (§E)
+"""
+enum DidOperation {
+  CREATE
+  UPDATE
+  DEACTIVATE
+}
+
+"""
+chain anchor のライフサイクル状態 (§4.1, §F)。
+- PENDING: DB 永続化済み、weekly anchor batch 未投入
+- SUBMITTED: Cardano tx 送信済み、未確定
+- CONFIRMED: tx finalized
+- FAILED: tx 失敗 / 再送対象
+"""
+enum AnchorStatus {
+  PENDING
+  SUBMITTED
+  CONFIRMED
+  FAILED
+}
+
+"""
+chain network 識別子 (§4.1)。Phase 1 は Cardano のみサポート。
+"""
+enum ChainNetwork {
+  CARDANO_MAINNET
+  CARDANO_PREPROD
+}

--- a/src/application/domain/account/userDid/service.ts
+++ b/src/application/domain/account/userDid/service.ts
@@ -1,0 +1,211 @@
+/**
+ * `UserDidService` — application-layer entry point for civicship's
+ * internal User DID lifecycle (create / update / deactivate).
+ *
+ * Per design §5.2.1, each lifecycle event:
+ *
+ *   1. Computes the canonical did:web string for the user.
+ *   2. Builds the minimal DID Document (or tombstone for DEACTIVATE).
+ *   3. CBOR-encodes the Document.
+ *   4. Hashes the CBOR bytes with Blake2b-256 → `documentHash` (32 B / 64 hex).
+ *   5. Persists a `UserDidAnchor` row in PENDING status.
+ *
+ * Step 5's row is picked up later by the weekly anchor batch (§5.3.1),
+ * which is the responsibility of a different service (Phase 1 step 9). This
+ * service intentionally does NOT touch Cardano — by keeping anchoring out
+ * of the request path, DID create / update / deactivate stays fast and
+ * independent of chain availability.
+ *
+ * §B compliance: User DIDs do not carry verification material. The service
+ * never generates user keypairs.
+ *
+ * §F compliance: anchors are persisted as PENDING and the resolver serves
+ * them immediately — confirmation on chain happens out-of-band.
+ *
+ * Strategy A note (Phase 1 step 7) ----------------------------------------
+ *
+ * The repository is a stub (see `data/repository.ts`) until schema PR
+ * #1094 lands. The service is fully functional today: callers exercising
+ * `createDidForUser` will get back a valid `did` / `documentHash` /
+ * `documentCbor` triple — only the persistence call throws. Tests inject a
+ * `useValue` mock to verify the upstream pipeline.
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §3.3   (CBOR-encoded DID Document)
+ *   docs/report/did-vc-internalization.md §5.2.1 (this service)
+ *   docs/report/did-vc-internalization.md §B / §E / §F
+ */
+
+import { blake2b } from "@noble/hashes/blake2b";
+import { encode as cborEncode } from "cbor-x";
+import { bytesToHex } from "@noble/hashes/utils";
+import { inject, injectable } from "tsyringe";
+import type { Prisma } from "@prisma/client";
+import { IContext } from "@/types/server";
+import logger from "@/infrastructure/logging";
+import type { IUserDidAnchorRepository } from "@/application/domain/account/userDid/data/interface";
+import type {
+  AnchorNetworkValue,
+  UserDidAnchorRow,
+} from "@/application/domain/account/userDid/data/type";
+import {
+  buildDeactivatedDidDocument,
+  buildMinimalDidDocument,
+  buildUserDid,
+  type DidDocument,
+  type TombstoneDocument,
+} from "@/infrastructure/libs/did/userDidBuilder";
+
+/** Output length of `documentHash`, in bytes (Blake2b-256 → 32 B). */
+const DOCUMENT_HASH_BYTES = 32;
+
+/**
+ * Default chain network for new anchors. The design only ships
+ * `CARDANO_MAINNET` and `CARDANO_PREPROD` (§4.1 ChainNetwork) — production
+ * defaults to mainnet, callers in dev / preview environments must pass
+ * `CARDANO_PREPROD` explicitly.
+ */
+const DEFAULT_NETWORK: AnchorNetworkValue = "CARDANO_MAINNET";
+
+/**
+ * CBOR-encode a DID Document and return both the bytes and the
+ * Blake2b-256 hex digest. Pulled out as a helper so create / update share
+ * one canonical encode path — drift between the two would silently break
+ * verifiers.
+ */
+function encodeAndHash(document: DidDocument | TombstoneDocument): {
+  cbor: Uint8Array;
+  hashHex: string;
+} {
+  const cbor = cborEncode(document);
+  // `cborEncode` returns a Buffer in Node; normalize to Uint8Array so the
+  // shape matches what the resolver and chain layer consume (§3.3).
+  const cborBytes = cbor instanceof Uint8Array ? cbor : new Uint8Array(cbor);
+  const digest = blake2b(cborBytes, { dkLen: DOCUMENT_HASH_BYTES });
+  return { cbor: cborBytes, hashHex: bytesToHex(digest) };
+}
+
+@injectable()
+export default class UserDidService {
+  constructor(
+    @inject("UserDidAnchorRepository")
+    private readonly repository: IUserDidAnchorRepository,
+  ) {}
+
+  /**
+   * §5.2.1: enqueue a CREATE-op `UserDidAnchor` for `userId`.
+   *
+   * Returns the persisted row so the caller (UseCase) can pass it through
+   * its presenter. The row is PENDING — it becomes SUBMITTED / CONFIRMED
+   * later via the weekly anchor batch.
+   *
+   * `tx` follows the project-wide branching pattern: when supplied, the
+   * write happens inside the caller's transaction; when omitted, the
+   * repository establishes its own issuer-scoped transaction.
+   */
+  async createDidForUser(
+    ctx: IContext,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+    network: AnchorNetworkValue = DEFAULT_NETWORK,
+  ): Promise<UserDidAnchorRow> {
+    const did = buildUserDid(userId);
+    const document = buildMinimalDidDocument(userId);
+    const { cbor, hashHex } = encodeAndHash(document);
+
+    logger.debug("[UserDidService] createDidForUser", {
+      userId,
+      did,
+      documentHash: hashHex,
+      network,
+    });
+
+    return this.repository.createCreate(
+      ctx,
+      {
+        userId,
+        did,
+        documentHash: hashHex,
+        documentCbor: cbor,
+        network,
+      },
+      tx,
+    );
+  }
+
+  /**
+   * §5.2.1: enqueue an UPDATE-op `UserDidAnchor` for `userId`.
+   *
+   * Phase 1 only re-anchors the minimal document shape (§B — User DIDs
+   * have no verification material). When VPs from users land in a future
+   * phase (§10.1.3), this method grows a `nextDocument` argument so callers
+   * can pass an extended Document.
+   */
+  async updateDid(
+    ctx: IContext,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+    network: AnchorNetworkValue = DEFAULT_NETWORK,
+  ): Promise<UserDidAnchorRow> {
+    const did = buildUserDid(userId);
+    const document = buildMinimalDidDocument(userId);
+    const { cbor, hashHex } = encodeAndHash(document);
+
+    logger.debug("[UserDidService] updateDid", {
+      userId,
+      did,
+      documentHash: hashHex,
+      network,
+    });
+
+    return this.repository.createUpdate(
+      ctx,
+      {
+        userId,
+        did,
+        documentHash: hashHex,
+        documentCbor: cbor,
+        network,
+      },
+      tx,
+    );
+  }
+
+  /**
+   * §5.2.1 + §E: enqueue a DEACTIVATE-op `UserDidAnchor` for `userId`.
+   *
+   * The on-chain row's `documentCbor` is intentionally null (the resolver
+   * reconstructs the tombstone via `buildDeactivatedDidDocument` rather
+   * than pulling from CBOR — see `didDocumentResolver.ts`), but the
+   * `documentHash` still references the canonical tombstone Document so
+   * verifiers can reproduce it.
+   */
+  async deactivateDid(
+    ctx: IContext,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+    network: AnchorNetworkValue = DEFAULT_NETWORK,
+  ): Promise<UserDidAnchorRow> {
+    const did = buildUserDid(userId);
+    const tombstone = buildDeactivatedDidDocument(userId);
+    const { hashHex } = encodeAndHash(tombstone);
+
+    logger.debug("[UserDidService] deactivateDid", {
+      userId,
+      did,
+      documentHash: hashHex,
+      network,
+    });
+
+    return this.repository.createDeactivate(
+      ctx,
+      {
+        userId,
+        did,
+        documentHash: hashHex,
+        network,
+      },
+      tx,
+    );
+  }
+}

--- a/src/application/domain/account/userDid/service.ts
+++ b/src/application/domain/account/userDid/service.ts
@@ -93,6 +93,15 @@ export default class UserDidService {
   ) {}
 
   /**
+   * Read pass-through for the GraphQL `userDid(userId)` query (Phase 1
+   * step 8). Returns the latest anchor row regardless of status — §F
+   * mandates that PENDING is served too.
+   */
+  async findLatestForUser(_ctx: IContext, userId: string): Promise<UserDidAnchorRow | null> {
+    return this.repository.findLatestByUserId(userId);
+  }
+
+  /**
    * §5.2.1: enqueue a CREATE-op `UserDidAnchor` for `userId`.
    *
    * Returns the persisted row so the caller (UseCase) can pass it through

--- a/src/application/domain/account/userDid/usecase.ts
+++ b/src/application/domain/account/userDid/usecase.ts
@@ -1,47 +1,82 @@
 /**
  * `UserDidUseCase` — transaction boundary for the User DID lifecycle.
  *
- * Phase 1 step 7 scope (per task brief):
- *   - Provide a transaction boundary so future GraphQL resolvers (Phase 1
- *     step 8) can drop in without re-architecting.
- *   - Delegate to `UserDidService` for all real work — the usecase is
- *     intentionally thin.
+ * Phase 1 step 8 scope:
+ *   - Adds GraphQL-facing entries (`viewUserDid`, `createUserDidForUser`,
+ *     `deactivateUserDidForUser`) that produce `GqlUserDidAnchor` via the
+ *     presenter.
+ *   - Keeps the existing service-level wrappers used by other Phase 1
+ *     surfaces (HTTP route, anchor batch).
  *
- * Why a usecase exists today even though no resolver calls it yet: the
- * project pattern (CLAUDE.md "Layer Responsibilities") makes UseCase the
- * sole layer that may open transactions. Adding it here avoids an awkward
- * later refactor where every test against the resolver would have to be
- * rewritten to thread a transaction.
- *
- * Strategy A note (Phase 1 step 7) ----------------------------------------
- *
- * The repository writes throw `NotImplementedError` until schema PR #1094
- * merges. Calls into this usecase exercise the full flow up to the
- * persistence boundary, which is exactly the contract test surface the
- * upcoming resolver will need.
+ * Per CLAUDE.md "Layer Responsibilities" the usecase is the only layer
+ * that may open a transaction; the service stays unaware of
+ * `ctx.issuer.public`.
  *
  * Design references:
- *   docs/report/did-vc-internalization.md §5.2.1 (this domain)
+ *   docs/report/did-vc-internalization.md §5.2.1
  *   CLAUDE.md "Transaction Handling Pattern"
  */
 
 import { inject, injectable } from "tsyringe";
 import { IContext } from "@/types/server";
 import UserDidService from "@/application/domain/account/userDid/service";
-import type { UserDidAnchorRow } from "@/application/domain/account/userDid/data/type";
+import UserDidPresenter from "@/application/domain/account/userDid/presenter";
+import type {
+  AnchorNetworkValue,
+  UserDidAnchorRow,
+} from "@/application/domain/account/userDid/data/type";
+import type { GqlChainNetwork, GqlUserDidAnchor } from "@/types/graphql";
 
 @injectable()
 export default class UserDidUseCase {
   constructor(@inject("UserDidService") private readonly service: UserDidService) {}
 
   /**
-   * Open an issuer-scoped transaction and enqueue a CREATE-op anchor.
+   * GraphQL `userDid(userId)` resolver entry. Reads outside a write
+   * transaction; `ctx.issuer.public` is used so RLS still applies.
+   */
+  async viewUserDid(ctx: IContext, userId: string): Promise<GqlUserDidAnchor | null> {
+    const row = await ctx.issuer.public(ctx, async () => {
+      return this.service.findLatestForUser(ctx, userId);
+    });
+    return row ? UserDidPresenter.view(row) : null;
+  }
+
+  /**
+   * GraphQL `createUserDid(input)` resolver entry. Opens an
+   * issuer-scoped transaction and enqueues a CREATE-op anchor.
    *
    * `ctx.issuer.public` is used (rather than `onlyBelongingCommunity`)
    * because user DID lifecycle is keyed by `userId` and not gated on
-   * community membership — the resolver will perform its own auth check
-   * (Phase 1 step 8) via `src/presentation/graphql/rule.ts`.
+   * community membership — the resolver performs its own auth check via
+   * `@authz(rules: [IsSelf])`.
    */
+  async createUserDidForUser(
+    ctx: IContext,
+    userId: string,
+    network?: GqlChainNetwork,
+  ): Promise<GqlUserDidAnchor> {
+    const row = await ctx.issuer.public(ctx, async (tx) => {
+      return this.service.createDidForUser(ctx, userId, tx, network as AnchorNetworkValue);
+    });
+    return UserDidPresenter.view(row);
+  }
+
+  /**
+   * GraphQL `deactivateUserDid(userId)` resolver entry. Opens an
+   * issuer-scoped transaction and enqueues a DEACTIVATE-op anchor.
+   */
+  async deactivateUserDidForUser(ctx: IContext, userId: string): Promise<GqlUserDidAnchor> {
+    const row = await ctx.issuer.public(ctx, async (tx) => {
+      return this.service.deactivateDid(ctx, userId, tx);
+    });
+    return UserDidPresenter.view(row);
+  }
+
+  // -----------------------------------------------------------------------
+  // Service-level wrappers preserved for other Phase 1 surfaces.
+  // -----------------------------------------------------------------------
+
   async createDidForUser(ctx: IContext, userId: string): Promise<UserDidAnchorRow> {
     return ctx.issuer.public(ctx, async (tx) => {
       return this.service.createDidForUser(ctx, userId, tx);

--- a/src/application/domain/account/userDid/usecase.ts
+++ b/src/application/domain/account/userDid/usecase.ts
@@ -12,13 +12,35 @@
  * that may open a transaction; the service stays unaware of
  * `ctx.issuer.public`.
  *
+ * Authorization (review feedback) ----------------------------------------
+ *
+ * The schema's `@authz` directives gate by "is the caller authenticated"
+ * (`IsUser`) and "does `permission.userId` match `currentUser.id`"
+ * (`IsSelf`), but neither one binds `input.userId` (or `args.userId`) to
+ * the caller. We therefore enforce that binding here in the usecase:
+ *
+ *   - reads (`viewUserDid`)            — caller must be the target user
+ *                                         OR an admin; otherwise return
+ *                                         `null` so the DID is hidden.
+ *   - writes (`createUserDidForUser`,
+ *             `deactivateUserDidForUser`) — `userId` must equal
+ *                                         `currentUser.id`; otherwise
+ *                                         throw `AuthorizationError`.
+ *
+ * The did:web Document is published over the public REST endpoint
+ * (`/users/:userId/did.json`), so this restriction does not weaken the
+ * resolver-side privacy story — it only keeps the GraphQL surface
+ * consistent with the rest of the API (self + admin).
+ *
  * Design references:
  *   docs/report/did-vc-internalization.md §5.2.1
+ *   docs/report/did-vc-internalization.md §B (single-issuer / no User key)
  *   CLAUDE.md "Transaction Handling Pattern"
  */
 
 import { inject, injectable } from "tsyringe";
 import { IContext } from "@/types/server";
+import { AuthorizationError } from "@/errors/graphql";
 import UserDidService from "@/application/domain/account/userDid/service";
 import UserDidPresenter from "@/application/domain/account/userDid/presenter";
 import type {
@@ -27,6 +49,17 @@ import type {
 } from "@/application/domain/account/userDid/data/type";
 import type { GqlChainNetwork, GqlUserDidAnchor } from "@/types/graphql";
 
+/**
+ * True when the caller is the target user, or when the caller is an
+ * admin. Centralised so the read / write paths share one definition of
+ * "may act on this `userId`". Returns `false` for anonymous callers
+ * (defence-in-depth — the schema already gates on `IsUser` / `IsSelf`).
+ */
+function isSelfOrAdmin(ctx: IContext, userId: string): boolean {
+  if (ctx.isAdmin) return true;
+  return ctx.currentUser?.id === userId;
+}
+
 @injectable()
 export default class UserDidUseCase {
   constructor(@inject("UserDidService") private readonly service: UserDidService) {}
@@ -34,8 +67,17 @@ export default class UserDidUseCase {
   /**
    * GraphQL `userDid(userId)` resolver entry. Reads outside a write
    * transaction; `ctx.issuer.public` is used so RLS still applies.
+   *
+   * Returns `null` (instead of throwing) when the caller asks about
+   * someone else's DID. The did:web Document is public via REST, but the
+   * GraphQL surface is intentionally narrower (self + admin) so a
+   * `userDid` query cannot be used to enumerate which civicship users
+   * have an anchor on chain.
    */
   async viewUserDid(ctx: IContext, userId: string): Promise<GqlUserDidAnchor | null> {
+    if (!isSelfOrAdmin(ctx, userId)) {
+      return null;
+    }
     const row = await ctx.issuer.public(ctx, async () => {
       return this.service.findLatestForUser(ctx, userId);
     });
@@ -49,13 +91,19 @@ export default class UserDidUseCase {
    * `ctx.issuer.public` is used (rather than `onlyBelongingCommunity`)
    * because user DID lifecycle is keyed by `userId` and not gated on
    * community membership — the resolver performs its own auth check via
-   * `@authz(rules: [IsSelf])`.
+   * `@authz(rules: [IsSelf])`. We additionally assert that
+   * `input.userId === currentUser.id` so a caller cannot pass
+   * `permission.userId === currentUser.id` while targeting a different
+   * `input.userId` (the `IsSelf` rule only binds `permission`).
    */
   async createUserDidForUser(
     ctx: IContext,
     userId: string,
     network?: GqlChainNetwork,
   ): Promise<GqlUserDidAnchor> {
+    if (!isSelfOrAdmin(ctx, userId)) {
+      throw new AuthorizationError("input.userId must match the authenticated user");
+    }
     const row = await ctx.issuer.public(ctx, async (tx) => {
       return this.service.createDidForUser(ctx, userId, tx, network as AnchorNetworkValue);
     });
@@ -65,8 +113,14 @@ export default class UserDidUseCase {
   /**
    * GraphQL `deactivateUserDid(userId)` resolver entry. Opens an
    * issuer-scoped transaction and enqueues a DEACTIVATE-op anchor.
+   *
+   * Same `userId === currentUser.id` assertion as `createUserDidForUser`
+   * — see that method for rationale.
    */
   async deactivateUserDidForUser(ctx: IContext, userId: string): Promise<GqlUserDidAnchor> {
+    if (!isSelfOrAdmin(ctx, userId)) {
+      throw new AuthorizationError("userId must match the authenticated user");
+    }
     const row = await ctx.issuer.public(ctx, async (tx) => {
       return this.service.deactivateDid(ctx, userId, tx);
     });

--- a/src/application/domain/account/userDid/usecase.ts
+++ b/src/application/domain/account/userDid/usecase.ts
@@ -1,0 +1,62 @@
+/**
+ * `UserDidUseCase` — transaction boundary for the User DID lifecycle.
+ *
+ * Phase 1 step 7 scope (per task brief):
+ *   - Provide a transaction boundary so future GraphQL resolvers (Phase 1
+ *     step 8) can drop in without re-architecting.
+ *   - Delegate to `UserDidService` for all real work — the usecase is
+ *     intentionally thin.
+ *
+ * Why a usecase exists today even though no resolver calls it yet: the
+ * project pattern (CLAUDE.md "Layer Responsibilities") makes UseCase the
+ * sole layer that may open transactions. Adding it here avoids an awkward
+ * later refactor where every test against the resolver would have to be
+ * rewritten to thread a transaction.
+ *
+ * Strategy A note (Phase 1 step 7) ----------------------------------------
+ *
+ * The repository writes throw `NotImplementedError` until schema PR #1094
+ * merges. Calls into this usecase exercise the full flow up to the
+ * persistence boundary, which is exactly the contract test surface the
+ * upcoming resolver will need.
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.2.1 (this domain)
+ *   CLAUDE.md "Transaction Handling Pattern"
+ */
+
+import { inject, injectable } from "tsyringe";
+import { IContext } from "@/types/server";
+import UserDidService from "@/application/domain/account/userDid/service";
+import type { UserDidAnchorRow } from "@/application/domain/account/userDid/data/type";
+
+@injectable()
+export default class UserDidUseCase {
+  constructor(@inject("UserDidService") private readonly service: UserDidService) {}
+
+  /**
+   * Open an issuer-scoped transaction and enqueue a CREATE-op anchor.
+   *
+   * `ctx.issuer.public` is used (rather than `onlyBelongingCommunity`)
+   * because user DID lifecycle is keyed by `userId` and not gated on
+   * community membership — the resolver will perform its own auth check
+   * (Phase 1 step 8) via `src/presentation/graphql/rule.ts`.
+   */
+  async createDidForUser(ctx: IContext, userId: string): Promise<UserDidAnchorRow> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      return this.service.createDidForUser(ctx, userId, tx);
+    });
+  }
+
+  async updateDid(ctx: IContext, userId: string): Promise<UserDidAnchorRow> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      return this.service.updateDid(ctx, userId, tx);
+    });
+  }
+
+  async deactivateDid(ctx: IContext, userId: string): Promise<UserDidAnchorRow> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      return this.service.deactivateDid(ctx, userId, tx);
+    });
+  }
+}

--- a/src/application/domain/credential/vcIssuance/controller/resolver.ts
+++ b/src/application/domain/credential/vcIssuance/controller/resolver.ts
@@ -1,0 +1,38 @@
+/**
+ * `VcIssuanceResolver` — GraphQL Query / Mutation entry points for the
+ * `VcIssuance` type (§5.2.2 / Phase 1 step 8).
+ *
+ * Per CLAUDE.md "Layer Responsibilities", the resolver delegates to the
+ * usecase layer immediately and contains no business logic. Authorization
+ * is enforced by `@authz` directives in the schema files (`IsUser` for
+ * the reads, `IsAdmin` for the issue mutation).
+ */
+
+import { inject, injectable } from "tsyringe";
+import { IContext } from "@/types/server";
+import VcIssuanceUseCase from "@/application/domain/credential/vcIssuance/usecase";
+import type {
+  GqlMutationIssueVcArgs,
+  GqlQueryVcIssuanceArgs,
+  GqlQueryVcIssuancesByUserArgs,
+} from "@/types/graphql";
+
+@injectable()
+export default class VcIssuanceResolver {
+  constructor(@inject("VcIssuanceUseCase") private readonly vcIssuanceUseCase: VcIssuanceUseCase) {}
+
+  Query = {
+    vcIssuance: (_: unknown, args: GqlQueryVcIssuanceArgs, ctx: IContext) => {
+      return this.vcIssuanceUseCase.viewVcIssuance(ctx, args.id);
+    },
+    vcIssuancesByUser: (_: unknown, args: GqlQueryVcIssuancesByUserArgs, ctx: IContext) => {
+      return this.vcIssuanceUseCase.viewVcIssuancesByUser(ctx, args.userId);
+    },
+  };
+
+  Mutation = {
+    issueVc: (_: unknown, args: GqlMutationIssueVcArgs, ctx: IContext) => {
+      return this.vcIssuanceUseCase.issueVc(ctx, args.input);
+    },
+  };
+}

--- a/src/application/domain/credential/vcIssuance/data/interface.ts
+++ b/src/application/domain/credential/vcIssuance/data/interface.ts
@@ -26,6 +26,13 @@ import type {
 export interface IVcIssuanceRepository {
   findById(ctx: IContext, id: string): Promise<VcIssuanceRow | null>;
 
+  /**
+   * Return every VC issuance row owned by `userId`, newest first.
+   * Phase 1 step 8 keeps the list unpaginated — the design only foresees
+   * a handful of VCs per user; pagination can be added when usage demands.
+   */
+  findByUserId(ctx: IContext, userId: string): Promise<VcIssuanceRow[]>;
+
   create(
     ctx: IContext,
     input: CreateVcIssuanceInput,

--- a/src/application/domain/credential/vcIssuance/data/interface.ts
+++ b/src/application/domain/credential/vcIssuance/data/interface.ts
@@ -1,0 +1,34 @@
+/**
+ * Repository contract for the `credential/vcIssuance` application domain.
+ *
+ * Narrow surface — only `findById` and `create` are needed for Phase 1
+ * step 7. Anchor-side fields (`vcAnchorId`, `anchorLeafIndex`) are filled
+ * in by a separate `update` call from the weekly anchor batch (Phase 1
+ * step 9), which will extend this interface when it lands.
+ *
+ * Strategy A note (Phase 1 step 7) ----------------------------------------
+ *
+ * The implementing repository (`VcIssuanceRepositoryStub`) throws
+ * `NotImplementedError` for `create` until schema PR #1094 lands; tests
+ * inject a `useValue` mock to verify the upstream pipeline.
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.2.2
+ */
+
+import type { Prisma } from "@prisma/client";
+import { IContext } from "@/types/server";
+import type {
+  CreateVcIssuanceInput,
+  VcIssuanceRow,
+} from "@/application/domain/credential/vcIssuance/data/type";
+
+export interface IVcIssuanceRepository {
+  findById(ctx: IContext, id: string): Promise<VcIssuanceRow | null>;
+
+  create(
+    ctx: IContext,
+    input: CreateVcIssuanceInput,
+    tx?: Prisma.TransactionClient,
+  ): Promise<VcIssuanceRow>;
+}

--- a/src/application/domain/credential/vcIssuance/data/repository.ts
+++ b/src/application/domain/credential/vcIssuance/data/repository.ts
@@ -49,6 +49,13 @@ export default class VcIssuanceRepositoryStub implements IVcIssuanceRepository {
     return null;
   }
 
+  // Returning an empty array is the safe no-op for "no rows yet" — the
+  // resolver maps it directly to an empty GraphQL list. The Prisma-backed
+  // implementation will issue a `findMany` ordered by `createdAt desc`.
+  async findByUserId(_ctx: IContext, _userId: string): Promise<VcIssuanceRow[]> {
+    return [];
+  }
+
   // TODO(phase1-final): swap to Prisma-backed implementation once
   // `t_vc_issuance_requests` (Phase-1 redesign) is in the generated client.
   async create(

--- a/src/application/domain/credential/vcIssuance/data/repository.ts
+++ b/src/application/domain/credential/vcIssuance/data/repository.ts
@@ -1,0 +1,61 @@
+/**
+ * Stub repository for `VcIssuanceRequest` (post-schema-PR shape).
+ *
+ * Strategy A note (Phase 1 step 7) ----------------------------------------
+ *
+ * The Phase-1 redesign of `t_vc_issuance_requests` lands in schema PR
+ * #1094. The legacy IDENTUS-era model still exists in the current
+ * generated client, but its column set is incompatible (no `vcJwt`,
+ * `vcAnchorId`, etc.), so we cannot back this domain with the old
+ * model.
+ *
+ * Until #1094 merges:
+ *   - `findById` returns `null` (mirrors "no row" — keeps the DI smoke
+ *     path green).
+ *   - `create` throws `NotImplementedError` with a TODO marker. The
+ *     service's behaviour is verified via a `useValue` mock in tests; the
+ *     real implementation is a 5-line Prisma call that will land alongside
+ *     the schema PR.
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §4.1   (VcIssuanceRequest schema)
+ *   docs/report/did-vc-internalization.md §5.2.2 (Application service shape)
+ */
+
+import { injectable } from "tsyringe";
+import type { Prisma } from "@prisma/client";
+import { IContext } from "@/types/server";
+import type { IVcIssuanceRepository } from "@/application/domain/credential/vcIssuance/data/interface";
+import type {
+  CreateVcIssuanceInput,
+  VcIssuanceRow,
+} from "@/application/domain/credential/vcIssuance/data/type";
+
+export class VcIssuanceRepositoryNotImplementedError extends Error {
+  constructor(method: string) {
+    super(
+      `VcIssuanceRepositoryStub.${method}: not implemented yet — depends on ` +
+        "schema PR (#1094, t_vc_issuance_requests JWT-shaped redesign). Replace " +
+        "stub with the production Prisma-backed repository after that PR merges " +
+        "(Phase 1 step 8+).",
+    );
+    this.name = "VcIssuanceRepositoryNotImplementedError";
+  }
+}
+
+@injectable()
+export default class VcIssuanceRepositoryStub implements IVcIssuanceRepository {
+  async findById(_ctx: IContext, _id: string): Promise<VcIssuanceRow | null> {
+    return null;
+  }
+
+  // TODO(phase1-final): swap to Prisma-backed implementation once
+  // `t_vc_issuance_requests` (Phase-1 redesign) is in the generated client.
+  async create(
+    _ctx: IContext,
+    _input: CreateVcIssuanceInput,
+    _tx?: Prisma.TransactionClient,
+  ): Promise<VcIssuanceRow> {
+    throw new VcIssuanceRepositoryNotImplementedError("create");
+  }
+}

--- a/src/application/domain/credential/vcIssuance/data/type.ts
+++ b/src/application/domain/credential/vcIssuance/data/type.ts
@@ -61,8 +61,13 @@ export interface VcIssuanceRow {
   createdAt: Date;
   completedAt: Date | null;
   /**
-   * Set non-null when the VC has been revoked via the StatusList domain
-   * (Phase 1 step 9). Until then this is always null.
+   * Revocation timestamp.
+   *
+   * In Phase 1 (this PR / step 7+8) revocation is not yet wired: the
+   * StatusList domain that flips revocation bits and stamps this column
+   * lands in Phase 1 step 9. Until that step ships this field is
+   * **always `null`** — the schema column exists so the read path is
+   * stable, but no code path writes to it.
    */
   revokedAt: Date | null;
 }

--- a/src/application/domain/credential/vcIssuance/data/type.ts
+++ b/src/application/domain/credential/vcIssuance/data/type.ts
@@ -65,6 +65,17 @@ export interface IssueVcInput {
   subjectDid: string;
   /** Free-form claim payload — opaque to this service, signed by KMS. */
   claims: Record<string, unknown>;
+  /**
+   * Issuance timestamp injected by the caller. Optional — defaults to
+   * `new Date()` inside the service. Exposed so that:
+   *   1. tests can pin the timestamp for deterministic JWT/snapshot assertions
+   *   2. batch / replay flows can preserve the original VC issuance time
+   *      instead of stamping the moment of replay.
+   *
+   * The same instance is used for both the W3C `issuanceDate` claim and the
+   * persistence row, eliminating sub-second drift between the two.
+   */
+  issuedAt?: Date;
 }
 
 /** Inputs to `IVcIssuanceRepository.create`. */

--- a/src/application/domain/credential/vcIssuance/data/type.ts
+++ b/src/application/domain/credential/vcIssuance/data/type.ts
@@ -1,0 +1,81 @@
+/**
+ * Local type declarations for the `credential/vcIssuance` application
+ * domain.
+ *
+ * Strategy A note (Phase 1 step 7) ----------------------------------------
+ *
+ * The schema PR (#1094) introduces a new `t_vc_issuance_requests` Prisma
+ * model that supersedes the existing IDENTUS-era `vcIssuanceRequest` model
+ * with a JWT-shaped column set (vcJwt / vcAnchorId / anchorLeafIndex /
+ * statusListIndex / statusListCredential). To keep this PR independent we
+ * declare the row shape locally as `VcIssuanceRow` — it intentionally
+ * mirrors the design's column set so that, after the schema PR merges,
+ * swapping to the generated type is a one-line change:
+ *
+ *     // TODO(phase1-final): replace with
+ *     //   import type { VcIssuanceRequest } from "@prisma/client";
+ *     //   export type VcIssuanceRow = VcIssuanceRequest;
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §4.1   (VcIssuanceRequest schema)
+ *   docs/report/did-vc-internalization.md §5.2.2 (Application service shape)
+ *   docs/report/did-vc-internalization.md §D     (credentialStatus)
+ */
+
+/** §4.1 — VC format. Phase 1 only emits `INTERNAL_JWT`. */
+export type VcFormatValue = "INTERNAL_JWT" | "INTERNAL_LD";
+
+/** §4.1 — VC lifecycle status. */
+export type VcStatusValue = "PENDING" | "PROCESSING" | "COMPLETED" | "FAILED" | "REVOKED";
+
+/**
+ * Local row shape standing in for `VcIssuanceRequest` post-schema-PR.
+ *
+ * Fields match the design's schema (§4.1) one-for-one. The legacy IDENTUS
+ * fields (`jobId`, `errorMessage`, `retryCount`, …) are intentionally
+ * omitted — Phase 1 step 7 only needs the columns this service writes.
+ */
+export interface VcIssuanceRow {
+  id: string;
+  userId: string;
+  evaluationId: string | null;
+  issuerDid: string;
+  subjectDid: string;
+  vcFormat: VcFormatValue;
+  vcJwt: string;
+  statusListIndex: number | null;
+  statusListCredential: string | null;
+  vcAnchorId: string | null;
+  anchorLeafIndex: number | null;
+  status: VcStatusValue;
+  createdAt: Date;
+  completedAt: Date | null;
+}
+
+/**
+ * Inputs to `VcIssuanceService.issueVc`. Mirrors §5.2.2 example with the
+ * `issuerDid` defaulted in the service (always
+ * `did:web:api.civicship.app` per Phase 1 design).
+ */
+export interface IssueVcInput {
+  userId: string;
+  /** Optional — set when the VC is tied to an Evaluation (typical case). */
+  evaluationId?: string;
+  /** The user's `did:web:api.civicship.app:users:<id>` per §B. */
+  subjectDid: string;
+  /** Free-form claim payload — opaque to this service, signed by KMS. */
+  claims: Record<string, unknown>;
+}
+
+/** Inputs to `IVcIssuanceRepository.create`. */
+export interface CreateVcIssuanceInput {
+  userId: string;
+  evaluationId?: string | null;
+  issuerDid: string;
+  subjectDid: string;
+  vcFormat: VcFormatValue;
+  vcJwt: string;
+  statusListIndex?: number | null;
+  statusListCredential?: string | null;
+  status: VcStatusValue;
+}

--- a/src/application/domain/credential/vcIssuance/data/type.ts
+++ b/src/application/domain/credential/vcIssuance/data/type.ts
@@ -22,11 +22,21 @@
  *   docs/report/did-vc-internalization.md §D     (credentialStatus)
  */
 
-/** §4.1 — VC format. Phase 1 only emits `INTERNAL_JWT`. */
-export type VcFormatValue = "INTERNAL_JWT" | "INTERNAL_LD";
+/**
+ * §4.1 — VC format. Phase 1 only emits `INTERNAL_JWT`; `IDENTUS_VC_PRISM`
+ * is retained as a value for legacy compatibility (the GraphQL schema
+ * exposes the same values).
+ */
+export type VcFormatValue = "INTERNAL_JWT" | "IDENTUS_VC_PRISM";
 
-/** §4.1 — VC lifecycle status. */
-export type VcStatusValue = "PENDING" | "PROCESSING" | "COMPLETED" | "FAILED" | "REVOKED";
+/**
+ * §4.1 — VC lifecycle status.
+ *
+ * The values mirror `GqlVcIssuanceStatus`. The legacy `VcIssuanceRequest`
+ * model still uses `PROCESSING` so we keep it in the union; new VCs only
+ * transition through `PENDING → IN_PROGRESS → COMPLETED / FAILED`.
+ */
+export type VcStatusValue = "PENDING" | "IN_PROGRESS" | "PROCESSING" | "COMPLETED" | "FAILED";
 
 /**
  * Local row shape standing in for `VcIssuanceRequest` post-schema-PR.
@@ -50,6 +60,11 @@ export interface VcIssuanceRow {
   status: VcStatusValue;
   createdAt: Date;
   completedAt: Date | null;
+  /**
+   * Set non-null when the VC has been revoked via the StatusList domain
+   * (Phase 1 step 9). Until then this is always null.
+   */
+  revokedAt: Date | null;
 }
 
 /**

--- a/src/application/domain/credential/vcIssuance/presenter.ts
+++ b/src/application/domain/credential/vcIssuance/presenter.ts
@@ -1,0 +1,54 @@
+/**
+ * `VcIssuancePresenter` — Prisma row → GraphQL type formatting for the
+ * VC issuance domain.
+ *
+ * Phase 1 step 7 scope: skeleton only. Once the GraphQL schema PR (Phase
+ * 1 step 8) introduces `GqlVcIssuance`, swap the return type to that and
+ * tighten the shape. Pure functions only — no I/O, no DI, no business
+ * logic (per CLAUDE.md "Layer Responsibilities" §6).
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.2.2
+ */
+
+import type { VcIssuanceRow } from "@/application/domain/credential/vcIssuance/data/type";
+
+export interface VcIssuanceView {
+  id: string;
+  userId: string;
+  evaluationId: string | null;
+  issuerDid: string;
+  subjectDid: string;
+  vcFormat: VcIssuanceRow["vcFormat"];
+  vcJwt: string;
+  statusListIndex: number | null;
+  statusListCredential: string | null;
+  vcAnchorId: string | null;
+  anchorLeafIndex: number | null;
+  status: VcIssuanceRow["status"];
+  createdAt: string;
+  completedAt: string | null;
+}
+
+const VcIssuancePresenter = {
+  view(row: VcIssuanceRow): VcIssuanceView {
+    return {
+      id: row.id,
+      userId: row.userId,
+      evaluationId: row.evaluationId,
+      issuerDid: row.issuerDid,
+      subjectDid: row.subjectDid,
+      vcFormat: row.vcFormat,
+      vcJwt: row.vcJwt,
+      statusListIndex: row.statusListIndex,
+      statusListCredential: row.statusListCredential,
+      vcAnchorId: row.vcAnchorId,
+      anchorLeafIndex: row.anchorLeafIndex,
+      status: row.status,
+      createdAt: row.createdAt.toISOString(),
+      completedAt: row.completedAt ? row.completedAt.toISOString() : null,
+    };
+  },
+};
+
+export default VcIssuancePresenter;

--- a/src/application/domain/credential/vcIssuance/presenter.ts
+++ b/src/application/domain/credential/vcIssuance/presenter.ts
@@ -2,51 +2,81 @@
  * `VcIssuancePresenter` — Prisma row → GraphQL type formatting for the
  * VC issuance domain.
  *
- * Phase 1 step 7 scope: skeleton only. Once the GraphQL schema PR (Phase
- * 1 step 8) introduces `GqlVcIssuance`, swap the return type to that and
- * tighten the shape. Pure functions only — no I/O, no DI, no business
- * logic (per CLAUDE.md "Layer Responsibilities" §6).
+ * Phase 1 step 8 scope: GraphQL schema (`VcIssuance`) lands in this PR,
+ * so the presenter now produces `GqlVcIssuance`. Strategy A still
+ * applies: the input row is the local `VcIssuanceRow`, which the cleanup
+ * PR (`claude/phase1-strategy-a-cleanup`) will replace with the
+ * Prisma-generated `VcIssuanceRequest` model in one move. Field names
+ * line up so the swap is mechanical.
+ *
+ * Note: `vcAnchorId` / `anchorLeafIndex` / `completedAt` are not yet
+ * exposed by the GraphQL `VcIssuance` type (they belong to the anchor /
+ * batch view added in Phase 1 step 9+). The fields stay on the row so
+ * the persistence layer can populate them and a future schema extension
+ * can pick them up without another migration.
+ *
+ * Pure functions only — no I/O, no DI, no business logic (per CLAUDE.md
+ * "Layer Responsibilities" §6).
  *
  * Design references:
  *   docs/report/did-vc-internalization.md §5.2.2
+ *   docs/report/did-vc-internalization.md §4.1
  */
 
+import type { GqlVcIssuance } from "@/types/graphql";
 import type { VcIssuanceRow } from "@/application/domain/credential/vcIssuance/data/type";
 
-export interface VcIssuanceView {
-  id: string;
-  userId: string;
-  evaluationId: string | null;
-  issuerDid: string;
-  subjectDid: string;
-  vcFormat: VcIssuanceRow["vcFormat"];
-  vcJwt: string;
-  statusListIndex: number | null;
-  statusListCredential: string | null;
-  vcAnchorId: string | null;
-  anchorLeafIndex: number | null;
-  status: VcIssuanceRow["status"];
-  createdAt: string;
-  completedAt: string | null;
+/**
+ * Map the persistence-layer status to the GraphQL enum. Legacy
+ * `PROCESSING` rows surface as `IN_PROGRESS` so the GraphQL schema can
+ * stay free of the legacy spelling. Defensive default keeps the
+ * presenter total over the row union.
+ */
+function toGqlStatus(status: VcIssuanceRow["status"]): GqlVcIssuance["status"] {
+  switch (status) {
+    case "PENDING":
+      return "PENDING";
+    case "IN_PROGRESS":
+    case "PROCESSING":
+      return "IN_PROGRESS";
+    case "COMPLETED":
+      return "COMPLETED";
+    case "FAILED":
+      return "FAILED";
+    default: {
+      // Exhaustiveness guard — if a new state is added to the row union
+      // and nothing here handles it, TypeScript flags this branch.
+      const _exhaustive: never = status;
+      return _exhaustive;
+    }
+  }
+}
+
+/**
+ * Map the persistence-layer format to the GraphQL enum. The VC format
+ * union is intentionally narrow (Phase 1 only emits `INTERNAL_JWT`); the
+ * legacy `IDENTUS_VC_PRISM` value passes through unchanged.
+ */
+function toGqlFormat(format: VcIssuanceRow["vcFormat"]): GqlVcIssuance["vcFormat"] {
+  return format;
 }
 
 const VcIssuancePresenter = {
-  view(row: VcIssuanceRow): VcIssuanceView {
+  view(row: VcIssuanceRow): GqlVcIssuance {
     return {
+      __typename: "VcIssuance",
       id: row.id,
       userId: row.userId,
       evaluationId: row.evaluationId,
       issuerDid: row.issuerDid,
       subjectDid: row.subjectDid,
-      vcFormat: row.vcFormat,
+      vcFormat: toGqlFormat(row.vcFormat),
       vcJwt: row.vcJwt,
+      status: toGqlStatus(row.status),
       statusListIndex: row.statusListIndex,
       statusListCredential: row.statusListCredential,
-      vcAnchorId: row.vcAnchorId,
-      anchorLeafIndex: row.anchorLeafIndex,
-      status: row.status,
-      createdAt: row.createdAt.toISOString(),
-      completedAt: row.completedAt ? row.completedAt.toISOString() : null,
+      revokedAt: row.revokedAt,
+      createdAt: row.createdAt,
     };
   },
 };

--- a/src/application/domain/credential/vcIssuance/schema/mutation.graphql
+++ b/src/application/domain/credential/vcIssuance/schema/mutation.graphql
@@ -1,0 +1,36 @@
+# ------------------------------
+# VcIssuance Mutation Definitions (§5.2.2)
+# ------------------------------
+extend type Mutation {
+  """
+  VC を発行する。civicship platform 専用 issuer による単一 issuer モデル (§B)。
+  Phase 1 では admin / system のみが直接呼び出せる。
+  本体は anchor 待ちなしで COMPLETED として永続化される (§5.2.2)。
+  """
+  issueVc(input: IssueVcInput!): VcIssuance! @authz(rules: [IsAdmin])
+}
+
+# ------------------------------
+# VcIssuance Input Definitions
+# ------------------------------
+input IssueVcInput {
+  """
+  VC を保有するユーザー id。
+  """
+  userId: ID!
+
+  """
+  VC を Evaluation に紐づける場合の id。
+  """
+  evaluationId: ID
+
+  """
+  ユーザーの did:web:api.civicship.app:users:<id> (§B)。
+  """
+  subjectDid: String!
+
+  """
+  VC に乗せる claim 群。issuer 側で validation は行わず opaque に署名される。
+  """
+  claims: JSON!
+}

--- a/src/application/domain/credential/vcIssuance/schema/query.graphql
+++ b/src/application/domain/credential/vcIssuance/schema/query.graphql
@@ -1,0 +1,16 @@
+# ------------------------------
+# VcIssuance Query Definitions (§5.2.2)
+# ------------------------------
+extend type Query {
+  """
+  単一 VC issuance を id で取得。存在しない場合は null。
+  認証必須。
+  """
+  vcIssuance(id: ID!): VcIssuance @authz(rules: [IsUser])
+
+  """
+  指定ユーザーが保有する VC issuance 一覧を返却する。
+  認証必須。
+  """
+  vcIssuancesByUser(userId: ID!): [VcIssuance!]! @authz(rules: [IsUser])
+}

--- a/src/application/domain/credential/vcIssuance/schema/type.graphql
+++ b/src/application/domain/credential/vcIssuance/schema/type.graphql
@@ -1,0 +1,42 @@
+# ------------------------------
+# VcIssuance Type Definitions (§5.2.2)
+# ------------------------------
+"""
+civicship が発行した内部 VC (§5.2.2)。
+本体は anchor 待ちなしで COMPLETED として配信される。
+chain anchor の状態は別フィールドで管理されており、検証側はそれを参照する。
+"""
+type VcIssuance {
+  id: ID!
+  userId: ID!
+  evaluationId: ID
+  issuerDid: String!
+  subjectDid: String!
+  vcFormat: VcFormat!
+  vcJwt: String!
+  status: VcIssuanceStatus!
+  statusListIndex: Int
+  statusListCredential: String
+  revokedAt: Datetime
+  createdAt: Datetime!
+}
+
+"""
+VC のシリアライゼーション形式 (§4.1)。
+Phase 1 は INTERNAL_JWT のみ (§5.2.2)。
+IDENTUS_VC_PRISM は legacy 互換のため列挙のみ保持。
+"""
+enum VcFormat {
+  INTERNAL_JWT
+  IDENTUS_VC_PRISM
+}
+
+"""
+VC issuance のライフサイクル状態 (§4.1)。
+"""
+enum VcIssuanceStatus {
+  PENDING
+  IN_PROGRESS
+  COMPLETED
+  FAILED
+}

--- a/src/application/domain/credential/vcIssuance/service.ts
+++ b/src/application/domain/credential/vcIssuance/service.ts
@@ -122,7 +122,11 @@ export default class VcIssuanceService {
     input: IssueVcInput,
     tx?: Prisma.TransactionClient,
   ): Promise<VcIssuanceRow> {
-    const issuedAt = new Date();
+    // Capture the issuance instant exactly once: re-using the same `Date`
+    // for both the JWT `issuanceDate` claim and downstream persistence
+    // avoids sub-second drift between payload and DB row. Callers (tests,
+    // replay batches) may override via `input.issuedAt`.
+    const issuedAt = input.issuedAt ?? new Date();
     const issuerDid = CIVICSHIP_ISSUER_DID;
 
     // 1) Build the W3C VC payload. §D `credentialStatus` is intentionally

--- a/src/application/domain/credential/vcIssuance/service.ts
+++ b/src/application/domain/credential/vcIssuance/service.ts
@@ -112,6 +112,16 @@ export default class VcIssuanceService {
     private readonly repository: IVcIssuanceRepository,
   ) {}
 
+  /** Pass-through for the GraphQL `vcIssuance` query (Phase 1 step 8). */
+  async findVcById(ctx: IContext, id: string): Promise<VcIssuanceRow | null> {
+    return this.repository.findById(ctx, id);
+  }
+
+  /** Pass-through for the GraphQL `vcIssuancesByUser` query. */
+  async findVcsByUserId(ctx: IContext, userId: string): Promise<VcIssuanceRow[]> {
+    return this.repository.findByUserId(ctx, userId);
+  }
+
   /**
    * §5.2.2: build a VC for the supplied claims, sign-stub it, and persist
    * the resulting row. Anchor wiring (vcAnchorId / anchorLeafIndex) is

--- a/src/application/domain/credential/vcIssuance/service.ts
+++ b/src/application/domain/credential/vcIssuance/service.ts
@@ -1,0 +1,181 @@
+/**
+ * `VcIssuanceService` — application-layer entry point for civicship's
+ * internal Verifiable Credential issuance flow (§5.2.2).
+ *
+ * Per design §5.2.2, each issuance:
+ *
+ *   1. Builds the W3C VC payload with a fixed civicship issuer DID.
+ *   2. Reserves a StatusList slot for revocation (§D credentialStatus).
+ *      ★ Phase 1 step 7 stub: StatusList domain lives in a sibling PR;
+ *        this service emits a placeholder slot reference and leaves
+ *        revocation wiring to Phase 1 step 9.
+ *   3. Encodes header.payload as base64url, leaves the signature empty
+ *      (stub — KMS signer is in `claude/phase1-infra-kms-issuer-did`,
+ *      out of scope for this PR per task brief).
+ *   4. Persists a `VcIssuanceRequest` row with `status = COMPLETED`. The
+ *      `vcAnchorId` is filled in later by the weekly anchor batch.
+ *
+ * Why issue and persist with `COMPLETED` even before anchor confirmation:
+ * §5.2.2 explicitly states "VC 本体は anchor 待ちなしで COMPLETED" — the
+ * UI must be able to present the VC immediately. Anchor state lives on a
+ * separate field (`vcAnchorId`) which the verifier inspects when stronger
+ * trust guarantees are needed.
+ *
+ * Strategy A note (Phase 1 step 7) ----------------------------------------
+ *
+ * The repository is a stub (see `data/repository.ts`) until schema PR
+ * #1094 lands. The signature stub (`vcJwt = "<header>.<payload>.stub-not-signed"`)
+ * exists because the KMS signer lives in PR `claude/phase1-infra-kms-issuer-did`.
+ * Both will be swapped to real implementations in Phase 1 step 9; the
+ * unit tests already verify the JWT shape so the swap is mechanical.
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.2.2 (this service)
+ *   docs/report/did-vc-internalization.md §D     (BitstringStatusList)
+ *   docs/report/did-vc-internalization.md §B     (issuer DID — civicship.app)
+ */
+
+import { inject, injectable } from "tsyringe";
+import type { Prisma } from "@prisma/client";
+import { IContext } from "@/types/server";
+import logger from "@/infrastructure/logging";
+import type { IVcIssuanceRepository } from "@/application/domain/credential/vcIssuance/data/interface";
+import type {
+  IssueVcInput,
+  VcIssuanceRow,
+} from "@/application/domain/credential/vcIssuance/data/type";
+
+/**
+ * Civicship platform issuer DID. Hardcoded per §B / §5.2.2 — civicship is
+ * a platform-issued credential model so there is exactly one issuer.
+ *
+ * TODO(phase1-final): replace with `IssuerDidService.getActiveIssuerDid()`
+ * once the KMS issuer DID PR (`claude/phase1-infra-kms-issuer-did`) lands.
+ */
+export const CIVICSHIP_ISSUER_DID = "did:web:api.civicship.app";
+
+/**
+ * Phase 1 step 7 placeholder for the JWT signature. Real signing lives in
+ * a sibling PR (`claude/phase1-infra-kms-issuer-did`) — we emit a
+ * deterministic non-base64url marker so:
+ *
+ *   1. Tests can assert "this is a stub VC" without false positives.
+ *   2. Verifiers will reject it (it's not a valid base64url signature).
+ *   3. The grep target is unique enough to find every stub site once
+ *      KMS lands.
+ */
+const STUB_SIGNATURE = "stub-not-signed";
+
+/**
+ * Build the unsigned VC payload (§5.2.2 `buildVcPayload`).
+ *
+ * Pure function so the JWT shape is testable without touching the service.
+ * Returns the payload object that becomes the JWT's middle segment.
+ */
+export function buildVcPayload(input: {
+  issuer: string;
+  subject: string;
+  claims: Record<string, unknown>;
+  issuedAt: Date;
+}): Record<string, unknown> {
+  return {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://w3id.org/security/data-integrity/v2",
+    ],
+    type: ["VerifiableCredential"],
+    issuer: input.issuer,
+    issuanceDate: input.issuedAt.toISOString(),
+    credentialSubject: {
+      id: input.subject,
+      ...input.claims,
+    },
+  };
+}
+
+/**
+ * Encode an arbitrary JSON-serializable object as base64url. Used for both
+ * the JWT header and payload segments.
+ *
+ * Spec note: base64url is base64 with `+` → `-`, `/` → `_`, and trailing
+ * `=` removed (RFC 4648 §5). `Buffer.toString("base64url")` does this
+ * natively in Node ≥14.18.
+ */
+function base64urlEncodeJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
+}
+
+@injectable()
+export default class VcIssuanceService {
+  constructor(
+    @inject("VcIssuanceRepository")
+    private readonly repository: IVcIssuanceRepository,
+  ) {}
+
+  /**
+   * §5.2.2: build a VC for the supplied claims, sign-stub it, and persist
+   * the resulting row. Anchor wiring (vcAnchorId / anchorLeafIndex) is
+   * left to the weekly batch.
+   */
+  async issueVc(
+    ctx: IContext,
+    input: IssueVcInput,
+    tx?: Prisma.TransactionClient,
+  ): Promise<VcIssuanceRow> {
+    const issuedAt = new Date();
+    const issuerDid = CIVICSHIP_ISSUER_DID;
+
+    // 1) Build the W3C VC payload. §D `credentialStatus` is intentionally
+    //    NOT embedded here — the StatusList domain lands in Phase 1 step 9
+    //    and will inject the slot via a follow-up service call. Tests
+    //    verify the payload shape independently.
+    const vcPayload = buildVcPayload({
+      issuer: issuerDid,
+      subject: input.subjectDid,
+      claims: input.claims,
+      issuedAt,
+    });
+
+    // 2) Build a JWT-shape envelope. KMS-backed signing lands in
+    //    `claude/phase1-infra-kms-issuer-did`; until then the signature
+    //    segment is a deterministic stub marker (see `STUB_SIGNATURE`).
+    const header = base64urlEncodeJson({
+      alg: "EdDSA",
+      typ: "JWT",
+      // `kid` will reference the active KMS key id once it lands.
+      kid: `${issuerDid}#stub`,
+    });
+    const payload = base64urlEncodeJson(vcPayload);
+    const vcJwt = `${header}.${payload}.${STUB_SIGNATURE}`;
+
+    logger.debug("[VcIssuanceService] issueVc", {
+      userId: input.userId,
+      subjectDid: input.subjectDid,
+      issuerDid,
+      vcFormat: "INTERNAL_JWT",
+      // Don't log the full JWT — it includes the (stub) signature segment
+      // and would create noise once real signatures arrive.
+      jwtLength: vcJwt.length,
+    });
+
+    return this.repository.create(
+      ctx,
+      {
+        userId: input.userId,
+        evaluationId: input.evaluationId ?? null,
+        issuerDid,
+        subjectDid: input.subjectDid,
+        vcFormat: "INTERNAL_JWT",
+        vcJwt,
+        // §D StatusList slot is reserved by a sibling service in Phase 1
+        // step 9; for now, leave both fields null and let the upgrade path
+        // patch them in.
+        statusListIndex: null,
+        statusListCredential: null,
+        // §5.2.2: VC body is COMPLETED even before chain anchor.
+        status: "COMPLETED",
+      },
+      tx,
+    );
+  }
+}

--- a/src/application/domain/credential/vcIssuance/usecase.ts
+++ b/src/application/domain/credential/vcIssuance/usecase.ts
@@ -1,0 +1,35 @@
+/**
+ * `VcIssuanceUseCase` — transaction boundary for the VC issuance flow.
+ *
+ * Phase 1 step 7 scope (per task brief): provide a transaction boundary so
+ * future GraphQL resolvers (Phase 1 step 8) can drop in without re-architecting.
+ * Delegates to `VcIssuanceService` for all real work.
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.2.2
+ *   CLAUDE.md "Transaction Handling Pattern"
+ */
+
+import { inject, injectable } from "tsyringe";
+import { IContext } from "@/types/server";
+import VcIssuanceService from "@/application/domain/credential/vcIssuance/service";
+import type {
+  IssueVcInput,
+  VcIssuanceRow,
+} from "@/application/domain/credential/vcIssuance/data/type";
+
+@injectable()
+export default class VcIssuanceUseCase {
+  constructor(@inject("VcIssuanceService") private readonly service: VcIssuanceService) {}
+
+  /**
+   * Open an issuer-scoped transaction and issue a VC for the supplied
+   * claims. The resulting row is `COMPLETED` per §5.2.2 (anchor state is
+   * tracked separately on `vcAnchorId`).
+   */
+  async issueVc(ctx: IContext, input: IssueVcInput): Promise<VcIssuanceRow> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      return this.service.issueVc(ctx, input, tx);
+    });
+  }
+}

--- a/src/application/domain/credential/vcIssuance/usecase.ts
+++ b/src/application/domain/credential/vcIssuance/usecase.ts
@@ -1,9 +1,15 @@
 /**
  * `VcIssuanceUseCase` — transaction boundary for the VC issuance flow.
  *
- * Phase 1 step 7 scope (per task brief): provide a transaction boundary so
- * future GraphQL resolvers (Phase 1 step 8) can drop in without re-architecting.
- * Delegates to `VcIssuanceService` for all real work.
+ * Phase 1 step 8 scope:
+ *   - Adds GraphQL-facing query handlers (`viewVcIssuance` /
+ *     `viewVcIssuancesByUser`) that delegate to the service and return
+ *     GraphQL types via the presenter.
+ *   - Keeps the existing `issueVc` mutation entry that opens a public
+ *     transaction.
+ *
+ * Per CLAUDE.md, the usecase is the only layer that may open a
+ * transaction; the service stays unaware of `ctx.issuer.public` etc.
  *
  * Design references:
  *   docs/report/did-vc-internalization.md §5.2.2
@@ -13,23 +19,53 @@
 import { inject, injectable } from "tsyringe";
 import { IContext } from "@/types/server";
 import VcIssuanceService from "@/application/domain/credential/vcIssuance/service";
-import type {
-  IssueVcInput,
-  VcIssuanceRow,
-} from "@/application/domain/credential/vcIssuance/data/type";
+import VcIssuancePresenter from "@/application/domain/credential/vcIssuance/presenter";
+import type { IssueVcInput as DomainIssueVcInput } from "@/application/domain/credential/vcIssuance/data/type";
+import type { GqlIssueVcInput, GqlVcIssuance } from "@/types/graphql";
 
 @injectable()
 export default class VcIssuanceUseCase {
   constructor(@inject("VcIssuanceService") private readonly service: VcIssuanceService) {}
 
   /**
+   * GraphQL `vcIssuance(id)` resolver entry. No transaction needed for a
+   * read; we still go through `ctx.issuer.public` so RLS is applied
+   * consistently with the rest of the codebase.
+   */
+  async viewVcIssuance(ctx: IContext, id: string): Promise<GqlVcIssuance | null> {
+    const row = await this.service.findVcById(ctx, id);
+    return row ? VcIssuancePresenter.view(row) : null;
+  }
+
+  /**
+   * GraphQL `vcIssuancesByUser(userId)` resolver entry. Returns an empty
+   * array — never null — to match the GraphQL `[VcIssuance!]!` contract.
+   */
+  async viewVcIssuancesByUser(ctx: IContext, userId: string): Promise<GqlVcIssuance[]> {
+    const rows = await this.service.findVcsByUserId(ctx, userId);
+    return rows.map((row) => VcIssuancePresenter.view(row));
+  }
+
+  /**
    * Open an issuer-scoped transaction and issue a VC for the supplied
    * claims. The resulting row is `COMPLETED` per §5.2.2 (anchor state is
    * tracked separately on `vcAnchorId`).
+   *
+   * Accepts the GraphQL input shape directly so the resolver stays
+   * transport-thin. The conversion to the service's `IssueVcInput` is a
+   * structural projection (only `evaluationId`'s `null → undefined`
+   * normalization is needed because the service signature uses optional).
    */
-  async issueVc(ctx: IContext, input: IssueVcInput): Promise<VcIssuanceRow> {
-    return ctx.issuer.public(ctx, async (tx) => {
-      return this.service.issueVc(ctx, input, tx);
+  async issueVc(ctx: IContext, input: GqlIssueVcInput): Promise<GqlVcIssuance> {
+    const serviceInput: DomainIssueVcInput = {
+      userId: input.userId,
+      evaluationId: input.evaluationId ?? undefined,
+      subjectDid: input.subjectDid,
+      claims: (input.claims ?? {}) as Record<string, unknown>,
+    };
+    const row = await ctx.issuer.public(ctx, async (tx) => {
+      return this.service.issueVc(ctx, serviceInput, tx);
     });
+    return VcIssuancePresenter.view(row);
   }
 }

--- a/src/application/domain/credential/vcIssuance/usecase.ts
+++ b/src/application/domain/credential/vcIssuance/usecase.ts
@@ -11,37 +11,86 @@
  * Per CLAUDE.md, the usecase is the only layer that may open a
  * transaction; the service stays unaware of `ctx.issuer.public` etc.
  *
+ * Authorization (review feedback) ----------------------------------------
+ *
+ * The schema gates on `IsUser` / `IsAdmin`, but neither rule restricts a
+ * read to "the VC's owner". We layer that ownership check here:
+ *
+ *   - `viewVcIssuance(id)`        — load the row, then return `null` if
+ *                                    the caller is neither the owner nor
+ *                                    an admin. `null` instead of `403`
+ *                                    keeps the surface symmetric with
+ *                                    "no such id" so we don't leak
+ *                                    existence to outsiders.
+ *   - `viewVcIssuancesByUser`     — caller must be the target user OR an
+ *                                    admin; otherwise throw
+ *                                    `AuthorizationError` (the request
+ *                                    explicitly names a different user,
+ *                                    so silently returning `[]` would be
+ *                                    indistinguishable from "no VCs yet"
+ *                                    and confusing for clients).
+ *
+ * `issueVc` is already gated on `IsAdmin` at the schema level (§B —
+ * civicship is a single-issuer platform), so no further check is needed.
+ *
  * Design references:
  *   docs/report/did-vc-internalization.md §5.2.2
+ *   docs/report/did-vc-internalization.md §B (single-issuer model)
  *   CLAUDE.md "Transaction Handling Pattern"
  */
 
 import { inject, injectable } from "tsyringe";
 import { IContext } from "@/types/server";
+import { AuthorizationError } from "@/errors/graphql";
 import VcIssuanceService from "@/application/domain/credential/vcIssuance/service";
 import VcIssuancePresenter from "@/application/domain/credential/vcIssuance/presenter";
 import type { IssueVcInput as DomainIssueVcInput } from "@/application/domain/credential/vcIssuance/data/type";
 import type { GqlIssueVcInput, GqlVcIssuance } from "@/types/graphql";
+
+/**
+ * True when the caller is the target user, or when the caller is an
+ * admin. Mirrors the helper in `userDid/usecase.ts`; kept local instead
+ * of cross-importing because a 3-line predicate isn't worth a shared
+ * utility module and the two domains may diverge.
+ */
+function isSelfOrAdmin(ctx: IContext, userId: string): boolean {
+  if (ctx.isAdmin) return true;
+  return ctx.currentUser?.id === userId;
+}
 
 @injectable()
 export default class VcIssuanceUseCase {
   constructor(@inject("VcIssuanceService") private readonly service: VcIssuanceService) {}
 
   /**
-   * GraphQL `vcIssuance(id)` resolver entry. No transaction needed for a
-   * read; we still go through `ctx.issuer.public` so RLS is applied
-   * consistently with the rest of the codebase.
+   * GraphQL `vcIssuance(id)` resolver entry. Reads outside a write
+   * transaction; we still go through `ctx.issuer.public` so RLS is
+   * applied consistently with the rest of the codebase. After the row
+   * is loaded we enforce ownership: callers who are neither the VC's
+   * `userId` nor an admin get `null` — matching the "no such id" path
+   * so we don't leak existence.
    */
   async viewVcIssuance(ctx: IContext, id: string): Promise<GqlVcIssuance | null> {
-    const row = await this.service.findVcById(ctx, id);
-    return row ? VcIssuancePresenter.view(row) : null;
+    const row = await ctx.issuer.public(ctx, async () => {
+      return this.service.findVcById(ctx, id);
+    });
+    if (!row) return null;
+    if (!isSelfOrAdmin(ctx, row.userId)) {
+      return null;
+    }
+    return VcIssuancePresenter.view(row);
   }
 
   /**
-   * GraphQL `vcIssuancesByUser(userId)` resolver entry. Returns an empty
+   * GraphQL `vcIssuancesByUser(userId)` resolver entry. Asserts the
+   * caller is the target user or an admin (the schema's `IsUser` rule
+   * only checks "logged in", not "is the right user"). Returns an empty
    * array — never null — to match the GraphQL `[VcIssuance!]!` contract.
    */
   async viewVcIssuancesByUser(ctx: IContext, userId: string): Promise<GqlVcIssuance[]> {
+    if (!isSelfOrAdmin(ctx, userId)) {
+      throw new AuthorizationError("userId must match the authenticated user");
+    }
     const rows = await this.service.findVcsByUserId(ctx, userId);
     return rows.map((row) => VcIssuancePresenter.view(row));
   }

--- a/src/application/domain/experience/evaluation/vcIssuanceRequest/data/converter.ts
+++ b/src/application/domain/experience/evaluation/vcIssuanceRequest/data/converter.ts
@@ -12,7 +12,20 @@ export default class VCIssuanceRequestConverter {
 
     if (!filter) return {};
 
-    if (filter.status) conditions.push({ status: filter.status });
+    if (filter.status) {
+      // The Phase-1 internal VcIssuance domain (§5.2.2) introduced
+      // `IN_PROGRESS` to the shared `VcIssuanceStatus` GraphQL enum, but the
+      // legacy `VcIssuanceRequest` Prisma model only knows
+      // `PENDING / PROCESSING / COMPLETED / FAILED`. Map the new value to
+      // the closest legacy state so callers filtering with the merged
+      // GraphQL enum still get a sensible result; everything else passes
+      // through unchanged.
+      const status =
+        filter.status === "IN_PROGRESS"
+          ? VcIssuanceStatus.PROCESSING
+          : (filter.status as VcIssuanceStatus);
+      conditions.push({ status });
+    }
     if (filter.userIds?.length) {
       conditions.push({ userId: { in: filter.userIds } });
     }
@@ -29,7 +42,8 @@ export default class VCIssuanceRequestConverter {
   }
 
   toVCIssuanceRequestInput = (evaluation: PrismaEvaluation): EvaluationCredentialPayload => {
-    const { status, opportunity, opportunitySlot, user, evaluator } = this.validateParticipationHasOpportunity(evaluation);
+    const { status, opportunity, opportunitySlot, user, evaluator } =
+      this.validateParticipationHasOpportunity(evaluation);
 
     return {
       claims: {
@@ -58,7 +72,7 @@ export default class VCIssuanceRequestConverter {
     evaluations: Array<{
       evaluation: PrismaEvaluation;
       userId: string;
-    }>
+    }>,
   ): Prisma.VcIssuanceRequestCreateManyInput[] {
     return evaluations.map(({ evaluation, userId }) => {
       const { claims } = this.toVCIssuanceRequestInput(evaluation);

--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -137,6 +137,16 @@ import AnalyticsUseCase from "@/application/domain/analytics/usecase";
 import AnalyticsCommunityService from "@/application/domain/analytics/community/service";
 import AnalyticsCommunityUseCase from "@/application/domain/analytics/community/usecase";
 
+// 🪪 User DID (§5.2 internal DID/VC, Phase 1 step 7 — Strategy A stubs)
+import UserDidService from "@/application/domain/account/userDid/service";
+import UserDidUseCase from "@/application/domain/account/userDid/usecase";
+import UserDidAnchorRepositoryStub from "@/application/domain/account/userDid/data/repository";
+
+// 🪪 VC Issuance (§5.2 internal DID/VC, Phase 1 step 7 — Strategy A stubs)
+import VcIssuanceService from "@/application/domain/credential/vcIssuance/service";
+import VcIssuanceUseCase from "@/application/domain/credential/vcIssuance/usecase";
+import VcIssuanceRepositoryStub from "@/application/domain/credential/vcIssuance/data/repository";
+
 export function registerProductionDependencies() {
   // ------------------------------
   // 🏗️ Infrastructure
@@ -235,6 +245,23 @@ export function registerProductionDependencies() {
   container.register("VCIssuanceRequestConverter", { useClass: VCIssuanceRequestConverter });
   container.register("VCIssuanceRequestService", { useClass: VCIssuanceRequestService });
   container.register("VCIssuanceRequestRepository", { useClass: VCIssuanceRequestRepository });
+
+  // 🪪 User DID (§5.2 internal DID/VC) — Strategy A stub repository.
+  // The stub satisfies `UserDidAnchorStore` (resolver, PR #1096) and the
+  // domain interface; Prisma-backed implementation lands after schema
+  // PR #1094 merges (Phase 1 step 8+).
+  container.register("UserDidAnchorRepository", { useClass: UserDidAnchorRepositoryStub });
+  // Alias used by `DidDocumentResolver` (PR #1096) — same instance.
+  container.register("UserDidAnchorStore", { useClass: UserDidAnchorRepositoryStub });
+  container.register("UserDidService", { useClass: UserDidService });
+  container.register("UserDidUseCase", { useClass: UserDidUseCase });
+
+  // 🪪 VC Issuance (§5.2 internal DID/VC) — Strategy A stub repository.
+  // Distinct from the legacy `VCIssuanceRequest*` registrations above:
+  // those wrap the IDENTUS-era model, this wraps the Phase-1 redesign.
+  container.register("VcIssuanceRepository", { useClass: VcIssuanceRepositoryStub });
+  container.register("VcIssuanceService", { useClass: VcIssuanceService });
+  container.register("VcIssuanceUseCase", { useClass: VcIssuanceUseCase });
 
   // ------------------------------
   // 📰 Content

--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -137,15 +137,19 @@ import AnalyticsUseCase from "@/application/domain/analytics/usecase";
 import AnalyticsCommunityService from "@/application/domain/analytics/community/service";
 import AnalyticsCommunityUseCase from "@/application/domain/analytics/community/usecase";
 
-// 🪪 User DID (§5.2 internal DID/VC, Phase 1 step 7 — Strategy A stubs)
+// 🪪 User DID (§5.2 internal DID/VC, Phase 1 step 7 — Strategy A stubs;
+//   step 8 adds the GraphQL resolver registration)
 import UserDidService from "@/application/domain/account/userDid/service";
 import UserDidUseCase from "@/application/domain/account/userDid/usecase";
 import UserDidAnchorRepositoryStub from "@/application/domain/account/userDid/data/repository";
+import UserDidResolver from "@/application/domain/account/userDid/controller/resolver";
 
-// 🪪 VC Issuance (§5.2 internal DID/VC, Phase 1 step 7 — Strategy A stubs)
+// 🪪 VC Issuance (§5.2 internal DID/VC, Phase 1 step 7 — Strategy A stubs;
+//   step 8 adds the GraphQL resolver registration)
 import VcIssuanceService from "@/application/domain/credential/vcIssuance/service";
 import VcIssuanceUseCase from "@/application/domain/credential/vcIssuance/usecase";
 import VcIssuanceRepositoryStub from "@/application/domain/credential/vcIssuance/data/repository";
+import VcIssuanceResolver from "@/application/domain/credential/vcIssuance/controller/resolver";
 
 export function registerProductionDependencies() {
   // ------------------------------
@@ -255,6 +259,7 @@ export function registerProductionDependencies() {
   container.register("UserDidAnchorStore", { useClass: UserDidAnchorRepositoryStub });
   container.register("UserDidService", { useClass: UserDidService });
   container.register("UserDidUseCase", { useClass: UserDidUseCase });
+  container.register("UserDidResolver", { useClass: UserDidResolver });
 
   // 🪪 VC Issuance (§5.2 internal DID/VC) — Strategy A stub repository.
   // Distinct from the legacy `VCIssuanceRequest*` registrations above:
@@ -262,6 +267,7 @@ export function registerProductionDependencies() {
   container.register("VcIssuanceRepository", { useClass: VcIssuanceRepositoryStub });
   container.register("VcIssuanceService", { useClass: VcIssuanceService });
   container.register("VcIssuanceUseCase", { useClass: VcIssuanceUseCase });
+  container.register("VcIssuanceResolver", { useClass: VcIssuanceResolver });
 
   // ------------------------------
   // 📰 Content

--- a/src/presentation/graphql/resolver.ts
+++ b/src/presentation/graphql/resolver.ts
@@ -31,6 +31,11 @@ import ReportResolver from "@/application/domain/report/controller/resolver";
 import ReportFeedbackResolver from "@/application/domain/report/feedback/controller/resolver";
 import AnalyticsCommunityResolver from "@/application/domain/analytics/community/controller/resolver";
 import AnalyticsResolver from "@/application/domain/analytics/controller/resolver";
+
+// 🪪 Internal DID/VC (§5.2 — Phase 1 step 8)
+import UserDidResolver from "@/application/domain/account/userDid/controller/resolver";
+import VcIssuanceResolver from "@/application/domain/credential/vcIssuance/controller/resolver";
+
 import scalarResolvers from "@/presentation/graphql/scalar";
 
 const identity = container.resolve(IdentityResolver);
@@ -70,6 +75,9 @@ const reportFeedback = container.resolve(ReportFeedbackResolver);
 const analyticsCommunity = container.resolve(AnalyticsCommunityResolver);
 const analytics = container.resolve(AnalyticsResolver);
 
+const userDid = container.resolve(UserDidResolver);
+const vcIssuance = container.resolve(VcIssuanceResolver);
+
 const resolvers = {
   Query: {
     ...identity.Query,
@@ -102,6 +110,8 @@ const resolvers = {
     ...reportFeedback.Query,
     ...analyticsCommunity.Query,
     ...analytics.Query,
+    ...userDid.Query,
+    ...vcIssuance.Query,
   },
   Mutation: {
     ...identity.Mutation,
@@ -122,6 +132,8 @@ const resolvers = {
     ...vote.Mutation,
     ...report.Mutation,
     ...reportFeedback.Mutation,
+    ...userDid.Mutation,
+    ...vcIssuance.Mutation,
   },
   Identity: identity.Identity,
   User: user.User,

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1169,6 +1169,21 @@ export type GqlAnalyticsWindowActivity = {
   senderCountPrev: Scalars['Int']['output'];
 };
 
+/**
+ * chain anchor のライフサイクル状態 (§4.1, §F)。
+ * - PENDING: DB 永続化済み、weekly anchor batch 未投入
+ * - SUBMITTED: Cardano tx 送信済み、未確定
+ * - CONFIRMED: tx finalized
+ * - FAILED: tx 失敗 / 再送対象
+ */
+export const GqlAnchorStatus = {
+  Confirmed: 'CONFIRMED',
+  Failed: 'FAILED',
+  Pending: 'PENDING',
+  Submitted: 'SUBMITTED'
+} as const;
+
+export type GqlAnchorStatus = typeof GqlAnchorStatus[keyof typeof GqlAnchorStatus];
 export type GqlApproveReportPayload = GqlApproveReportSuccess;
 
 export type GqlApproveReportSuccess = {
@@ -1305,6 +1320,13 @@ export const GqlAuthZRules = {
 } as const;
 
 export type GqlAuthZRules = typeof GqlAuthZRules[keyof typeof GqlAuthZRules];
+/** chain network 識別子 (§4.1)。Phase 1 は Cardano のみサポート。 */
+export const GqlChainNetwork = {
+  CardanoMainnet: 'CARDANO_MAINNET',
+  CardanoPreprod: 'CARDANO_PREPROD'
+} as const;
+
+export type GqlChainNetwork = typeof GqlChainNetwork[keyof typeof GqlChainNetwork];
 export type GqlCheckCommunityPermissionInput = {
   communityId: Scalars['ID']['input'];
 };
@@ -1575,6 +1597,12 @@ export type GqlCommunityUpdateProfileSuccess = {
   community: GqlCommunity;
 };
 
+export type GqlCreateUserDidInput = {
+  /** 対象 chain network。未指定時は CARDANO_MAINNET (§5.2.1)。 */
+  network?: InputMaybe<GqlChainNetwork>;
+  userId: Scalars['ID']['input'];
+};
+
 export type GqlCurrentPointView = {
   __typename?: 'CurrentPointView';
   currentPoint: Scalars['BigInt']['output'];
@@ -1623,6 +1651,19 @@ export const GqlDidIssuanceStatus = {
 } as const;
 
 export type GqlDidIssuanceStatus = typeof GqlDidIssuanceStatus[keyof typeof GqlDidIssuanceStatus];
+/**
+ * DID lifecycle 操作種別 (§4.1)。
+ * - CREATE: 初回作成
+ * - UPDATE: 既存 DID Document の差し替え
+ * - DEACTIVATE: tombstone (§E)
+ */
+export const GqlDidOperation = {
+  Create: 'CREATE',
+  Deactivate: 'DEACTIVATE',
+  Update: 'UPDATE'
+} as const;
+
+export type GqlDidOperation = typeof GqlDidOperation[keyof typeof GqlDidOperation];
 export type GqlEdge = {
   cursor: Scalars['String']['output'];
 };
@@ -1896,6 +1937,17 @@ export type GqlIncentiveGrantsConnection = {
   totalCount: Scalars['Int']['output'];
 };
 
+export type GqlIssueVcInput = {
+  /** VC に乗せる claim 群。issuer 側で validation は行わず opaque に署名される。 */
+  claims: Scalars['JSON']['input'];
+  /** VC を Evaluation に紐づける場合の id。 */
+  evaluationId?: InputMaybe<Scalars['ID']['input']>;
+  /** ユーザーの did:web:api.civicship.app:users:<id> (§B)。 */
+  subjectDid: Scalars['String']['input'];
+  /** VC を保有するユーザー id。 */
+  userId: Scalars['ID']['input'];
+};
+
 export const GqlLanguage = {
   En: 'EN',
   Ja: 'JA'
@@ -2066,10 +2118,26 @@ export type GqlMutation = {
   communityCreate?: Maybe<GqlCommunityCreatePayload>;
   communityDelete?: Maybe<GqlCommunityDeletePayload>;
   communityUpdateProfile?: Maybe<GqlCommunityUpdateProfilePayload>;
+  /**
+   * ユーザー DID を新規作成する。CREATE-op の UserDidAnchor を PENDING で永続化する。
+   * 自分の userId のみ許可。`permission.userId` と `input.userId` が一致しなければならない。
+   */
+  createUserDid: GqlUserDidAnchor;
+  /**
+   * ユーザー DID を deactivate する。DEACTIVATE-op の UserDidAnchor を PENDING で永続化する。
+   * 自分の userId のみ許可。
+   */
+  deactivateUserDid: GqlUserDidAnchor;
   evaluationBulkCreate?: Maybe<GqlEvaluationBulkCreatePayload>;
   generateReport?: Maybe<GqlGenerateReportPayload>;
   identityCheckPhoneUser: GqlIdentityCheckPhoneUserPayload;
   incentiveGrantRetry?: Maybe<GqlIncentiveGrantRetryPayload>;
+  /**
+   * VC を発行する。civicship platform 専用 issuer による単一 issuer モデル (§B)。
+   * Phase 1 では admin / system のみが直接呼び出せる。
+   * 本体は anchor 待ちなしで COMPLETED として永続化される (§5.2.2)。
+   */
+  issueVc: GqlVcIssuance;
   linkPhoneAuth?: Maybe<GqlLinkPhoneAuthPayload>;
   membershipAcceptMyInvitation?: Maybe<GqlMembershipSetInvitationStatusPayload>;
   membershipAssignManager?: Maybe<GqlMembershipSetRolePayload>;
@@ -2194,6 +2262,18 @@ export type GqlMutationCommunityUpdateProfileArgs = {
 };
 
 
+export type GqlMutationCreateUserDidArgs = {
+  input: GqlCreateUserDidInput;
+  permission: GqlCheckIsSelfPermissionInput;
+};
+
+
+export type GqlMutationDeactivateUserDidArgs = {
+  permission: GqlCheckIsSelfPermissionInput;
+  userId: Scalars['ID']['input'];
+};
+
+
 export type GqlMutationEvaluationBulkCreateArgs = {
   input: GqlEvaluationBulkCreateInput;
   permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
@@ -2214,6 +2294,11 @@ export type GqlMutationIdentityCheckPhoneUserArgs = {
 export type GqlMutationIncentiveGrantRetryArgs = {
   input: GqlIncentiveGrantRetryInput;
   permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationIssueVcArgs = {
+  input: GqlIssueVcInput;
 };
 
 
@@ -3356,11 +3441,27 @@ export type GqlQuery = {
   transaction?: Maybe<GqlTransaction>;
   transactions: GqlTransactionsConnection;
   user?: Maybe<GqlUser>;
+  /**
+   * 指定ユーザーの最新 UserDidAnchor を返却する。
+   * 存在しない場合は null。PENDING 状態でも返却される (§F)。
+   * 認証必須。
+   */
+  userDid?: Maybe<GqlUserDidAnchor>;
   users: GqlUsersConnection;
   utilities: GqlUtilitiesConnection;
   utility?: Maybe<GqlUtility>;
+  /**
+   * 単一 VC issuance を id で取得。存在しない場合は null。
+   * 認証必須。
+   */
+  vcIssuance?: Maybe<GqlVcIssuance>;
   vcIssuanceRequest?: Maybe<GqlVcIssuanceRequest>;
   vcIssuanceRequests: GqlVcIssuanceRequestsConnection;
+  /**
+   * 指定ユーザーが保有する VC issuance 一覧を返却する。
+   * 認証必須。
+   */
+  vcIssuancesByUser: Array<GqlVcIssuance>;
   /**
    * Verify transactions against the Cardano blockchain.
    * - Retrieves Merkle proofs for specified transactions
@@ -3776,6 +3877,11 @@ export type GqlQueryUserArgs = {
 };
 
 
+export type GqlQueryUserDidArgs = {
+  userId: Scalars['ID']['input'];
+};
+
+
 export type GqlQueryUsersArgs = {
   cursor?: InputMaybe<Scalars['String']['input']>;
   filter?: InputMaybe<GqlUserFilterInput>;
@@ -3798,6 +3904,11 @@ export type GqlQueryUtilityArgs = {
 };
 
 
+export type GqlQueryVcIssuanceArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
 export type GqlQueryVcIssuanceRequestArgs = {
   id: Scalars['ID']['input'];
 };
@@ -3808,6 +3919,11 @@ export type GqlQueryVcIssuanceRequestsArgs = {
   filter?: InputMaybe<GqlVcIssuanceRequestFilterInput>;
   first?: InputMaybe<Scalars['Int']['input']>;
   sort?: InputMaybe<GqlVcIssuanceRequestSortInput>;
+};
+
+
+export type GqlQueryVcIssuancesByUserArgs = {
+  userId: Scalars['ID']['input'];
 };
 
 
@@ -4750,6 +4866,25 @@ export type GqlUserDeletePayload = {
   userId?: Maybe<Scalars['ID']['output']>;
 };
 
+/**
+ * ユーザー DID の chain anchor 1 件を表す。
+ * PENDING 状態でも返却される（§F: PENDING も resolver で配信）。
+ * chainTxHash / chainOpIndex / confirmedAt は CONFIRMED で初めて埋まる。
+ */
+export type GqlUserDidAnchor = {
+  __typename?: 'UserDidAnchor';
+  chainOpIndex?: Maybe<Scalars['Int']['output']>;
+  chainTxHash?: Maybe<Scalars['String']['output']>;
+  confirmedAt?: Maybe<Scalars['Datetime']['output']>;
+  createdAt: Scalars['Datetime']['output'];
+  did: Scalars['String']['output'];
+  documentHash: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  network: GqlChainNetwork;
+  operation: GqlDidOperation;
+  status: GqlAnchorStatus;
+};
+
 export type GqlUserEdge = GqlEdge & {
   __typename?: 'UserEdge';
   cursor: Scalars['String']['output'];
@@ -4907,6 +5042,38 @@ export const GqlValueType = {
 } as const;
 
 export type GqlValueType = typeof GqlValueType[keyof typeof GqlValueType];
+/**
+ * VC のシリアライゼーション形式 (§4.1)。
+ * Phase 1 は INTERNAL_JWT のみ (§5.2.2)。
+ * IDENTUS_VC_PRISM は legacy 互換のため列挙のみ保持。
+ */
+export const GqlVcFormat = {
+  IdentusVcPrism: 'IDENTUS_VC_PRISM',
+  InternalJwt: 'INTERNAL_JWT'
+} as const;
+
+export type GqlVcFormat = typeof GqlVcFormat[keyof typeof GqlVcFormat];
+/**
+ * civicship が発行した内部 VC (§5.2.2)。
+ * 本体は anchor 待ちなしで COMPLETED として配信される。
+ * chain anchor の状態は別フィールドで管理されており、検証側はそれを参照する。
+ */
+export type GqlVcIssuance = {
+  __typename?: 'VcIssuance';
+  createdAt: Scalars['Datetime']['output'];
+  evaluationId?: Maybe<Scalars['ID']['output']>;
+  id: Scalars['ID']['output'];
+  issuerDid: Scalars['String']['output'];
+  revokedAt?: Maybe<Scalars['Datetime']['output']>;
+  status: GqlVcIssuanceStatus;
+  statusListCredential?: Maybe<Scalars['String']['output']>;
+  statusListIndex?: Maybe<Scalars['Int']['output']>;
+  subjectDid: Scalars['String']['output'];
+  userId: Scalars['ID']['output'];
+  vcFormat: GqlVcFormat;
+  vcJwt: Scalars['String']['output'];
+};
+
 export type GqlVcIssuanceRequest = {
   __typename?: 'VcIssuanceRequest';
   completedAt?: Maybe<Scalars['Datetime']['output']>;
@@ -4944,9 +5111,11 @@ export type GqlVcIssuanceRequestsConnection = {
   totalCount: Scalars['Int']['output'];
 };
 
+/** VC issuance のライフサイクル状態 (§4.1)。 */
 export const GqlVcIssuanceStatus = {
   Completed: 'COMPLETED',
   Failed: 'FAILED',
+  InProgress: 'IN_PROGRESS',
   Pending: 'PENDING',
   Processing: 'PROCESSING'
 } as const;
@@ -5438,6 +5607,7 @@ export type GqlResolversTypes = ResolversObject<{
   AnalyticsUserSortField: GqlAnalyticsUserSortField;
   AnalyticsWeeklyRetention: ResolverTypeWrapper<GqlAnalyticsWeeklyRetention>;
   AnalyticsWindowActivity: ResolverTypeWrapper<GqlAnalyticsWindowActivity>;
+  AnchorStatus: GqlAnchorStatus;
   ApproveReportPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['ApproveReportPayload']>;
   ApproveReportSuccess: ResolverTypeWrapper<Omit<GqlApproveReportSuccess, 'report'> & { report: GqlResolversTypes['Report'] }>;
   Article: ResolverTypeWrapper<Article>;
@@ -5459,6 +5629,7 @@ export type GqlResolversTypes = ResolversObject<{
   AuthZRules: GqlAuthZRules;
   BigInt: ResolverTypeWrapper<Scalars['BigInt']['output']>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
+  ChainNetwork: GqlChainNetwork;
   CheckCommunityPermissionInput: GqlCheckCommunityPermissionInput;
   CheckIsSelfPermissionInput: GqlCheckIsSelfPermissionInput;
   CheckOpportunityPermissionInput: GqlCheckOpportunityPermissionInput;
@@ -5495,6 +5666,7 @@ export type GqlResolversTypes = ResolversObject<{
   CommunityUpdateProfileInput: GqlCommunityUpdateProfileInput;
   CommunityUpdateProfilePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['CommunityUpdateProfilePayload']>;
   CommunityUpdateProfileSuccess: ResolverTypeWrapper<Omit<GqlCommunityUpdateProfileSuccess, 'community'> & { community: GqlResolversTypes['Community'] }>;
+  CreateUserDidInput: GqlCreateUserDidInput;
   CurrentPointView: ResolverTypeWrapper<CurrentPointView>;
   CurrentPrefecture: GqlCurrentPrefecture;
   CurrentUserPayload: ResolverTypeWrapper<Omit<GqlCurrentUserPayload, 'user'> & { user?: Maybe<GqlResolversTypes['User']> }>;
@@ -5503,6 +5675,7 @@ export type GqlResolversTypes = ResolversObject<{
   Decimal: ResolverTypeWrapper<Scalars['Decimal']['output']>;
   DidIssuanceRequest: ResolverTypeWrapper<GqlDidIssuanceRequest>;
   DidIssuanceStatus: GqlDidIssuanceStatus;
+  DidOperation: GqlDidOperation;
   Edge: ResolverTypeWrapper<GqlResolversInterfaceTypes<GqlResolversTypes>['Edge']>;
   Error: ResolverTypeWrapper<GqlError>;
   ErrorCode: GqlErrorCode;
@@ -5544,6 +5717,7 @@ export type GqlResolversTypes = ResolversObject<{
   IncentiveGrantType: GqlIncentiveGrantType;
   IncentiveGrantsConnection: ResolverTypeWrapper<Omit<GqlIncentiveGrantsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['IncentiveGrantEdge']>>> }>;
   Int: ResolverTypeWrapper<Scalars['Int']['output']>;
+  IssueVcInput: GqlIssueVcInput;
   JSON: ResolverTypeWrapper<Scalars['JSON']['output']>;
   Language: GqlLanguage;
   LineRichMenuType: GqlLineRichMenuType;
@@ -5790,6 +5964,7 @@ export type GqlResolversTypes = ResolversObject<{
   Upload: ResolverTypeWrapper<Scalars['Upload']['output']>;
   User: ResolverTypeWrapper<User>;
   UserDeletePayload: ResolverTypeWrapper<GqlUserDeletePayload>;
+  UserDidAnchor: ResolverTypeWrapper<GqlUserDidAnchor>;
   UserEdge: ResolverTypeWrapper<Omit<GqlUserEdge, 'node'> & { node?: Maybe<GqlResolversTypes['User']> }>;
   UserFilterInput: GqlUserFilterInput;
   UserSignUpInput: GqlUserSignUpInput;
@@ -5815,6 +5990,8 @@ export type GqlResolversTypes = ResolversObject<{
   UtilityUpdateInfoPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['UtilityUpdateInfoPayload']>;
   UtilityUpdateInfoSuccess: ResolverTypeWrapper<Omit<GqlUtilityUpdateInfoSuccess, 'utility'> & { utility: GqlResolversTypes['Utility'] }>;
   ValueType: GqlValueType;
+  VcFormat: GqlVcFormat;
+  VcIssuance: ResolverTypeWrapper<GqlVcIssuance>;
   VcIssuanceRequest: ResolverTypeWrapper<Omit<GqlVcIssuanceRequest, 'evaluation' | 'user'> & { evaluation?: Maybe<GqlResolversTypes['Evaluation']>, user?: Maybe<GqlResolversTypes['User']> }>;
   VcIssuanceRequestEdge: ResolverTypeWrapper<Omit<GqlVcIssuanceRequestEdge, 'node'> & { node?: Maybe<GqlResolversTypes['VcIssuanceRequest']> }>;
   VcIssuanceRequestFilterInput: GqlVcIssuanceRequestFilterInput;
@@ -5941,6 +6118,7 @@ export type GqlResolversParentTypes = ResolversObject<{
   CommunityUpdateProfileInput: GqlCommunityUpdateProfileInput;
   CommunityUpdateProfilePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['CommunityUpdateProfilePayload'];
   CommunityUpdateProfileSuccess: Omit<GqlCommunityUpdateProfileSuccess, 'community'> & { community: GqlResolversParentTypes['Community'] };
+  CreateUserDidInput: GqlCreateUserDidInput;
   CurrentPointView: CurrentPointView;
   CurrentUserPayload: Omit<GqlCurrentUserPayload, 'user'> & { user?: Maybe<GqlResolversParentTypes['User']> };
   DateTimeRangeFilter: GqlDateTimeRangeFilter;
@@ -5982,6 +6160,7 @@ export type GqlResolversParentTypes = ResolversObject<{
   IncentiveGrantSortInput: GqlIncentiveGrantSortInput;
   IncentiveGrantsConnection: Omit<GqlIncentiveGrantsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['IncentiveGrantEdge']>>> };
   Int: Scalars['Int']['output'];
+  IssueVcInput: GqlIssueVcInput;
   JSON: Scalars['JSON']['output'];
   LinkPhoneAuthInput: GqlLinkPhoneAuthInput;
   LinkPhoneAuthPayload: Omit<GqlLinkPhoneAuthPayload, 'user'> & { user?: Maybe<GqlResolversParentTypes['User']> };
@@ -6201,6 +6380,7 @@ export type GqlResolversParentTypes = ResolversObject<{
   Upload: Scalars['Upload']['output'];
   User: User;
   UserDeletePayload: GqlUserDeletePayload;
+  UserDidAnchor: GqlUserDidAnchor;
   UserEdge: Omit<GqlUserEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['User']> };
   UserFilterInput: GqlUserFilterInput;
   UserSignUpInput: GqlUserSignUpInput;
@@ -6225,6 +6405,7 @@ export type GqlResolversParentTypes = ResolversObject<{
   UtilityUpdateInfoInput: GqlUtilityUpdateInfoInput;
   UtilityUpdateInfoPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['UtilityUpdateInfoPayload'];
   UtilityUpdateInfoSuccess: Omit<GqlUtilityUpdateInfoSuccess, 'utility'> & { utility: GqlResolversParentTypes['Utility'] };
+  VcIssuance: GqlVcIssuance;
   VcIssuanceRequest: Omit<GqlVcIssuanceRequest, 'evaluation' | 'user'> & { evaluation?: Maybe<GqlResolversParentTypes['Evaluation']>, user?: Maybe<GqlResolversParentTypes['User']> };
   VcIssuanceRequestEdge: Omit<GqlVcIssuanceRequestEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['VcIssuanceRequest']> };
   VcIssuanceRequestFilterInput: GqlVcIssuanceRequestFilterInput;
@@ -6953,10 +7134,13 @@ export type GqlMutationResolvers<ContextType = any, ParentType extends GqlResolv
   communityCreate?: Resolver<Maybe<GqlResolversTypes['CommunityCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationCommunityCreateArgs, 'input'>>;
   communityDelete?: Resolver<Maybe<GqlResolversTypes['CommunityDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationCommunityDeleteArgs, 'id'>>;
   communityUpdateProfile?: Resolver<Maybe<GqlResolversTypes['CommunityUpdateProfilePayload']>, ParentType, ContextType, RequireFields<GqlMutationCommunityUpdateProfileArgs, 'id' | 'input'>>;
+  createUserDid?: Resolver<GqlResolversTypes['UserDidAnchor'], ParentType, ContextType, RequireFields<GqlMutationCreateUserDidArgs, 'input' | 'permission'>>;
+  deactivateUserDid?: Resolver<GqlResolversTypes['UserDidAnchor'], ParentType, ContextType, RequireFields<GqlMutationDeactivateUserDidArgs, 'permission' | 'userId'>>;
   evaluationBulkCreate?: Resolver<Maybe<GqlResolversTypes['EvaluationBulkCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationEvaluationBulkCreateArgs, 'input'>>;
   generateReport?: Resolver<Maybe<GqlResolversTypes['GenerateReportPayload']>, ParentType, ContextType, RequireFields<GqlMutationGenerateReportArgs, 'input'>>;
   identityCheckPhoneUser?: Resolver<GqlResolversTypes['IdentityCheckPhoneUserPayload'], ParentType, ContextType, RequireFields<GqlMutationIdentityCheckPhoneUserArgs, 'input'>>;
   incentiveGrantRetry?: Resolver<Maybe<GqlResolversTypes['IncentiveGrantRetryPayload']>, ParentType, ContextType, RequireFields<GqlMutationIncentiveGrantRetryArgs, 'input'>>;
+  issueVc?: Resolver<GqlResolversTypes['VcIssuance'], ParentType, ContextType, RequireFields<GqlMutationIssueVcArgs, 'input'>>;
   linkPhoneAuth?: Resolver<Maybe<GqlResolversTypes['LinkPhoneAuthPayload']>, ParentType, ContextType, RequireFields<GqlMutationLinkPhoneAuthArgs, 'input' | 'permission'>>;
   membershipAcceptMyInvitation?: Resolver<Maybe<GqlResolversTypes['MembershipSetInvitationStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationMembershipAcceptMyInvitationArgs, 'input' | 'permission'>>;
   membershipAssignManager?: Resolver<Maybe<GqlResolversTypes['MembershipSetRolePayload']>, ParentType, ContextType, RequireFields<GqlMutationMembershipAssignManagerArgs, 'input'>>;
@@ -7456,11 +7640,14 @@ export type GqlQueryResolvers<ContextType = any, ParentType extends GqlResolvers
   transaction?: Resolver<Maybe<GqlResolversTypes['Transaction']>, ParentType, ContextType, RequireFields<GqlQueryTransactionArgs, 'id'>>;
   transactions?: Resolver<GqlResolversTypes['TransactionsConnection'], ParentType, ContextType, Partial<GqlQueryTransactionsArgs>>;
   user?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType, RequireFields<GqlQueryUserArgs, 'id'>>;
+  userDid?: Resolver<Maybe<GqlResolversTypes['UserDidAnchor']>, ParentType, ContextType, RequireFields<GqlQueryUserDidArgs, 'userId'>>;
   users?: Resolver<GqlResolversTypes['UsersConnection'], ParentType, ContextType, Partial<GqlQueryUsersArgs>>;
   utilities?: Resolver<GqlResolversTypes['UtilitiesConnection'], ParentType, ContextType, Partial<GqlQueryUtilitiesArgs>>;
   utility?: Resolver<Maybe<GqlResolversTypes['Utility']>, ParentType, ContextType, RequireFields<GqlQueryUtilityArgs, 'id'>>;
+  vcIssuance?: Resolver<Maybe<GqlResolversTypes['VcIssuance']>, ParentType, ContextType, RequireFields<GqlQueryVcIssuanceArgs, 'id'>>;
   vcIssuanceRequest?: Resolver<Maybe<GqlResolversTypes['VcIssuanceRequest']>, ParentType, ContextType, RequireFields<GqlQueryVcIssuanceRequestArgs, 'id'>>;
   vcIssuanceRequests?: Resolver<GqlResolversTypes['VcIssuanceRequestsConnection'], ParentType, ContextType, Partial<GqlQueryVcIssuanceRequestsArgs>>;
+  vcIssuancesByUser?: Resolver<Array<GqlResolversTypes['VcIssuance']>, ParentType, ContextType, RequireFields<GqlQueryVcIssuancesByUserArgs, 'userId'>>;
   verifyTransactions?: Resolver<Maybe<Array<GqlResolversTypes['TransactionVerificationResult']>>, ParentType, ContextType, RequireFields<GqlQueryVerifyTransactionsArgs, 'txIds'>>;
   voteTopic?: Resolver<Maybe<GqlResolversTypes['VoteTopic']>, ParentType, ContextType, RequireFields<GqlQueryVoteTopicArgs, 'id'>>;
   voteTopics?: Resolver<GqlResolversTypes['VoteTopicsConnection'], ParentType, ContextType, RequireFields<GqlQueryVoteTopicsArgs, 'communityId'>>;
@@ -8002,6 +8189,19 @@ export type GqlUserDeletePayloadResolvers<ContextType = any, ParentType extends 
   userId?: Resolver<Maybe<GqlResolversTypes['ID']>, ParentType, ContextType>;
 }>;
 
+export type GqlUserDidAnchorResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['UserDidAnchor'] = GqlResolversParentTypes['UserDidAnchor']> = ResolversObject<{
+  chainOpIndex?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  chainTxHash?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  confirmedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  did?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  documentHash?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  network?: Resolver<GqlResolversTypes['ChainNetwork'], ParentType, ContextType>;
+  operation?: Resolver<GqlResolversTypes['DidOperation'], ParentType, ContextType>;
+  status?: Resolver<GqlResolversTypes['AnchorStatus'], ParentType, ContextType>;
+}>;
+
 export type GqlUserEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['UserEdge'] = GqlResolversParentTypes['UserEdge']> = ResolversObject<{
   cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
   node?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
@@ -8085,6 +8285,21 @@ export type GqlUtilityUpdateInfoPayloadResolvers<ContextType = any, ParentType e
 export type GqlUtilityUpdateInfoSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['UtilityUpdateInfoSuccess'] = GqlResolversParentTypes['UtilityUpdateInfoSuccess']> = ResolversObject<{
   utility?: Resolver<GqlResolversTypes['Utility'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVcIssuanceResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VcIssuance'] = GqlResolversParentTypes['VcIssuance']> = ResolversObject<{
+  createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  evaluationId?: Resolver<Maybe<GqlResolversTypes['ID']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  issuerDid?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  revokedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  status?: Resolver<GqlResolversTypes['VcIssuanceStatus'], ParentType, ContextType>;
+  statusListCredential?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  statusListIndex?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  subjectDid?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  userId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  vcFormat?: Resolver<GqlResolversTypes['VcFormat'], ParentType, ContextType>;
+  vcJwt?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
 }>;
 
 export type GqlVcIssuanceRequestResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VcIssuanceRequest'] = GqlResolversParentTypes['VcIssuanceRequest']> = ResolversObject<{
@@ -8462,6 +8677,7 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   Upload?: GraphQLScalarType;
   User?: GqlUserResolvers<ContextType>;
   UserDeletePayload?: GqlUserDeletePayloadResolvers<ContextType>;
+  UserDidAnchor?: GqlUserDidAnchorResolvers<ContextType>;
   UserEdge?: GqlUserEdgeResolvers<ContextType>;
   UserUpdateProfilePayload?: GqlUserUpdateProfilePayloadResolvers<ContextType>;
   UserUpdateProfileSuccess?: GqlUserUpdateProfileSuccessResolvers<ContextType>;
@@ -8477,6 +8693,7 @@ export type GqlResolvers<ContextType = any> = ResolversObject<{
   UtilitySetPublishStatusSuccess?: GqlUtilitySetPublishStatusSuccessResolvers<ContextType>;
   UtilityUpdateInfoPayload?: GqlUtilityUpdateInfoPayloadResolvers<ContextType>;
   UtilityUpdateInfoSuccess?: GqlUtilityUpdateInfoSuccessResolvers<ContextType>;
+  VcIssuance?: GqlVcIssuanceResolvers<ContextType>;
   VcIssuanceRequest?: GqlVcIssuanceRequestResolvers<ContextType>;
   VcIssuanceRequestEdge?: GqlVcIssuanceRequestEdgeResolvers<ContextType>;
   VcIssuanceRequestsConnection?: GqlVcIssuanceRequestsConnectionResolvers<ContextType>;


### PR DESCRIPTION
## 概要

DID/VC 内製化 Phase 1 step 8 (H) として、`UserDid` / `VcIssuance` ドメインの GraphQL Query / Mutation を実装する。設計書 `docs/report/did-vc-internalization.md` §5.2.1 / §5.2.2 に対応。

スタック関係:
- 親 PR: #1082 (`claude/did-vc-internalization-review-eptzS`)
- 依存 PR: #1098 (`claude/phase1-app-services`) — 本 PR は app services の上で実装している。`#1098` がマージされた後にレビュー / マージすること。

## 追加した GraphQL schema

### `UserDidAnchor` (account/userDid)
- `type UserDidAnchor` + `enum DidOperation` / `AnchorStatus` / `ChainNetwork`
- `Query.userDid(userId: ID!): UserDidAnchor` — 認証必須 (`IsUser`)
- `Mutation.createUserDid(input: CreateUserDidInput!, permission: CheckIsSelfPermissionInput!): UserDidAnchor!` — `IsSelf`
- `Mutation.deactivateUserDid(userId: ID!, permission: CheckIsSelfPermissionInput!): UserDidAnchor!` — `IsSelf`

### `VcIssuance` (credential/vcIssuance)
- `type VcIssuance` + `enum VcFormat` (既存 `VcIssuanceStatus` enum に `IN_PROGRESS` を追加)
- `Query.vcIssuance(id: ID!): VcIssuance` — `IsUser`
- `Query.vcIssuancesByUser(userId: ID!): [VcIssuance!]!` — `IsUser`
- `Mutation.issueVc(input: IssueVcInput!): VcIssuance!` — `IsAdmin`

## 追加した Resolver / DI

- `UserDidResolver` / `VcIssuanceResolver` を `controller/resolver.ts` に追加。usecase 委譲のみ。
- `provider.ts` に `UserDidResolver` / `VcIssuanceResolver` を登録。
- `presentation/graphql/resolver.ts` の Query/Mutation merge 経路に組み込み。

## Authorization rule

すべて schema の `@authz(rules: [...])` ディレクティブで宣言（既存パターン）:
- `IsUser`: 認証ユーザー全般 (Query 群)
- `IsSelf`: 自分の userId のみ (`createUserDid` / `deactivateUserDid`)
- `IsAdmin`: 管理者のみ (`issueVc`)

## UseCase / Service / Presenter の変更

- `UserDidUseCase` に GraphQL 向けエントリ (`viewUserDid`, `createUserDidForUser`, `deactivateUserDidForUser`) を追加し、presenter で `GqlUserDidAnchor` を返却。既存の service 用 wrapper も保持。
- `VcIssuanceUseCase` 同様に `viewVcIssuance` / `viewVcIssuancesByUser` / `issueVc` を整備。
- 戦略 A の row 型 (`UserDidAnchorRow` / `VcIssuanceRow`) に GraphQL が要求する `id` / `userId` / `createdAt` / `revokedAt` を追加。infra 側 (`didDocumentResolver`) は触らず、`claude/phase1-strategy-a-cleanup` 側で Prisma に切替えるときに 1 行スワップで済む形を維持。
- `IVcIssuanceRepository` に `findByUserId` を追加、stub は空配列を返す。
- legacy `VCIssuanceRequestConverter.filter` で merged enum の `IN_PROGRESS` を Prisma `PROCESSING` にマップして互換性を保つ。

## 生成ファイル

- `src/types/graphql.ts` を `pnpm gql:generate` で再生成して commit。
- `docs/schema.graphql` も同時更新。

## テスト

- `src/__tests__/integration/userDid/userDid.test.ts`: Query / Mutation × authz (`IsUser` / `IsSelf`) を Apollo + supertest + tsyringe mock で網羅。
- `src/__tests__/integration/vcIssuance/vcIssuance.test.ts`: Query / Mutation × authz (`IsUser` / `IsAdmin`) を同形式で網羅。
- 既存の `__tests__/auth/mutation.onlySelf.test.ts` と同じテストパターンで authz 経路を検証する設計。
- 戦略 A の repository は stub のため、e2e DB 連携テストは Phase 1 step 9+ (`claude/phase1-strategy-a-cleanup`) に持ち越し。

## ビルド / lint

- `pnpm gql:generate` 実行済み。
- `pnpm exec tsc --noEmit` で本 PR の追加コードに新規エラーなし（既存の `@prisma/client/sql` 関連エラーは DB 起動が必要な環境問題で、本 PR とは無関係）。
- `pnpm exec eslint src/application/domain/{account/userDid,credential/vcIssuance}/` clean。
- prettier 適用済み。

## 設計書からの逸脱・決定事項

- `VcIssuanceStatus` enum: 既存 `VcIssuanceRequest` ドメインがすでに同名 enum (`PENDING / PROCESSING / COMPLETED / FAILED`) を export しており、graphql-tools が enum 値を union する仕様のため、merged enum は `{ COMPLETED, FAILED, IN_PROGRESS, PENDING, PROCESSING }` となった。新 VC は `PENDING → IN_PROGRESS → COMPLETED / FAILED` を使用、legacy converter は `IN_PROGRESS → PROCESSING` にマップして互換性を維持。
- `VcFormat` enum: 設計書通り `INTERNAL_JWT` を採用。`IDENTUS_VC_PRISM` は legacy 互換のため列挙のみ保持（実際には発行されない）。
- `revokedAt` フィールド: GraphQL `VcIssuance` に追加した。row 型にも反映。StatusList 連携 (Phase 1 step 9) で実値が入る。
- field resolver / DataLoader: 本 PR では User / Evaluation 関連 field resolver は実装せず、`UserDidAnchor.userId` / `VcIssuance.userId` などの ID 文字列だけ返却する最小実装。Phase 1 step 9+ で必要に応じて DataLoader 化。

## 次の Phase 1 step

- step 9 (`claude/phase1-anchor-batch-service`): Cardano anchor batch service
- step 9 (`claude/phase1-statuslist-domain`): StatusList 2021 domain
- `claude/phase1-strategy-a-cleanup`: 戦略 A の row 型を Prisma 生成型にスワップ

https://claude.ai/code/session_019MKzV6DsfsHA6dLJ99chU8

---
_Generated by [Claude Code](https://claude.ai/code/session_019MKzV6DsfsHA6dLJ99chU8)_