### PR TITLE
phase1(app): AnchorBatchService — 週次 Cardano anchor バッチ

### DIFF
--- a/docs/operations/anchor-batch-deploy-checklist.md
+++ b/docs/operations/anchor-batch-deploy-checklist.md
@@ -1,0 +1,112 @@
+# Anchor Batch Deploy Checklist
+
+`POST /admin/anchor-batch/run` を Cloud Scheduler から週次起動する運用に
+入れる前に確認するチェックリスト。
+
+設計参照:
+
+- `docs/report/did-vc-internalization.md` §5.1.6 (label 1985 metadata)
+- `docs/report/did-vc-internalization.md` §5.1.7 (Merkle 構築)
+- `docs/report/did-vc-internalization.md` §5.2.3 (anchor ドメイン)
+- `docs/report/did-vc-internalization.md` §5.3.1 (週次バッチ + idempotency)
+
+## 1. Cloud Run timeout (Blocker)
+
+### 必須要件: `request timeout >= 600s`
+
+`AnchorBatchService.runWeeklyBatch` は **同一リクエスト内で** 以下を直列に実行する:
+
+1. PENDING anchor の取得 + CAS claim (DB)
+2. Merkle root 計算 + AuxiliaryData 構築
+3. Blockfrost への UTXO / protocol params / 最新 slot 取得
+4. Cardano tx の build + 署名
+5. Blockfrost への submit
+6. **`awaitConfirmation` (default 5 分待機)**
+
+このため Cloud Run の default `request timeout = 300s` のままだと、
+ブロック確定を待っている最中に外側でタイムアウトが発生し、
+`markFailed` まで到達できないリスクがある。
+
+#### Cloud Run 設定
+
+| 環境       | request timeout | 根拠                                        |
+| ---------- | --------------- | ------------------------------------------- |
+| local      | 任意            | テスト時は短縮可                            |
+| staging    | 600s 以上       | `awaitConfirmation` default + tx build 余裕 |
+| production | 600s 以上       | 同上。場合により 900s 推奨                  |
+
+#### `gcloud` 例
+
+```bash
+gcloud run services update civicship-api \
+  --region=asia-northeast1 \
+  --timeout=600s
+```
+
+### `CARDANO_AWAIT_CONFIRM_TIMEOUT_MS` env による override
+
+`awaitConfirmation` の待機時間は `CARDANO_AWAIT_CONFIRM_TIMEOUT_MS` で
+ms 単位に override できる（unset または不正値の場合は default 300_000ms）。
+
+| 環境       | 推奨値      | 想定                                                  |
+| ---------- | ----------- | ----------------------------------------------------- |
+| staging    | `60000`     | 1 分。preprod は確定が早いので短く保つ                |
+| production | `240000`    | 4 分。確定遅延の余裕を持たせつつ Cloud Run 内に収める |
+| local test | `5000` 未満 | Cloud Run に乗せない単体テスト時のみ                  |
+
+**制約**: `Cloud Run timeout > CARDANO_AWAIT_CONFIRM_TIMEOUT_MS + 60s` の
+余裕を必ず持たせる（tx build/submit + DB write の上限を 60s と見積もる）。
+
+> **Phase 1.5 / Phase 2 TODO**: `runWeeklyBatch` を 2 段階
+> `submitBatch` (submit まで → SUBMITTED 永続化で即 return) と
+> `confirmBatch` (Cloud Tasks 等で別呼び出し、`awaitConfirmation` のみ)
+> に分離する。これにより 1 リクエスト辺りの timeout 制約を緩和できる。
+
+## 2. Cloud Scheduler
+
+### 必須 env
+
+| Key                                | 用途                                                          |
+| ---------------------------------- | ------------------------------------------------------------- |
+| `CLOUD_SCHEDULER_TOKEN`            | Scheduler → API 認証用の固定 header 値（Secret Manager 配信） |
+| `CARDANO_PLATFORM_ADDRESS`         | issuer enterprise address (bech32)                            |
+| `CARDANO_PLATFORM_PRIVATE_KEY_HEX` | 32-byte ed25519 seed の hex (raw)。Phase 1 暫定               |
+| `CARDANO_NETWORK`                  | `preprod` または `mainnet`                                    |
+| `CARDANO_AWAIT_CONFIRM_TIMEOUT_MS` | (任意) override                                               |
+
+### Scheduler ジョブ設定
+
+- **頻度**: 週 1 回（例: `0 3 * * MON` / Asia/Tokyo）
+- **HTTP method**: `POST`
+- **URL**: `https://<cloud-run-url>/admin/anchor-batch/run`
+- **Body**: `{}` または `{"weeklyKey": "2026-W19"}`（省略時はサーバ側で計算）
+- **Headers**: `Content-Type: application/json` / `X-CloudScheduler-Token: <secret>`
+- **Retry config**:
+  - `retryCount`: 3
+  - `minBackoffDuration`: 60s
+  - `maxBackoffDuration`: 600s
+  - `maxDoublings`: 3
+- **Attempt deadline**: Cloud Run timeout と一致させる（例: 600s）
+
+> **重要**: idempotency は server 側で `getBatchTerminalStatus` により
+> 担保しているため、Scheduler の retry が同 weeklyKey を再投入しても
+> 二重 submit にはならない（`§5.3.1`）。ただし `awaitConfirmation` の
+> 途中で Cloud Run timeout に当たって 503 が返った場合は次の retry が
+> `claimPendingAnchors` で 0 件 claim → PENDING で early return する
+> ため、人手で `markFailed` するか別 batchId に逃がす運用が必要。
+
+## 3. 監視・アラート（最低限）
+
+| メトリクス                                       | 閾値                 | アクション                                   |
+| ------------------------------------------------ | -------------------- | -------------------------------------------- |
+| Cloud Run 5xx (anchor-batch endpoint)            | >= 1 / week          | on-call → 手動トリガで再実行                 |
+| Cloud Scheduler job failure                      | >= 1 retry exhausted | on-call → ログ確認 → manual `runBatch`       |
+| `[AnchorBatchService] batch failed` log 出現     | >= 1 / week          | failure reason 確認 → 必要に応じて DB 修復   |
+| `markFailed` で記録された TransactionAnchor 件数 | > 0                  | 当該 weeklyKey の anchor を別 batch で再処理 |
+
+## 4. Phase 2 で見直す項目
+
+- §G overlap multi-key 仕様（key rotation 中の重複 batch）
+- KMS 経由署名（`KmsSigner.signEd25519` → vkey witness 手動 attach）
+- `documentCbor` の chain inclusion（現状は metadata の `h` で改ざん検知）
+- `runBatch` を fire-and-forget に分離（submit / confirm 2 endpoint）

