### PR TITLE
phase1.5(presentation): /vc/:vcId/inclusion-proof 本実装 (Merkle proof generation)

### DIFF
--- a/src/__tests__/unit/application/domain/credential/vcIssuance/service.test.ts
+++ b/src/__tests__/unit/application/domain/credential/vcIssuance/service.test.ts
@@ -13,10 +13,17 @@
 
 import "reflect-metadata";
 import { container } from "tsyringe";
+import { AnchorStatus } from "@prisma/client";
 import VcIssuanceService, {
   CIVICSHIP_ISSUER_DID,
   buildVcPayload,
 } from "@/application/domain/credential/vcIssuance/service";
+import { buildRoot, verifyProof } from "@/infrastructure/libs/merkle/merkleTreeBuilder";
+import type {
+  VcAnchorRow,
+  VcIssuanceRow,
+  VcJwtLeaf,
+} from "@/application/domain/credential/vcIssuance/data/type";
 import { IContext } from "@/types/server";
 
 const SUBJECT_DID = "did:web:api.civicship.app:users:u_xyz_phase1";
@@ -25,7 +32,31 @@ const FAKE_STATUS_URL = "https://api.civicship.app/credentials/status/1.jwt";
 
 class MockVcIssuanceRepository {
   findById = jest.fn().mockResolvedValue(null);
+  findByUserId = jest.fn().mockResolvedValue([]);
   create = jest.fn();
+  findVcAnchorById = jest.fn().mockResolvedValue(null);
+  findVcJwtsByIds = jest.fn().mockResolvedValue([]);
+}
+
+function makeVcRow(overrides: Partial<VcIssuanceRow> = {}): VcIssuanceRow {
+  return {
+    id: "vc-1",
+    userId: "u_1",
+    evaluationId: "eval-1",
+    issuerDid: CIVICSHIP_ISSUER_DID,
+    subjectDid: SUBJECT_DID,
+    vcFormat: "INTERNAL_JWT",
+    vcJwt: "header.payload.sig-1",
+    statusListIndex: 0,
+    statusListCredential: FAKE_STATUS_URL,
+    vcAnchorId: null,
+    anchorLeafIndex: null,
+    status: "COMPLETED",
+    createdAt: new Date("2026-05-01T00:00:00Z"),
+    completedAt: new Date("2026-05-01T00:00:00Z"),
+    revokedAt: null,
+    ...overrides,
+  };
 }
 
 class MockStatusListService {
@@ -181,6 +212,180 @@ describe("VcIssuanceService", () => {
         score: 5,
         label: "GOOD",
       });
+    });
+  });
+
+  describe("generateInclusionProof (§5.4.6)", () => {
+    /**
+     * Helper: build the canonical sorted-leaf set for a fixture batch and
+     * compute the on-chain root via `buildRoot`. The test then asserts
+     * that the proof returned by the service verifies against THIS root,
+     * which is what the design guarantees end-to-end.
+     */
+    function buildAnchoredFixture(jwts: string[]): {
+      sorted: string[];
+      rootHex: string;
+      anchor: VcAnchorRow;
+      leafRows: VcJwtLeaf[];
+    } {
+      const sorted = [...jwts].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+      const rootBytes = buildRoot(sorted);
+      const rootHex = Buffer.from(rootBytes).toString("hex");
+      // VcAnchor.leafIds carry VcIssuanceRequest ids — use synthetic ids
+      // 1:1 with each JWT so the repository mock can resolve them back.
+      const leafRows = jwts.map((jwt, i) => ({
+        vcIssuanceRequestId: `vc-${i}`,
+        vcJwt: jwt,
+      }));
+      const anchor: VcAnchorRow = {
+        id: "vca-1",
+        rootHash: rootHex,
+        leafIds: leafRows.map((r) => r.vcIssuanceRequestId),
+        chainTxHash: "ab".repeat(32),
+        blockHeight: 12345,
+        status: AnchorStatus.CONFIRMED,
+      };
+      return { sorted, rootHex, anchor, leafRows };
+    }
+
+    it("returns a proof that verifies against the anchored root for a CONFIRMED batch", async () => {
+      const jwts = ["d.payload", "a.payload", "c.payload", "b.payload", "e.payload"];
+      const { anchor, leafRows, rootHex } = buildAnchoredFixture(jwts);
+      const targetJwt = "c.payload";
+      const targetVcId = leafRows.find((r) => r.vcJwt === targetJwt)!.vcIssuanceRequestId;
+
+      mockRepository.findById.mockResolvedValueOnce(
+        makeVcRow({ id: targetVcId, vcJwt: targetJwt, vcAnchorId: anchor.id }),
+      );
+      mockRepository.findVcAnchorById.mockResolvedValueOnce(anchor);
+      mockRepository.findVcJwtsByIds.mockResolvedValueOnce(leafRows);
+
+      const proof = await service.generateInclusionProof(mockCtx, targetVcId);
+
+      expect(proof).not.toBeNull();
+      expect(proof!.vcId).toBe(targetVcId);
+      expect(proof!.vcJwt).toBe(targetJwt);
+      expect(proof!.vcAnchorId).toBe(anchor.id);
+      expect(proof!.rootHash).toBe(rootHex);
+      expect(proof!.chainTxHash).toBe(anchor.chainTxHash);
+      expect(proof!.blockHeight).toBe(anchor.blockHeight);
+
+      // Verifier round-trip: rebuild bytes from hex and run verifyProof
+      // against the same root the service published.
+      const proofBytes = proof!.proofPath.map((h) => Buffer.from(h, "hex"));
+      const rootBytes = Buffer.from(proof!.rootHash, "hex");
+      expect(verifyProof(targetJwt, proof!.leafIndex, proofBytes, rootBytes)).toBe(true);
+    });
+
+    it("returns a verifying proof for a 7-leaf (odd) batch (last-leaf-duplication path)", async () => {
+      // 7 leaves exercises the §5.1.7 odd-tail rule at multiple layers.
+      const jwts = ["a", "b", "c", "d", "e", "f", "g"];
+      const { anchor, leafRows } = buildAnchoredFixture(jwts);
+      const targetJwt = "g"; // last leaf — sibling-self at the leaf layer
+      const targetVcId = leafRows.find((r) => r.vcJwt === targetJwt)!.vcIssuanceRequestId;
+
+      mockRepository.findById.mockResolvedValueOnce(
+        makeVcRow({ id: targetVcId, vcJwt: targetJwt, vcAnchorId: anchor.id }),
+      );
+      mockRepository.findVcAnchorById.mockResolvedValueOnce(anchor);
+      mockRepository.findVcJwtsByIds.mockResolvedValueOnce(leafRows);
+
+      const proof = await service.generateInclusionProof(mockCtx, targetVcId);
+      expect(proof).not.toBeNull();
+      const proofBytes = proof!.proofPath.map((h) => Buffer.from(h, "hex"));
+      const rootBytes = Buffer.from(proof!.rootHash, "hex");
+      expect(verifyProof(targetJwt, proof!.leafIndex, proofBytes, rootBytes)).toBe(true);
+    });
+
+    it("returns null when the VC row is missing", async () => {
+      mockRepository.findById.mockResolvedValueOnce(null);
+      const result = await service.generateInclusionProof(mockCtx, "missing");
+      expect(result).toBeNull();
+      expect(mockRepository.findVcAnchorById).not.toHaveBeenCalled();
+    });
+
+    it("returns null when the VC has no vcAnchorId yet", async () => {
+      mockRepository.findById.mockResolvedValueOnce(makeVcRow({ id: "vc-1", vcAnchorId: null }));
+      const result = await service.generateInclusionProof(mockCtx, "vc-1");
+      expect(result).toBeNull();
+      expect(mockRepository.findVcAnchorById).not.toHaveBeenCalled();
+    });
+
+    it("returns null when the VC's JWT is empty (unidentifiable leaf)", async () => {
+      mockRepository.findById.mockResolvedValueOnce(
+        makeVcRow({ id: "vc-1", vcJwt: "", vcAnchorId: "vca-1" }),
+      );
+      const result = await service.generateInclusionProof(mockCtx, "vc-1");
+      expect(result).toBeNull();
+      expect(mockRepository.findVcAnchorById).not.toHaveBeenCalled();
+    });
+
+    it("returns null when the anchor row is missing (VC points at vanished anchor)", async () => {
+      mockRepository.findById.mockResolvedValueOnce(
+        makeVcRow({ id: "vc-1", vcJwt: "j", vcAnchorId: "vca-missing" }),
+      );
+      mockRepository.findVcAnchorById.mockResolvedValueOnce(null);
+      const result = await service.generateInclusionProof(mockCtx, "vc-1");
+      expect(result).toBeNull();
+    });
+
+    it("returns null when the anchor is PENDING (not yet anchored on-chain)", async () => {
+      const { leafRows } = buildAnchoredFixture(["a", "b"]);
+      const pending: VcAnchorRow = {
+        id: "vca-pending",
+        rootHash: "00".repeat(32),
+        leafIds: leafRows.map((r) => r.vcIssuanceRequestId),
+        chainTxHash: null,
+        blockHeight: null,
+        status: AnchorStatus.PENDING,
+      };
+      mockRepository.findById.mockResolvedValueOnce(
+        makeVcRow({ id: leafRows[0].vcIssuanceRequestId, vcJwt: "a", vcAnchorId: pending.id }),
+      );
+      mockRepository.findVcAnchorById.mockResolvedValueOnce(pending);
+
+      const result = await service.generateInclusionProof(mockCtx, leafRows[0].vcIssuanceRequestId);
+      expect(result).toBeNull();
+      // We never reach the leaf re-fetch when the anchor is not CONFIRMED.
+      expect(mockRepository.findVcJwtsByIds).not.toHaveBeenCalled();
+    });
+
+    it("returns null when the anchor is SUBMITTED (chain not finalised)", async () => {
+      const { leafRows } = buildAnchoredFixture(["a", "b"]);
+      const submitted: VcAnchorRow = {
+        id: "vca-submitted",
+        rootHash: "11".repeat(32),
+        leafIds: leafRows.map((r) => r.vcIssuanceRequestId),
+        chainTxHash: "cd".repeat(32),
+        blockHeight: null,
+        status: AnchorStatus.SUBMITTED,
+      };
+      mockRepository.findById.mockResolvedValueOnce(
+        makeVcRow({
+          id: leafRows[0].vcIssuanceRequestId,
+          vcJwt: "a",
+          vcAnchorId: submitted.id,
+        }),
+      );
+      mockRepository.findVcAnchorById.mockResolvedValueOnce(submitted);
+
+      const result = await service.generateInclusionProof(mockCtx, leafRows[0].vcIssuanceRequestId);
+      expect(result).toBeNull();
+    });
+
+    it("throws when the row's JWT is not present in the anchor's leaf set (integrity violation)", async () => {
+      const { anchor, leafRows } = buildAnchoredFixture(["a", "b", "c"]);
+      // Row claims membership but its JWT is foreign — should NOT be a
+      // happy null (that would silently produce a misleading 404).
+      mockRepository.findById.mockResolvedValueOnce(
+        makeVcRow({ id: leafRows[0].vcIssuanceRequestId, vcJwt: "FOREIGN", vcAnchorId: anchor.id }),
+      );
+      mockRepository.findVcAnchorById.mockResolvedValueOnce(anchor);
+      mockRepository.findVcJwtsByIds.mockResolvedValueOnce(leafRows);
+
+      await expect(
+        service.generateInclusionProof(mockCtx, leafRows[0].vcIssuanceRequestId),
+      ).rejects.toThrow(/not present in anchor/);
     });
   });
 });

--- a/src/__tests__/unit/application/domain/credential/vcIssuance/usecase.test.ts
+++ b/src/__tests__/unit/application/domain/credential/vcIssuance/usecase.test.ts
@@ -42,9 +42,11 @@ function makeRow(overrides: Partial<VcIssuanceRow> = {}): VcIssuanceRow {
 
 function makeIssuer() {
   return {
-    public: jest.fn().mockImplementation(async (_ctx: IContext, cb: (tx: unknown) => unknown) =>
-      cb({ sentinel: "tx" }),
-    ),
+    public: jest
+      .fn()
+      .mockImplementation(async (_ctx: IContext, cb: (tx: unknown) => unknown) =>
+        cb({ sentinel: "tx" }),
+      ),
   };
 }
 
@@ -61,7 +63,7 @@ function makeCtx(overrides: Partial<IContext> = {}): IContext {
 
 describe("VcIssuanceUseCase (authz hardening for PR #1101)", () => {
   let mockService: jest.Mocked<
-    Pick<VcIssuanceService, "findVcById" | "findVcsByUserId" | "issueVc">
+    Pick<VcIssuanceService, "findVcById" | "findVcsByUserId" | "issueVc" | "generateInclusionProof">
   >;
   let usecase: VcIssuanceUseCase;
 
@@ -73,6 +75,7 @@ describe("VcIssuanceUseCase (authz hardening for PR #1101)", () => {
       findVcById: jest.fn(),
       findVcsByUserId: jest.fn(),
       issueVc: jest.fn(),
+      generateInclusionProof: jest.fn(),
     };
 
     container.register("VcIssuanceService", { useValue: mockService });
@@ -157,6 +160,34 @@ describe("VcIssuanceUseCase (authz hardening for PR #1101)", () => {
       const result = await usecase.viewVcIssuancesByUser(ctx, OTHER_USER_ID);
 
       expect(result).toHaveLength(1);
+    });
+  });
+
+  describe("getInclusionProof (§5.4.6)", () => {
+    it("returns null when the service yields null (PENDING / missing)", async () => {
+      mockService.generateInclusionProof.mockResolvedValueOnce(null);
+      const ctx = makeCtx();
+
+      const result = await usecase.getInclusionProof(ctx, "vc-x");
+      expect(result).toBeNull();
+    });
+
+    it("returns the presented proof when the service yields one", async () => {
+      const proof = {
+        vcId: "vc-1",
+        vcJwt: "h.p.s",
+        vcAnchorId: "vca-1",
+        rootHash: "ab".repeat(32),
+        chainTxHash: "cd".repeat(32),
+        proofPath: ["ee".repeat(32)],
+        leafIndex: 0,
+        blockHeight: 999,
+      };
+      mockService.generateInclusionProof.mockResolvedValueOnce(proof);
+      const ctx = makeCtx();
+
+      const result = await usecase.getInclusionProof(ctx, "vc-1");
+      expect(result).toEqual(proof);
     });
   });
 });

--- a/src/__tests__/unit/infrastructure/libs/merkle/merkleTreeBuilder.test.ts
+++ b/src/__tests__/unit/infrastructure/libs/merkle/merkleTreeBuilder.test.ts
@@ -15,6 +15,7 @@
 
 import { blake2b } from "@noble/hashes/blake2b";
 import {
+  buildProof,
   buildRoot,
   canonicalLeafHash,
   getProof,
@@ -62,10 +63,7 @@ describe("merkleTreeBuilder — Blake2b-256 vectors", () => {
   it("hashPair concatenates raw bytes (NOT hex)", () => {
     const a = new Uint8Array(32).fill(0x11);
     const b = new Uint8Array(32).fill(0x22);
-    const expected = blake2b(
-      new Uint8Array([...a, ...b]),
-      { dkLen: MERKLE_NODE_BYTES },
-    );
+    const expected = blake2b(new Uint8Array([...a, ...b]), { dkLen: MERKLE_NODE_BYTES });
     expect(bytesToHex(hashPair(a, b))).toBe(bytesToHex(expected));
   });
 });
@@ -161,5 +159,40 @@ describe("merkleTreeBuilder — proof round-trip", () => {
     expect(() => getProof(["a", "b"], 5)).toThrow(/out of range/);
     expect(() => getProof(["a", "b"], -1)).toThrow(/out of range/);
     expect(() => getProof([], 0)).toThrow(/non-empty/);
+  });
+});
+
+describe("merkleTreeBuilder — buildProof (target-leaf wrapper, §5.4.6)", () => {
+  it("returns the same proof as getProof when the target index is known", () => {
+    const sorted = ["a", "b", "c", "d", "e"];
+    for (let i = 0; i < sorted.length; i++) {
+      const expected = getProof(sorted, i);
+      const actual = buildProof(sorted, sorted[i]);
+      expect(actual.length).toBe(expected.length);
+      for (let j = 0; j < expected.length; j++) {
+        expect(bytesToHex(actual[j])).toBe(bytesToHex(expected[j]));
+      }
+    }
+  });
+
+  it("verifies against the anchored root for every leaf in a 7-leaf (odd-tail) tree", () => {
+    const sorted = ["a", "b", "c", "d", "e", "f", "g"];
+    const root = buildRoot(sorted);
+    for (let i = 0; i < sorted.length; i++) {
+      const proof = buildProof(sorted, sorted[i]);
+      expect(verifyProof(sorted[i], i, proof, root)).toBe(true);
+    }
+  });
+
+  it("returns an empty proof for the single-leaf case", () => {
+    expect(buildProof(["only"], "only")).toEqual([]);
+  });
+
+  it("throws when the target leaf is not in the sorted list", () => {
+    expect(() => buildProof(["a", "b", "c"], "WRONG")).toThrow(/not in tree/);
+  });
+
+  it("throws on empty input", () => {
+    expect(() => buildProof([], "a")).toThrow(/non-empty/);
   });
 });