--- a/src/__tests__/unit/application/domain/anchor/anchorBatch/service.test.ts
+++ b/src/__tests__/unit/application/domain/anchor/anchorBatch/service.test.ts
@@ -397,7 +397,9 @@ describe("AnchorBatchService", () => {
 
   describe("Merkle root determinism", () => {
     it("buildRoot is deterministic for the same sorted JWT inputs", () => {
-      const inputs = ["c.payload.sig", "a.payload.sig", "b.payload.sig"].sort();
+      const inputs = ["c.payload.sig", "a.payload.sig", "b.payload.sig"].sort((a, b) =>
+        a < b ? -1 : a > b ? 1 : 0,
+      );
       const r1 = buildRoot(inputs);
       const r2 = buildRoot([...inputs]);
       expect(Buffer.from(r1).equals(Buffer.from(r2))).toBe(true);

--- a/src/__tests__/unit/application/domain/anchor/anchorBatch/service.test.ts
+++ b/src/__tests__/unit/application/domain/anchor/anchorBatch/service.test.ts
@@ -1,0 +1,439 @@
+/**
+ * Unit tests for `AnchorBatchService`.
+ *
+ * カバレッジ:
+ *   - PENDING が 0 件 → early return（submit 走らない）
+ *   - 同 weeklyKey の SUBMITTED batch → idempotent early return
+ *   - submit 成功 → 全 anchor SUBMITTED
+ *   - awaitConfirmation 成功 → CONFIRMED
+ *   - awaitConfirmation 失敗 → FAILED + failureReason
+ *   - Merkle root が決定論的（同入力 → 同 hex）
+ *
+ * BlockfrostClient / KmsSigner / SlotProvider はモック。
+ */
+
+import "reflect-metadata";
+import { container } from "tsyringe";
+import { AnchorStatus, DidOperation } from "@prisma/client";
+import {
+  AnchorBatchService,
+  computeIsoWeeklyKey,
+  isValidWeeklyKey,
+} from "@/application/domain/anchor/anchorBatch/service";
+import { IContext } from "@/types/server";
+import { buildRoot } from "@/infrastructure/libs/merkle/merkleTreeBuilder";
+import { generateCardanoKeypair } from "@/infrastructure/libs/cardano/keygen";
+
+// Cardano serialization は重いので、txBuilder を最小限モック
+const mockBuildAnchorTx = jest.fn();
+const mockBuildAuxiliaryData = jest.fn();
+jest.mock("@/infrastructure/libs/cardano/txBuilder", () => {
+  const actual = jest.requireActual("@/infrastructure/libs/cardano/txBuilder");
+  return {
+    ...actual,
+    buildAnchorTx: (...args: unknown[]) => mockBuildAnchorTx(...args),
+    buildAuxiliaryData: (...args: unknown[]) => mockBuildAuxiliaryData(...args),
+  };
+});
+
+// resolvePlatformSignKey の中で deriveCardanoKeypair が呼ばれる。
+// テスト用に env から hex seed を渡せばよいが、CSL の load コストを避けるため
+// service.ts 内の resolvePlatformSignKey もモック対象とする
+jest.mock("@/infrastructure/libs/cardano/keygen", () => {
+  const actual = jest.requireActual("@/infrastructure/libs/cardano/keygen");
+  return {
+    ...actual,
+    deriveCardanoKeypair: jest.fn(() => ({
+      cslPrivateKey: { __mock: "PrivateKey" },
+      cslPublicKey: { __mock: "PublicKey" },
+      addressBech32: "addr_test1mock",
+      paymentKeyHashHex: "00".repeat(28),
+      privateKeySeed: new Uint8Array(32),
+      publicKey: new Uint8Array(32),
+      network: "preprod" as const,
+    })),
+  };
+});
+
+// 32-byte seed (raw hex) — テスト用
+const TEST_SEED_HEX = "11".repeat(32);
+const TEST_BECH32 = "addr_test1mock";
+
+const ENV_BACKUP: Record<string, string | undefined> = {};
+
+function setEnv(key: string, value: string | undefined): void {
+  ENV_BACKUP[key] ??= process.env[key];
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+function restoreEnv(): void {
+  for (const k of Object.keys(ENV_BACKUP)) {
+    const v = ENV_BACKUP[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+}
+
+describe("AnchorBatchService", () => {
+  let mockRepository: {
+    findExistingBatchTransactionAnchors: jest.Mock;
+    findPendingAnchors: jest.Mock;
+    findVcJwtsByVcIssuanceRequestIds: jest.Mock;
+    findPreviousAnchorChainTxHashes: jest.Mock;
+    claimPendingAnchors: jest.Mock;
+    markSubmitted: jest.Mock;
+    markConfirmed: jest.Mock;
+    markFailed: jest.Mock;
+    getBatchTerminalStatus: jest.Mock;
+  };
+  let mockBlockfrost: {
+    getProtocolParams: jest.Mock;
+    getUtxos: jest.Mock;
+    submitTx: jest.Mock;
+    awaitConfirmation: jest.Mock;
+    getNetwork: jest.Mock;
+  };
+  let mockSlotProvider: { getCurrentSlot: jest.Mock };
+  let mockKmsSigner: { signEd25519: jest.Mock; getPublicKey: jest.Mock };
+
+  const ctx = {} as IContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    container.reset();
+
+    setEnv("CARDANO_PLATFORM_PRIVATE_KEY_HEX", TEST_SEED_HEX);
+    setEnv("CARDANO_PLATFORM_ADDRESS", TEST_BECH32);
+    setEnv("CARDANO_NETWORK", "preprod");
+
+    mockRepository = {
+      findExistingBatchTransactionAnchors: jest.fn().mockResolvedValue([]),
+      findPendingAnchors: jest.fn().mockResolvedValue({
+        transactionAnchors: [],
+        vcAnchors: [],
+        userDidAnchors: [],
+      }),
+      findVcJwtsByVcIssuanceRequestIds: jest.fn().mockResolvedValue([]),
+      findPreviousAnchorChainTxHashes: jest.fn().mockResolvedValue([]),
+      claimPendingAnchors: jest.fn().mockResolvedValue({
+        transactionAnchors: 0,
+        vcAnchors: 0,
+        userDidAnchors: 0,
+      }),
+      markSubmitted: jest.fn().mockResolvedValue(undefined),
+      markConfirmed: jest.fn().mockResolvedValue(undefined),
+      markFailed: jest.fn().mockResolvedValue(undefined),
+      getBatchTerminalStatus: jest.fn().mockResolvedValue(null),
+    };
+
+    mockBlockfrost = {
+      getProtocolParams: jest.fn().mockResolvedValue({
+        min_fee_a: 44,
+        min_fee_b: 155381,
+        pool_deposit: "500000000",
+        key_deposit: "2000000",
+        max_val_size: "5000",
+        max_tx_size: 16384,
+        coins_per_utxo_size: "4310",
+      }),
+      getUtxos: jest.fn().mockResolvedValue([
+        {
+          tx_hash: "ab".repeat(32),
+          output_index: 0,
+          amount: [{ unit: "lovelace", quantity: "10000000" }],
+        },
+      ]),
+      submitTx: jest.fn().mockResolvedValue("dead".repeat(16)),
+      awaitConfirmation: jest.fn().mockResolvedValue({
+        hash: "dead".repeat(16),
+        block_height: 12345,
+        block_time: 1700000000,
+      }),
+      getNetwork: jest.fn().mockReturnValue("CARDANO_PREPROD"),
+    };
+
+    mockSlotProvider = { getCurrentSlot: jest.fn().mockResolvedValue(1_000_000) };
+    mockKmsSigner = {
+      signEd25519: jest.fn().mockResolvedValue(new Uint8Array(64)),
+      getPublicKey: jest.fn().mockResolvedValue(new Uint8Array(32)),
+    };
+
+    mockBuildAnchorTx.mockReturnValue({
+      tx: { __mock: "Transaction" },
+      txHashHex: "dead".repeat(16),
+      txCborBytes: new Uint8Array([0x01, 0x02, 0x03]),
+    });
+    mockBuildAuxiliaryData.mockReturnValue({ __mock: "AuxiliaryData" });
+
+    container.register("AnchorBatchRepository", { useValue: mockRepository });
+    container.register("BlockfrostClient", { useValue: mockBlockfrost });
+    container.register("BlockfrostLatestSlotProvider", { useValue: mockSlotProvider });
+    container.register("KmsSigner", { useValue: mockKmsSigner });
+    container.register("AnchorBatchService", { useClass: AnchorBatchService });
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  describe("isValidWeeklyKey / computeIsoWeeklyKey", () => {
+    it("accepts ISO 8601 week format", () => {
+      expect(isValidWeeklyKey("2026-W19")).toBe(true);
+      expect(isValidWeeklyKey("2025-W01")).toBe(true);
+      expect(isValidWeeklyKey("2024-W53")).toBe(true);
+    });
+
+    it("rejects malformed keys", () => {
+      expect(isValidWeeklyKey("2026-19")).toBe(false);
+      expect(isValidWeeklyKey("2026-W")).toBe(false);
+      expect(isValidWeeklyKey("2026-W54")).toBe(false);
+      expect(isValidWeeklyKey("not-a-key")).toBe(false);
+    });
+
+    it("computeIsoWeeklyKey returns YYYY-Www", () => {
+      const key = computeIsoWeeklyKey(new Date("2026-05-10T12:00:00Z"));
+      expect(key).toMatch(/^\d{4}-W\d{2}$/);
+    });
+  });
+
+  describe("runWeeklyBatch", () => {
+    it("returns early when no PENDING anchors are found", async () => {
+      const service = container.resolve(AnchorBatchService);
+      const result = await service.runWeeklyBatch(ctx, { weeklyKey: "2026-W19" });
+
+      expect(result.submitted).toBe(false);
+      expect(result.txHash).toBeNull();
+      expect(result.anchorCounts).toEqual({ userDid: 0, vc: 0, tx: 0 });
+      expect(result.status).toBe(AnchorStatus.PENDING);
+
+      expect(mockRepository.claimPendingAnchors).not.toHaveBeenCalled();
+      expect(mockBlockfrost.submitTx).not.toHaveBeenCalled();
+    });
+
+    it("returns early (idempotent) when the same weeklyKey is already SUBMITTED", async () => {
+      mockRepository.getBatchTerminalStatus.mockResolvedValue(AnchorStatus.SUBMITTED);
+      mockRepository.findExistingBatchTransactionAnchors.mockResolvedValue([
+        {
+          id: "tx_anchor_1",
+          leafIds: ["t_aaa"],
+          leafCount: 1,
+          rootHash: "00".repeat(32),
+          network: "CARDANO_PREPROD",
+          status: AnchorStatus.SUBMITTED,
+          batchId: "2026-W19",
+          chainTxHash: "ff".repeat(32),
+          periodStart: new Date(),
+          periodEnd: new Date(),
+        },
+      ]);
+
+      const service = container.resolve(AnchorBatchService);
+      const result = await service.runWeeklyBatch(ctx, { weeklyKey: "2026-W19" });
+
+      expect(result.submitted).toBe(true);
+      expect(result.status).toBe(AnchorStatus.SUBMITTED);
+      expect(result.txHash).toBe("ff".repeat(32));
+      expect(mockRepository.findPendingAnchors).not.toHaveBeenCalled();
+      expect(mockBlockfrost.submitTx).not.toHaveBeenCalled();
+    });
+
+    it("returns early (idempotent) when the same weeklyKey is already CONFIRMED", async () => {
+      mockRepository.getBatchTerminalStatus.mockResolvedValue(AnchorStatus.CONFIRMED);
+      mockRepository.findExistingBatchTransactionAnchors.mockResolvedValue([]);
+
+      const service = container.resolve(AnchorBatchService);
+      const result = await service.runWeeklyBatch(ctx, { weeklyKey: "2026-W19" });
+
+      expect(result.status).toBe(AnchorStatus.CONFIRMED);
+      expect(mockBlockfrost.submitTx).not.toHaveBeenCalled();
+    });
+
+    it("submits and marks all anchors SUBMITTED then CONFIRMED on success", async () => {
+      mockRepository.findPendingAnchors.mockResolvedValue({
+        transactionAnchors: [
+          {
+            id: "tx_anchor_1",
+            leafIds: ["t_aaa", "t_bbb"],
+            leafCount: 2,
+            rootHash: "00".repeat(32),
+            network: "CARDANO_PREPROD",
+            status: AnchorStatus.PENDING,
+            batchId: null,
+            periodStart: new Date(),
+            periodEnd: new Date(),
+          },
+        ],
+        vcAnchors: [
+          {
+            id: "vc_anchor_1",
+            leafIds: ["vc_req_1"],
+            leafCount: 1,
+            rootHash: "00".repeat(32),
+            network: "CARDANO_PREPROD",
+            status: AnchorStatus.PENDING,
+            batchId: null,
+            periodStart: new Date(),
+            periodEnd: new Date(),
+          },
+        ],
+        userDidAnchors: [
+          {
+            id: "did_anchor_1",
+            did: "did:web:api.civicship.app:users:u_xyz",
+            operation: DidOperation.CREATE,
+            documentHash: "ab".repeat(32),
+            documentCbor: null,
+            previousAnchorId: null,
+            network: "CARDANO_PREPROD",
+            status: AnchorStatus.PENDING,
+            batchId: null,
+            userId: "u_xyz",
+          },
+        ],
+      });
+
+      mockRepository.claimPendingAnchors.mockResolvedValue({
+        transactionAnchors: 1,
+        vcAnchors: 1,
+        userDidAnchors: 1,
+      });
+
+      mockRepository.findVcJwtsByVcIssuanceRequestIds.mockResolvedValue([
+        { vcIssuanceRequestId: "vc_req_1", vcJwt: "header.payload.signature" },
+      ]);
+
+      const service = container.resolve(AnchorBatchService);
+      const result = await service.runWeeklyBatch(ctx, { weeklyKey: "2026-W19" });
+
+      expect(result.submitted).toBe(true);
+      expect(result.txHash).toBe("dead".repeat(16));
+      expect(result.status).toBe(AnchorStatus.CONFIRMED);
+      expect(result.anchorCounts).toEqual({ userDid: 1, vc: 1, tx: 1 });
+
+      expect(mockRepository.claimPendingAnchors).toHaveBeenCalledWith(
+        ctx,
+        expect.objectContaining({
+          batchId: "2026-W19",
+          transactionAnchorIds: ["tx_anchor_1"],
+          vcAnchorIds: ["vc_anchor_1"],
+          userDidAnchorIds: ["did_anchor_1"],
+        }),
+      );
+      expect(mockRepository.markSubmitted).toHaveBeenCalledWith(
+        ctx,
+        expect.objectContaining({
+          batchId: "2026-W19",
+          chainTxHash: "dead".repeat(16),
+        }),
+      );
+      expect(mockRepository.markConfirmed).toHaveBeenCalledWith(
+        ctx,
+        expect.objectContaining({
+          batchId: "2026-W19",
+          blockHeight: 12345,
+        }),
+      );
+      expect(mockRepository.markFailed).not.toHaveBeenCalled();
+    });
+
+    it("marks anchors FAILED when awaitConfirmation throws", async () => {
+      mockRepository.findPendingAnchors.mockResolvedValue({
+        transactionAnchors: [
+          {
+            id: "tx_anchor_1",
+            leafIds: ["t_aaa"],
+            leafCount: 1,
+            rootHash: "00".repeat(32),
+            network: "CARDANO_PREPROD",
+            status: AnchorStatus.PENDING,
+            batchId: null,
+            periodStart: new Date(),
+            periodEnd: new Date(),
+          },
+        ],
+        vcAnchors: [],
+        userDidAnchors: [],
+      });
+      mockRepository.claimPendingAnchors.mockResolvedValue({
+        transactionAnchors: 1,
+        vcAnchors: 0,
+        userDidAnchors: 0,
+      });
+      mockBlockfrost.awaitConfirmation.mockRejectedValue(
+        new Error("awaitConfirmation timed out after 300000ms"),
+      );
+
+      const service = container.resolve(AnchorBatchService);
+      const result = await service.runWeeklyBatch(ctx, { weeklyKey: "2026-W19" });
+
+      expect(result.submitted).toBe(false);
+      expect(result.status).toBe(AnchorStatus.FAILED);
+      expect(result.failureReason).toMatch(/timed out/);
+      expect(mockRepository.markFailed).toHaveBeenCalledWith(
+        ctx,
+        expect.objectContaining({
+          batchId: "2026-W19",
+          failureReason: expect.stringContaining("timed out"),
+        }),
+      );
+    });
+
+    it("marks anchors FAILED when submitTx throws", async () => {
+      mockRepository.findPendingAnchors.mockResolvedValue({
+        transactionAnchors: [
+          {
+            id: "tx_anchor_1",
+            leafIds: ["t_aaa"],
+            leafCount: 1,
+            rootHash: "00".repeat(32),
+            network: "CARDANO_PREPROD",
+            status: AnchorStatus.PENDING,
+            batchId: null,
+            periodStart: new Date(),
+            periodEnd: new Date(),
+          },
+        ],
+        vcAnchors: [],
+        userDidAnchors: [],
+      });
+      mockRepository.claimPendingAnchors.mockResolvedValue({
+        transactionAnchors: 1,
+        vcAnchors: 0,
+        userDidAnchors: 0,
+      });
+      mockBlockfrost.submitTx.mockRejectedValue(new Error("submit 5xx"));
+
+      const service = container.resolve(AnchorBatchService);
+      const result = await service.runWeeklyBatch(ctx, { weeklyKey: "2026-W19" });
+
+      expect(result.status).toBe(AnchorStatus.FAILED);
+      expect(mockRepository.markFailed).toHaveBeenCalled();
+      expect(mockRepository.markConfirmed).not.toHaveBeenCalled();
+    });
+
+    it("rejects malformed weeklyKey", async () => {
+      const service = container.resolve(AnchorBatchService);
+      await expect(service.runWeeklyBatch(ctx, { weeklyKey: "bad-key" })).rejects.toThrow(
+        /YYYY-Www/,
+      );
+    });
+  });
+
+  describe("Merkle root determinism", () => {
+    it("buildRoot is deterministic for the same sorted JWT inputs", () => {
+      const inputs = ["c.payload.sig", "a.payload.sig", "b.payload.sig"].sort();
+      const r1 = buildRoot(inputs);
+      const r2 = buildRoot([...inputs]);
+      expect(Buffer.from(r1).equals(Buffer.from(r2))).toBe(true);
+      expect(r1.length).toBe(32);
+    });
+  });
+});
+
+describe("generateCardanoKeypair smoke (does not require KMS / network)", () => {
+  it("does not crash when used as a fallback for resolvePlatformSignKey", async () => {
+    // smoke test — we don't actually run it (ESM dynamic import is fragile in Jest)
+    expect(typeof generateCardanoKeypair).toBe("function");
+  });
+});

--- a/src/__tests__/unit/application/domain/anchor/anchorBatch/service.test.ts
+++ b/src/__tests__/unit/application/domain/anchor/anchorBatch/service.test.ts
@@ -4,12 +4,15 @@
  * カバレッジ:
  *   - PENDING が 0 件 → early return（submit 走らない）
  *   - 同 weeklyKey の SUBMITTED batch → idempotent early return
+ *   - claimPendingAnchors が 0 件しか claim できなかった場合（並行 batch 競合）
+ *     → submit 走らずに PENDING で early return（§5.3.1 CAS）
  *   - submit 成功 → 全 anchor SUBMITTED
  *   - awaitConfirmation 成功 → CONFIRMED
  *   - awaitConfirmation 失敗 → FAILED + failureReason
  *   - Merkle root が決定論的（同入力 → 同 hex）
  *
- * BlockfrostClient / KmsSigner / SlotProvider はモック。
+ * BlockfrostClient / SlotProvider はモック。
+ * Phase 1 では `KmsSigner` を inject しないため、tsyringe へのモック登録も不要。
  */
 
 import "reflect-metadata";
@@ -22,7 +25,6 @@ import {
 } from "@/application/domain/anchor/anchorBatch/service";
 import { IContext } from "@/types/server";
 import { buildRoot } from "@/infrastructure/libs/merkle/merkleTreeBuilder";
-import { generateCardanoKeypair } from "@/infrastructure/libs/cardano/keygen";
 
 // Cardano serialization は重いので、txBuilder を最小限モック
 const mockBuildAnchorTx = jest.fn();
@@ -95,7 +97,6 @@ describe("AnchorBatchService", () => {
     getNetwork: jest.Mock;
   };
   let mockSlotProvider: { getCurrentSlot: jest.Mock };
-  let mockKmsSigner: { signEd25519: jest.Mock; getPublicKey: jest.Mock };
 
   const ctx = {} as IContext;
 
@@ -154,10 +155,6 @@ describe("AnchorBatchService", () => {
     };
 
     mockSlotProvider = { getCurrentSlot: jest.fn().mockResolvedValue(1_000_000) };
-    mockKmsSigner = {
-      signEd25519: jest.fn().mockResolvedValue(new Uint8Array(64)),
-      getPublicKey: jest.fn().mockResolvedValue(new Uint8Array(32)),
-    };
 
     mockBuildAnchorTx.mockReturnValue({
       tx: { __mock: "Transaction" },
@@ -169,7 +166,6 @@ describe("AnchorBatchService", () => {
     container.register("AnchorBatchRepository", { useValue: mockRepository });
     container.register("BlockfrostClient", { useValue: mockBlockfrost });
     container.register("BlockfrostLatestSlotProvider", { useValue: mockSlotProvider });
-    container.register("KmsSigner", { useValue: mockKmsSigner });
     container.register("AnchorBatchService", { useClass: AnchorBatchService });
   });
 
@@ -219,9 +215,9 @@ describe("AnchorBatchService", () => {
   };
 
   function setupPending(opts: {
-    transactionAnchors?: typeof PENDING_TX[];
-    vcAnchors?: typeof PENDING_VC[];
-    userDidAnchors?: typeof PENDING_DID[];
+    transactionAnchors?: (typeof PENDING_TX)[];
+    vcAnchors?: (typeof PENDING_VC)[];
+    userDidAnchors?: (typeof PENDING_DID)[];
   }) {
     const tx = opts.transactionAnchors ?? [];
     const vc = opts.vcAnchors ?? [];
@@ -270,6 +266,38 @@ describe("AnchorBatchService", () => {
 
       expect(mockRepository.claimPendingAnchors).not.toHaveBeenCalled();
       expect(mockBlockfrost.submitTx).not.toHaveBeenCalled();
+    });
+
+    it("returns early when CAS claims 0 rows (concurrent batch race)", async () => {
+      // findPendingAnchors では行が見えたが、claimPendingAnchors の CAS で
+      // 別 worker に取られて 0 件しか claim できなかったケース。
+      // §5.3.1 の CAS 設計通り、submit は走らずに PENDING で early return する。
+      setupPending({
+        transactionAnchors: [PENDING_TX],
+        vcAnchors: [PENDING_VC],
+        userDidAnchors: [PENDING_DID],
+      });
+      // setupPending の後で claim だけ 0 件に上書き
+      mockRepository.claimPendingAnchors.mockResolvedValue({
+        transactionAnchors: 0,
+        vcAnchors: 0,
+        userDidAnchors: 0,
+      });
+
+      const service = container.resolve(AnchorBatchService);
+      const result = await service.runWeeklyBatch(ctx, { weeklyKey: "2026-W19" });
+
+      expect(result.submitted).toBe(false);
+      expect(result.txHash).toBeNull();
+      expect(result.anchorCounts).toEqual({ userDid: 0, vc: 0, tx: 0 });
+      expect(result.status).toBe(AnchorStatus.PENDING);
+
+      // 並行 batch 競合では submit / markSubmitted / markFailed のいずれも走らない
+      expect(mockRepository.claimPendingAnchors).toHaveBeenCalledTimes(1);
+      expect(mockBlockfrost.submitTx).not.toHaveBeenCalled();
+      expect(mockRepository.markSubmitted).not.toHaveBeenCalled();
+      expect(mockRepository.markConfirmed).not.toHaveBeenCalled();
+      expect(mockRepository.markFailed).not.toHaveBeenCalled();
     });
 
     it("returns early (idempotent) when the same weeklyKey is already SUBMITTED", async () => {
@@ -393,6 +421,28 @@ describe("AnchorBatchService", () => {
         /YYYY-Www/,
       );
     });
+
+    it("uses CARDANO_AWAIT_CONFIRM_TIMEOUT_MS when set to a positive integer", async () => {
+      // env override が awaitConfirmation の第 2 引数に渡されることを確認。
+      setEnv("CARDANO_AWAIT_CONFIRM_TIMEOUT_MS", "60000");
+      setupPending({ transactionAnchors: [PENDING_TX] });
+
+      const service = container.resolve(AnchorBatchService);
+      await service.runWeeklyBatch(ctx, { weeklyKey: "2026-W19" });
+
+      expect(mockBlockfrost.awaitConfirmation).toHaveBeenCalledWith(expect.any(String), 60000);
+    });
+
+    it("falls back to the default timeout when CARDANO_AWAIT_CONFIRM_TIMEOUT_MS is invalid", async () => {
+      setEnv("CARDANO_AWAIT_CONFIRM_TIMEOUT_MS", "not-a-number");
+      setupPending({ transactionAnchors: [PENDING_TX] });
+
+      const service = container.resolve(AnchorBatchService);
+      await service.runWeeklyBatch(ctx, { weeklyKey: "2026-W19" });
+
+      // default は 5 * 60 * 1000 = 300_000ms
+      expect(mockBlockfrost.awaitConfirmation).toHaveBeenCalledWith(expect.any(String), 300_000);
+    });
   });
 
   describe("Merkle root determinism", () => {
@@ -405,12 +455,5 @@ describe("AnchorBatchService", () => {
       expect(Buffer.from(r1).equals(Buffer.from(r2))).toBe(true);
       expect(r1.length).toBe(32);
     });
-  });
-});
-
-describe("generateCardanoKeypair smoke (does not require KMS / network)", () => {
-  it("does not crash when used as a fallback for resolvePlatformSignKey", async () => {
-    // smoke test — we don't actually run it (ESM dynamic import is fragile in Jest)
-    expect(typeof generateCardanoKeypair).toBe("function");
   });
 });

--- a/src/__tests__/unit/application/domain/anchor/anchorBatch/service.test.ts
+++ b/src/__tests__/unit/application/domain/anchor/anchorBatch/service.test.ts
@@ -177,6 +177,67 @@ describe("AnchorBatchService", () => {
     restoreEnv();
   });
 
+  // Fixture builders — keep test bodies focused on the assertion under test.
+  // Sonar's duplicate detection (≥ 100 token block) was tripping on the
+  // repeated `findPendingAnchors.mockResolvedValue({...})` shape across the
+  // success / awaitConfirmation-fail / submit-fail cases.
+  const PENDING_TX = {
+    id: "tx_anchor_1",
+    leafIds: ["t_aaa"],
+    leafCount: 1,
+    rootHash: "00".repeat(32),
+    network: "CARDANO_PREPROD",
+    status: AnchorStatus.PENDING,
+    batchId: null,
+    periodStart: new Date(),
+    periodEnd: new Date(),
+  };
+
+  const PENDING_VC = {
+    id: "vc_anchor_1",
+    leafIds: ["vc_req_1"],
+    leafCount: 1,
+    rootHash: "00".repeat(32),
+    network: "CARDANO_PREPROD",
+    status: AnchorStatus.PENDING,
+    batchId: null,
+    periodStart: new Date(),
+    periodEnd: new Date(),
+  };
+
+  const PENDING_DID = {
+    id: "did_anchor_1",
+    did: "did:web:api.civicship.app:users:u_xyz",
+    operation: DidOperation.CREATE,
+    documentHash: "ab".repeat(32),
+    documentCbor: null,
+    previousAnchorId: null,
+    network: "CARDANO_PREPROD",
+    status: AnchorStatus.PENDING,
+    batchId: null,
+    userId: "u_xyz",
+  };
+
+  function setupPending(opts: {
+    transactionAnchors?: typeof PENDING_TX[];
+    vcAnchors?: typeof PENDING_VC[];
+    userDidAnchors?: typeof PENDING_DID[];
+  }) {
+    const tx = opts.transactionAnchors ?? [];
+    const vc = opts.vcAnchors ?? [];
+    const did = opts.userDidAnchors ?? [];
+    mockRepository.findPendingAnchors.mockResolvedValue({
+      transactionAnchors: tx,
+      vcAnchors: vc,
+      userDidAnchors: did,
+    });
+    mockRepository.claimPendingAnchors.mockResolvedValue({
+      transactionAnchors: tx.length,
+      vcAnchors: vc.length,
+      userDidAnchors: did.length,
+    });
+  }
+
   describe("isValidWeeklyKey / computeIsoWeeklyKey", () => {
     it("accepts ISO 8601 week format", () => {
       expect(isValidWeeklyKey("2026-W19")).toBe(true);
@@ -250,55 +311,11 @@ describe("AnchorBatchService", () => {
     });
 
     it("submits and marks all anchors SUBMITTED then CONFIRMED on success", async () => {
-      mockRepository.findPendingAnchors.mockResolvedValue({
-        transactionAnchors: [
-          {
-            id: "tx_anchor_1",
-            leafIds: ["t_aaa", "t_bbb"],
-            leafCount: 2,
-            rootHash: "00".repeat(32),
-            network: "CARDANO_PREPROD",
-            status: AnchorStatus.PENDING,
-            batchId: null,
-            periodStart: new Date(),
-            periodEnd: new Date(),
-          },
-        ],
-        vcAnchors: [
-          {
-            id: "vc_anchor_1",
-            leafIds: ["vc_req_1"],
-            leafCount: 1,
-            rootHash: "00".repeat(32),
-            network: "CARDANO_PREPROD",
-            status: AnchorStatus.PENDING,
-            batchId: null,
-            periodStart: new Date(),
-            periodEnd: new Date(),
-          },
-        ],
-        userDidAnchors: [
-          {
-            id: "did_anchor_1",
-            did: "did:web:api.civicship.app:users:u_xyz",
-            operation: DidOperation.CREATE,
-            documentHash: "ab".repeat(32),
-            documentCbor: null,
-            previousAnchorId: null,
-            network: "CARDANO_PREPROD",
-            status: AnchorStatus.PENDING,
-            batchId: null,
-            userId: "u_xyz",
-          },
-        ],
+      setupPending({
+        transactionAnchors: [{ ...PENDING_TX, leafIds: ["t_aaa", "t_bbb"], leafCount: 2 }],
+        vcAnchors: [PENDING_VC],
+        userDidAnchors: [PENDING_DID],
       });
-
-      mockRepository.claimPendingAnchors.mockResolvedValue({
-        transactionAnchors: 1,
-        vcAnchors: 1,
-        userDidAnchors: 1,
-      });
-
       mockRepository.findVcJwtsByVcIssuanceRequestIds.mockResolvedValue([
         { vcIssuanceRequestId: "vc_req_1", vcJwt: "header.payload.signature" },
       ]);
@@ -338,28 +355,7 @@ describe("AnchorBatchService", () => {
     });
 
     it("marks anchors FAILED when awaitConfirmation throws", async () => {
-      mockRepository.findPendingAnchors.mockResolvedValue({
-        transactionAnchors: [
-          {
-            id: "tx_anchor_1",
-            leafIds: ["t_aaa"],
-            leafCount: 1,
-            rootHash: "00".repeat(32),
-            network: "CARDANO_PREPROD",
-            status: AnchorStatus.PENDING,
-            batchId: null,
-            periodStart: new Date(),
-            periodEnd: new Date(),
-          },
-        ],
-        vcAnchors: [],
-        userDidAnchors: [],
-      });
-      mockRepository.claimPendingAnchors.mockResolvedValue({
-        transactionAnchors: 1,
-        vcAnchors: 0,
-        userDidAnchors: 0,
-      });
+      setupPending({ transactionAnchors: [PENDING_TX] });
       mockBlockfrost.awaitConfirmation.mockRejectedValue(
         new Error("awaitConfirmation timed out after 300000ms"),
       );
@@ -380,28 +376,7 @@ describe("AnchorBatchService", () => {
     });
 
     it("marks anchors FAILED when submitTx throws", async () => {
-      mockRepository.findPendingAnchors.mockResolvedValue({
-        transactionAnchors: [
-          {
-            id: "tx_anchor_1",
-            leafIds: ["t_aaa"],
-            leafCount: 1,
-            rootHash: "00".repeat(32),
-            network: "CARDANO_PREPROD",
-            status: AnchorStatus.PENDING,
-            batchId: null,
-            periodStart: new Date(),
-            periodEnd: new Date(),
-          },
-        ],
-        vcAnchors: [],
-        userDidAnchors: [],
-      });
-      mockRepository.claimPendingAnchors.mockResolvedValue({
-        transactionAnchors: 1,
-        vcAnchors: 0,
-        userDidAnchors: 0,
-      });
+      setupPending({ transactionAnchors: [PENDING_TX] });
       mockBlockfrost.submitTx.mockRejectedValue(new Error("submit 5xx"));
 
       const service = container.resolve(AnchorBatchService);

--- a/src/__tests__/unit/presentation/router/admin/anchorBatch.test.ts
+++ b/src/__tests__/unit/presentation/router/admin/anchorBatch.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for `POST /admin/anchor-batch/run`.
+ *
+ * - X-CloudScheduler-Token 不一致 → 401
+ * - token 一致 + UseCase 成功 → 200 with body
+ * - body.weeklyKey 不正 → 400
+ */
+
+import "reflect-metadata";
+import express from "express";
+import request from "supertest";
+import { container } from "tsyringe";
+
+import anchorBatchRouter from "@/presentation/router/admin/anchorBatch";
+import AnchorBatchUseCase from "@/application/domain/anchor/anchorBatch/usecase";
+
+describe("POST /admin/anchor-batch/run", () => {
+  let app: express.Express;
+  let mockUseCase: { runBatch: jest.Mock };
+  const ENV_BACKUP: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    container.reset();
+
+    ENV_BACKUP.CLOUD_SCHEDULER_TOKEN = process.env.CLOUD_SCHEDULER_TOKEN;
+    process.env.CLOUD_SCHEDULER_TOKEN = "secret-token";
+
+    mockUseCase = {
+      runBatch: jest.fn().mockResolvedValue({
+        batchId: "2026-W19",
+        submitted: true,
+        txHash: "dead".repeat(16),
+        status: "CONFIRMED",
+        anchorCounts: { userDid: 1, vc: 2, tx: 3 },
+      }),
+    };
+    container.register("PrismaClientIssuer", { useValue: { internal: jest.fn() } });
+    container.registerInstance(AnchorBatchUseCase, mockUseCase as unknown as AnchorBatchUseCase);
+
+    app = express();
+    app.use("/admin/anchor-batch", anchorBatchRouter);
+  });
+
+  afterEach(() => {
+    if (ENV_BACKUP.CLOUD_SCHEDULER_TOKEN === undefined) {
+      delete process.env.CLOUD_SCHEDULER_TOKEN;
+    } else {
+      process.env.CLOUD_SCHEDULER_TOKEN = ENV_BACKUP.CLOUD_SCHEDULER_TOKEN;
+    }
+  });
+
+  it("returns 401 without the token header", async () => {
+    const res = await request(app).post("/admin/anchor-batch/run").send({});
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: "Unauthorized" });
+    expect(mockUseCase.runBatch).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 with a wrong token", async () => {
+    const res = await request(app)
+      .post("/admin/anchor-batch/run")
+      .set("X-CloudScheduler-Token", "wrong")
+      .send({});
+    expect(res.status).toBe(401);
+    expect(mockUseCase.runBatch).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 and the result when the token matches", async () => {
+    const res = await request(app)
+      .post("/admin/anchor-batch/run")
+      .set("X-CloudScheduler-Token", "secret-token")
+      .send({ weeklyKey: "2026-W19" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      batchId: "2026-W19",
+      submitted: true,
+      txHash: "dead".repeat(16),
+      status: "CONFIRMED",
+      anchorCounts: { userDid: 1, vc: 2, tx: 3 },
+    });
+    expect(mockUseCase.runBatch).toHaveBeenCalledWith(expect.anything(), { weeklyKey: "2026-W19" });
+  });
+
+  it("returns 400 when weeklyKey is malformed", async () => {
+    const res = await request(app)
+      .post("/admin/anchor-batch/run")
+      .set("X-CloudScheduler-Token", "secret-token")
+      .send({ weeklyKey: "not-a-week" });
+    expect(res.status).toBe(400);
+    expect(mockUseCase.runBatch).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when weeklyKey is non-string", async () => {
+    const res = await request(app)
+      .post("/admin/anchor-batch/run")
+      .set("X-CloudScheduler-Token", "secret-token")
+      .send({ weeklyKey: 12345 });
+    expect(res.status).toBe(400);
+    expect(mockUseCase.runBatch).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 when no body is provided (server computes weeklyKey)", async () => {
+    const res = await request(app)
+      .post("/admin/anchor-batch/run")
+      .set("X-CloudScheduler-Token", "secret-token")
+      .send();
+
+    expect(res.status).toBe(200);
+    expect(mockUseCase.runBatch).toHaveBeenCalled();
+  });
+
+  it("returns 500 when CLOUD_SCHEDULER_TOKEN is not configured", async () => {
+    delete process.env.CLOUD_SCHEDULER_TOKEN;
+    const res = await request(app)
+      .post("/admin/anchor-batch/run")
+      .set("X-CloudScheduler-Token", "anything")
+      .send({});
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: "Internal Server Error" });
+  });
+
+  it("returns 500 when the usecase throws", async () => {
+    mockUseCase.runBatch.mockRejectedValue(new Error("boom"));
+    const res = await request(app)
+      .post("/admin/anchor-batch/run")
+      .set("X-CloudScheduler-Token", "secret-token")
+      .send({});
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: "Internal Server Error" });
+  });
+});

--- a/src/__tests__/unit/presentation/router/admin/anchorBatch.test.ts
+++ b/src/__tests__/unit/presentation/router/admin/anchorBatch.test.ts
@@ -66,6 +66,18 @@ describe("POST /admin/anchor-batch/run", () => {
     expect(mockUseCase.runBatch).not.toHaveBeenCalled();
   });
 
+  it("returns 401 when the provided token has a different length (timing-safe pre-check)", async () => {
+    // expected = "secret-token" (12 bytes), provided = "secret" (6 bytes)
+    // crypto.timingSafeEqual は長さ違いで throw するため、長さ違いを先に
+    // 401 で短絡させる pre-check が必要。
+    const res = await request(app)
+      .post("/admin/anchor-batch/run")
+      .set("X-CloudScheduler-Token", "secret")
+      .send({});
+    expect(res.status).toBe(401);
+    expect(mockUseCase.runBatch).not.toHaveBeenCalled();
+  });
+
   it("returns 200 and the result when the token matches", async () => {
     const res = await request(app)
       .post("/admin/anchor-batch/run")

--- a/src/application/domain/anchor/anchorBatch/data/interface.ts
+++ b/src/application/domain/anchor/anchorBatch/data/interface.ts
@@ -1,0 +1,121 @@
+/**
+ * AnchorBatch repository インターフェース。
+ *
+ * 設計参照:
+ *   docs/report/did-vc-internalization.md §5.2.3 (repository.ts)
+ *   docs/report/did-vc-internalization.md §5.3.1 (idempotency / CAS)
+ */
+
+import { AnchorStatus } from "@prisma/client";
+import { IContext } from "@/types/server";
+import {
+  AnchorBatchPendingSet,
+  PendingTransactionAnchor,
+  PendingUserDidAnchor,
+  PendingVcAnchor,
+  PreviousAnchorChainTx,
+  VcJwtLeaf,
+} from "@/application/domain/anchor/anchorBatch/data/type";
+
+/**
+ * AnchorBatch の repository interface。
+ *
+ * idempotency の責務:
+ *   - `findExistingBatch(batchId)`: 同じ weeklyKey で submit 済 batch があるか確認
+ *   - `claimPending(...)`: PENDING + batchId IS NULL の行に対して CAS で batchId を埋め込む
+ *     （二重 submit 防止）
+ *   - `markSubmitted(...)`: tx submit 直後の状態遷移
+ *   - `markConfirmed(...)`: confirmation 後の終端遷移
+ *   - `markFailed(...)`: timeout / submit エラー時の終端遷移
+ */
+export interface IAnchorBatchRepository {
+  /**
+   * 既存の同 batchId（= weeklyKey）の TransactionAnchor 行を返す。
+   * idempotency: 同 weeklyKey で既に SUBMITTED / CONFIRMED な batch があれば早期 return。
+   */
+  findExistingBatchTransactionAnchors(
+    ctx: IContext,
+    batchId: string,
+  ): Promise<PendingTransactionAnchor[]>;
+
+  /** PENDING + batchId IS NULL な anchor 行を全件取得（型別に分けて返す）。 */
+  findPendingAnchors(ctx: IContext): Promise<AnchorBatchPendingSet>;
+
+  /** vcIssuanceRequestId のリストから vcJwt を取得（merkle root 入力）。 */
+  findVcJwtsByVcIssuanceRequestIds(
+    ctx: IContext,
+    vcIssuanceRequestIds: string[],
+  ): Promise<VcJwtLeaf[]>;
+
+  /** UserDidAnchor.previousAnchorId から chainTxHash を取得（ops.prev 構築用）。 */
+  findPreviousAnchorChainTxHashes(
+    ctx: IContext,
+    previousAnchorIds: string[],
+  ): Promise<PreviousAnchorChainTx[]>;
+
+  /**
+   * `status = PENDING AND batchId IS NULL` な anchor 群に対して `batchId` を CAS で
+   * 書き込む。同時に並行 batch が走った場合に 2 つ目はここで 0 件 update を観測する。
+   */
+  claimPendingAnchors(
+    ctx: IContext,
+    args: {
+      batchId: string;
+      transactionAnchorIds: string[];
+      vcAnchorIds: string[];
+      userDidAnchorIds: string[];
+    },
+  ): Promise<{
+    transactionAnchors: number;
+    vcAnchors: number;
+    userDidAnchors: number;
+  }>;
+
+  /** 全 anchor 行を SUBMITTED 状態に遷移し、chainTxHash を埋める。 */
+  markSubmitted(
+    ctx: IContext,
+    args: {
+      batchId: string;
+      chainTxHash: string;
+      transactionAnchorIds: string[];
+      vcAnchorIds: string[];
+      userDidAnchorIds: string[];
+    },
+  ): Promise<void>;
+
+  /** 全 anchor 行を CONFIRMED に遷移。 */
+  markConfirmed(
+    ctx: IContext,
+    args: {
+      batchId: string;
+      blockHeight: number | null;
+      transactionAnchorIds: string[];
+      vcAnchorIds: string[];
+      userDidAnchorIds: string[];
+    },
+  ): Promise<void>;
+
+  /** 全 anchor 行を FAILED に遷移し、failureReason を残す。 */
+  markFailed(
+    ctx: IContext,
+    args: {
+      batchId: string;
+      failureReason: string;
+      transactionAnchorIds: string[];
+      vcAnchorIds: string[];
+      userDidAnchorIds: string[];
+    },
+  ): Promise<void>;
+
+  /** 既存 batch の終端ステータス（idempotency 早期 return 判定用）。 */
+  getBatchTerminalStatus(ctx: IContext, batchId: string): Promise<AnchorStatus | null>;
+
+  /** 任意：batchId に紐づく PENDING な VcAnchor を返す（resume パス用、未使用でも interface に含める）。 */
+  findPendingVcAnchorsByBatchId?(ctx: IContext, batchId: string): Promise<PendingVcAnchor[]>;
+
+  /** 任意：batchId に紐づく PENDING な UserDidAnchor を返す（resume パス用）。 */
+  findPendingUserDidAnchorsByBatchId?(
+    ctx: IContext,
+    batchId: string,
+  ): Promise<PendingUserDidAnchor[]>;
+}

--- a/src/application/domain/anchor/anchorBatch/data/repository.ts
+++ b/src/application/domain/anchor/anchorBatch/data/repository.ts
@@ -248,6 +248,11 @@ export default class AnchorBatchRepository implements IAnchorBatchRepository {
   ): Promise<void> {
     const issuer = ctx.issuer ?? this.getIssuer();
     await issuer.internal(async (tx) => {
+      // NOTE: Prisma の interactive `$transaction` callback 内では
+      // 同一 `tx` を介した発行クエリは serialize される（接続が 1 本のため）。
+      // ここでの `Promise.all` は記述上の集約であって、実際の実行は
+      // 順次（transactionAnchor → vcAnchor → userDidAnchor の順）になる
+      // ことを意図している。並列性を期待した実装ではない点に注意。
       await Promise.all([
         args.transactionAnchorIds.length
           ? tx.transactionAnchor.updateMany({

--- a/src/application/domain/anchor/anchorBatch/data/repository.ts
+++ b/src/application/domain/anchor/anchorBatch/data/repository.ts
@@ -7,7 +7,7 @@
  */
 
 import { container, injectable } from "tsyringe";
-import { AnchorStatus } from "@prisma/client";
+import { AnchorStatus, Prisma } from "@prisma/client";
 import { IContext } from "@/types/server";
 import { PrismaClientIssuer } from "@/infrastructure/prisma/client";
 import { IAnchorBatchRepository } from "@/application/domain/anchor/anchorBatch/data/interface";
@@ -181,41 +181,11 @@ export default class AnchorBatchRepository implements IAnchorBatchRepository {
       userDidAnchorIds: string[];
     },
   ): Promise<void> {
-    const issuer = ctx.issuer ?? this.getIssuer();
     const submittedAt = new Date();
-    await issuer.internal(async (tx) => {
-      await Promise.all([
-        args.transactionAnchorIds.length
-          ? tx.transactionAnchor.updateMany({
-              where: { id: { in: args.transactionAnchorIds } },
-              data: {
-                status: AnchorStatus.SUBMITTED,
-                chainTxHash: args.chainTxHash,
-                submittedAt,
-              },
-            })
-          : Promise.resolve(),
-        args.vcAnchorIds.length
-          ? tx.vcAnchor.updateMany({
-              where: { id: { in: args.vcAnchorIds } },
-              data: {
-                status: AnchorStatus.SUBMITTED,
-                chainTxHash: args.chainTxHash,
-                submittedAt,
-              },
-            })
-          : Promise.resolve(),
-        args.userDidAnchorIds.length
-          ? tx.userDidAnchor.updateMany({
-              where: { id: { in: args.userDidAnchorIds } },
-              data: {
-                status: AnchorStatus.SUBMITTED,
-                chainTxHash: args.chainTxHash,
-                submittedAt,
-              },
-            })
-          : Promise.resolve(),
-      ]);
+    await this.applyToAllAnchors(ctx, args, {
+      txData: { status: AnchorStatus.SUBMITTED, chainTxHash: args.chainTxHash, submittedAt },
+      vcData: { status: AnchorStatus.SUBMITTED, chainTxHash: args.chainTxHash, submittedAt },
+      didData: { status: AnchorStatus.SUBMITTED, chainTxHash: args.chainTxHash, submittedAt },
     });
   }
 
@@ -229,40 +199,12 @@ export default class AnchorBatchRepository implements IAnchorBatchRepository {
       userDidAnchorIds: string[];
     },
   ): Promise<void> {
-    const issuer = ctx.issuer ?? this.getIssuer();
     const confirmedAt = new Date();
-    await issuer.internal(async (tx) => {
-      await Promise.all([
-        args.transactionAnchorIds.length
-          ? tx.transactionAnchor.updateMany({
-              where: { id: { in: args.transactionAnchorIds } },
-              data: {
-                status: AnchorStatus.CONFIRMED,
-                confirmedAt,
-                blockHeight: args.blockHeight,
-              },
-            })
-          : Promise.resolve(),
-        args.vcAnchorIds.length
-          ? tx.vcAnchor.updateMany({
-              where: { id: { in: args.vcAnchorIds } },
-              data: {
-                status: AnchorStatus.CONFIRMED,
-                confirmedAt,
-                blockHeight: args.blockHeight,
-              },
-            })
-          : Promise.resolve(),
-        args.userDidAnchorIds.length
-          ? tx.userDidAnchor.updateMany({
-              where: { id: { in: args.userDidAnchorIds } },
-              data: {
-                status: AnchorStatus.CONFIRMED,
-                confirmedAt,
-              },
-            })
-          : Promise.resolve(),
-      ]);
+    await this.applyToAllAnchors(ctx, args, {
+      txData: { status: AnchorStatus.CONFIRMED, confirmedAt, blockHeight: args.blockHeight },
+      vcData: { status: AnchorStatus.CONFIRMED, confirmedAt, blockHeight: args.blockHeight },
+      // userDidAnchor has no blockHeight column.
+      didData: { status: AnchorStatus.CONFIRMED, confirmedAt },
     });
   }
 
@@ -276,33 +218,53 @@ export default class AnchorBatchRepository implements IAnchorBatchRepository {
       userDidAnchorIds: string[];
     },
   ): Promise<void> {
+    await this.applyToAllAnchors(ctx, args, {
+      txData: { status: AnchorStatus.FAILED, lastError: args.failureReason },
+      vcData: { status: AnchorStatus.FAILED, lastError: args.failureReason },
+      // userDidAnchor has no lastError column.
+      didData: { status: AnchorStatus.FAILED },
+    });
+  }
+
+  /**
+   * Fan a status update across all three anchor tables in one
+   * `issuer.internal` transaction. Empty id lists short-circuit to
+   * `Promise.resolve()` so we never issue a no-op `updateMany` (and the
+   * per-table `data` shape stays explicit for the few schema columns
+   * that diverge — e.g. `userDidAnchor` has no `blockHeight` / `lastError`).
+   */
+  private async applyToAllAnchors(
+    ctx: IContext,
+    args: {
+      transactionAnchorIds: string[];
+      vcAnchorIds: string[];
+      userDidAnchorIds: string[];
+    },
+    data: {
+      txData: Prisma.TransactionAnchorUpdateManyMutationInput;
+      vcData: Prisma.VcAnchorUpdateManyMutationInput;
+      didData: Prisma.UserDidAnchorUpdateManyMutationInput;
+    },
+  ): Promise<void> {
     const issuer = ctx.issuer ?? this.getIssuer();
     await issuer.internal(async (tx) => {
       await Promise.all([
         args.transactionAnchorIds.length
           ? tx.transactionAnchor.updateMany({
               where: { id: { in: args.transactionAnchorIds } },
-              data: {
-                status: AnchorStatus.FAILED,
-                lastError: args.failureReason,
-              },
+              data: data.txData,
             })
           : Promise.resolve(),
         args.vcAnchorIds.length
           ? tx.vcAnchor.updateMany({
               where: { id: { in: args.vcAnchorIds } },
-              data: {
-                status: AnchorStatus.FAILED,
-                lastError: args.failureReason,
-              },
+              data: data.vcData,
             })
           : Promise.resolve(),
         args.userDidAnchorIds.length
           ? tx.userDidAnchor.updateMany({
               where: { id: { in: args.userDidAnchorIds } },
-              data: {
-                status: AnchorStatus.FAILED,
-              },
+              data: data.didData,
             })
           : Promise.resolve(),
       ]);

--- a/src/application/domain/anchor/anchorBatch/data/repository.ts
+++ b/src/application/domain/anchor/anchorBatch/data/repository.ts
@@ -1,0 +1,372 @@
+/**
+ * AnchorBatchRepository.
+ *
+ * 設計参照:
+ *   docs/report/did-vc-internalization.md §5.2.3 (anchor.repository.ts)
+ *   docs/report/did-vc-internalization.md §5.3.1 (idempotency / CAS)
+ */
+
+import { container, injectable } from "tsyringe";
+import { AnchorStatus } from "@prisma/client";
+import { IContext } from "@/types/server";
+import { PrismaClientIssuer } from "@/infrastructure/prisma/client";
+import { IAnchorBatchRepository } from "@/application/domain/anchor/anchorBatch/data/interface";
+import {
+  AnchorBatchPendingSet,
+  PendingTransactionAnchor,
+  PendingUserDidAnchor,
+  PendingVcAnchor,
+  PreviousAnchorChainTx,
+  VcJwtLeaf,
+} from "@/application/domain/anchor/anchorBatch/data/type";
+
+@injectable()
+export default class AnchorBatchRepository implements IAnchorBatchRepository {
+  private getIssuer(): PrismaClientIssuer {
+    return container.resolve<PrismaClientIssuer>("PrismaClientIssuer");
+  }
+
+  async findExistingBatchTransactionAnchors(
+    ctx: IContext,
+    batchId: string,
+  ): Promise<PendingTransactionAnchor[]> {
+    const issuer = ctx.issuer ?? this.getIssuer();
+    return issuer.internal((tx) =>
+      tx.transactionAnchor.findMany({
+        where: { batchId },
+        select: TX_ANCHOR_SELECT,
+      }),
+    );
+  }
+
+  async getBatchTerminalStatus(ctx: IContext, batchId: string): Promise<AnchorStatus | null> {
+    const issuer = ctx.issuer ?? this.getIssuer();
+    const rows = await issuer.internal((tx) =>
+      tx.transactionAnchor.findMany({
+        where: { batchId },
+        select: { status: true },
+      }),
+    );
+    if (rows.length === 0) return null;
+    // 1 batch 内に異なる status が混在することは通常ないが、
+    // 「終端ステータス」の判定として SUBMITTED / CONFIRMED / FAILED が
+    // 1 つでも含まれていれば早期 return 対象とする。
+    const statuses = new Set(rows.map((r) => r.status));
+    if (statuses.has(AnchorStatus.CONFIRMED)) return AnchorStatus.CONFIRMED;
+    if (statuses.has(AnchorStatus.SUBMITTED)) return AnchorStatus.SUBMITTED;
+    if (statuses.has(AnchorStatus.FAILED)) return AnchorStatus.FAILED;
+    return AnchorStatus.PENDING;
+  }
+
+  async findPendingAnchors(ctx: IContext): Promise<AnchorBatchPendingSet> {
+    const issuer = ctx.issuer ?? this.getIssuer();
+    return issuer.internal(async (tx) => {
+      const [transactionAnchors, vcAnchors, userDidAnchors] = await Promise.all([
+        tx.transactionAnchor.findMany({
+          where: { status: AnchorStatus.PENDING, batchId: null },
+          select: TX_ANCHOR_SELECT,
+        }),
+        tx.vcAnchor.findMany({
+          where: { status: AnchorStatus.PENDING, batchId: null },
+          select: VC_ANCHOR_SELECT,
+        }),
+        tx.userDidAnchor.findMany({
+          where: { status: AnchorStatus.PENDING, batchId: null },
+          select: USER_DID_ANCHOR_SELECT,
+        }),
+      ]);
+      return {
+        transactionAnchors,
+        vcAnchors,
+        userDidAnchors,
+      };
+    });
+  }
+
+  async findVcJwtsByVcIssuanceRequestIds(
+    ctx: IContext,
+    vcIssuanceRequestIds: string[],
+  ): Promise<VcJwtLeaf[]> {
+    if (vcIssuanceRequestIds.length === 0) return [];
+    const issuer = ctx.issuer ?? this.getIssuer();
+    const rows = await issuer.internal((tx) =>
+      tx.vcIssuanceRequest.findMany({
+        where: { id: { in: vcIssuanceRequestIds } },
+        select: { id: true, vcJwt: true },
+      }),
+    );
+    return rows
+      .filter(
+        (r): r is { id: string; vcJwt: string } =>
+          typeof r.vcJwt === "string" && r.vcJwt.length > 0,
+      )
+      .map((r) => ({ vcIssuanceRequestId: r.id, vcJwt: r.vcJwt }));
+  }
+
+  async findPreviousAnchorChainTxHashes(
+    ctx: IContext,
+    previousAnchorIds: string[],
+  ): Promise<PreviousAnchorChainTx[]> {
+    if (previousAnchorIds.length === 0) return [];
+    const issuer = ctx.issuer ?? this.getIssuer();
+    const rows = await issuer.internal((tx) =>
+      tx.userDidAnchor.findMany({
+        where: { id: { in: previousAnchorIds } },
+        select: { id: true, chainTxHash: true },
+      }),
+    );
+    return rows.map((r) => ({ id: r.id, chainTxHash: r.chainTxHash }));
+  }
+
+  async claimPendingAnchors(
+    ctx: IContext,
+    args: {
+      batchId: string;
+      transactionAnchorIds: string[];
+      vcAnchorIds: string[];
+      userDidAnchorIds: string[];
+    },
+  ): Promise<{
+    transactionAnchors: number;
+    vcAnchors: number;
+    userDidAnchors: number;
+  }> {
+    const issuer = ctx.issuer ?? this.getIssuer();
+    return issuer.internal(async (tx) => {
+      const txRes = args.transactionAnchorIds.length
+        ? await tx.transactionAnchor.updateMany({
+            where: {
+              id: { in: args.transactionAnchorIds },
+              status: AnchorStatus.PENDING,
+              batchId: null,
+            },
+            data: { batchId: args.batchId },
+          })
+        : { count: 0 };
+      const vcRes = args.vcAnchorIds.length
+        ? await tx.vcAnchor.updateMany({
+            where: {
+              id: { in: args.vcAnchorIds },
+              status: AnchorStatus.PENDING,
+              batchId: null,
+            },
+            data: { batchId: args.batchId },
+          })
+        : { count: 0 };
+      const didRes = args.userDidAnchorIds.length
+        ? await tx.userDidAnchor.updateMany({
+            where: {
+              id: { in: args.userDidAnchorIds },
+              status: AnchorStatus.PENDING,
+              batchId: null,
+            },
+            data: { batchId: args.batchId },
+          })
+        : { count: 0 };
+      return {
+        transactionAnchors: txRes.count,
+        vcAnchors: vcRes.count,
+        userDidAnchors: didRes.count,
+      };
+    });
+  }
+
+  async markSubmitted(
+    ctx: IContext,
+    args: {
+      batchId: string;
+      chainTxHash: string;
+      transactionAnchorIds: string[];
+      vcAnchorIds: string[];
+      userDidAnchorIds: string[];
+    },
+  ): Promise<void> {
+    const issuer = ctx.issuer ?? this.getIssuer();
+    const submittedAt = new Date();
+    await issuer.internal(async (tx) => {
+      await Promise.all([
+        args.transactionAnchorIds.length
+          ? tx.transactionAnchor.updateMany({
+              where: { id: { in: args.transactionAnchorIds } },
+              data: {
+                status: AnchorStatus.SUBMITTED,
+                chainTxHash: args.chainTxHash,
+                submittedAt,
+              },
+            })
+          : Promise.resolve(),
+        args.vcAnchorIds.length
+          ? tx.vcAnchor.updateMany({
+              where: { id: { in: args.vcAnchorIds } },
+              data: {
+                status: AnchorStatus.SUBMITTED,
+                chainTxHash: args.chainTxHash,
+                submittedAt,
+              },
+            })
+          : Promise.resolve(),
+        args.userDidAnchorIds.length
+          ? tx.userDidAnchor.updateMany({
+              where: { id: { in: args.userDidAnchorIds } },
+              data: {
+                status: AnchorStatus.SUBMITTED,
+                chainTxHash: args.chainTxHash,
+                submittedAt,
+              },
+            })
+          : Promise.resolve(),
+      ]);
+    });
+  }
+
+  async markConfirmed(
+    ctx: IContext,
+    args: {
+      batchId: string;
+      blockHeight: number | null;
+      transactionAnchorIds: string[];
+      vcAnchorIds: string[];
+      userDidAnchorIds: string[];
+    },
+  ): Promise<void> {
+    const issuer = ctx.issuer ?? this.getIssuer();
+    const confirmedAt = new Date();
+    await issuer.internal(async (tx) => {
+      await Promise.all([
+        args.transactionAnchorIds.length
+          ? tx.transactionAnchor.updateMany({
+              where: { id: { in: args.transactionAnchorIds } },
+              data: {
+                status: AnchorStatus.CONFIRMED,
+                confirmedAt,
+                blockHeight: args.blockHeight,
+              },
+            })
+          : Promise.resolve(),
+        args.vcAnchorIds.length
+          ? tx.vcAnchor.updateMany({
+              where: { id: { in: args.vcAnchorIds } },
+              data: {
+                status: AnchorStatus.CONFIRMED,
+                confirmedAt,
+                blockHeight: args.blockHeight,
+              },
+            })
+          : Promise.resolve(),
+        args.userDidAnchorIds.length
+          ? tx.userDidAnchor.updateMany({
+              where: { id: { in: args.userDidAnchorIds } },
+              data: {
+                status: AnchorStatus.CONFIRMED,
+                confirmedAt,
+              },
+            })
+          : Promise.resolve(),
+      ]);
+    });
+  }
+
+  async markFailed(
+    ctx: IContext,
+    args: {
+      batchId: string;
+      failureReason: string;
+      transactionAnchorIds: string[];
+      vcAnchorIds: string[];
+      userDidAnchorIds: string[];
+    },
+  ): Promise<void> {
+    const issuer = ctx.issuer ?? this.getIssuer();
+    await issuer.internal(async (tx) => {
+      await Promise.all([
+        args.transactionAnchorIds.length
+          ? tx.transactionAnchor.updateMany({
+              where: { id: { in: args.transactionAnchorIds } },
+              data: {
+                status: AnchorStatus.FAILED,
+                lastError: args.failureReason,
+              },
+            })
+          : Promise.resolve(),
+        args.vcAnchorIds.length
+          ? tx.vcAnchor.updateMany({
+              where: { id: { in: args.vcAnchorIds } },
+              data: {
+                status: AnchorStatus.FAILED,
+                lastError: args.failureReason,
+              },
+            })
+          : Promise.resolve(),
+        args.userDidAnchorIds.length
+          ? tx.userDidAnchor.updateMany({
+              where: { id: { in: args.userDidAnchorIds } },
+              data: {
+                status: AnchorStatus.FAILED,
+              },
+            })
+          : Promise.resolve(),
+      ]);
+    });
+  }
+
+  async findPendingVcAnchorsByBatchId(ctx: IContext, batchId: string): Promise<PendingVcAnchor[]> {
+    const issuer = ctx.issuer ?? this.getIssuer();
+    return issuer.internal((tx) =>
+      tx.vcAnchor.findMany({
+        where: { batchId },
+        select: VC_ANCHOR_SELECT,
+      }),
+    );
+  }
+
+  async findPendingUserDidAnchorsByBatchId(
+    ctx: IContext,
+    batchId: string,
+  ): Promise<PendingUserDidAnchor[]> {
+    const issuer = ctx.issuer ?? this.getIssuer();
+    return issuer.internal((tx) =>
+      tx.userDidAnchor.findMany({
+        where: { batchId },
+        select: USER_DID_ANCHOR_SELECT,
+      }),
+    );
+  }
+}
+
+const TX_ANCHOR_SELECT = {
+  id: true,
+  leafIds: true,
+  leafCount: true,
+  rootHash: true,
+  network: true,
+  status: true,
+  batchId: true,
+  chainTxHash: true,
+  periodStart: true,
+  periodEnd: true,
+} as const;
+
+const VC_ANCHOR_SELECT = {
+  id: true,
+  leafIds: true,
+  leafCount: true,
+  rootHash: true,
+  network: true,
+  status: true,
+  batchId: true,
+  periodStart: true,
+  periodEnd: true,
+} as const;
+
+const USER_DID_ANCHOR_SELECT = {
+  id: true,
+  did: true,
+  operation: true,
+  documentHash: true,
+  documentCbor: true,
+  previousAnchorId: true,
+  network: true,
+  status: true,
+  batchId: true,
+  userId: true,
+} as const;

--- a/src/application/domain/anchor/anchorBatch/data/type.ts
+++ b/src/application/domain/anchor/anchorBatch/data/type.ts
@@ -1,0 +1,96 @@
+/**
+ * AnchorBatch 用の Prisma row 型定義。
+ *
+ * 設計参照:
+ *   docs/report/did-vc-internalization.md §5.2.3 (anchor ドメイン)
+ *   docs/report/did-vc-internalization.md §5.3.1 (週次バッチ)
+ */
+
+import {
+  AnchorStatus,
+  ChainNetwork,
+  DidOperation,
+  TransactionAnchor,
+  UserDidAnchor,
+  VcAnchor,
+} from "@prisma/client";
+
+/** PENDING な TransactionAnchor 行（必要列のみ）。 */
+export type PendingTransactionAnchor = Pick<
+  TransactionAnchor,
+  | "id"
+  | "leafIds"
+  | "leafCount"
+  | "rootHash"
+  | "network"
+  | "status"
+  | "batchId"
+  | "chainTxHash"
+  | "periodStart"
+  | "periodEnd"
+>;
+
+/** PENDING な VcAnchor 行（必要列のみ）。 */
+export type PendingVcAnchor = Pick<
+  VcAnchor,
+  | "id"
+  | "leafIds"
+  | "leafCount"
+  | "rootHash"
+  | "network"
+  | "status"
+  | "batchId"
+  | "periodStart"
+  | "periodEnd"
+>;
+
+/** PENDING な UserDidAnchor 行（必要列のみ）。 */
+export type PendingUserDidAnchor = Pick<
+  UserDidAnchor,
+  | "id"
+  | "did"
+  | "operation"
+  | "documentHash"
+  | "documentCbor"
+  | "previousAnchorId"
+  | "network"
+  | "status"
+  | "batchId"
+  | "userId"
+>;
+
+/** VC JWT を leaf として merkle root を計算するために必要な最小情報。 */
+export interface VcJwtLeaf {
+  /** VcIssuanceRequest.id（DB 側 leafId）。 */
+  vcIssuanceRequestId: string;
+  /** vcJwt 本体（merkle leaf hash 入力）。 */
+  vcJwt: string;
+}
+
+/** UserDidAnchor の前 anchor の chainTxHash 取得用。 */
+export interface PreviousAnchorChainTx {
+  id: string;
+  chainTxHash: string | null;
+}
+
+export interface AnchorBatchPendingSet {
+  transactionAnchors: PendingTransactionAnchor[];
+  vcAnchors: PendingVcAnchor[];
+  userDidAnchors: PendingUserDidAnchor[];
+}
+
+/** runWeeklyBatch の出力。 */
+export interface AnchorBatchRunResult {
+  batchId: string;
+  submitted: boolean;
+  txHash: string | null;
+  anchorCounts: {
+    userDid: number;
+    vc: number;
+    tx: number;
+  };
+  status: AnchorStatus;
+  failureReason?: string;
+}
+
+export type { AnchorStatus, ChainNetwork, DidOperation };

--- a/src/application/domain/anchor/anchorBatch/presenter.ts
+++ b/src/application/domain/anchor/anchorBatch/presenter.ts
@@ -1,0 +1,33 @@
+/**
+ * AnchorBatchPresenter.
+ *
+ * runWeeklyBatch の結果を REST レスポンス用 DTO に変換する pure function。
+ */
+
+import { AnchorBatchRunResult } from "@/application/domain/anchor/anchorBatch/data/type";
+
+export interface AnchorBatchHttpResponse {
+  batchId: string;
+  submitted: boolean;
+  txHash: string | null;
+  status: string;
+  anchorCounts: {
+    userDid: number;
+    vc: number;
+    tx: number;
+  };
+  failureReason?: string;
+}
+
+export default class AnchorBatchPresenter {
+  static toHttpResponse(result: AnchorBatchRunResult): AnchorBatchHttpResponse {
+    return {
+      batchId: result.batchId,
+      submitted: result.submitted,
+      txHash: result.txHash,
+      status: result.status,
+      anchorCounts: result.anchorCounts,
+      ...(result.failureReason ? { failureReason: result.failureReason } : {}),
+    };
+  }
+}

--- a/src/application/domain/anchor/anchorBatch/service.ts
+++ b/src/application/domain/anchor/anchorBatch/service.ts
@@ -23,7 +23,6 @@ import {
   type DidOp,
 } from "@/infrastructure/libs/cardano/txBuilder";
 import { BlockfrostClient } from "@/infrastructure/libs/blockfrost/client";
-import { KmsSigner } from "@/infrastructure/libs/kms/kmsSigner";
 import { deriveCardanoKeypair } from "@/infrastructure/libs/cardano/keygen";
 import { IAnchorBatchRepository } from "@/application/domain/anchor/anchorBatch/data/interface";
 import {
@@ -34,8 +33,47 @@ import {
   PendingTransactionAnchor,
 } from "@/application/domain/anchor/anchorBatch/data/type";
 
-/** awaitConfirmation のデフォルト timeout（5 分）。 */
+/**
+ * `awaitConfirmation` のデフォルト timeout（5 分）。
+ *
+ * Cloud Run の default request timeout が 300s であるため、5 分待機 +
+ * tx build/submit を 1 リクエストでこなすと容易にタイムアウトする。
+ * 暫定対応として:
+ *   - 本 PR では Cloud Run timeout >= 600s を deploy gate とし、
+ *     `docs/operations/anchor-batch-deploy-checklist.md` に運用注意を明記する。
+ *   - `CARDANO_AWAIT_CONFIRM_TIMEOUT_MS` で env から override 可能とし、
+ *     prd では 4min、staging では 1min 等にチューニングできるようにする。
+ *
+ * TODO(Phase 1.5 / Phase 2): `runWeeklyBatch` を 2 段階
+ *   `submitBatch` (submit まで → SUBMITTED 永続化で即 return) と
+ *   `confirmBatch` (Cloud Tasks 等で別呼び出し、awaitConfirmation のみ)
+ *   に分離し、router にも 2 endpoint 追加することで fire-and-forget 化する。
+ *   設計参照: docs/report/did-vc-internalization.md §5.3.1。
+ */
 const DEFAULT_CONFIRM_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * `CARDANO_AWAIT_CONFIRM_TIMEOUT_MS` env から timeout(ms) を解決する。
+ *
+ * 不正値（NaN / 負数 / 非数値）は default にフォールバックする。
+ * Cloud Run 側の HTTP request timeout を超える値を設定すると外側で
+ * 503 になり markFailed まで到達できないため、運用ドキュメントで
+ * `Cloud Run timeout > CARDANO_AWAIT_CONFIRM_TIMEOUT_MS + 60s` の
+ * 余裕を持たせるよう周知する。
+ */
+function resolveAwaitConfirmTimeoutMs(): number {
+  const raw = process.env.CARDANO_AWAIT_CONFIRM_TIMEOUT_MS;
+  if (raw === undefined || raw === "") return DEFAULT_CONFIRM_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    logger.warn(
+      "[AnchorBatchService] invalid CARDANO_AWAIT_CONFIRM_TIMEOUT_MS; falling back to default",
+      { raw, default: DEFAULT_CONFIRM_TIMEOUT_MS },
+    );
+    return DEFAULT_CONFIRM_TIMEOUT_MS;
+  }
+  return parsed;
+}
 
 /** Cardano slot を取得するための小さなインターフェース。 */
 export interface BlockfrostLatestSlotProvider {
@@ -72,8 +110,6 @@ export interface AnchorBatchServiceDeps {
   repository: IAnchorBatchRepository;
   blockfrost: BlockfrostClient;
   slotProvider: BlockfrostLatestSlotProvider;
-  /** Phase 1 では env から seed を直接渡す。Phase 2 で KmsSigner 経由に切替。 */
-  signer?: KmsSigner;
   /** 設定（platform 鍵 / KMS resource）。 */
   signerConfig: PlatformSignerConfig;
   /** confirmation 待機 timeout (ms)。テスト時短縮用。 */
@@ -84,10 +120,13 @@ export interface AnchorBatchServiceDeps {
 export class AnchorBatchService {
   /**
    * Phase 1 では env 上の raw seed (`CARDANO_PLATFORM_PRIVATE_KEY_HEX`) で
-   * 直接署名する。KmsSigner は将来の Phase 2 切替（KMS 署名）に向けた
-   * 配線を残すため inject だけしておく。実際に呼び出すのは Phase 2 で
-   * tx body hash を `KmsSigner.signEd25519` に渡し、vkey witness を
-   * 手動で attach する経路に差し替える時。
+   * 直接署名する。
+   *
+   * TODO(Phase 2): KMS 経由署名（vkey witness 手動 attach）を導入する PR で
+   *   `KmsSigner` を改めて `@inject("KmsSigner")` する。本 PR では実際に
+   *   利用しないため inject せず、DI 設計負債（`void this._signer` の
+   *   握りつぶし）を残さない方針とする。
+   *   設計参照: docs/report/did-vc-internalization.md §5.1.6 / §5.3.1。
    */
   constructor(
     @inject("AnchorBatchRepository")
@@ -96,12 +135,7 @@ export class AnchorBatchService {
     private readonly blockfrost: BlockfrostClient,
     @inject("BlockfrostLatestSlotProvider")
     private readonly slotProvider: BlockfrostLatestSlotProvider,
-    @inject("KmsSigner")
-    private readonly _signer: KmsSigner,
-  ) {
-    // _signer は Phase 1 では未使用（Phase 2 で利用）。lint 抑制のため void。
-    void this._signer;
-  }
+  ) {}
 
   /**
    * 週次バッチ実行。設計書 §5.3.1 のフローに沿う。
@@ -286,7 +320,7 @@ export class AnchorBatchService {
 
     // 8. awaitConfirmation
     try {
-      const tx = await this.blockfrost.awaitConfirmation(txHash, DEFAULT_CONFIRM_TIMEOUT_MS);
+      const tx = await this.blockfrost.awaitConfirmation(txHash, resolveAwaitConfirmTimeoutMs());
       await this.repository.markConfirmed(ctx, {
         batchId: weeklyKey,
         blockHeight: tx.block_height,
@@ -312,9 +346,7 @@ export class AnchorBatchService {
     // ordering for Merkle determinism, which is what JS's `<`/`>` give on
     // strings (UTF-16 code-unit compare). `String.localeCompare` would
     // introduce locale-dependent collation and break cross-host hashes.
-    const sorted = [...jwts]
-      .map((j) => j.vcJwt)
-      .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    const sorted = [...jwts].map((j) => j.vcJwt).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
     const root = buildRoot(sorted);
     return { root, count: sorted.length };
   }
@@ -474,14 +506,22 @@ export function resolvePlatformSignKey(config: PlatformSignerConfig): CSL.Privat
   }
   const seed = hexToBytes(config.privateKeyHex);
   if (seed.length !== 32) {
+    // length チェックで弾く前にも seed bytes を握っているため、確実に zeroize する。
+    seed.fill(0);
     throw new Error(
       `CARDANO_PLATFORM_PRIVATE_KEY_HEX must be 32 bytes (64 hex chars), got ${seed.length} bytes.`,
     );
   }
-  // deriveCardanoKeypair で CSL.PrivateKey を取得（network は anchoring に無関係だが
-  // 引数として要求されるため、config.network を渡す）。
-  const kp = deriveCardanoKeypair(seed, config.network);
-  return kp.cslPrivateKey;
+  try {
+    // deriveCardanoKeypair で CSL.PrivateKey を取得（network は anchoring に無関係だが
+    // 引数として要求されるため、config.network を渡す）。CSL.PrivateKey は seed bytes を
+    // 内部的にコピーするため、ここで zeroize しても署名は影響を受けない。
+    const kp = deriveCardanoKeypair(seed, config.network);
+    return kp.cslPrivateKey;
+  } finally {
+    // CSL に渡した直後にプロセス上から seed の痕跡を消す（メモリダンプ対策）。
+    seed.fill(0);
+  }
 }
 
 function hexToBytes(h: string): Uint8Array {

--- a/src/application/domain/anchor/anchorBatch/service.ts
+++ b/src/application/domain/anchor/anchorBatch/service.ts
@@ -1,0 +1,493 @@
+/**
+ * AnchorBatchService.
+ *
+ * 週次で PENDING な UserDidAnchor / VcAnchor / TransactionAnchor を 1 つの Cardano
+ * tx に集約して anchor する。
+ *
+ * 設計参照:
+ *   docs/report/did-vc-internalization.md §5.1.6 (label 1985 metadata)
+ *   docs/report/did-vc-internalization.md §5.1.7 (Merkle 構築)
+ *   docs/report/did-vc-internalization.md §5.2.3 (anchor ドメイン)
+ *   docs/report/did-vc-internalization.md §5.3.1 (週次バッチ + idempotency)
+ */
+
+import { inject, injectable } from "tsyringe";
+import * as CSL from "@emurgo/cardano-serialization-lib-nodejs";
+import { AnchorStatus, DidOperation } from "@prisma/client";
+import { IContext } from "@/types/server";
+import logger from "@/infrastructure/logging";
+import { buildRoot } from "@/infrastructure/libs/merkle/merkleTreeBuilder";
+import {
+  buildAnchorTx,
+  buildAuxiliaryData,
+  type DidOp,
+} from "@/infrastructure/libs/cardano/txBuilder";
+import { BlockfrostClient } from "@/infrastructure/libs/blockfrost/client";
+import { KmsSigner } from "@/infrastructure/libs/kms/kmsSigner";
+import { deriveCardanoKeypair } from "@/infrastructure/libs/cardano/keygen";
+import { IAnchorBatchRepository } from "@/application/domain/anchor/anchorBatch/data/interface";
+import {
+  AnchorBatchPendingSet,
+  AnchorBatchRunResult,
+  PendingUserDidAnchor,
+  PendingVcAnchor,
+  PendingTransactionAnchor,
+} from "@/application/domain/anchor/anchorBatch/data/type";
+
+/** awaitConfirmation のデフォルト timeout（5 分）。 */
+const DEFAULT_CONFIRM_TIMEOUT_MS = 5 * 60 * 1000;
+
+/** Cardano slot を取得するための小さなインターフェース。 */
+export interface BlockfrostLatestSlotProvider {
+  /** 最新ブロックの slot 番号を返す。 */
+  getCurrentSlot(): Promise<number>;
+}
+
+/**
+ * Anchoring に必要な platform 鍵情報。env 変数から組み立てる。
+ *
+ * - `CARDANO_PLATFORM_PRIVATE_KEY_HEX`: 32-byte ed25519 seed の hex (raw)。
+ *   KMS 経由で署名する Phase 2 までの暫定。Phase 1 では env から直接読む
+ *   （§I 0-2: Phase 0 で生成した seed を Secret Manager で配信）。
+ * - `CARDANO_PLATFORM_ADDRESS`: bech32 enterprise address（preprod / mainnet）。
+ * - `CARDANO_PLATFORM_KMS_KEY_RESOURCE_NAME`: KMS 経由署名時のリソース名
+ *   （Phase 2 以降）。Phase 1 では env_seed が優先される。
+ */
+export interface PlatformSignerConfig {
+  /** Phase 1: raw 32-byte seed (hex)。 */
+  privateKeyHex?: string;
+  /** Phase 2: KMS resource name。 */
+  kmsKeyResourceName?: string;
+  /** issuer address (bech32)。 */
+  changeAddressBech32: string;
+  /** "preprod" | "mainnet"。 */
+  network: "preprod" | "mainnet";
+}
+
+/**
+ * AnchorBatchService が依存する外部 IO の集合。テスト容易性のため interface として
+ * 切り出し、UseCase / DI から組み立てる。
+ */
+export interface AnchorBatchServiceDeps {
+  repository: IAnchorBatchRepository;
+  blockfrost: BlockfrostClient;
+  slotProvider: BlockfrostLatestSlotProvider;
+  /** Phase 1 では env から seed を直接渡す。Phase 2 で KmsSigner 経由に切替。 */
+  signer?: KmsSigner;
+  /** 設定（platform 鍵 / KMS resource）。 */
+  signerConfig: PlatformSignerConfig;
+  /** confirmation 待機 timeout (ms)。テスト時短縮用。 */
+  confirmTimeoutMs?: number;
+}
+
+@injectable()
+export class AnchorBatchService {
+  /**
+   * Phase 1 では env 上の raw seed (`CARDANO_PLATFORM_PRIVATE_KEY_HEX`) で
+   * 直接署名する。KmsSigner は将来の Phase 2 切替（KMS 署名）に向けた
+   * 配線を残すため inject だけしておく。実際に呼び出すのは Phase 2 で
+   * tx body hash を `KmsSigner.signEd25519` に渡し、vkey witness を
+   * 手動で attach する経路に差し替える時。
+   */
+  constructor(
+    @inject("AnchorBatchRepository")
+    private readonly repository: IAnchorBatchRepository,
+    @inject("BlockfrostClient")
+    private readonly blockfrost: BlockfrostClient,
+    @inject("BlockfrostLatestSlotProvider")
+    private readonly slotProvider: BlockfrostLatestSlotProvider,
+    @inject("KmsSigner")
+    private readonly _signer: KmsSigner,
+  ) {
+    // _signer は Phase 1 では未使用（Phase 2 で利用）。lint 抑制のため void。
+    void this._signer;
+  }
+
+  /**
+   * 週次バッチ実行。設計書 §5.3.1 のフローに沿う。
+   *
+   * 1. 同 weeklyKey の TransactionAnchor が SUBMITTED/CONFIRMED 済 → 早期 return
+   * 2. PENDING + batchId IS NULL を全件取得
+   * 3. 何も無ければ早期 return
+   * 4. claim（CAS で batchId をセット）
+   * 5. Merkle root 計算 + metadata 構築
+   * 6. UTXO / 鍵を取得して tx 構築 + 署名
+   * 7. submit + DB を SUBMITTED に
+   * 8. awaitConfirmation → CONFIRMED / FAILED
+   */
+  async runWeeklyBatch(ctx: IContext, args: { weeklyKey: string }): Promise<AnchorBatchRunResult> {
+    const { weeklyKey } = args;
+    if (!isValidWeeklyKey(weeklyKey)) {
+      throw new Error(
+        `runWeeklyBatch: weeklyKey "${weeklyKey}" must match YYYY-Www (ISO 8601 week).`,
+      );
+    }
+
+    // 1. idempotency 早期 return
+    const terminal = await this.repository.getBatchTerminalStatus(ctx, weeklyKey);
+    if (terminal === AnchorStatus.SUBMITTED || terminal === AnchorStatus.CONFIRMED) {
+      logger.info("[AnchorBatchService] weeklyKey already processed; skipping", {
+        weeklyKey,
+        terminal,
+      });
+      const existing = await this.repository.findExistingBatchTransactionAnchors(ctx, weeklyKey);
+      const txHash = await this.firstChainTxHashOf(ctx, weeklyKey);
+      return {
+        batchId: weeklyKey,
+        submitted: true,
+        txHash,
+        anchorCounts: countsFor(existing, [], []),
+        status: terminal,
+      };
+    }
+
+    // 2. PENDING 取得
+    const pending = await this.repository.findPendingAnchors(ctx);
+    const total =
+      pending.transactionAnchors.length + pending.vcAnchors.length + pending.userDidAnchors.length;
+    if (total === 0) {
+      logger.info("[AnchorBatchService] no PENDING anchors; nothing to submit", {
+        weeklyKey,
+      });
+      return {
+        batchId: weeklyKey,
+        submitted: false,
+        txHash: null,
+        anchorCounts: { userDid: 0, vc: 0, tx: 0 },
+        status: AnchorStatus.PENDING,
+      };
+    }
+
+    // 3. claim（CAS）
+    const ids = collectIds(pending);
+    const claimed = await this.repository.claimPendingAnchors(ctx, {
+      batchId: weeklyKey,
+      ...ids,
+    });
+    if (
+      claimed.transactionAnchors === 0 &&
+      claimed.vcAnchors === 0 &&
+      claimed.userDidAnchors === 0
+    ) {
+      logger.warn("[AnchorBatchService] CAS claimed 0 rows; another batch may be running", {
+        weeklyKey,
+      });
+      return {
+        batchId: weeklyKey,
+        submitted: false,
+        txHash: null,
+        anchorCounts: { userDid: 0, vc: 0, tx: 0 },
+        status: AnchorStatus.PENDING,
+      };
+    }
+
+    try {
+      const { txHash, blockHeight } = await this.buildAndSubmitAndConfirm(ctx, {
+        weeklyKey,
+        pending,
+      });
+      return {
+        batchId: weeklyKey,
+        submitted: true,
+        txHash,
+        anchorCounts: countsFor(
+          pending.transactionAnchors,
+          pending.vcAnchors,
+          pending.userDidAnchors,
+        ),
+        status: blockHeight === null ? AnchorStatus.SUBMITTED : AnchorStatus.CONFIRMED,
+      };
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      logger.error("[AnchorBatchService] batch failed", { weeklyKey, reason });
+      await this.repository.markFailed(ctx, {
+        batchId: weeklyKey,
+        failureReason: reason,
+        ...ids,
+      });
+      return {
+        batchId: weeklyKey,
+        submitted: false,
+        txHash: null,
+        anchorCounts: countsFor(
+          pending.transactionAnchors,
+          pending.vcAnchors,
+          pending.userDidAnchors,
+        ),
+        status: AnchorStatus.FAILED,
+        failureReason: reason,
+      };
+    }
+  }
+
+  /**
+   * Merkle 計算 → metadata 構築 → tx 構築 → submit → awaitConfirmation。
+   *
+   * テスト容易性のため切り出し。例外は呼び元で markFailed される。
+   */
+  private async buildAndSubmitAndConfirm(
+    ctx: IContext,
+    args: {
+      weeklyKey: string;
+      pending: AnchorBatchPendingSet;
+    },
+  ): Promise<{ txHash: string; blockHeight: number | null }> {
+    const { weeklyKey, pending } = args;
+
+    // 4. Merkle root 計算 + ops 構築
+    const txRoot = buildTxRoot(pending.transactionAnchors);
+    const vcRoot = await this.buildVcRoot(ctx, pending.vcAnchors);
+    const ops = await this.buildDidOps(ctx, pending.userDidAnchors);
+
+    // 5. AuxiliaryData を組み立て
+    const aux = buildAuxiliaryData({
+      v: 1,
+      bid: weeklyKey,
+      ts: Math.floor(Date.now() / 1000),
+      tx: txRoot,
+      vc: vcRoot,
+      ops,
+    });
+
+    // 6. UTXO + 鍵
+    const config = resolvePlatformSignerConfig();
+    const [params, utxos, currentSlot] = await Promise.all([
+      this.blockfrost.getProtocolParams(),
+      this.blockfrost.getUtxos(config.changeAddressBech32),
+      this.slotProvider.getCurrentSlot(),
+    ]);
+
+    const signKey = resolvePlatformSignKey(config);
+
+    const built = buildAnchorTx({
+      utxos,
+      params,
+      signKey,
+      auxiliaryData: aux,
+      changeAddressBech32: config.changeAddressBech32,
+      currentSlot,
+    });
+
+    // 7. submit
+    const txHash = await this.blockfrost.submitTx(built.txCborBytes);
+    if (txHash !== built.txHashHex) {
+      logger.warn("[AnchorBatchService] submit returned hash differs from local hash", {
+        local: built.txHashHex,
+        remote: txHash,
+      });
+    }
+
+    const ids = collectIds(pending);
+    await this.repository.markSubmitted(ctx, {
+      batchId: weeklyKey,
+      chainTxHash: txHash,
+      ...ids,
+    });
+
+    // 8. awaitConfirmation
+    try {
+      const tx = await this.blockfrost.awaitConfirmation(txHash, DEFAULT_CONFIRM_TIMEOUT_MS);
+      await this.repository.markConfirmed(ctx, {
+        batchId: weeklyKey,
+        blockHeight: tx.block_height,
+        ...ids,
+      });
+      return { txHash, blockHeight: tx.block_height };
+    } catch (err) {
+      // markFailed は呼び元（catch）で実施するため、ここでは throw のみ
+      throw err instanceof Error ? err : new Error(`awaitConfirmation failed: ${String(err)}`);
+    }
+  }
+
+  private async buildVcRoot(
+    ctx: IContext,
+    vcAnchors: PendingVcAnchor[],
+  ): Promise<{ root: Uint8Array; count: number } | undefined> {
+    if (vcAnchors.length === 0) return undefined;
+    const allLeafIds = vcAnchors.flatMap((a) => a.leafIds);
+    if (allLeafIds.length === 0) return undefined;
+    const jwts = await this.repository.findVcJwtsByVcIssuanceRequestIds(ctx, allLeafIds);
+    if (jwts.length === 0) return undefined;
+    const sorted = [...jwts].map((j) => j.vcJwt).sort();
+    const root = buildRoot(sorted);
+    return { root, count: sorted.length };
+  }
+
+  private async buildDidOps(
+    ctx: IContext,
+    userDidAnchors: PendingUserDidAnchor[],
+  ): Promise<DidOp[]> {
+    if (userDidAnchors.length === 0) return [];
+    // 「sorted by did asc」で決定論的出力にする（§5.3.1 の bid + 順序）
+    const sorted = [...userDidAnchors].sort((a, b) => (a.did < b.did ? -1 : a.did > b.did ? 1 : 0));
+    const prevIds = sorted
+      .map((a) => a.previousAnchorId)
+      .filter((id): id is string => typeof id === "string");
+    const prevs = prevIds.length
+      ? await this.repository.findPreviousAnchorChainTxHashes(ctx, prevIds)
+      : [];
+    const prevByAnchorId = new Map(prevs.map((p) => [p.id, p.chainTxHash]));
+
+    return sorted.map((a) => buildOp(a, prevByAnchorId));
+  }
+
+  /** SUBMITTED/CONFIRMED 済 batch から chainTxHash を 1 件取得（idempotency 早期 return 用）。 */
+  private async firstChainTxHashOf(ctx: IContext, weeklyKey: string): Promise<string | null> {
+    const rows = await this.repository.findExistingBatchTransactionAnchors(ctx, weeklyKey);
+    for (const r of rows) {
+      if (typeof r.chainTxHash === "string" && r.chainTxHash.length > 0) {
+        return r.chainTxHash;
+      }
+    }
+    return null;
+  }
+}
+
+/** UserDidAnchor → DidOp 変換。 */
+function buildOp(a: PendingUserDidAnchor, prevByAnchorId: Map<string, string | null>): DidOp {
+  const prevHash = a.previousAnchorId ? (prevByAnchorId.get(a.previousAnchorId) ?? null) : null;
+
+  if (a.operation === DidOperation.DEACTIVATE) {
+    return {
+      k: "d",
+      did: a.did,
+      // d は prev 必須（§5.1.6）。なければ空文字（CSL に native null が無いため）
+      prev: prevHash ?? "",
+    };
+  }
+
+  // CREATE / UPDATE: documentCbor は DB に保存済の CBOR bytes だが、
+  // txBuilder.buildOpMap が `cborEncode(op.doc)` を呼ぶため plain object を
+  // 渡す必要がある。Phase 1 では最小 doc（id のみ）を渡し、改ざん検知は
+  // metadata の `h` (Blake2b-256 hash) で担保する（§5.1.6 注釈）。
+  const minimalDoc: Record<string, unknown> = { id: a.did };
+
+  return {
+    k: a.operation === DidOperation.CREATE ? "c" : "u",
+    did: a.did,
+    h: a.documentHash,
+    doc: minimalDoc,
+    prev: prevHash ?? null,
+  };
+}
+
+/** TransactionAnchor の leafIds を全結合して merkle root を計算。 */
+function buildTxRoot(
+  txAnchors: PendingTransactionAnchor[],
+): { root: Uint8Array; count: number } | undefined {
+  if (txAnchors.length === 0) return undefined;
+  const all = txAnchors.flatMap((a) => a.leafIds);
+  if (all.length === 0) return undefined;
+  // ASCII byte 昇順（§5.1.7 canonical）
+  const sorted = [...all].sort();
+  return { root: buildRoot(sorted), count: sorted.length };
+}
+
+function collectIds(pending: AnchorBatchPendingSet): {
+  transactionAnchorIds: string[];
+  vcAnchorIds: string[];
+  userDidAnchorIds: string[];
+} {
+  return {
+    transactionAnchorIds: pending.transactionAnchors.map((a) => a.id),
+    vcAnchorIds: pending.vcAnchors.map((a) => a.id),
+    userDidAnchorIds: pending.userDidAnchors.map((a) => a.id),
+  };
+}
+
+function countsFor(
+  txAnchors: PendingTransactionAnchor[],
+  vcAnchors: PendingVcAnchor[],
+  userDidAnchors: PendingUserDidAnchor[],
+): { userDid: number; vc: number; tx: number } {
+  return {
+    userDid: userDidAnchors.length,
+    vc: vcAnchors.length,
+    tx: txAnchors.length,
+  };
+}
+
+/** ISO 8601 week-numbering: `YYYY-Www`（例: "2026-W19"）。 */
+const WEEKLY_KEY_REGEX = /^\d{4}-W\d{2}$/;
+
+export function isValidWeeklyKey(key: string): boolean {
+  if (typeof key !== "string") return false;
+  if (!WEEKLY_KEY_REGEX.test(key)) return false;
+  const wk = Number.parseInt(key.slice(6, 8), 10);
+  return wk >= 1 && wk <= 53;
+}
+
+/**
+ * 現在日時から ISO 8601 週キー `YYYY-Www` を計算（UTC 基準）。
+ *
+ * ISO 8601: 木曜日を含む週がその年の第 1 週。
+ */
+export function computeIsoWeeklyKey(date: Date = new Date()): string {
+  const utc = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  // 木曜日 = 4 (1=月..7=日) 基準で week-numbering year を決定
+  const dayOfWeek = utc.getUTCDay() === 0 ? 7 : utc.getUTCDay();
+  utc.setUTCDate(utc.getUTCDate() + 4 - dayOfWeek);
+  const yearStart = new Date(Date.UTC(utc.getUTCFullYear(), 0, 1));
+  const weekNo = Math.ceil(((utc.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  return `${utc.getUTCFullYear()}-W${String(weekNo).padStart(2, "0")}`;
+}
+
+/** env から platform signer 設定を組み立てる（Phase 1 暫定）。 */
+export function resolvePlatformSignerConfig(): PlatformSignerConfig {
+  const networkRaw = process.env.CARDANO_NETWORK ?? "preprod";
+  const network = networkRaw === "mainnet" ? "mainnet" : "preprod";
+  const changeAddressBech32 = process.env.CARDANO_PLATFORM_ADDRESS;
+  if (!changeAddressBech32) {
+    throw new Error(
+      "AnchorBatchService: CARDANO_PLATFORM_ADDRESS is not set. Anchor submission requires the issuer bech32 address.",
+    );
+  }
+  return {
+    privateKeyHex: process.env.CARDANO_PLATFORM_PRIVATE_KEY_HEX,
+    kmsKeyResourceName: process.env.CARDANO_PLATFORM_KMS_KEY_RESOURCE_NAME,
+    changeAddressBech32,
+    network,
+  };
+}
+
+/**
+ * tx 署名に使う `CSL.PrivateKey` を取得する。
+ *
+ * Phase 1: `CARDANO_PLATFORM_PRIVATE_KEY_HEX` を Secret Manager から env に投入し、
+ *   raw 32-byte seed として CSL に渡す。
+ * Phase 2: KMS 経由で署名するように差し替え予定（KmsSigner.signEd25519）。
+ */
+export function resolvePlatformSignKey(config: PlatformSignerConfig): CSL.PrivateKey {
+  if (!config.privateKeyHex) {
+    throw new Error(
+      "AnchorBatchService: CARDANO_PLATFORM_PRIVATE_KEY_HEX is not set. " +
+        "Phase 1 anchor submission requires the raw seed in env (Secret Manager).",
+    );
+  }
+  const seed = hexToBytes(config.privateKeyHex);
+  if (seed.length !== 32) {
+    throw new Error(
+      `CARDANO_PLATFORM_PRIVATE_KEY_HEX must be 32 bytes (64 hex chars), got ${seed.length} bytes.`,
+    );
+  }
+  // deriveCardanoKeypair で CSL.PrivateKey を取得（network は anchoring に無関係だが
+  // 引数として要求されるため、config.network を渡す）。
+  const kp = deriveCardanoKeypair(seed, config.network);
+  return kp.cslPrivateKey;
+}
+
+function hexToBytes(h: string): Uint8Array {
+  const clean = h.startsWith("0x") ? h.slice(2) : h;
+  if (clean.length % 2 !== 0) {
+    throw new Error(`hex string must have even length, got ${clean.length}`);
+  }
+  const out = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    const pair = clean.slice(i * 2, i * 2 + 2);
+    if (!/^[0-9a-fA-F]{2}$/.test(pair)) {
+      throw new Error(`invalid hex char at offset ${i * 2}`);
+    }
+    out[i] = Number.parseInt(pair, 16);
+  }
+  return out;
+}

--- a/src/application/domain/anchor/anchorBatch/service.ts
+++ b/src/application/domain/anchor/anchorBatch/service.ts
@@ -308,7 +308,13 @@ export class AnchorBatchService {
     if (allLeafIds.length === 0) return undefined;
     const jwts = await this.repository.findVcJwtsByVcIssuanceRequestIds(ctx, allLeafIds);
     if (jwts.length === 0) return undefined;
-    const sorted = [...jwts].map((j) => j.vcJwt).sort();
+    // Explicit byte-order comparator: §5.1.7 mandates canonical ASCII byte
+    // ordering for Merkle determinism, which is what JS's `<`/`>` give on
+    // strings (UTF-16 code-unit compare). `String.localeCompare` would
+    // introduce locale-dependent collation and break cross-host hashes.
+    const sorted = [...jwts]
+      .map((j) => j.vcJwt)
+      .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
     const root = buildRoot(sorted);
     return { root, count: sorted.length };
   }
@@ -378,8 +384,10 @@ function buildTxRoot(
   if (txAnchors.length === 0) return undefined;
   const all = txAnchors.flatMap((a) => a.leafIds);
   if (all.length === 0) return undefined;
-  // ASCII byte 昇順（§5.1.7 canonical）
-  const sorted = [...all].sort();
+  // §5.1.7 canonical ASCII byte order. Use an explicit code-unit
+  // comparator instead of bare `.sort()` so cross-host runs hash to the
+  // same Merkle root regardless of process locale.
+  const sorted = [...all].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
   return { root: buildRoot(sorted), count: sorted.length };
 }
 

--- a/src/application/domain/anchor/anchorBatch/usecase.ts
+++ b/src/application/domain/anchor/anchorBatch/usecase.ts
@@ -1,0 +1,42 @@
+/**
+ * AnchorBatchUseCase.
+ *
+ * 週次バッチの起動エントリ。Cron / 管理 REST endpoint から呼ばれる。
+ *
+ * 設計参照:
+ *   docs/report/did-vc-internalization.md §5.2.3 / §5.3.1
+ */
+
+import { inject, injectable } from "tsyringe";
+import { IContext } from "@/types/server";
+import {
+  AnchorBatchService,
+  computeIsoWeeklyKey,
+} from "@/application/domain/anchor/anchorBatch/service";
+import AnchorBatchPresenter, {
+  AnchorBatchHttpResponse,
+} from "@/application/domain/anchor/anchorBatch/presenter";
+
+@injectable()
+export default class AnchorBatchUseCase {
+  constructor(
+    @inject("AnchorBatchService")
+    private readonly service: AnchorBatchService,
+  ) {}
+
+  /**
+   * 週次バッチを実行する。
+   *
+   * 注: anchor batch は内部 service / repository が `internal()` を使うため
+   * `onlyBelongingCommunity` トランザクションは張らない。冪等性は
+   * batchId（= weeklyKey）の CAS で担保する（§5.3.1）。
+   */
+  async runBatch(
+    ctx: IContext,
+    args: { weeklyKey?: string } = {},
+  ): Promise<AnchorBatchHttpResponse> {
+    const weeklyKey = args.weeklyKey ?? computeIsoWeeklyKey();
+    const result = await this.service.runWeeklyBatch(ctx, { weeklyKey });
+    return AnchorBatchPresenter.toHttpResponse(result);
+  }
+}

--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -143,7 +143,6 @@ import {
 } from "@/application/domain/anchor/anchorBatch/service";
 import AnchorBatchUseCase from "@/application/domain/anchor/anchorBatch/usecase";
 import { BlockfrostClient } from "@/infrastructure/libs/blockfrost/client";
-import { KmsSigner } from "@/infrastructure/libs/kms/kmsSigner";
 
 export function registerProductionDependencies() {
   // ------------------------------
@@ -415,13 +414,15 @@ export function registerProductionDependencies() {
   // ------------------------------
   // ⚓ Anchor (DID/VC internalization, Phase 1)
   // ------------------------------
-  // BlockfrostClient / KmsSigner は本 PR で初めて DI 登録される。
+  // BlockfrostClient は本 PR で初めて DI 登録される。
   // BlockfrostLatestSlotProvider は currentSlot 取得用の薄い factory
   // （/blocks/latest を直接叩く。本来は BlockfrostClient に追加すべき
   //  だが、本 PR では infrastructure/libs を読み取り専用扱いにしている
   //  ため、provider 側で動的 import → factory として配線する）。
+  // KmsSigner は Phase 2 で KMS 経由署名を導入する PR で登録する
+  //  （現時点では誰も `@inject("KmsSigner")` していないため、未使用 DI を
+  //  残さない方針で削除した）。
   container.registerSingleton("BlockfrostClient", BlockfrostClient);
-  container.registerSingleton("KmsSigner", KmsSigner);
   container.register<BlockfrostLatestSlotProvider>("BlockfrostLatestSlotProvider", {
     useFactory: () => createBlockfrostLatestSlotProvider(),
   });

--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -136,6 +136,14 @@ import AnalyticsPlatformService from "@/application/domain/analytics/platform/se
 import AnalyticsUseCase from "@/application/domain/analytics/usecase";
 import AnalyticsCommunityService from "@/application/domain/analytics/community/service";
 import AnalyticsCommunityUseCase from "@/application/domain/analytics/community/usecase";
+import AnchorBatchRepository from "@/application/domain/anchor/anchorBatch/data/repository";
+import {
+  AnchorBatchService,
+  type BlockfrostLatestSlotProvider,
+} from "@/application/domain/anchor/anchorBatch/service";
+import AnchorBatchUseCase from "@/application/domain/anchor/anchorBatch/usecase";
+import { BlockfrostClient } from "@/infrastructure/libs/blockfrost/client";
+import { KmsSigner } from "@/infrastructure/libs/kms/kmsSigner";
 
 export function registerProductionDependencies() {
   // ------------------------------
@@ -403,6 +411,51 @@ export function registerProductionDependencies() {
 
   container.register("NmkrClient", { useClass: NmkrClient });
   container.register("CardanoShopifyAppClient", { useClass: CardanoShopifyAppClient });
+
+  // ------------------------------
+  // ⚓ Anchor (DID/VC internalization, Phase 1)
+  // ------------------------------
+  // BlockfrostClient / KmsSigner は本 PR で初めて DI 登録される。
+  // BlockfrostLatestSlotProvider は currentSlot 取得用の薄い factory
+  // （/blocks/latest を直接叩く。本来は BlockfrostClient に追加すべき
+  //  だが、本 PR では infrastructure/libs を読み取り専用扱いにしている
+  //  ため、provider 側で動的 import → factory として配線する）。
+  container.registerSingleton("BlockfrostClient", BlockfrostClient);
+  container.registerSingleton("KmsSigner", KmsSigner);
+  container.register<BlockfrostLatestSlotProvider>("BlockfrostLatestSlotProvider", {
+    useFactory: () => createBlockfrostLatestSlotProvider(),
+  });
+  container.register("AnchorBatchRepository", { useClass: AnchorBatchRepository });
+  container.register("AnchorBatchService", { useClass: AnchorBatchService });
+  container.register("AnchorBatchUseCase", { useClass: AnchorBatchUseCase });
+}
+
+/**
+ * `@blockfrost/blockfrost-js` の `BlockFrostAPI.blocksLatest()` を直接叩く
+ * 軽量 factory。BlockfrostClient 本体（src/infrastructure/libs/blockfrost）
+ * は本 PR では変更不可なため、provider 側に閉じた配線でカバーする。
+ */
+function createBlockfrostLatestSlotProvider(): BlockfrostLatestSlotProvider {
+  return {
+    async getCurrentSlot(): Promise<number> {
+      // 動的 import で起動時の dependency 評価を避ける（テスト時に DI を
+      // 別 provider に差し替えるためメインのプロセスでは初期化されない）。
+      const { BlockFrostAPI } = await import("@blockfrost/blockfrost-js");
+      const networkRaw = process.env.CARDANO_NETWORK ?? "preprod";
+      const network = networkRaw === "mainnet" ? "mainnet" : "preprod";
+      const projectId = process.env.BLOCKFROST_PROJECT_ID;
+      if (!projectId) {
+        throw new Error("BlockfrostLatestSlotProvider: BLOCKFROST_PROJECT_ID is not set.");
+      }
+      const api = new BlockFrostAPI({ projectId, network });
+      const latest = (await api.blocksLatest()) as { slot?: number | null };
+      const slot = latest?.slot;
+      if (typeof slot !== "number") {
+        throw new Error("BlockfrostLatestSlotProvider: blocksLatest returned no slot.");
+      }
+      return slot;
+    },
+  };
 }
 
 registerProductionDependencies();

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { createApolloServer } from "@/presentation/graphql/server";
 import logger from "@/infrastructure/logging";
 import { authHandler } from "@/presentation/middleware/auth";
 import lineRouter from "@/presentation/router/line";
+import anchorBatchRouter from "@/presentation/router/admin/anchorBatch";
 import { batchProcess } from "@/batch";
 import express from "express";
 import { corsHandler } from "@/presentation/middleware/cors";
@@ -75,6 +76,7 @@ async function startServer() {
     authHandler(apolloServer),
   );
   app.use("/line", lineRouter);
+  app.use("/admin/anchor-batch", anchorBatchRouter);
 
   app.get("/health", (req, res) => {
     res.status(200).json({ status: "healthy", service: "internal-api" });
@@ -83,22 +85,29 @@ async function startServer() {
   // Error handler — must be registered after all routes.
   // Distinguishes client errors (4xx) from server errors (5xx) so that
   // malformed multipart requests return 400 instead of 500.
-  app.use((err: Error & { status?: number; expose?: boolean }, req: express.Request, res: express.Response, _next: express.NextFunction) => {
-    const status = typeof err.status === "number" ? err.status : 500;
-    if (status < 500) {
-      logger.warn("Client error:", {
-        status,
-        message: err.message,
-        url: req.originalUrl,
-      });
-    } else {
-      logger.error("Unhandled Express Error:", {
-        message: err.message,
-        stack: err.stack,
-      });
-    }
-    res.status(status).json({ error: err.expose ? err.message : "Internal Server Error" });
-  });
+  app.use(
+    (
+      err: Error & { status?: number; expose?: boolean },
+      req: express.Request,
+      res: express.Response,
+      _next: express.NextFunction,
+    ) => {
+      const status = typeof err.status === "number" ? err.status : 500;
+      if (status < 500) {
+        logger.warn("Client error:", {
+          status,
+          message: err.message,
+          url: req.originalUrl,
+        });
+      } else {
+        logger.error("Unhandled Express Error:", {
+          message: err.message,
+          stack: err.stack,
+        });
+      }
+      res.status(status).json({ error: err.expose ? err.message : "Internal Server Error" });
+    },
+  );
 
   step("Middleware registered");
 

--- a/src/presentation/router/admin/anchorBatch.ts
+++ b/src/presentation/router/admin/anchorBatch.ts
@@ -1,0 +1,71 @@
+/**
+ * Admin REST endpoint: 週次 anchor バッチを起動する。
+ *
+ * - 認可: `X-CloudScheduler-Token` ヘッダの一致 (`CLOUD_SCHEDULER_TOKEN`)
+ *   - 不一致 / 未設定 → 401
+ * - リクエスト body: `{ weeklyKey?: string }`
+ *   - 省略時はサーバ側で ISO 週キーを計算
+ * - レスポンス: AnchorBatchPresenter.toHttpResponse の DTO
+ *
+ * 設計参照:
+ *   docs/report/did-vc-internalization.md §5.3.1 (週次バッチ)
+ */
+
+import express, { Request, Response } from "express";
+import { container } from "tsyringe";
+import logger from "@/infrastructure/logging";
+import AnchorBatchUseCase from "@/application/domain/anchor/anchorBatch/usecase";
+import { isValidWeeklyKey } from "@/application/domain/anchor/anchorBatch/service";
+import { IContext } from "@/types/server";
+import { PrismaClientIssuer } from "@/infrastructure/prisma/client";
+
+const router = express.Router();
+
+/**
+ * Cloud Scheduler から呼ばれる internal endpoint。
+ *
+ * Cloud Scheduler は HTTP target に固定 header (`X-CloudScheduler-Token`) を
+ * 付けて呼び出す運用にし、その値を Secret Manager 経由で env に投入する。
+ */
+router.post("/run", express.json({ limit: "1mb" }), async (req: Request, res: Response) => {
+  const expected = process.env.CLOUD_SCHEDULER_TOKEN;
+  if (!expected) {
+    logger.error("[anchorBatch] CLOUD_SCHEDULER_TOKEN is not configured; refusing request");
+    res.status(500).json({ error: "Internal Server Error" });
+    return;
+  }
+  const provided = req.header("X-CloudScheduler-Token");
+  if (provided !== expected) {
+    logger.warn("[anchorBatch] unauthorized request: token mismatch");
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  const { weeklyKey: rawWeeklyKey } = req.body ?? {};
+  if (rawWeeklyKey !== undefined && typeof rawWeeklyKey !== "string") {
+    res.status(400).json({ error: "weeklyKey must be a string" });
+    return;
+  }
+  if (typeof rawWeeklyKey === "string" && !isValidWeeklyKey(rawWeeklyKey)) {
+    res.status(400).json({ error: "weeklyKey must match YYYY-Www" });
+    return;
+  }
+
+  try {
+    const issuer = container.resolve<PrismaClientIssuer>("PrismaClientIssuer");
+    const ctx = { issuer } as IContext;
+    const usecase = container.resolve(AnchorBatchUseCase);
+    const result = await usecase.runBatch(ctx, {
+      weeklyKey: rawWeeklyKey,
+    });
+    res.status(200).json(result);
+  } catch (err) {
+    logger.error("[anchorBatch] runBatch failed", {
+      message: err instanceof Error ? err.message : String(err),
+      stack: err instanceof Error ? err.stack : undefined,
+    });
+    res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+export default router;

--- a/src/presentation/router/admin/anchorBatch.ts
+++ b/src/presentation/router/admin/anchorBatch.ts
@@ -12,6 +12,7 @@
  */
 
 import express, { Request, Response } from "express";
+import { timingSafeEqual } from "node:crypto";
 import { container } from "tsyringe";
 import logger from "@/infrastructure/logging";
 import AnchorBatchUseCase from "@/application/domain/anchor/anchorBatch/usecase";
@@ -20,6 +21,21 @@ import { IContext } from "@/types/server";
 import { PrismaClientIssuer } from "@/infrastructure/prisma/client";
 
 const router = express.Router();
+
+/**
+ * Timing-safe な token 比較。
+ *
+ * - `provided` / `expected` の長さが異なる場合は `timingSafeEqual` が
+ *   throw するため、長さ違いを先に false で短絡させる。
+ * - `req.header()` は `string | string[] | undefined` を返すため、
+ *   string narrowing も呼び出し側で行う前提。
+ */
+function safeTokenEqual(provided: string, expected: string): boolean {
+  const providedBuf = Buffer.from(provided, "utf8");
+  const expectedBuf = Buffer.from(expected, "utf8");
+  if (providedBuf.length !== expectedBuf.length) return false;
+  return timingSafeEqual(providedBuf, expectedBuf);
+}
 
 /**
  * Cloud Scheduler から呼ばれる internal endpoint。
@@ -35,7 +51,9 @@ router.post("/run", express.json({ limit: "1mb" }), async (req: Request, res: Re
     return;
   }
   const provided = req.header("X-CloudScheduler-Token");
-  if (provided !== expected) {
+  // `req.header()` は `string | string[] | undefined`。配列で渡された場合は
+  // 認可失敗扱い（複数 token は仕様外）。
+  if (typeof provided !== "string" || !safeTokenEqual(provided, expected)) {
     logger.warn("[anchorBatch] unauthorized request: token mismatch");
     res.status(401).json({ error: "Unauthorized" });
     return;


### PR DESCRIPTION
## 概要

DID/VC 内製化 Phase 1 step 8 (F)。`§5.2.3` (anchor ドメイン) と `§5.3.1` (週次バッチ + idempotency) を実装。週次で PENDING な `UserDidAnchor` / `VcAnchor` / `TransactionAnchor` を 1 つの Cardano tx に集約して anchor する。

親 PR: #1082 (`claude/did-vc-internalization-review-eptzS`) にスタック。

## 追加ファイル

```
src/application/domain/anchor/anchorBatch/
├── data/
│   ├── type.ts            Pending* / VcJwtLeaf / AnchorBatchRunResult
│   ├── interface.ts       IAnchorBatchRepository
│   └── repository.ts      Prisma クエリ層 (CAS / 状態遷移)
├── service.ts             AnchorBatchService.runWeeklyBatch
├── usecase.ts             AnchorBatchUseCase
└── presenter.ts           AnchorBatchPresenter (REST DTO 変換)

src/presentation/router/admin/
└── anchorBatch.ts         POST /admin/anchor-batch/run

src/__tests__/unit/application/domain/anchor/anchorBatch/
└── service.test.ts        13 件
src/__tests__/unit/presentation/router/admin/
└── anchorBatch.test.ts    7 件
```

`src/application/provider.ts` / `src/index.ts` に DI 登録 + router 配線を追加。

## フロー説明

設計書 `§5.3.1` のフローに沿う:

1. **idempotency 早期 return**: 同 `weeklyKey` で `TransactionAnchor` が `SUBMITTED`/`CONFIRMED` 済なら即 return
2. **PENDING 抽出**: `status = PENDING AND batchId IS NULL` を 3 種 (`UserDidAnchor` / `VcAnchor` / `TransactionAnchor`) 全件取得
3. **CAS で claim**: `batchId = weeklyKey` を `updateMany({ where: { ..., batchId: null } })` で書き込む。並行 batch があれば 0 件 update を観測して abort
4. **Merkle root 計算**:
   - tx: `TransactionAnchor.leafIds` (Transaction.id 群) を flatten + sort ASC → `MerkleTreeBuilder.buildRoot`
   - vc: `VcAnchor.leafIds` (`VcIssuanceRequest.id` 群) → JOIN で `vcJwt` を取得 → JWT 文字列で sort ASC + buildRoot
   - did: `UserDidAnchor` は `§5.1.6` ops[] に直接展開（root 化はしない）
5. **metadata 1985 構築**: `txBuilder.buildAuxiliaryData({ v, bid: weeklyKey, ts, tx, vc, ops })`
6. **tx 構築 + 署名**: `BlockfrostClient.getProtocolParams` / `getUtxos` + 最新 slot 取得 → `txBuilder.buildAnchorTx`
7. **submit + DB 更新**: `BlockfrostClient.submitTx(cborBytes)` → `markSubmitted(chainTxHash)`
8. **awaitConfirmation**: 5 分 timeout → 成功時 `markConfirmed(blockHeight)`、失敗時 `markFailed(failureReason)`

## DI 登録

- `BlockfrostClient` / `KmsSigner` を初めて DI 登録（singleton）
- `BlockfrostLatestSlotProvider`: `libs/blockfrost` を変更不可制約のため、provider 側に閉じた factory として `BlockFrostAPI.blocksLatest()` を直接叩く配線
- `AnchorBatchRepository` / `AnchorBatchService` / `AnchorBatchUseCase`

## cron 連携

- Cloud Scheduler が固定 header `X-CloudScheduler-Token` で `POST /admin/anchor-batch/run` を叩く運用
- token 値は `CLOUD_SCHEDULER_TOKEN` env (Secret Manager) で配信
- 不一致 → 401 / token 未設定 → 500
- body: `{ weeklyKey?: "YYYY-Www" }` 省略時は ISO 8601 週キーをサーバ計算

## テスト結果

```
pnpm test --testPathPattern '(domain/anchor/anchorBatch|router/admin/anchorBatch)'
Test Suites: 2 passed, 2 total
Tests:       20 passed, 20 total
```

カバレッジ:
- `service.test.ts` (13 件):
  - PENDING ゼロ → early return (submit 走らず)
  - 同 weeklyKey が SUBMITTED → idempotent early return + chainTxHash 返却
  - 同 weeklyKey が CONFIRMED → idempotent early return
  - submit 成功 + confirmation 成功 → 全 anchor SUBMITTED→CONFIRMED
  - awaitConfirmation timeout → FAILED + failureReason
  - submit 失敗 → FAILED
  - weeklyKey バリデーション (`YYYY-Www`)
  - Merkle 決定論性
- `anchorBatch.test.ts` (7 件):
  - token なし / 一致しない → 401
  - 一致 + UseCase 成功 → 200 with body
  - body 省略 → 200 (server 計算)
  - weeklyKey 不正 → 400
  - `CLOUD_SCHEDULER_TOKEN` 未設定 → 500
  - usecase 例外 → 500

ビルド / lint:
- `pnpm exec tsc --noEmit`: 新規エラーゼロ（pre-existing schema/sql エラーは別 issue）
- `pnpm exec eslint src/application/domain/anchor/ src/presentation/router/admin/`: clean
- `prettier` 適用済

## 設計書からの主な逸脱・決定事項

- **tx 署名は raw seed 経由 (Phase 1 暫定)**: `txBuilder.buildAnchorTx` が `CSL.PrivateKey` を要求するため、`KmsSigner.signEd25519` 経由の署名 (`§5.1.1`) は Phase 2 で「tx body hash を取り出して KMS で署名し vkey witness を手動 attach」する経路に切替予定。本 PR では `CARDANO_PLATFORM_PRIVATE_KEY_HEX` (Secret Manager) 経由の raw seed で署名し、`KmsSigner` は inject だけして配線を残す
- **DID Document の chain inclusion は Phase 2 へ**: `§5.1.6` 注釈通り、`ops[].doc` には最小 doc `{id}` を渡し、改ざん検知は `h` (Blake2b-256 hash) で担保。`documentCbor` の chain 載せは Phase 2 検討
- **UserDidAnchor は did.root を持たず ops[] に展開**: `§5.1.6` 通り。タスク文書の「documentHash の merkle root」記述ではなく仕様優先
- **BlockfrostLatestSlotProvider は provider 側 factory**: `libs/blockfrost` の読み取り専用制約のため、`/blocks/latest` 取得は provider に閉じた配線。長期的には `BlockfrostClient` に `getCurrentSlot` を追加して整理する
- **ISO 週キー**: `computeIsoWeeklyKey` で UTC 基準の `YYYY-Www` を計算。クライアント (Cloud Scheduler) は省略可

## 次の Phase 1 step

- `recoveryService.ts` (§5.2.3) で起動時の in-flight batch 復旧
- StatusList domain (§5.2.4) で VC revocation
- Phase 2 で `KmsSigner.signEd25519` 経由の署名へ移行

## Test plan

- [x] `pnpm test --testPathPattern '(domain/anchor/anchorBatch|router/admin/anchorBatch)'` 全 20 件 pass
- [x] `pnpm exec eslint src/application/domain/anchor/ src/presentation/router/admin/` clean
- [x] `pnpm exec tsc --noEmit` で本 PR 起因のエラーゼロ
- [ ] preprod で Cardano testnet 1 回 anchor して end-to-end 確認 (Phase 1 後半 step)
- [ ] in-flight crash → recoveryService の改修と組み合わせて動作確認

https://claude.ai/code/session_019MKzV6DsfsHA6dLJ99chU8

---
_Generated by [Claude Code](https://claude.ai/code/session_019MKzV6DsfsHA6dLJ99chU8)_