--- a/src/__tests__/unit/presentation/router/did.test.ts
+++ b/src/__tests__/unit/presentation/router/did.test.ts
@@ -30,11 +30,14 @@ import { container } from "tsyringe";
 
 import didRouter from "@/presentation/router/did";
 import type IssuerDidUseCase from "@/application/domain/credential/issuerDid/usecase";
+import type VcIssuanceUseCase from "@/application/domain/credential/vcIssuance/usecase";
 import type { IssuerDidDocument } from "@/infrastructure/libs/did/issuerDidBuilder";
 import type {
   DidDocumentResolver,
   DidDocumentWithProof,
 } from "@/infrastructure/libs/did/didDocumentResolver";
+import type { PrismaClientIssuer } from "@/infrastructure/prisma/client";
+import type { InclusionProofResponse } from "@/application/domain/credential/vcIssuance/presenter";
 
 const USER_ID = "u_alice";
 const USER_DID = "did:web:api.civicship.app:users:u_alice";
@@ -92,6 +95,21 @@ function registerResolverMock(buildDidDocument: jest.Mock): void {
 function registerIssuerDidUseCaseMock(getActiveIssuerDidDocument: jest.Mock): void {
   const mock: Partial<IssuerDidUseCase> = { getActiveIssuerDidDocument };
   container.register("IssuerDidUseCase", { useValue: mock as IssuerDidUseCase });
+}
+
+function registerVcIssuanceUseCaseMock(getInclusionProof: jest.Mock): void {
+  const mock: Partial<VcIssuanceUseCase> = { getInclusionProof };
+  container.register("VcIssuanceUseCase", { useValue: mock as VcIssuanceUseCase });
+}
+
+/**
+ * `PrismaClientIssuer` is resolved by the inclusion-proof handler to
+ * build the anonymous `IContext`. We never reach into it (the use case
+ * mock short-circuits the call), so a sentinel object is enough.
+ */
+function registerPrismaIssuerStub(): void {
+  const stub = { __sentinel: "PrismaClientIssuer" } as unknown as PrismaClientIssuer;
+  container.register("PrismaClientIssuer", { useValue: stub });
 }
 
 function buildFullIssuerDoc(): IssuerDidDocument {
@@ -220,14 +238,54 @@ describe("router/did (§5.4)", () => {
   });
 
   describe("GET /vc/:vcId/inclusion-proof", () => {
-    it("returns 501 not_implemented for any vcId until the batch worker lands", async () => {
+    function buildSampleProof(): InclusionProofResponse {
+      return {
+        vcId: "vc_123",
+        vcJwt: "header.payload.sig",
+        vcAnchorId: "vca_abc",
+        rootHash: "ab".repeat(32),
+        chainTxHash: "cd".repeat(32),
+        proofPath: ["ee".repeat(32), "ff".repeat(32)],
+        leafIndex: 1,
+        blockHeight: 12345,
+      };
+    }
+
+    it("returns 200 with the proof DTO when the use case yields one (CONFIRMED anchor)", async () => {
+      registerPrismaIssuerStub();
+      const sample = buildSampleProof();
+      const getInclusionProof = jest.fn().mockResolvedValue(sample);
+      registerVcIssuanceUseCaseMock(getInclusionProof);
+
       const res = await request(buildApp()).get("/vc/vc_123/inclusion-proof");
 
-      expect(res.status).toBe(501);
-      expect(res.body).toMatchObject({
-        error: "not_implemented",
-        message: expect.stringContaining("Phase 1 step 7"),
-      });
+      expect(res.status).toBe(200);
+      expect(getInclusionProof).toHaveBeenCalledTimes(1);
+      const [, vcIdArg] = getInclusionProof.mock.calls[0];
+      expect(vcIdArg).toBe("vc_123");
+      expect(res.body).toEqual(sample);
+    });
+
+    it("returns 404 not_anchored when the use case yields null (PENDING / missing)", async () => {
+      registerPrismaIssuerStub();
+      const getInclusionProof = jest.fn().mockResolvedValue(null);
+      registerVcIssuanceUseCaseMock(getInclusionProof);
+
+      const res = await request(buildApp()).get("/vc/vc_pending/inclusion-proof");
+
+      expect(res.status).toBe(404);
+      expect(res.body).toMatchObject({ error: "not_anchored" });
+    });
+
+    it("returns 500 when the use case throws (integrity violation / DB error)", async () => {
+      registerPrismaIssuerStub();
+      const getInclusionProof = jest.fn().mockRejectedValue(new Error("boom"));
+      registerVcIssuanceUseCaseMock(getInclusionProof);
+
+      const res = await request(buildApp()).get("/vc/vc_err/inclusion-proof");
+
+      expect(res.status).toBe(500);
+      expect(res.body).toEqual({ error: "Internal Server Error" });
     });
   });
 });

--- a/src/application/domain/credential/vcIssuance/data/interface.ts
+++ b/src/application/domain/credential/vcIssuance/data/interface.ts
@@ -50,9 +50,12 @@ export interface IVcIssuanceRepository {
    * being indexed in the cached row alone because the proof must verify
    * against the full sibling set of the anchor batch.
    *
-   * Rows with a missing/empty `vcJwt` are dropped silently — a corrupt
-   * row at this point would only weaken the proof for OTHER leaves, and
-   * the surface is read-only.
+   * Rows with a missing/empty `vcJwt` are returned with `vcJwt: ""` so the
+   * Service layer can detect the mismatch. Merkle integrity requires the
+   * exact same leaf set as anchor time — even one missing leaf shifts the
+   * tree and invalidates **every** proof in the batch (not just the
+   * affected leaf). Service compares `leaves.length` against
+   * `anchor.leafIds.length` and throws on mismatch.
    */
   findVcJwtsByIds(ctx: IContext, vcIssuanceRequestIds: string[]): Promise<VcJwtLeaf[]>;
 }

--- a/src/application/domain/credential/vcIssuance/data/interface.ts
+++ b/src/application/domain/credential/vcIssuance/data/interface.ts
@@ -14,7 +14,9 @@ import type { Prisma } from "@prisma/client";
 import { IContext } from "@/types/server";
 import type {
   CreateVcIssuanceInput,
+  VcAnchorRow,
   VcIssuanceRow,
+  VcJwtLeaf,
 } from "@/application/domain/credential/vcIssuance/data/type";
 
 export interface IVcIssuanceRepository {
@@ -32,4 +34,25 @@ export interface IVcIssuanceRepository {
     input: CreateVcIssuanceInput,
     tx?: Prisma.TransactionClient,
   ): Promise<VcIssuanceRow>;
+
+  /**
+   * Look up the `VcAnchor` row that backs a confirmed batch (§5.1.6 /
+   * §5.4.6). Returns `null` for unknown ids so the caller can map the
+   * "VC has `vcAnchorId` but the anchor row is gone" edge case to a 404
+   * rather than crashing.
+   */
+  findVcAnchorById(ctx: IContext, vcAnchorId: string): Promise<VcAnchorRow | null>;
+
+  /**
+   * Return the `vcJwt` strings for the supplied `VcIssuanceRequest.id`
+   * list. Used to re-derive the canonical Merkle leaves for the
+   * `/vc/:vcId/inclusion-proof` endpoint — we cannot rely on `vcJwt`
+   * being indexed in the cached row alone because the proof must verify
+   * against the full sibling set of the anchor batch.
+   *
+   * Rows with a missing/empty `vcJwt` are dropped silently — a corrupt
+   * row at this point would only weaken the proof for OTHER leaves, and
+   * the surface is read-only.
+   */
+  findVcJwtsByIds(ctx: IContext, vcIssuanceRequestIds: string[]): Promise<VcJwtLeaf[]>;
 }

--- a/src/application/domain/credential/vcIssuance/data/repository.ts
+++ b/src/application/domain/credential/vcIssuance/data/repository.ts
@@ -211,12 +211,15 @@ export default class VcIssuanceRepository implements IVcIssuanceRepository {
         select: { id: true, vcJwt: true },
       }),
     );
-    return rows
-      .filter(
-        (r): r is { id: string; vcJwt: string } =>
-          typeof r.vcJwt === "string" && r.vcJwt.length > 0,
-      )
-      .map((r) => ({ vcIssuanceRequestId: r.id, vcJwt: r.vcJwt }));
+    // Do NOT silently filter rows with missing/empty vcJwt — Merkle root
+    // depends on the exact leaf set used at anchor time; dropping a leaf
+    // here invalidates every proof in the batch, not just the affected
+    // one. Service layer enforces the integrity invariant
+    // (leaves.length === anchor.leafIds.length).
+    return rows.map((r) => ({
+      vcIssuanceRequestId: r.id,
+      vcJwt: typeof r.vcJwt === "string" ? r.vcJwt : "",
+    }));
   }
 }
 

--- a/src/application/domain/credential/vcIssuance/data/repository.ts
+++ b/src/application/domain/credential/vcIssuance/data/repository.ts
@@ -32,8 +32,10 @@ import { PrismaClientIssuer } from "@/infrastructure/prisma/client";
 import type { IVcIssuanceRepository } from "@/application/domain/credential/vcIssuance/data/interface";
 import type {
   CreateVcIssuanceInput,
+  VcAnchorRow,
   VcFormatValue,
   VcIssuanceRow,
+  VcJwtLeaf,
   VcStatusValue,
 } from "@/application/domain/credential/vcIssuance/data/type";
 
@@ -166,6 +168,55 @@ export default class VcIssuanceRepository implements IVcIssuanceRepository {
       : await this.issuer.public(ctx, (innerTx) => innerTx.vcIssuanceRequest.create({ data }));
 
     return toRow(persisted, input.issuerDid, input.subjectDid);
+  }
+
+  /**
+   * Read the `VcAnchor` row backing a confirmed batch. Uses
+   * `issuer.internal()` for the same reason `UserDidAnchorRepository`
+   * does on its public-route path: the `/vc/:vcId/inclusion-proof`
+   * endpoint is unauthenticated and there is no community-scoped RLS
+   * decision to apply to global anchor metadata.
+   */
+  async findVcAnchorById(ctx: IContext, vcAnchorId: string): Promise<VcAnchorRow | null> {
+    const persisted = await this.issuer.internal((tx) =>
+      tx.vcAnchor.findUnique({
+        where: { id: vcAnchorId },
+        select: {
+          id: true,
+          rootHash: true,
+          leafIds: true,
+          chainTxHash: true,
+          blockHeight: true,
+          status: true,
+        },
+      }),
+    );
+    if (!persisted) return null;
+    return persisted;
+  }
+
+  /**
+   * Bulk-read VC JWT segments for a list of `VcIssuanceRequest.id`s.
+   * Mirrors `AnchorBatchRepository.findVcJwtsByVcIssuanceRequestIds` but
+   * lives in the vcIssuance domain because the read consumer (inclusion-
+   * proof endpoint) is here. Callers MUST sort the result themselves
+   * (ASCII byte order, §5.1.7) before computing the proof — the
+   * repository layer has no business deciding leaf order.
+   */
+  async findVcJwtsByIds(ctx: IContext, vcIssuanceRequestIds: string[]): Promise<VcJwtLeaf[]> {
+    if (vcIssuanceRequestIds.length === 0) return [];
+    const rows = await this.issuer.internal((tx) =>
+      tx.vcIssuanceRequest.findMany({
+        where: { id: { in: vcIssuanceRequestIds } },
+        select: { id: true, vcJwt: true },
+      }),
+    );
+    return rows
+      .filter(
+        (r): r is { id: string; vcJwt: string } =>
+          typeof r.vcJwt === "string" && r.vcJwt.length > 0,
+      )
+      .map((r) => ({ vcIssuanceRequestId: r.id, vcJwt: r.vcJwt }));
   }
 }
 

--- a/src/application/domain/credential/vcIssuance/data/type.ts
+++ b/src/application/domain/credential/vcIssuance/data/type.ts
@@ -15,7 +15,7 @@
  *   docs/report/did-vc-internalization.md §D     (credentialStatus)
  */
 
-import type { VcFormat, VcIssuanceStatus } from "@prisma/client";
+import type { AnchorStatus, VcFormat, VcIssuanceStatus } from "@prisma/client";
 
 /**
  * §4.1 — VC format. Phase 1 only emits `INTERNAL_JWT`. Aliased to the
@@ -93,6 +93,37 @@ export interface IssueVcInput {
    * persistence row, eliminating sub-second drift between the two.
    */
   issuedAt?: Date;
+}
+
+/**
+ * Application-layer view of a `VcAnchor` row, narrowed to the columns the
+ * `/vc/:vcId/inclusion-proof` endpoint needs (§5.4.6).
+ *
+ * Lives in the vcIssuance domain because the consumer is here — the
+ * anchor batch domain owns the *write* side and exposes its own anchor
+ * row type internally; this is the read-side projection.
+ */
+export interface VcAnchorRow {
+  id: string;
+  rootHash: string;
+  /** ASC-sorted (caller responsibility) `VcIssuanceRequest.id` array. */
+  leafIds: string[];
+  /** `null` until the batch has been submitted to the chain. */
+  chainTxHash: string | null;
+  /** `null` until the chain confirmation cycle yields a block height. */
+  blockHeight: number | null;
+  status: AnchorStatus;
+}
+
+/**
+ * Pair of `VcIssuanceRequest.id` and its `vcJwt`. Used to rebuild the
+ * canonical (ASCII-byte sorted) leaf list for inclusion-proof generation
+ * — the proof must verify against the same leaves the batch hashed at
+ * anchor time.
+ */
+export interface VcJwtLeaf {
+  vcIssuanceRequestId: string;
+  vcJwt: string;
 }
 
 /** Inputs to `IVcIssuanceRepository.create`. */

--- a/src/application/domain/credential/vcIssuance/presenter.ts
+++ b/src/application/domain/credential/vcIssuance/presenter.ts
@@ -25,6 +25,26 @@
 
 import type { GqlVcIssuance } from "@/types/graphql";
 import type { VcIssuanceRow } from "@/application/domain/credential/vcIssuance/data/type";
+import type { InclusionProof } from "@/application/domain/credential/vcIssuance/service";
+
+/**
+ * Wire shape for `GET /vc/:vcId/inclusion-proof` (§5.4.6).
+ *
+ * Mirrors the service-layer `InclusionProof` 1:1 today; declared here
+ * separately so HTTP-shape changes (e.g. snake_case rename, additional
+ * verification metadata) can land in this file without touching the
+ * service contract.
+ */
+export interface InclusionProofResponse {
+  vcId: string;
+  vcJwt: string;
+  vcAnchorId: string;
+  rootHash: string;
+  chainTxHash: string;
+  proofPath: string[];
+  leafIndex: number;
+  blockHeight: number | null;
+}
 
 /**
  * Map the persistence-layer status (Prisma `VcIssuanceStatus`) to the
@@ -94,6 +114,26 @@ const VcIssuancePresenter = {
       statusListCredential: row.statusListCredential,
       revokedAt: row.revokedAt,
       createdAt: row.createdAt,
+    };
+  },
+
+  /**
+   * §5.4.6 — wire shape for the `/vc/:vcId/inclusion-proof` endpoint.
+   *
+   * The transformation is a pure passthrough today; kept as a presenter
+   * call so future schema migrations (e.g. snake_case for HTTP) do not
+   * leak into the service.
+   */
+  toInclusionProofResponse(proof: InclusionProof): InclusionProofResponse {
+    return {
+      vcId: proof.vcId,
+      vcJwt: proof.vcJwt,
+      vcAnchorId: proof.vcAnchorId,
+      rootHash: proof.rootHash,
+      chainTxHash: proof.chainTxHash,
+      proofPath: proof.proofPath,
+      leafIndex: proof.leafIndex,
+      blockHeight: proof.blockHeight,
     };
   },
 };

--- a/src/application/domain/credential/vcIssuance/service.ts
+++ b/src/application/domain/credential/vcIssuance/service.ts
@@ -34,7 +34,7 @@
  */
 
 import { inject, injectable } from "tsyringe";
-import type { Prisma } from "@prisma/client";
+import { AnchorStatus, type Prisma } from "@prisma/client";
 import { IContext } from "@/types/server";
 import logger from "@/infrastructure/logging";
 import type { IVcIssuanceRepository } from "@/application/domain/credential/vcIssuance/data/interface";
@@ -44,6 +44,29 @@ import type {
 } from "@/application/domain/credential/vcIssuance/data/type";
 import StatusListService from "@/application/domain/credential/statusList/service";
 import { CIVICSHIP_ISSUER_DID } from "@/application/domain/credential/shared/constants";
+import { buildProof } from "@/infrastructure/libs/merkle/merkleTreeBuilder";
+
+/**
+ * Inclusion proof DTO for the `/vc/:vcId/inclusion-proof` REST endpoint
+ * (§5.4.6). Every byte field is hex-encoded to keep the wire format
+ * stable across language clients (the verifier in civicship-portal has
+ * its own Uint8Array adapters).
+ */
+export interface InclusionProof {
+  vcId: string;
+  vcJwt: string;
+  vcAnchorId: string;
+  /** Hex-encoded 32-byte Blake2b-256 root committed on-chain. */
+  rootHash: string;
+  /** Cardano tx hash (hex). Always populated for CONFIRMED anchors. */
+  chainTxHash: string;
+  /** Sibling hashes bottom-up, hex-encoded. */
+  proofPath: string[];
+  /** Index of the target VC JWT in the canonical (ASCII-sorted) leaf set. */
+  leafIndex: number;
+  /** Cardano block height; `null` if confirmation has not stamped one yet. */
+  blockHeight: number | null;
+}
 
 /**
  * Re-export so the public symbol's path stays stable. The canonical
@@ -225,5 +248,119 @@ export default class VcIssuanceService {
       },
       tx,
     );
+  }
+
+  /**
+   * §5.4.6 — Generate the Merkle inclusion proof for an anchored VC.
+   *
+   * Returns `null` when the proof cannot be produced for any of the
+   * "expected, not exceptional" reasons:
+   *
+   *   - `vcId` does not resolve to a row.
+   *   - The row is not yet attached to a `VcAnchor` (e.g. the next
+   *     weekly batch has not run yet).
+   *   - The anchor exists but is not CONFIRMED yet (PENDING / SUBMITTED /
+   *     FAILED).
+   *   - The row's JWT is missing/empty so we cannot identify the leaf.
+   *
+   * Throws on genuinely-impossible states (the row claims membership in
+   * an anchor whose `leafIds` does not contain it). Callers (router) map
+   * `null` to 404 and exceptions to 500.
+   *
+   * Leaf canonicalisation is replayed exactly as in
+   * `AnchorBatchService.buildVcRoot` (§5.1.7): the leaves are the VC
+   * JWT strings themselves, sorted by ASCII byte order. Reusing the
+   * same comparator here is what makes the proof verify against the
+   * anchored root.
+   */
+  async generateInclusionProof(ctx: IContext, vcId: string): Promise<InclusionProof | null> {
+    const vc = await this.repository.findById(ctx, vcId);
+    if (!vc) {
+      logger.debug("[VcIssuanceService] generateInclusionProof: vc not found", { vcId });
+      return null;
+    }
+    if (!vc.vcAnchorId) {
+      logger.debug("[VcIssuanceService] generateInclusionProof: vc not yet anchored", {
+        vcId,
+      });
+      return null;
+    }
+    if (!vc.vcJwt) {
+      // Row exists but JWT is empty — we cannot identify the leaf in the
+      // canonical sorted list, so a proof would be meaningless. Treat as
+      // "not anchored" from the verifier's perspective.
+      logger.warn("[VcIssuanceService] generateInclusionProof: vc has empty vcJwt", {
+        vcId,
+        vcAnchorId: vc.vcAnchorId,
+      });
+      return null;
+    }
+
+    const anchor = await this.repository.findVcAnchorById(ctx, vc.vcAnchorId);
+    if (!anchor) {
+      logger.warn("[VcIssuanceService] generateInclusionProof: anchor row missing", {
+        vcId,
+        vcAnchorId: vc.vcAnchorId,
+      });
+      return null;
+    }
+    if (anchor.status !== AnchorStatus.CONFIRMED) {
+      logger.debug("[VcIssuanceService] generateInclusionProof: anchor not yet confirmed", {
+        vcId,
+        vcAnchorId: anchor.id,
+        anchorStatus: anchor.status,
+      });
+      return null;
+    }
+    if (!anchor.chainTxHash) {
+      // CONFIRMED implies chainTxHash but defensive: the verifier UX
+      // breaks without it, so prefer 404 to a partial response.
+      logger.warn(
+        "[VcIssuanceService] generateInclusionProof: confirmed anchor missing chainTxHash",
+        { vcId, vcAnchorId: anchor.id },
+      );
+      return null;
+    }
+
+    const leaves = await this.repository.findVcJwtsByIds(ctx, anchor.leafIds);
+    if (leaves.length === 0) {
+      logger.warn("[VcIssuanceService] generateInclusionProof: anchor has no resolvable leaves", {
+        vcId,
+        vcAnchorId: anchor.id,
+        leafCount: anchor.leafIds.length,
+      });
+      return null;
+    }
+
+    // §5.1.7 canonical ASCII byte order. Mirror `AnchorBatchService.buildVcRoot`
+    // (`a < b ? -1 : a > b ? 1 : 0`) so the proof verifies against the same
+    // root that was anchored on-chain. SonarCloud S2871: explicit comparator
+    // — never bare `.sort()` on JWT strings.
+    const sortedJwts = leaves.map((l) => l.vcJwt).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+
+    const leafIndex = sortedJwts.indexOf(vc.vcJwt);
+    if (leafIndex < 0) {
+      // The row claims membership in this anchor but the JWT is not
+      // among the resolved leaves. Either (a) the JWT was rewritten
+      // after anchoring (should never happen — `vcJwt` is immutable
+      // post-issuance), or (b) the anchor's `leafIds` is missing this
+      // row's id. Both are integrity violations, not "happy null" cases.
+      throw new Error(
+        `generateInclusionProof: vcJwt for vc ${vcId} not present in anchor ${anchor.id} leaf set`,
+      );
+    }
+
+    const proofBytes = buildProof(sortedJwts, vc.vcJwt);
+
+    return {
+      vcId: vc.id,
+      vcJwt: vc.vcJwt,
+      vcAnchorId: anchor.id,
+      rootHash: anchor.rootHash,
+      chainTxHash: anchor.chainTxHash,
+      proofPath: proofBytes.map((b) => Buffer.from(b).toString("hex")),
+      leafIndex,
+      blockHeight: anchor.blockHeight,
+    };
   }
 }

--- a/src/application/domain/credential/vcIssuance/service.ts
+++ b/src/application/domain/credential/vcIssuance/service.ts
@@ -323,6 +323,38 @@ export default class VcIssuanceService {
     }
 
     const leaves = await this.repository.findVcJwtsByIds(ctx, anchor.leafIds);
+    // Merkle integrity invariant: every leaf id stored on the anchor must
+    // resolve to a row. A single missing or deleted row shifts the tree
+    // and invalidates EVERY proof in the batch. Treat as 5xx.
+    if (leaves.length !== anchor.leafIds.length) {
+      logger.error(
+        "[VcIssuanceService] generateInclusionProof: anchor leaf count mismatch — Merkle integrity violation",
+        {
+          vcId,
+          vcAnchorId: anchor.id,
+          expected: anchor.leafIds.length,
+          actual: leaves.length,
+        },
+      );
+      throw new Error(
+        `generateInclusionProof: anchor ${anchor.id} integrity violation (leaf count mismatch: expected ${anchor.leafIds.length}, got ${leaves.length})`,
+      );
+    }
+    // Empty vcJwt slots (preserved instead of silently filtered) break sort
+    // determinism — throw rather than serve a corrupt proof.
+    if (leaves.some((l) => l.vcJwt.length === 0)) {
+      logger.error(
+        "[VcIssuanceService] generateInclusionProof: anchor contains a row with empty vcJwt",
+        {
+          vcId,
+          vcAnchorId: anchor.id,
+          emptyCount: leaves.filter((l) => l.vcJwt.length === 0).length,
+        },
+      );
+      throw new Error(
+        `generateInclusionProof: anchor ${anchor.id} integrity violation (empty vcJwt in leaf set)`,
+      );
+    }
     if (leaves.length === 0) {
       logger.warn("[VcIssuanceService] generateInclusionProof: anchor has no resolvable leaves", {
         vcId,

--- a/src/application/domain/credential/vcIssuance/usecase.ts
+++ b/src/application/domain/credential/vcIssuance/usecase.ts
@@ -43,7 +43,9 @@ import { inject, injectable } from "tsyringe";
 import { IContext } from "@/types/server";
 import { AuthorizationError } from "@/errors/graphql";
 import VcIssuanceService from "@/application/domain/credential/vcIssuance/service";
-import VcIssuancePresenter from "@/application/domain/credential/vcIssuance/presenter";
+import VcIssuancePresenter, {
+  type InclusionProofResponse,
+} from "@/application/domain/credential/vcIssuance/presenter";
 import type { IssueVcInput as DomainIssueVcInput } from "@/application/domain/credential/vcIssuance/data/type";
 import type { GqlIssueVcInput, GqlVcIssuance } from "@/types/graphql";
 
@@ -116,5 +118,25 @@ export default class VcIssuanceUseCase {
       return this.service.issueVc(ctx, serviceInput, tx);
     });
     return VcIssuancePresenter.view(row);
+  }
+
+  /**
+   * §5.4.6 — Resolve the Merkle inclusion proof for the supplied VC.
+   *
+   * Public REST endpoint backing this method (`/vc/:vcId/inclusion-proof`)
+   * is unauthenticated, so we do not enforce an ownership check here:
+   * the proof reveals only the on-chain anchor metadata + the canonical
+   * leaf path, both of which are public information once the batch tx
+   * is on-chain. The router maps `null` to 404; exceptions to 500.
+   *
+   * No transaction is opened — every read goes through `issuer.internal`
+   * inside the repository (matching the precedent set by
+   * `UserDidAnchorRepository.findLatestByUserId` for the sibling
+   * `/users/:userId/did.json` route).
+   */
+  async getInclusionProof(ctx: IContext, vcId: string): Promise<InclusionProofResponse | null> {
+    const proof = await this.service.generateInclusionProof(ctx, vcId);
+    if (proof === null) return null;
+    return VcIssuancePresenter.toInclusionProofResponse(proof);
   }
 }

--- a/src/infrastructure/libs/merkle/merkleTreeBuilder.ts
+++ b/src/infrastructure/libs/merkle/merkleTreeBuilder.ts
@@ -100,8 +100,7 @@ export function getProof(leafIds: string[], idx: number): Uint8Array[] {
     const isLeft = cursor % 2 === 0;
     const siblingIdx = isLeft ? cursor + 1 : cursor - 1;
     // Odd-tail: when there is no right sibling at this level, duplicate self.
-    const sibling =
-      siblingIdx < level.length ? level[siblingIdx] : level[cursor];
+    const sibling = siblingIdx < level.length ? level[siblingIdx] : level[cursor];
     proof.push(sibling);
 
     const next: Uint8Array[] = [];
@@ -114,6 +113,38 @@ export function getProof(leafIds: string[], idx: number): Uint8Array[] {
     cursor = Math.floor(cursor / 2);
   }
   return proof;
+}
+
+/**
+ * Compute a proof-of-inclusion for `targetLeaf` in the canonical tree built
+ * from `sortedLeaves`. Convenience wrapper around `getProof` that locates
+ * the target by exact-string match instead of requiring the caller to
+ * thread the index through.
+ *
+ * Used by the public `/vc/:vcId/inclusion-proof` endpoint (§5.4.6): the
+ * caller supplies the VC JWT it wants a proof for and we recover the index
+ * from the canonically-sorted leaf list (`vcAnchor.leafIds` mapped through
+ * `findVcJwtsByVcIssuanceRequestIds` and re-sorted by ASCII byte order).
+ *
+ * Throws when `targetLeaf` is not present in `sortedLeaves` — that is a
+ * caller bug (the row's `vcAnchorId` claims membership but the JWT is
+ * missing from the anchor's `leafIds` set) and silently returning `[]`
+ * would leak as a proof that verifies against an empty path.
+ */
+export function buildProof(sortedLeaves: string[], targetLeaf: string): Uint8Array[] {
+  if (sortedLeaves.length === 0) {
+    throw new Error("buildProof: sortedLeaves must be non-empty");
+  }
+  // `indexOf` is O(n) but the leaf set is tiny (one weekly batch) and a
+  // Map indirection would obscure the comparator semantics — we want the
+  // exact-string match the spec mandates, not a hash-keyed lookup.
+  const idx = sortedLeaves.indexOf(targetLeaf);
+  if (idx < 0) {
+    throw new Error(
+      `buildProof: leaf not in tree (sorted leaf set has ${sortedLeaves.length} entries)`,
+    );
+  }
+  return getProof(sortedLeaves, idx);
 }
 
 /**

--- a/src/presentation/router/did.ts
+++ b/src/presentation/router/did.ts
@@ -21,11 +21,15 @@
  *     state (§F), so we do not need extra branching here.
  *
  *   GET /vc/:vcId/inclusion-proof
- *     Stubbed 501 Not Implemented for this PR. The real handler depends
- *     on the batch worker (Phase 1 step 7) that produces Merkle inclusion
- *     proofs for VCs once their batch is anchored. Returning 501 — rather
- *     than 404 — communicates "endpoint exists but not yet implemented"
- *     and lets clients retry later without changing URL.
+ *     Returns the Merkle inclusion proof for a VC whose batch has been
+ *     anchored on-chain (§5.4.6). Maps:
+ *       - VC not found / not yet anchored / anchor PENDING|SUBMITTED|FAILED
+ *                                                  → 404 (`not_anchored`)
+ *       - CONFIRMED anchor                         → 200 with proof DTO
+ *       - genuine errors (DB, malformed leaf set)  → 500
+ *     The body shape is documented on `InclusionProofResponse` in the
+ *     vcIssuance presenter — every byte field is hex-encoded so the
+ *     verifier in civicship-portal can deserialize without ambiguity.
  *
  * Design references:
  *   docs/report/did-vc-internalization.md §5.4   (public routes)
@@ -37,6 +41,7 @@
 import express, { Request, Response } from "express";
 import { container } from "tsyringe";
 import IssuerDidUseCase from "@/application/domain/credential/issuerDid/usecase";
+import VcIssuanceUseCase from "@/application/domain/credential/vcIssuance/usecase";
 import {
   DidDocumentResolver,
   type DidDocumentWithProof,
@@ -46,7 +51,9 @@ import {
   buildUserDid,
   isValidUserId,
 } from "@/infrastructure/libs/did/userDidBuilder";
+import { PrismaClientIssuer } from "@/infrastructure/prisma/client";
 import logger from "@/infrastructure/logging";
+import type { IContext } from "@/types/server";
 
 const router = express.Router();
 
@@ -152,7 +159,7 @@ router.get("/users/:userId/did.json", async (req: Request, res: Response) => {
 // VC Inclusion Proof — /vc/:vcId/inclusion-proof
 // ---------------------------------------------------------------------------
 
-router.get("/vc/:vcId/inclusion-proof", (req: Request, res: Response) => {
+router.get("/vc/:vcId/inclusion-proof", async (req: Request, res: Response) => {
   const { vcId } = req.params;
 
   if (typeof vcId !== "string" || vcId.length === 0) {
@@ -162,10 +169,32 @@ router.get("/vc/:vcId/inclusion-proof", (req: Request, res: Response) => {
     });
   }
 
-  return res.status(501).json({
-    error: "not_implemented",
-    message: "VC inclusion-proof endpoint will land in Phase 1 step 7 (batch worker)",
-  });
+  try {
+    // Public route: there is no request-scoped issuer auth (no
+    // session/idToken on `/vc/:id/inclusion-proof`). We construct a
+    // minimal `IContext` carrying just the `PrismaClientIssuer` so the
+    // service layer's `issuer.internal()` calls work — same shape as
+    // the admin anchor-batch route (`router/admin/anchorBatch.ts`).
+    const issuer = container.resolve<PrismaClientIssuer>("PrismaClientIssuer");
+    const ctx = { issuer } as IContext;
+    const usecase = container.resolve<VcIssuanceUseCase>("VcIssuanceUseCase");
+
+    const proof = await usecase.getInclusionProof(ctx, vcId);
+    if (proof === null) {
+      return res.status(404).json({
+        error: "not_anchored",
+        message: `No confirmed anchor for VC ${vcId}`,
+      });
+    }
+    return res.status(200).json(proof);
+  } catch (err) {
+    logger.error("[router/did] failed to build VC inclusion proof", {
+      vcId,
+      message: err instanceof Error ? err.message : String(err),
+      stack: err instanceof Error ? err.stack : undefined,
+    });
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
 });
 
 export default router;


### PR DESCRIPTION
## Summary

設計書 §5.4.2 / §5.4.6 に沿って、#1097 で暫定 501 stub にしていた `/vc/:vcId/inclusion-proof` REST endpoint を本実装化する。#1103 (AnchorBatch) と #1102 (StatusList) のマージにより anchor 後の VC の Merkle inclusion proof を生成できる状態になったため、anchor 状態別の挙動 (PENDING / SUBMITTED / CONFIRMED) を備えた 200 ハンドラに置換する。

### 主な変更

- **Merkle**: `buildProof(sortedLeaves, targetLeaf)` を `merkleTreeBuilder` に追加（既存 `getProof(idx)` の薄い target-leaf wrapper）。
- **Service**: `VcIssuanceService.generateInclusionProof(vcId, ctx)` を追加。
  - VC 不在 / vcAnchorId 未付与 / vcJwt 空 / anchor 不在 / anchor が CONFIRMED 以外 → `null`（router で 404）。
  - CONFIRMED anchor: `findVcJwtsByIds(anchor.leafIds)` で JWT 群を再取得 → §5.1.7 ASCII byte sort（`AnchorBatchService.buildVcRoot` と完全一致）→ `buildProof` で proof path 生成。
  - row が anchor の leaf 集合に属さない異常系は throw（router で 500）。
- **UseCase / Presenter**: `getInclusionProof(vcId, ctx)` を `VcIssuanceUseCase` に追加し、`InclusionProofResponse` DTO に変換（hex-encoded proof path）。
- **Repository**: `IVcIssuanceRepository` に `findVcAnchorById` / `findVcJwtsByIds` を追加。`/vc/:vcId/inclusion-proof` は公開 endpoint のため `issuer.internal()` を使用（precedent: `UserDidAnchorRepository.findLatestByUserId`）。
- **Router**: 501 ハンドラを 200 / 404 / 500 ハンドラに置換。`{ issuer }` 最小 `IContext` を構築（admin/anchorBatch.ts と同じパターン）。

### Status マッピング

| anchor.status | response |
|---|---|
| (no row / no vcAnchorId) | 404 `not_anchored` |
| PENDING | 404 `not_anchored` |
| SUBMITTED | 404 `not_anchored` |
| FAILED | 404 `not_anchored` |
| CONFIRMED | 200 + proof DTO |

### 設計参照

- `docs/report/did-vc-internalization.md §5.4.2` / `§5.4.6` (this endpoint)
- `docs/report/did-vc-internalization.md §5.1.7` (canonical leaf encoding — ASCII byte order)

## Test plan

- [x] `pnpm test --testPathPattern '(merkle|presentation/router/did|domain/credential/vcIssuance)'` → **58/58 pass**
  - `merkleTreeBuilder.test.ts`: `buildProof` の `getProof` との一致 / 7-leaf odd-tail verifyProof / single-leaf empty / 不在 leaf throw / 空入力 throw
  - `service.test.ts > generateInclusionProof`: 5-leaf / 7-leaf 全パスで `verifyProof` round-trip 通過、PENDING / SUBMITTED / 不在 anchor / 空 JWT / vcAnchorId 未付与 で null、整合性違反で throw
  - `usecase.test.ts > getInclusionProof`: service が null → null、proof → そのまま透過
  - `router/did.test.ts > GET /vc/:vcId/inclusion-proof`: 200 (CONFIRMED) / 404 (PENDING / null) / 500 (throw) を supertest で確認
- [x] `pnpm exec tsc --noEmit` → baseline 維持（既存 SQL 型生成エラーのみ、本 PR 由来 0 件）
- [x] `pnpm exec eslint` clean
- [x] `pnpm exec prettier --check` clean
- [x] **SonarCloud S2871**: sort comparator は `(a, b) => (a < b ? -1 : a > b ? 1 : 0)` を service / test の両方で明示
- [x] **SonarCloud S2189**: `buildProof` は既存 `getProof` の `while (level.length > 1)` に委譲、毎 iteration `Math.floor(curIdx / 2)` で index が単調減少 → bounded
- [ ] (後続) 統合テスト: 実 DB に VcAnchor + VC 行を投入してエンドツーエンドで 200 レスポンスを確認（本 PR 範囲外）

https://claude.ai/code/session_019MKzV6DsfsHA6dLJ99chU8

---
_Generated by [Claude Code](https://claude.ai/code/session_019MKzV6DsfsHA6dLJ99chU8)_