### PR TITLE
phase1.5(graphql): Mutation.revokeUserVc — VC revoke 配線

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -2182,6 +2182,12 @@ type Mutation {
   reservationCreate(input: ReservationCreateInput!): ReservationCreatePayload
   reservationJoin(id: ID!): ReservationSetStatusPayload
   reservationReject(id: ID!, input: ReservationRejectInput!, permission: CheckOpportunityPermissionInput!): ReservationSetStatusPayload
+
+  """
+  VC を revoke する。StatusList の bit を立て、`revokedAt` を更新する。
+  Admin のみ実行可能 (将来 issuer 自身でも可能にする想定)。
+  """
+  revokeUserVc(input: RevokeUserVcInput!): VcIssuance!
   storePhoneAuthToken(input: StorePhoneAuthTokenInput!, permission: CheckIsSelfPermissionInput!): StorePhoneAuthTokenPayload
   submitReportFeedback(input: SubmitReportFeedbackInput!, permission: CheckCommunityPermissionInput @deprecated(reason: "Use the `x-community-id` request header instead; this argument is ignored when the header is present.")): SubmitReportFeedbackPayload
   ticketClaim(input: TicketClaimInput!): TicketClaimPayload
@@ -3317,6 +3323,14 @@ type ReservationsConnection {
   edges: [ReservationEdge!]!
   pageInfo: PageInfo!
   totalCount: Int!
+}
+
+input RevokeUserVcInput {
+  """Revoke 理由 (audit log 用、任意)。"""
+  reason: String
+
+  """Revoke 対象の VC issuance id。"""
+  vcId: ID!
 }
 
 enum Role {

--- a/src/__tests__/integration/vcIssuance/revokeUserVc.test.ts
+++ b/src/__tests__/integration/vcIssuance/revokeUserVc.test.ts
@@ -1,0 +1,253 @@
+/**
+ * `Mutation.revokeUserVc` GraphQL integration tests (Phase 1.5).
+ *
+ * Covers the full Apollo + AuthZ + Resolver path with the usecase
+ * mocked via tsyringe (the same pattern as `vcIssuance.test.ts`).
+ *
+ * Cases (per the Phase 1.5 task brief):
+ *   - Admin → 200 + presented VC with `revokedAt` populated.
+ *   - Non-admin / unauthenticated → FORBIDDEN (IsAdmin gate).
+ *   - Missing vcId → NOT_FOUND surfaced from the usecase's
+ *     `NotFoundError` (the `revokeUserVc` non-null payload means an
+ *     errors-array response, not `data: null`).
+ *   - Idempotent re-revoke → returns the existing snapshot unchanged.
+ *
+ * The transactional / StatusList wiring is exercised in the unit tests
+ * (`__tests__/unit/application/domain/credential/vcIssuance/usecase.test.ts`);
+ * here we only verify the GraphQL surface.
+ */
+
+import "reflect-metadata";
+import { container } from "tsyringe";
+import { registerProductionDependencies } from "@/application/provider";
+import { createApolloTestServer } from "@/__tests__/helper/test-server";
+import request from "supertest";
+import path from "path";
+import { PrismaClientIssuer } from "@/infrastructure/prisma/client";
+import { NotFoundError } from "@/errors/graphql";
+
+jest.mock("@/presentation/graphql/scalar", () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock("@/presentation/graphql/schema/esmPath", () => ({
+  getESMDirname: jest.fn(() => path.resolve(__dirname, "../../../../src/presentation/graphql/schema")),
+}));
+
+jest.mock("@/application/domain/utils", () => ({
+  getCurrentUserId: jest.fn(() => "admin-1"),
+}));
+
+const REVOKE_MUTATION = /* GraphQL */ `
+  mutation ($input: RevokeUserVcInput!) {
+    revokeUserVc(input: $input) {
+      id
+      userId
+      status
+      revokedAt
+    }
+  }
+`;
+
+const baseRevokedVc = {
+  __typename: "VcIssuance" as const,
+  id: "vc-1",
+  userId: "user-1",
+  evaluationId: null,
+  issuerDid: "did:web:api.civicship.app",
+  subjectDid: "did:web:api.civicship.app:users:user-1",
+  vcFormat: "INTERNAL_JWT",
+  vcJwt: "h.p.s",
+  // Phase 1.5: persisted `status` stays `COMPLETED` — the
+  // `VcIssuanceStatus.REVOKED` enum value lands in a follow-up schema
+  // PR. Verifiers detect revocation via the StatusList JWT.
+  status: "COMPLETED",
+  statusListIndex: 0,
+  statusListCredential: "https://api.civicship.app/credentials/status/1.jwt",
+  revokedAt: new Date("2026-05-10T12:00:00Z"),
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+};
+
+let issuer: PrismaClientIssuer;
+
+const mockVcIssuanceUseCase = {
+  viewVcIssuance: jest.fn(),
+  viewVcIssuancesByUser: jest.fn(),
+  issueVc: jest.fn(),
+  revokeUserVc: jest.fn(),
+};
+
+describe("Mutation revokeUserVc (Phase 1.5)", () => {
+  beforeAll(() => {
+    container.reset();
+    registerProductionDependencies();
+    issuer = container.resolve(PrismaClientIssuer);
+    container.register("VcIssuanceUseCase", { useValue: mockVcIssuanceUseCase });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("authorization (IsAdmin)", () => {
+    it("invokes the usecase when the caller is admin and returns the revoked VC", async () => {
+      mockVcIssuanceUseCase.revokeUserVc.mockResolvedValueOnce(baseRevokedVc);
+
+      const app = await createApolloTestServer({
+        isAdmin: true,
+        currentUser: { id: "admin-1", sysRole: "SYS_ADMIN" },
+        issuer,
+      });
+      const res = await request(app)
+        .post("/graphql")
+        .send({
+          query: REVOKE_MUTATION,
+          variables: {
+            input: { vcId: "vc-1", reason: "user-requested" },
+          },
+        });
+
+      expect(res.body.errors).toBeUndefined();
+      expect(res.body.data.revokeUserVc).toMatchObject({
+        id: "vc-1",
+        userId: "user-1",
+      });
+      // `revokedAt` round-trips through the `Datetime` scalar; assert it
+      // is populated rather than asserting an exact serialized form,
+      // which depends on the scalar's encoding.
+      expect(res.body.data.revokeUserVc.revokedAt).toBeTruthy();
+      expect(mockVcIssuanceUseCase.revokeUserVc).toHaveBeenCalledTimes(1);
+      expect(mockVcIssuanceUseCase.revokeUserVc).toHaveBeenCalledWith(
+        expect.anything(),
+        { vcId: "vc-1", reason: "user-requested" },
+      );
+    });
+
+    it("rejects non-admin callers with FORBIDDEN before reaching the usecase", async () => {
+      const app = await createApolloTestServer({
+        currentUser: { id: "user-1", sysRole: "USER" },
+        issuer,
+      });
+      const res = await request(app)
+        .post("/graphql")
+        .send({
+          query: REVOKE_MUTATION,
+          variables: { input: { vcId: "vc-1" } },
+        });
+
+      const code = res.body.errors?.[0]?.code ?? res.body.errors?.[0]?.extensions?.code;
+      expect(code).toBe("FORBIDDEN");
+      expect(mockVcIssuanceUseCase.revokeUserVc).not.toHaveBeenCalled();
+    });
+
+    it("rejects unauthenticated callers with FORBIDDEN", async () => {
+      const app = await createApolloTestServer({ issuer });
+      const res = await request(app)
+        .post("/graphql")
+        .send({
+          query: REVOKE_MUTATION,
+          variables: { input: { vcId: "vc-1" } },
+        });
+
+      const code = res.body.errors?.[0]?.code ?? res.body.errors?.[0]?.extensions?.code;
+      expect(code).toBe("FORBIDDEN");
+      expect(mockVcIssuanceUseCase.revokeUserVc).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("not-found / idempotency", () => {
+    it("surfaces NOT_FOUND when the vcId does not exist", async () => {
+      mockVcIssuanceUseCase.revokeUserVc.mockRejectedValueOnce(
+        new NotFoundError("VcIssuance", { id: "missing" }),
+      );
+
+      const app = await createApolloTestServer({
+        isAdmin: true,
+        currentUser: { id: "admin-1", sysRole: "SYS_ADMIN" },
+        issuer,
+      });
+      const res = await request(app)
+        .post("/graphql")
+        .send({
+          query: REVOKE_MUTATION,
+          variables: { input: { vcId: "missing" } },
+        });
+
+      expect(res.body.errors).toBeDefined();
+      const code = res.body.errors?.[0]?.code ?? res.body.errors?.[0]?.extensions?.code;
+      expect(code).toBe("NOT_FOUND");
+    });
+
+    it("re-revoking an already-revoked VC returns the same snapshot (idempotent)", async () => {
+      // The usecase enforces idempotency by returning the original
+      // snapshot without re-invoking the StatusList. We mirror that
+      // by returning `baseRevokedVc` from a single mock call: the
+      // resolver should pass the response through unchanged.
+      mockVcIssuanceUseCase.revokeUserVc.mockResolvedValueOnce(baseRevokedVc);
+
+      const app = await createApolloTestServer({
+        isAdmin: true,
+        currentUser: { id: "admin-1", sysRole: "SYS_ADMIN" },
+        issuer,
+      });
+      const res = await request(app)
+        .post("/graphql")
+        .send({
+          query: REVOKE_MUTATION,
+          variables: { input: { vcId: "vc-1" } },
+        });
+
+      expect(res.body.errors).toBeUndefined();
+      expect(res.body.data.revokeUserVc.id).toBe("vc-1");
+      expect(res.body.data.revokeUserVc.revokedAt).toBeTruthy();
+    });
+  });
+
+  describe("input wiring", () => {
+    it("forwards the optional `reason` to the usecase verbatim", async () => {
+      mockVcIssuanceUseCase.revokeUserVc.mockResolvedValueOnce(baseRevokedVc);
+
+      const app = await createApolloTestServer({
+        isAdmin: true,
+        currentUser: { id: "admin-1", sysRole: "SYS_ADMIN" },
+        issuer,
+      });
+      await request(app)
+        .post("/graphql")
+        .send({
+          query: REVOKE_MUTATION,
+          variables: {
+            input: { vcId: "vc-1", reason: "policy violation" },
+          },
+        });
+
+      expect(mockVcIssuanceUseCase.revokeUserVc).toHaveBeenCalledWith(
+        expect.anything(),
+        { vcId: "vc-1", reason: "policy violation" },
+      );
+    });
+
+    it("works without a `reason` (optional field omitted)", async () => {
+      mockVcIssuanceUseCase.revokeUserVc.mockResolvedValueOnce(baseRevokedVc);
+
+      const app = await createApolloTestServer({
+        isAdmin: true,
+        currentUser: { id: "admin-1", sysRole: "SYS_ADMIN" },
+        issuer,
+      });
+      const res = await request(app)
+        .post("/graphql")
+        .send({
+          query: REVOKE_MUTATION,
+          variables: { input: { vcId: "vc-1" } },
+        });
+
+      expect(res.body.errors).toBeUndefined();
+      expect(mockVcIssuanceUseCase.revokeUserVc).toHaveBeenCalledWith(
+        expect.anything(),
+        { vcId: "vc-1" },
+      );
+    });
+  });
+});

--- a/src/__tests__/unit/application/domain/credential/vcIssuance/usecase.test.ts
+++ b/src/__tests__/unit/application/domain/credential/vcIssuance/usecase.test.ts
@@ -12,7 +12,7 @@ import "reflect-metadata";
 import { container } from "tsyringe";
 import VcIssuanceUseCase from "@/application/domain/credential/vcIssuance/usecase";
 import VcIssuanceService from "@/application/domain/credential/vcIssuance/service";
-import { AuthorizationError } from "@/errors/graphql";
+import { AuthorizationError, NotFoundError } from "@/errors/graphql";
 import type { IContext } from "@/types/server";
 import type { VcIssuanceRow } from "@/application/domain/credential/vcIssuance/data/type";
 
@@ -65,6 +65,10 @@ describe("VcIssuanceUseCase (authz hardening for PR #1101)", () => {
   let mockService: jest.Mocked<
     Pick<VcIssuanceService, "findVcById" | "findVcsByUserId" | "issueVc" | "generateInclusionProof">
   >;
+  // Phase 1.5: the usecase now also depends on StatusListService for the
+  // revoke flow. The legacy authz tests below don't exercise it, but we
+  // still need a registration so the container can construct the usecase.
+  let mockStatusListService: { revokeVc: jest.Mock };
   let usecase: VcIssuanceUseCase;
 
   beforeEach(() => {
@@ -77,8 +81,12 @@ describe("VcIssuanceUseCase (authz hardening for PR #1101)", () => {
       issueVc: jest.fn(),
       generateInclusionProof: jest.fn(),
     };
+    mockStatusListService = {
+      revokeVc: jest.fn(),
+    };
 
     container.register("VcIssuanceService", { useValue: mockService });
+    container.register("StatusListService", { useValue: mockStatusListService });
     container.register("VcIssuanceUseCase", { useClass: VcIssuanceUseCase });
 
     usecase = container.resolve(VcIssuanceUseCase);
@@ -188,6 +196,71 @@ describe("VcIssuanceUseCase (authz hardening for PR #1101)", () => {
 
       const result = await usecase.getInclusionProof(ctx, "vc-1");
       expect(result).toEqual(proof);
+    });
+  });
+
+  describe("revokeUserVc (Phase 1.5)", () => {
+    it("invokes StatusListService.revokeVc and returns the updated row", async () => {
+      const liveRow = makeRow({ revokedAt: null });
+      const revokedAt = new Date("2026-05-10T12:00:00Z");
+      const revokedRow = makeRow({ revokedAt });
+
+      mockService.findVcById
+        .mockResolvedValueOnce(liveRow)
+        .mockResolvedValueOnce(revokedRow);
+      mockStatusListService.revokeVc.mockResolvedValueOnce(undefined);
+
+      const ctx = makeCtx({ isAdmin: true, currentUser: { id: "admin-1" } as never });
+
+      const result = await usecase.revokeUserVc(ctx, {
+        vcId: "vc-1",
+        reason: "user-requested",
+      });
+
+      expect(mockStatusListService.revokeVc).toHaveBeenCalledTimes(1);
+      expect(mockStatusListService.revokeVc).toHaveBeenCalledWith(
+        ctx,
+        { vcRequestId: "vc-1", reason: "user-requested" },
+        expect.anything(),
+      );
+      expect(result.revokedAt).toEqual(revokedAt);
+    });
+
+    it("is idempotent: already-revoked rows are returned without re-invoking StatusList", async () => {
+      const revokedAt = new Date("2026-05-09T12:00:00Z");
+      const alreadyRevoked = makeRow({ revokedAt });
+      mockService.findVcById.mockResolvedValueOnce(alreadyRevoked);
+
+      const ctx = makeCtx({ isAdmin: true, currentUser: { id: "admin-1" } as never });
+
+      const result = await usecase.revokeUserVc(ctx, { vcId: "vc-1" });
+
+      expect(mockStatusListService.revokeVc).not.toHaveBeenCalled();
+      expect(result.revokedAt).toEqual(revokedAt);
+    });
+
+    it("throws NotFoundError when no row matches the supplied vcId", async () => {
+      mockService.findVcById.mockResolvedValueOnce(null);
+
+      const ctx = makeCtx({ isAdmin: true, currentUser: { id: "admin-1" } as never });
+
+      await expect(usecase.revokeUserVc(ctx, { vcId: "missing" })).rejects.toBeInstanceOf(
+        NotFoundError,
+      );
+      expect(mockStatusListService.revokeVc).not.toHaveBeenCalled();
+    });
+
+    it("opens exactly one ctx.issuer.public transaction for the whole flow", async () => {
+      mockService.findVcById
+        .mockResolvedValueOnce(makeRow({ revokedAt: null }))
+        .mockResolvedValueOnce(makeRow({ revokedAt: new Date() }));
+      mockStatusListService.revokeVc.mockResolvedValueOnce(undefined);
+
+      const ctx = makeCtx({ isAdmin: true, currentUser: { id: "admin-1" } as never });
+
+      await usecase.revokeUserVc(ctx, { vcId: "vc-1" });
+
+      expect((ctx.issuer.public as jest.Mock).mock.calls).toHaveLength(1);
     });
   });
 });

--- a/src/application/domain/credential/vcIssuance/controller/resolver.ts
+++ b/src/application/domain/credential/vcIssuance/controller/resolver.ts
@@ -33,6 +33,7 @@ import { IContext } from "@/types/server";
 import VcIssuanceUseCase from "@/application/domain/credential/vcIssuance/usecase";
 import type {
   GqlMutationIssueVcArgs,
+  GqlMutationRevokeUserVcArgs,
   GqlQueryVcIssuanceArgs,
   GqlQueryVcIssuancesByUserArgs,
   GqlVcIssuance,
@@ -54,6 +55,9 @@ export default class VcIssuanceResolver {
   Mutation = {
     issueVc: (_: unknown, args: GqlMutationIssueVcArgs, ctx: IContext) => {
       return this.vcIssuanceUseCase.issueVc(ctx, args.input);
+    },
+    revokeUserVc: (_: unknown, args: GqlMutationRevokeUserVcArgs, ctx: IContext) => {
+      return this.vcIssuanceUseCase.revokeUserVc(ctx, args.input);
     },
   };
 

--- a/src/application/domain/credential/vcIssuance/data/interface.ts
+++ b/src/application/domain/credential/vcIssuance/data/interface.ts
@@ -20,7 +20,17 @@ import type {
 } from "@/application/domain/credential/vcIssuance/data/type";
 
 export interface IVcIssuanceRepository {
-  findById(ctx: IContext, id: string): Promise<VcIssuanceRow | null>;
+  /**
+   * Look up a VC issuance row by id.
+   *
+   * `tx` is optional: callers running inside an outer transaction (e.g.
+   * the revoke flow which composes a StatusList write + `revokedAt`
+   * stamp + a re-read in a single commit) supply it so the read happens
+   * on the same client and observes the in-progress writes. Read-only
+   * callers (the `vcIssuance` query resolver) omit it and the repository
+   * opens an issuer-scoped public transaction.
+   */
+  findById(ctx: IContext, id: string, tx?: Prisma.TransactionClient): Promise<VcIssuanceRow | null>;
 
   /**
    * Return every VC issuance row owned by `userId`, newest first.

--- a/src/application/domain/credential/vcIssuance/data/repository.ts
+++ b/src/application/domain/credential/vcIssuance/data/repository.ts
@@ -103,10 +103,22 @@ export default class VcIssuanceRepository implements IVcIssuanceRepository {
    * but to keep this method purely persistence-bound we decode the JWT
    * payload's `issuer` / `credentialSubject.id` instead.
    */
-  async findById(ctx: IContext, id: string): Promise<VcIssuanceRow | null> {
-    const persisted = await this.issuer.public(ctx, (tx) => {
-      return tx.vcIssuanceRequest.findUnique({ where: { id } });
-    });
+  async findById(
+    ctx: IContext,
+    id: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<VcIssuanceRow | null> {
+    // When a caller-supplied `tx` is present we MUST read on it so the
+    // lookup observes in-progress writes from the same transaction
+    // (Phase 1.5: the revoke flow stamps `revokedAt` then re-reads the
+    // row to surface the new timestamp through the GraphQL response).
+    // Without a `tx`, fall back to an issuer-scoped public transaction
+    // so RLS stays applied for the standalone query path.
+    const persisted = tx
+      ? await tx.vcIssuanceRequest.findUnique({ where: { id } })
+      : await this.issuer.public(ctx, (innerTx) =>
+          innerTx.vcIssuanceRequest.findUnique({ where: { id } }),
+        );
     if (!persisted) return null;
     const { issuerDid, subjectDid } = decodeIssuerSubjectFromJwt(persisted.vcJwt, persisted.id);
     return toRow(persisted, issuerDid, subjectDid);

--- a/src/application/domain/credential/vcIssuance/schema/mutation.graphql
+++ b/src/application/domain/credential/vcIssuance/schema/mutation.graphql
@@ -8,6 +8,12 @@ extend type Mutation {
   本体は anchor 待ちなしで COMPLETED として永続化される (§5.2.2)。
   """
   issueVc(input: IssueVcInput!): VcIssuance! @authz(rules: [IsAdmin])
+
+  """
+  VC を revoke する。StatusList の bit を立て、`revokedAt` を更新する。
+  Admin のみ実行可能 (将来 issuer 自身でも可能にする想定)。
+  """
+  revokeUserVc(input: RevokeUserVcInput!): VcIssuance! @authz(rules: [IsAdmin])
 }
 
 # ------------------------------
@@ -33,4 +39,16 @@ input IssueVcInput {
   VC に乗せる claim 群。issuer 側で validation は行わず opaque に署名される。
   """
   claims: JSON!
+}
+
+input RevokeUserVcInput {
+  """
+  Revoke 対象の VC issuance id。
+  """
+  vcId: ID!
+
+  """
+  Revoke 理由 (audit log 用、任意)。
+  """
+  reason: String
 }

--- a/src/application/domain/credential/vcIssuance/service.ts
+++ b/src/application/domain/credential/vcIssuance/service.ts
@@ -146,9 +146,19 @@ export default class VcIssuanceService {
     private readonly statusListService: StatusListService,
   ) {}
 
-  /** Pass-through for the GraphQL `vcIssuance` query (Phase 1 step 8). */
-  async findVcById(ctx: IContext, id: string): Promise<VcIssuanceRow | null> {
-    return this.repository.findById(ctx, id);
+  /**
+   * Pass-through for the GraphQL `vcIssuance` query (Phase 1 step 8).
+   *
+   * `tx` is forwarded so transactional callers (Phase 1.5 revoke flow)
+   * can re-read a row inside the same commit and observe the just-stamped
+   * `revokedAt` without nesting transactions.
+   */
+  async findVcById(
+    ctx: IContext,
+    id: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<VcIssuanceRow | null> {
+    return this.repository.findById(ctx, id, tx);
   }
 
   /** Pass-through for the GraphQL `vcIssuancesByUser` query. */

--- a/src/application/domain/credential/vcIssuance/usecase.ts
+++ b/src/application/domain/credential/vcIssuance/usecase.ts
@@ -8,6 +8,15 @@
  *   - Keeps the existing `issueVc` mutation entry that opens a public
  *     transaction.
  *
+ * Phase 1.5 scope:
+ *   - Adds `revokeUserVc` (`Mutation.revokeUserVc`). Delegates the actual
+ *     bit-flip + `revokedAt` update to `StatusListService.revokeVc`, then
+ *     re-reads the row through the VC issuance service so the GraphQL
+ *     response surfaces the updated `revokedAt`. The two writes commit
+ *     inside the same `ctx.issuer.public` transaction so a partial
+ *     failure cannot leave the StatusList ahead of the VC row (or vice
+ *     versa).
+ *
  * Per CLAUDE.md, the usecase is the only layer that may open a
  * transaction; the service stays unaware of `ctx.issuer.public` etc.
  *
@@ -30,24 +39,31 @@
  *                                    indistinguishable from "no VCs yet"
  *                                    and confusing for clients).
  *
- * `issueVc` is already gated on `IsAdmin` at the schema level (§B —
- * civicship is a single-issuer platform), so no further check is needed.
+ * `issueVc` / `revokeUserVc` are already gated on `IsAdmin` at the schema
+ * level (§B — civicship is a single-issuer platform), so no further check
+ * is needed.
  *
  * Design references:
  *   docs/report/did-vc-internalization.md §5.2.2
+ *   docs/report/did-vc-internalization.md §5.2.4 (StatusList wiring)
  *   docs/report/did-vc-internalization.md §B (single-issuer model)
  *   CLAUDE.md "Transaction Handling Pattern"
  */
 
 import { inject, injectable } from "tsyringe";
 import { IContext } from "@/types/server";
-import { AuthorizationError } from "@/errors/graphql";
+import { AuthorizationError, NotFoundError } from "@/errors/graphql";
 import VcIssuanceService from "@/application/domain/credential/vcIssuance/service";
+import StatusListService from "@/application/domain/credential/statusList/service";
 import VcIssuancePresenter, {
   type InclusionProofResponse,
 } from "@/application/domain/credential/vcIssuance/presenter";
 import type { IssueVcInput as DomainIssueVcInput } from "@/application/domain/credential/vcIssuance/data/type";
-import type { GqlIssueVcInput, GqlVcIssuance } from "@/types/graphql";
+import type {
+  GqlIssueVcInput,
+  GqlRevokeUserVcInput,
+  GqlVcIssuance,
+} from "@/types/graphql";
 
 /**
  * True when the caller is the target user, or when the caller is an
@@ -62,7 +78,10 @@ function isSelfOrAdmin(ctx: IContext, userId: string): boolean {
 
 @injectable()
 export default class VcIssuanceUseCase {
-  constructor(@inject("VcIssuanceService") private readonly service: VcIssuanceService) {}
+  constructor(
+    @inject("VcIssuanceService") private readonly service: VcIssuanceService,
+    @inject("StatusListService") private readonly statusListService: StatusListService,
+  ) {}
 
   /**
    * GraphQL `vcIssuance(id)` resolver entry. Reads outside a write
@@ -138,5 +157,59 @@ export default class VcIssuanceUseCase {
     const proof = await this.service.generateInclusionProof(ctx, vcId);
     if (proof === null) return null;
     return VcIssuancePresenter.toInclusionProofResponse(proof);
+  }
+
+  /**
+   * Phase 1.5 — `Mutation.revokeUserVc` resolver entry. Authorization is
+   * gated on `IsAdmin` at the schema level (single-issuer model, §B), so
+   * no further self-or-admin check is needed here.
+   *
+   * Flow:
+   *   1. Open an issuer-scoped transaction so the StatusList bitstring
+   *      update and the `revokedAt` stamp commit atomically — a partial
+   *      failure must never leave the list bit set while the row still
+   *      reads as live (or vice versa).
+   *   2. Pre-check the row via `findVcById` so a missing id surfaces as
+   *      `NotFoundError` *before* StatusListService throws its own less
+   *      specific `Error("…not found.")`. This keeps the GraphQL error
+   *      shape consistent with the rest of the codebase (`NOT_FOUND`).
+   *   3. Idempotency: if the row is already revoked we re-read and return
+   *      it without invoking the StatusListService (the bit is already
+   *      flipped; touching it again would re-sign the list VC for no
+   *      reason). The original `revokedAt` is preserved.
+   *   4. Otherwise call `StatusListService.revokeVc` (flips bit + stamps
+   *      `revokedAt`) and re-load the row to surface the updated
+   *      timestamp through the presenter.
+   *
+   * `reason` is forwarded to the StatusList service, which currently logs
+   * it but does not persist beyond `revocationReason`. The schema PR
+   * `schema/phase1.5-revoke-and-index` will extend persistence; no
+   * GraphQL change required at that point.
+   */
+  async revokeUserVc(ctx: IContext, input: GqlRevokeUserVcInput): Promise<GqlVcIssuance> {
+    return ctx.issuer.public(ctx, async (tx) => {
+      const existing = await this.service.findVcById(ctx, input.vcId, tx);
+      if (!existing) {
+        throw new NotFoundError("VcIssuance", { id: input.vcId });
+      }
+      if (existing.revokedAt) {
+        return VcIssuancePresenter.view(existing);
+      }
+
+      await this.statusListService.revokeVc(
+        ctx,
+        {
+          vcRequestId: input.vcId,
+          reason: input.reason ?? undefined,
+        },
+        tx,
+      );
+
+      const refreshed = await this.service.findVcById(ctx, input.vcId, tx);
+      if (!refreshed) {
+        throw new NotFoundError("VcIssuance", { id: input.vcId });
+      }
+      return VcIssuancePresenter.view(refreshed);
+    });
   }
 }

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1708,3 +1708,7155 @@ export const GqlErrorCode = {
 } as const;
 
 export type GqlErrorCode = typeof GqlErrorCode[keyof typeof GqlErrorCode];
+export type GqlEvaluation = {
+  __typename?: 'Evaluation';
+  comment?: Maybe<Scalars['String']['output']>;
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
+  credentialUrl?: Maybe<Scalars['String']['output']>;
+  evaluator?: Maybe<GqlUser>;
+  histories?: Maybe<Array<GqlEvaluationHistory>>;
+  id: Scalars['ID']['output'];
+  issuedAt?: Maybe<Scalars['Datetime']['output']>;
+  participation?: Maybe<GqlParticipation>;
+  status: GqlEvaluationStatus;
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+  vcIssuanceRequest?: Maybe<GqlVcIssuanceRequest>;
+};
+
+export type GqlEvaluationBulkCreateInput = {
+  evaluations: Array<GqlEvaluationItem>;
+};
+
+export type GqlEvaluationBulkCreatePayload = GqlEvaluationBulkCreateSuccess;
+
+export type GqlEvaluationBulkCreateSuccess = {
+  __typename?: 'EvaluationBulkCreateSuccess';
+  evaluations: Array<GqlEvaluation>;
+};
+
+export type GqlEvaluationCreateInput = {
+  comment?: InputMaybe<Scalars['String']['input']>;
+  participationId: Scalars['ID']['input'];
+};
+
+export type GqlEvaluationEdge = GqlEdge & {
+  __typename?: 'EvaluationEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlEvaluation>;
+};
+
+export type GqlEvaluationFilterInput = {
+  communityId?: InputMaybe<Scalars['ID']['input']>;
+  evaluatorId?: InputMaybe<Scalars['ID']['input']>;
+  participationId?: InputMaybe<Scalars['ID']['input']>;
+  status?: InputMaybe<GqlEvaluationStatus>;
+};
+
+export type GqlEvaluationHistoriesConnection = {
+  __typename?: 'EvaluationHistoriesConnection';
+  edges: Array<GqlEvaluationHistoryEdge>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type GqlEvaluationHistory = {
+  __typename?: 'EvaluationHistory';
+  comment?: Maybe<Scalars['String']['output']>;
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
+  createdByUser?: Maybe<GqlUser>;
+  evaluation?: Maybe<GqlEvaluation>;
+  id: Scalars['ID']['output'];
+  status: GqlEvaluationStatus;
+};
+
+export type GqlEvaluationHistoryEdge = GqlEdge & {
+  __typename?: 'EvaluationHistoryEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlEvaluationHistory>;
+};
+
+export type GqlEvaluationHistoryFilterInput = {
+  createdByUserId?: InputMaybe<Scalars['ID']['input']>;
+  evaluationId?: InputMaybe<Scalars['ID']['input']>;
+  status?: InputMaybe<GqlEvaluationStatus>;
+};
+
+export type GqlEvaluationHistorySortInput = {
+  createdAt?: InputMaybe<GqlSortDirection>;
+};
+
+export type GqlEvaluationItem = {
+  comment?: InputMaybe<Scalars['String']['input']>;
+  participationId: Scalars['ID']['input'];
+  status: GqlEvaluationStatus;
+};
+
+export type GqlEvaluationSortInput = {
+  createdAt?: InputMaybe<GqlSortDirection>;
+  updatedAt?: InputMaybe<GqlSortDirection>;
+};
+
+export const GqlEvaluationStatus = {
+  Failed: 'FAILED',
+  Passed: 'PASSED',
+  Pending: 'PENDING'
+} as const;
+
+export type GqlEvaluationStatus = typeof GqlEvaluationStatus[keyof typeof GqlEvaluationStatus];
+export type GqlEvaluationsConnection = {
+  __typename?: 'EvaluationsConnection';
+  edges: Array<GqlEvaluationEdge>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type GqlGenerateReportInput = {
+  communityId: Scalars['ID']['input'];
+  parentRunId?: InputMaybe<Scalars['ID']['input']>;
+  periodFrom: Scalars['Datetime']['input'];
+  periodTo: Scalars['Datetime']['input'];
+  variant: GqlReportVariant;
+};
+
+export type GqlGenerateReportPayload = GqlGenerateReportSuccess;
+
+export type GqlGenerateReportSuccess = {
+  __typename?: 'GenerateReportSuccess';
+  report: GqlReport;
+};
+
+export type GqlIdentity = {
+  __typename?: 'Identity';
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
+  platform?: Maybe<GqlIdentityPlatform>;
+  uid: Scalars['String']['output'];
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+  user?: Maybe<GqlUser>;
+};
+
+export type GqlIdentityCheckPhoneUserInput = {
+  phoneUid: Scalars['String']['input'];
+};
+
+export type GqlIdentityCheckPhoneUserPayload = {
+  __typename?: 'IdentityCheckPhoneUserPayload';
+  membership?: Maybe<GqlMembership>;
+  status: GqlPhoneUserStatus;
+  user?: Maybe<GqlUser>;
+};
+
+export const GqlIdentityPlatform = {
+  Facebook: 'FACEBOOK',
+  Line: 'LINE',
+  Phone: 'PHONE'
+} as const;
+
+export type GqlIdentityPlatform = typeof GqlIdentityPlatform[keyof typeof GqlIdentityPlatform];
+export type GqlImageInput = {
+  alt?: InputMaybe<Scalars['String']['input']>;
+  caption?: InputMaybe<Scalars['String']['input']>;
+  file?: InputMaybe<Scalars['Upload']['input']>;
+};
+
+export type GqlIncentiveGrant = {
+  __typename?: 'IncentiveGrant';
+  attemptCount: Scalars['Int']['output'];
+  community?: Maybe<GqlCommunity>;
+  createdAt: Scalars['Datetime']['output'];
+  failureCode?: Maybe<GqlIncentiveGrantFailureCode>;
+  id: Scalars['ID']['output'];
+  lastAttemptedAt?: Maybe<Scalars['Datetime']['output']>;
+  lastError?: Maybe<Scalars['String']['output']>;
+  sourceId: Scalars['String']['output'];
+  status: GqlIncentiveGrantStatus;
+  transaction?: Maybe<GqlTransaction>;
+  type: GqlIncentiveGrantType;
+  updatedAt: Scalars['Datetime']['output'];
+  user?: Maybe<GqlUser>;
+};
+
+export type GqlIncentiveGrantEdge = GqlEdge & {
+  __typename?: 'IncentiveGrantEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlIncentiveGrant>;
+};
+
+export const GqlIncentiveGrantFailureCode = {
+  DatabaseError: 'DATABASE_ERROR',
+  InsufficientFunds: 'INSUFFICIENT_FUNDS',
+  Timeout: 'TIMEOUT',
+  Unknown: 'UNKNOWN',
+  WalletNotFound: 'WALLET_NOT_FOUND'
+} as const;
+
+export type GqlIncentiveGrantFailureCode = typeof GqlIncentiveGrantFailureCode[keyof typeof GqlIncentiveGrantFailureCode];
+export type GqlIncentiveGrantFilterInput = {
+  and?: InputMaybe<Array<GqlIncentiveGrantFilterInput>>;
+  communityId?: InputMaybe<Scalars['ID']['input']>;
+  not?: InputMaybe<GqlIncentiveGrantFilterInput>;
+  or?: InputMaybe<Array<GqlIncentiveGrantFilterInput>>;
+  status?: InputMaybe<GqlIncentiveGrantStatus>;
+  type?: InputMaybe<GqlIncentiveGrantType>;
+  userId?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type GqlIncentiveGrantRetryInput = {
+  incentiveGrantId: Scalars['ID']['input'];
+};
+
+export type GqlIncentiveGrantRetryPayload = GqlIncentiveGrantRetrySuccess;
+
+export type GqlIncentiveGrantRetrySuccess = {
+  __typename?: 'IncentiveGrantRetrySuccess';
+  incentiveGrant: GqlIncentiveGrant;
+  transaction?: Maybe<GqlTransaction>;
+};
+
+export type GqlIncentiveGrantSortInput = {
+  createdAt?: InputMaybe<GqlSortDirection>;
+  updatedAt?: InputMaybe<GqlSortDirection>;
+};
+
+export const GqlIncentiveGrantStatus = {
+  Completed: 'COMPLETED',
+  Failed: 'FAILED',
+  Pending: 'PENDING',
+  Retrying: 'RETRYING'
+} as const;
+
+export type GqlIncentiveGrantStatus = typeof GqlIncentiveGrantStatus[keyof typeof GqlIncentiveGrantStatus];
+export const GqlIncentiveGrantType = {
+  Signup: 'SIGNUP'
+} as const;
+
+export type GqlIncentiveGrantType = typeof GqlIncentiveGrantType[keyof typeof GqlIncentiveGrantType];
+export type GqlIncentiveGrantsConnection = {
+  __typename?: 'IncentiveGrantsConnection';
+  edges?: Maybe<Array<Maybe<GqlIncentiveGrantEdge>>>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type GqlIssueVcInput = {
+  /** VC に乗せる claim 群。issuer 側で validation は行わず opaque に署名される。 */
+  claims: Scalars['JSON']['input'];
+  /** VC を Evaluation に紐づける場合の id。 */
+  evaluationId?: InputMaybe<Scalars['ID']['input']>;
+  /** ユーザーの did:web:api.civicship.app:users:<id> (§B)。 */
+  subjectDid: Scalars['String']['input'];
+  /** VC を保有するユーザー id。 */
+  userId: Scalars['ID']['input'];
+};
+
+export const GqlLanguage = {
+  En: 'EN',
+  Ja: 'JA'
+} as const;
+
+export type GqlLanguage = typeof GqlLanguage[keyof typeof GqlLanguage];
+export const GqlLineRichMenuType = {
+  Admin: 'ADMIN',
+  Public: 'PUBLIC',
+  User: 'USER'
+} as const;
+
+export type GqlLineRichMenuType = typeof GqlLineRichMenuType[keyof typeof GqlLineRichMenuType];
+export type GqlLinkPhoneAuthInput = {
+  phoneUid: Scalars['String']['input'];
+};
+
+export type GqlLinkPhoneAuthPayload = {
+  __typename?: 'LinkPhoneAuthPayload';
+  success: Scalars['Boolean']['output'];
+  user?: Maybe<GqlUser>;
+};
+
+export type GqlMembership = {
+  __typename?: 'Membership';
+  bio?: Maybe<Scalars['String']['output']>;
+  community?: Maybe<GqlCommunity>;
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
+  headline?: Maybe<Scalars['String']['output']>;
+  histories?: Maybe<Array<GqlMembershipHistory>>;
+  reason: GqlMembershipStatusReason;
+  role: GqlRole;
+  status: GqlMembershipStatus;
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+  user?: Maybe<GqlUser>;
+};
+
+export type GqlMembershipCursorInput = {
+  communityId: Scalars['ID']['input'];
+  userId: Scalars['ID']['input'];
+};
+
+export type GqlMembershipEdge = GqlEdge & {
+  __typename?: 'MembershipEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlMembership>;
+};
+
+export type GqlMembershipFilterInput = {
+  communityId?: InputMaybe<Scalars['ID']['input']>;
+  keyword?: InputMaybe<Scalars['String']['input']>;
+  role?: InputMaybe<Array<GqlRole>>;
+  status?: InputMaybe<GqlMembershipStatus>;
+  userId?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type GqlMembershipHistory = {
+  __typename?: 'MembershipHistory';
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
+  createdByUser?: Maybe<GqlUser>;
+  id: Scalars['ID']['output'];
+  membership: GqlMembership;
+  reason: GqlMembershipStatusReason;
+  role: GqlRole;
+  status: GqlMembershipStatus;
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+};
+
+export type GqlMembershipInviteInput = {
+  communityId: Scalars['ID']['input'];
+  role?: InputMaybe<GqlRole>;
+  userId: Scalars['ID']['input'];
+};
+
+export type GqlMembershipInvitePayload = GqlMembershipInviteSuccess;
+
+export type GqlMembershipInviteSuccess = {
+  __typename?: 'MembershipInviteSuccess';
+  membership: GqlMembership;
+};
+
+export type GqlMembershipRemoveInput = {
+  communityId: Scalars['ID']['input'];
+  userId: Scalars['ID']['input'];
+};
+
+export type GqlMembershipRemovePayload = GqlMembershipRemoveSuccess;
+
+export type GqlMembershipRemoveSuccess = {
+  __typename?: 'MembershipRemoveSuccess';
+  communityId: Scalars['ID']['output'];
+  userId: Scalars['ID']['output'];
+};
+
+export type GqlMembershipSetInvitationStatusInput = {
+  communityId: Scalars['ID']['input'];
+  userId: Scalars['ID']['input'];
+};
+
+export type GqlMembershipSetInvitationStatusPayload = GqlMembershipSetInvitationStatusSuccess;
+
+export type GqlMembershipSetInvitationStatusSuccess = {
+  __typename?: 'MembershipSetInvitationStatusSuccess';
+  membership: GqlMembership;
+};
+
+export type GqlMembershipSetRoleInput = {
+  communityId: Scalars['ID']['input'];
+  userId: Scalars['ID']['input'];
+};
+
+export type GqlMembershipSetRolePayload = GqlMembershipSetRoleSuccess;
+
+export type GqlMembershipSetRoleSuccess = {
+  __typename?: 'MembershipSetRoleSuccess';
+  membership: GqlMembership;
+};
+
+export type GqlMembershipSortInput = {
+  createdAt?: InputMaybe<GqlSortDirection>;
+};
+
+export const GqlMembershipStatus = {
+  Joined: 'JOINED',
+  Left: 'LEFT',
+  Pending: 'PENDING'
+} as const;
+
+export type GqlMembershipStatus = typeof GqlMembershipStatus[keyof typeof GqlMembershipStatus];
+export const GqlMembershipStatusReason = {
+  AcceptedInvitation: 'ACCEPTED_INVITATION',
+  Assigned: 'ASSIGNED',
+  CanceledInvitation: 'CANCELED_INVITATION',
+  CreatedCommunity: 'CREATED_COMMUNITY',
+  DeclinedInvitation: 'DECLINED_INVITATION',
+  Invited: 'INVITED',
+  Removed: 'REMOVED',
+  Withdrawn: 'WITHDRAWN'
+} as const;
+
+export type GqlMembershipStatusReason = typeof GqlMembershipStatusReason[keyof typeof GqlMembershipStatusReason];
+export type GqlMembershipWithdrawInput = {
+  communityId: Scalars['ID']['input'];
+  userId: Scalars['ID']['input'];
+};
+
+export type GqlMembershipWithdrawPayload = GqlMembershipWithdrawSuccess;
+
+export type GqlMembershipWithdrawSuccess = {
+  __typename?: 'MembershipWithdrawSuccess';
+  communityId: Scalars['ID']['output'];
+  userId: Scalars['ID']['output'];
+};
+
+export type GqlMembershipsConnection = {
+  __typename?: 'MembershipsConnection';
+  edges?: Maybe<Array<Maybe<GqlMembershipEdge>>>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type GqlMutation = {
+  __typename?: 'Mutation';
+  approveReport?: Maybe<GqlApproveReportPayload>;
+  articleCreate?: Maybe<GqlArticleCreatePayload>;
+  articleDelete?: Maybe<GqlArticleDeletePayload>;
+  articleUpdateContent?: Maybe<GqlArticleUpdateContentPayload>;
+  communityCreate?: Maybe<GqlCommunityCreatePayload>;
+  communityDelete?: Maybe<GqlCommunityDeletePayload>;
+  communityUpdateProfile?: Maybe<GqlCommunityUpdateProfilePayload>;
+  /**
+   * ユーザー DID を新規作成する。CREATE-op の UserDidAnchor を PENDING で永続化する。
+   * 自分の userId のみ許可。`permission.userId` と `input.userId` が一致しなければならない。
+   */
+  createUserDid: GqlUserDidAnchor;
+  /**
+   * ユーザー DID を deactivate する。DEACTIVATE-op の UserDidAnchor を PENDING で永続化する。
+   * 自分の userId のみ許可。
+   */
+  deactivateUserDid: GqlUserDidAnchor;
+  evaluationBulkCreate?: Maybe<GqlEvaluationBulkCreatePayload>;
+  generateReport?: Maybe<GqlGenerateReportPayload>;
+  identityCheckPhoneUser: GqlIdentityCheckPhoneUserPayload;
+  incentiveGrantRetry?: Maybe<GqlIncentiveGrantRetryPayload>;
+  /**
+   * VC を発行する。civicship platform 専用 issuer による単一 issuer モデル (§B)。
+   * Phase 1 では admin / system のみが直接呼び出せる。
+   * 本体は anchor 待ちなしで COMPLETED として永続化される (§5.2.2)。
+   */
+  issueVc: GqlVcIssuance;
+  linkPhoneAuth?: Maybe<GqlLinkPhoneAuthPayload>;
+  membershipAcceptMyInvitation?: Maybe<GqlMembershipSetInvitationStatusPayload>;
+  membershipAssignManager?: Maybe<GqlMembershipSetRolePayload>;
+  membershipAssignMember?: Maybe<GqlMembershipSetRolePayload>;
+  membershipAssignOwner?: Maybe<GqlMembershipSetRolePayload>;
+  membershipCancelInvitation?: Maybe<GqlMembershipSetInvitationStatusPayload>;
+  membershipDenyMyInvitation?: Maybe<GqlMembershipSetInvitationStatusPayload>;
+  membershipInvite?: Maybe<GqlMembershipInvitePayload>;
+  membershipRemove?: Maybe<GqlMembershipRemovePayload>;
+  membershipWithdraw?: Maybe<GqlMembershipWithdrawPayload>;
+  mutationEcho: Scalars['String']['output'];
+  opportunityCreate?: Maybe<GqlOpportunityCreatePayload>;
+  opportunityDelete?: Maybe<GqlOpportunityDeletePayload>;
+  opportunitySetPublishStatus?: Maybe<GqlOpportunitySetPublishStatusPayload>;
+  opportunitySlotCreate?: Maybe<GqlOpportunitySlotCreatePayload>;
+  opportunitySlotSetHostingStatus?: Maybe<GqlOpportunitySlotSetHostingStatusPayload>;
+  opportunitySlotsBulkUpdate?: Maybe<GqlOpportunitySlotsBulkUpdatePayload>;
+  opportunityUpdateContent?: Maybe<GqlOpportunityUpdateContentPayload>;
+  participationBulkCreate?: Maybe<GqlParticipationBulkCreatePayload>;
+  participationCreatePersonalRecord?: Maybe<GqlParticipationCreatePersonalRecordPayload>;
+  participationDeletePersonalRecord?: Maybe<GqlParticipationDeletePayload>;
+  placeCreate?: Maybe<GqlPlaceCreatePayload>;
+  placeDelete?: Maybe<GqlPlaceDeletePayload>;
+  placeUpdate?: Maybe<GqlPlaceUpdatePayload>;
+  publishReport?: Maybe<GqlPublishReportPayload>;
+  rejectReport?: Maybe<GqlRejectReportPayload>;
+  reservationAccept?: Maybe<GqlReservationSetStatusPayload>;
+  reservationCancel?: Maybe<GqlReservationSetStatusPayload>;
+  reservationCreate?: Maybe<GqlReservationCreatePayload>;
+  reservationJoin?: Maybe<GqlReservationSetStatusPayload>;
+  reservationReject?: Maybe<GqlReservationSetStatusPayload>;
+  /**
+   * VC を revoke する。StatusList の bit を立て、`revokedAt` を更新する。
+   * Admin のみ実行可能 (将来 issuer 自身でも可能にする想定)。
+   */
+  revokeUserVc: GqlVcIssuance;
+  storePhoneAuthToken?: Maybe<GqlStorePhoneAuthTokenPayload>;
+  submitReportFeedback?: Maybe<GqlSubmitReportFeedbackPayload>;
+  ticketClaim?: Maybe<GqlTicketClaimPayload>;
+  ticketIssue?: Maybe<GqlTicketIssuePayload>;
+  ticketPurchase?: Maybe<GqlTicketPurchasePayload>;
+  ticketRefund?: Maybe<GqlTicketRefundPayload>;
+  ticketUse?: Maybe<GqlTicketUsePayload>;
+  transactionDonateSelfPoint?: Maybe<GqlTransactionDonateSelfPointPayload>;
+  transactionGrantCommunityPoint?: Maybe<GqlTransactionGrantCommunityPointPayload>;
+  transactionIssueCommunityPoint?: Maybe<GqlTransactionIssueCommunityPointPayload>;
+  transactionUpdateMetadata?: Maybe<GqlTransactionUpdateMetadataPayload>;
+  updatePortalConfig: GqlCommunityPortalConfig;
+  updateReportTemplate?: Maybe<GqlUpdateReportTemplatePayload>;
+  updateSignupBonusConfig: GqlCommunitySignupBonusConfig;
+  userDeleteMe?: Maybe<GqlUserDeletePayload>;
+  userSignUp?: Maybe<GqlCurrentUserPayload>;
+  userUpdateMyProfile?: Maybe<GqlUserUpdateProfilePayload>;
+  utilityCreate?: Maybe<GqlUtilityCreatePayload>;
+  utilityDelete?: Maybe<GqlUtilityDeletePayload>;
+  utilitySetPublishStatus?: Maybe<GqlUtilitySetPublishStatusPayload>;
+  utilityUpdateInfo?: Maybe<GqlUtilityUpdateInfoPayload>;
+  /**
+   * ユーザー: 投票実行。
+   * 同一 topicId への再投票は **upsert で上書き** される（投票履歴は残らない）。
+   * 投票の取消（withdraw）は現時点で未サポート。
+   * eligibility と power は呼び出しごとに再チェックされ、NFT_COUNT の場合は呼び出し時点の保有数が新しい power として記録される。
+   */
+  voteCast: GqlVoteCastPayload;
+  /**
+   * 管理者: 投票テーマ・ゲート・ポリシー・選択肢を 1 トランザクションで一括作成。
+   * Gate.type=NFT かつ PowerPolicy.type=NFT_COUNT の場合、両者の nftTokenId は
+   * 一致していなければならない（バックエンドで検証、違反時は `VALIDATION_ERROR`）。
+   * 詳細は VoteGate 型の説明を参照。
+   */
+  voteTopicCreate: GqlVoteTopicCreatePayload;
+  /**
+   * 管理者: 投票テーマ削除。UPCOMING フェーズ（投票開始前）のみ許可。
+   * OPEN / CLOSED フェーズでは `VOTE_TOPIC_NOT_EDITABLE` エラーが返る。
+   * gate / powerPolicy / options は onDelete: Cascade で自動削除される（UPCOMING 限定なので ballots は存在しない）。
+   */
+  voteTopicDelete: GqlVoteTopicDeletePayload;
+  /**
+   * 管理者: 投票テーマを更新する。UPCOMING フェーズ（投票開始前）のみ許可。
+   * OPEN / CLOSED フェーズでは `VOTE_TOPIC_NOT_EDITABLE` エラーが返る。
+   * options は全量置換される（UPCOMING なので投票0件が保証されており安全）。
+   * gate / powerPolicy も同時に再設定可能。
+   */
+  voteTopicUpdate: GqlVoteTopicUpdatePayload;
+};
+
+
+export type GqlMutationApproveReportArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlMutationArticleCreateArgs = {
+  input: GqlArticleCreateInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationArticleDeleteArgs = {
+  id: Scalars['ID']['input'];
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationArticleUpdateContentArgs = {
+  id: Scalars['ID']['input'];
+  input: GqlArticleUpdateContentInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationCommunityCreateArgs = {
+  input: GqlCommunityCreateInput;
+};
+
+
+export type GqlMutationCommunityDeleteArgs = {
+  id: Scalars['ID']['input'];
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationCommunityUpdateProfileArgs = {
+  id: Scalars['ID']['input'];
+  input: GqlCommunityUpdateProfileInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationCreateUserDidArgs = {
+  input: GqlCreateUserDidInput;
+  permission: GqlCheckIsSelfPermissionInput;
+};
+
+
+export type GqlMutationDeactivateUserDidArgs = {
+  permission: GqlCheckIsSelfPermissionInput;
+  userId: Scalars['ID']['input'];
+};
+
+
+export type GqlMutationEvaluationBulkCreateArgs = {
+  input: GqlEvaluationBulkCreateInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationGenerateReportArgs = {
+  input: GqlGenerateReportInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationIdentityCheckPhoneUserArgs = {
+  input: GqlIdentityCheckPhoneUserInput;
+};
+
+
+export type GqlMutationIncentiveGrantRetryArgs = {
+  input: GqlIncentiveGrantRetryInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationIssueVcArgs = {
+  input: GqlIssueVcInput;
+};
+
+
+export type GqlMutationLinkPhoneAuthArgs = {
+  input: GqlLinkPhoneAuthInput;
+  permission: GqlCheckIsSelfPermissionInput;
+};
+
+
+export type GqlMutationMembershipAcceptMyInvitationArgs = {
+  input: GqlMembershipSetInvitationStatusInput;
+  permission: GqlCheckIsSelfPermissionInput;
+};
+
+
+export type GqlMutationMembershipAssignManagerArgs = {
+  input: GqlMembershipSetRoleInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationMembershipAssignMemberArgs = {
+  input: GqlMembershipSetRoleInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationMembershipAssignOwnerArgs = {
+  input: GqlMembershipSetRoleInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationMembershipCancelInvitationArgs = {
+  input: GqlMembershipSetInvitationStatusInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationMembershipDenyMyInvitationArgs = {
+  input: GqlMembershipSetInvitationStatusInput;
+  permission: GqlCheckIsSelfPermissionInput;
+};
+
+
+export type GqlMutationMembershipInviteArgs = {
+  input: GqlMembershipInviteInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationMembershipRemoveArgs = {
+  input: GqlMembershipRemoveInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationMembershipWithdrawArgs = {
+  input: GqlMembershipWithdrawInput;
+  permission: GqlCheckIsSelfPermissionInput;
+};
+
+
+export type GqlMutationOpportunityCreateArgs = {
+  input: GqlOpportunityCreateInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationOpportunityDeleteArgs = {
+  id: Scalars['ID']['input'];
+  permission: GqlCheckOpportunityPermissionInput;
+};
+
+
+export type GqlMutationOpportunitySetPublishStatusArgs = {
+  id: Scalars['ID']['input'];
+  input: GqlOpportunitySetPublishStatusInput;
+  permission: GqlCheckOpportunityPermissionInput;
+};
+
+
+export type GqlMutationOpportunitySlotCreateArgs = {
+  input: GqlOpportunitySlotCreateInput;
+  opportunityId: Scalars['ID']['input'];
+  permission: GqlCheckOpportunityPermissionInput;
+};
+
+
+export type GqlMutationOpportunitySlotSetHostingStatusArgs = {
+  id: Scalars['ID']['input'];
+  input: GqlOpportunitySlotSetHostingStatusInput;
+  permission: GqlCheckOpportunityPermissionInput;
+};
+
+
+export type GqlMutationOpportunitySlotsBulkUpdateArgs = {
+  input: GqlOpportunitySlotsBulkUpdateInput;
+  permission: GqlCheckOpportunityPermissionInput;
+};
+
+
+export type GqlMutationOpportunityUpdateContentArgs = {
+  id: Scalars['ID']['input'];
+  input: GqlOpportunityUpdateContentInput;
+  permission: GqlCheckOpportunityPermissionInput;
+};
+
+
+export type GqlMutationParticipationBulkCreateArgs = {
+  input: GqlParticipationBulkCreateInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationParticipationCreatePersonalRecordArgs = {
+  input: GqlParticipationCreatePersonalRecordInput;
+};
+
+
+export type GqlMutationParticipationDeletePersonalRecordArgs = {
+  id: Scalars['ID']['input'];
+  permission: GqlCheckIsSelfPermissionInput;
+};
+
+
+export type GqlMutationPlaceCreateArgs = {
+  input: GqlPlaceCreateInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationPlaceDeleteArgs = {
+  id: Scalars['ID']['input'];
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationPlaceUpdateArgs = {
+  id: Scalars['ID']['input'];
+  input: GqlPlaceUpdateInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationPublishReportArgs = {
+  finalContent: Scalars['String']['input'];
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlMutationRejectReportArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlMutationReservationAcceptArgs = {
+  id: Scalars['ID']['input'];
+  permission: GqlCheckOpportunityPermissionInput;
+};
+
+
+export type GqlMutationReservationCancelArgs = {
+  id: Scalars['ID']['input'];
+  input: GqlReservationCancelInput;
+  permission: GqlCheckIsSelfPermissionInput;
+};
+
+
+export type GqlMutationReservationCreateArgs = {
+  input: GqlReservationCreateInput;
+};
+
+
+export type GqlMutationReservationJoinArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlMutationReservationRejectArgs = {
+  id: Scalars['ID']['input'];
+  input: GqlReservationRejectInput;
+  permission: GqlCheckOpportunityPermissionInput;
+};
+
+
+export type GqlMutationRevokeUserVcArgs = {
+  input: GqlRevokeUserVcInput;
+};
+
+
+export type GqlMutationStorePhoneAuthTokenArgs = {
+  input: GqlStorePhoneAuthTokenInput;
+  permission: GqlCheckIsSelfPermissionInput;
+};
+
+
+export type GqlMutationSubmitReportFeedbackArgs = {
+  input: GqlSubmitReportFeedbackInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationTicketClaimArgs = {
+  input: GqlTicketClaimInput;
+};
+
+
+export type GqlMutationTicketIssueArgs = {
+  input: GqlTicketIssueInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationTicketPurchaseArgs = {
+  input: GqlTicketPurchaseInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationTicketRefundArgs = {
+  id: Scalars['ID']['input'];
+  input: GqlTicketRefundInput;
+  permission: GqlCheckIsSelfPermissionInput;
+};
+
+
+export type GqlMutationTicketUseArgs = {
+  id: Scalars['ID']['input'];
+  permission: GqlCheckIsSelfPermissionInput;
+};
+
+
+export type GqlMutationTransactionDonateSelfPointArgs = {
+  input: GqlTransactionDonateSelfPointInput;
+  permission: GqlCheckIsSelfPermissionInput;
+};
+
+
+export type GqlMutationTransactionGrantCommunityPointArgs = {
+  input: GqlTransactionGrantCommunityPointInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationTransactionIssueCommunityPointArgs = {
+  input: GqlTransactionIssueCommunityPointInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationTransactionUpdateMetadataArgs = {
+  communityPermission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+  id: Scalars['ID']['input'];
+  input: GqlTransactionUpdateMetadataInput;
+  permission?: InputMaybe<GqlCheckIsSelfPermissionInput>;
+};
+
+
+export type GqlMutationUpdatePortalConfigArgs = {
+  input: GqlCommunityPortalConfigInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationUpdateReportTemplateArgs = {
+  communityId?: InputMaybe<Scalars['ID']['input']>;
+  input: GqlUpdateReportTemplateInput;
+  variant: GqlReportVariant;
+};
+
+
+export type GqlMutationUpdateSignupBonusConfigArgs = {
+  input: GqlUpdateSignupBonusConfigInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationUserDeleteMeArgs = {
+  permission: GqlCheckIsSelfPermissionInput;
+};
+
+
+export type GqlMutationUserSignUpArgs = {
+  input: GqlUserSignUpInput;
+};
+
+
+export type GqlMutationUserUpdateMyProfileArgs = {
+  input: GqlUserUpdateProfileInput;
+  permission: GqlCheckIsSelfPermissionInput;
+};
+
+
+export type GqlMutationUtilityCreateArgs = {
+  input: GqlUtilityCreateInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationUtilityDeleteArgs = {
+  id: Scalars['ID']['input'];
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationUtilitySetPublishStatusArgs = {
+  id: Scalars['ID']['input'];
+  input: GqlUtilitySetPublishStatusInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationUtilityUpdateInfoArgs = {
+  id: Scalars['ID']['input'];
+  input: GqlUtilityUpdateInfoInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationVoteCastArgs = {
+  input: GqlVoteCastInput;
+};
+
+
+export type GqlMutationVoteTopicCreateArgs = {
+  input: GqlVoteTopicCreateInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationVoteTopicDeleteArgs = {
+  id: Scalars['ID']['input'];
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlMutationVoteTopicUpdateArgs = {
+  id: Scalars['ID']['input'];
+  input: GqlVoteTopicUpdateInput;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+/** ログインユーザーの投票資格と現状。再投票可能性の判定にも利用する。 */
+export type GqlMyVoteEligibility = {
+  __typename?: 'MyVoteEligibility';
+  /**
+   * **リクエスト時点**で計算される power。
+   * VoteBallot.power（投票時スナップショット）とは別物で、NFT_COUNT ポリシー下では乖離しうる。
+   */
+  currentPower?: Maybe<Scalars['Int']['output']>;
+  /**
+   * 投票可能か。**投票済みでも再投票可能なら true** を返す
+   * （期間内 & ゲート通過なら常に true。投票済みフラグは myBallot の有無で判定）。
+   */
+  eligible: Scalars['Boolean']['output'];
+  /** ログインユーザーの投票（VoteTopic.myBallot と同じ値）。 */
+  myBallot?: Maybe<GqlVoteBallot>;
+  /**
+   * eligible=false 時の理由コード。次のいずれか:
+   * GATE_NOT_CONFIGURED / GATE_NFT_TOKEN_NOT_CONFIGURED / REQUIRED_NFT_NOT_FOUND /
+   * NOT_A_MEMBER / INSUFFICIENT_ROLE / UNKNOWN_GATE_TYPE
+   */
+  reason?: Maybe<Scalars['String']['output']>;
+};
+
+export type GqlNestedPlaceConnectOrCreateInput = {
+  create?: InputMaybe<GqlNestedPlaceCreateInput>;
+  where?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type GqlNestedPlaceCreateInput = {
+  address: Scalars['String']['input'];
+  cityCode: Scalars['ID']['input'];
+  communityId?: InputMaybe<Scalars['ID']['input']>;
+  googlePlaceId?: InputMaybe<Scalars['String']['input']>;
+  isManual: Scalars['Boolean']['input'];
+  latitude: Scalars['Decimal']['input'];
+  longitude: Scalars['Decimal']['input'];
+  mapLocation?: InputMaybe<Scalars['JSON']['input']>;
+  name: Scalars['String']['input'];
+};
+
+export type GqlNestedPlacesBulkConnectOrCreateInput = {
+  data?: InputMaybe<Array<GqlNestedPlaceConnectOrCreateInput>>;
+};
+
+export type GqlNestedPlacesBulkUpdateInput = {
+  connectOrCreate?: InputMaybe<Array<GqlNestedPlaceConnectOrCreateInput>>;
+  disconnect?: InputMaybe<Array<Scalars['ID']['input']>>;
+};
+
+export type GqlNftInstance = {
+  __typename?: 'NftInstance';
+  community?: Maybe<GqlCommunity>;
+  createdAt: Scalars['Datetime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  imageUrl?: Maybe<Scalars['String']['output']>;
+  instanceId: Scalars['String']['output'];
+  json?: Maybe<Scalars['JSON']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+  nftToken?: Maybe<GqlNftToken>;
+  nftWallet?: Maybe<GqlNftWallet>;
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+};
+
+export type GqlNftInstanceEdge = GqlEdge & {
+  __typename?: 'NftInstanceEdge';
+  cursor: Scalars['String']['output'];
+  node: GqlNftInstance;
+};
+
+export type GqlNftInstanceFilterInput = {
+  and?: InputMaybe<Array<GqlNftInstanceFilterInput>>;
+  communityId?: InputMaybe<Scalars['ID']['input']>;
+  hasDescription?: InputMaybe<Scalars['Boolean']['input']>;
+  hasImage?: InputMaybe<Scalars['Boolean']['input']>;
+  hasName?: InputMaybe<Scalars['Boolean']['input']>;
+  nftTokenAddress?: InputMaybe<Array<Scalars['String']['input']>>;
+  nftTokenType?: InputMaybe<Array<Scalars['String']['input']>>;
+  nftWalletId?: InputMaybe<Array<Scalars['ID']['input']>>;
+  not?: InputMaybe<GqlNftInstanceFilterInput>;
+  or?: InputMaybe<Array<GqlNftInstanceFilterInput>>;
+  userId?: InputMaybe<Array<Scalars['ID']['input']>>;
+};
+
+export type GqlNftInstanceSortInput = {
+  createdAt?: InputMaybe<GqlSortDirection>;
+  instanceId?: InputMaybe<GqlSortDirection>;
+  name?: InputMaybe<GqlSortDirection>;
+};
+
+export type GqlNftInstancesConnection = {
+  __typename?: 'NftInstancesConnection';
+  edges: Array<GqlNftInstanceEdge>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type GqlNftToken = {
+  __typename?: 'NftToken';
+  address: Scalars['String']['output'];
+  /**
+   * トークンを所有するコミュニティ。複数コミュニティで共用する場合や運用都合で未設定の場合は null。
+   * portal 側の「このコミュニティに属する NftToken」一覧取得で参照される。
+   */
+  community?: Maybe<GqlCommunity>;
+  createdAt: Scalars['Datetime']['output'];
+  id: Scalars['ID']['output'];
+  json?: Maybe<Scalars['JSON']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+  symbol?: Maybe<Scalars['String']['output']>;
+  type: Scalars['String']['output'];
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+};
+
+export type GqlNftTokenEdge = GqlEdge & {
+  __typename?: 'NftTokenEdge';
+  cursor: Scalars['String']['output'];
+  node: GqlNftToken;
+};
+
+export type GqlNftTokenFilterInput = {
+  address?: InputMaybe<Array<Scalars['String']['input']>>;
+  and?: InputMaybe<Array<GqlNftTokenFilterInput>>;
+  /**
+   * 指定したコミュニティに直接紐付く NftToken に絞る（NftToken.community_id を直接参照）。
+   * NftToken.communityId が NULL のトークンは除外される。
+   */
+  communityId?: InputMaybe<Scalars['ID']['input']>;
+  not?: InputMaybe<GqlNftTokenFilterInput>;
+  or?: InputMaybe<Array<GqlNftTokenFilterInput>>;
+  type?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
+export type GqlNftTokenSortInput = {
+  address?: InputMaybe<GqlSortDirection>;
+  createdAt?: InputMaybe<GqlSortDirection>;
+  name?: InputMaybe<GqlSortDirection>;
+};
+
+export type GqlNftTokensConnection = {
+  __typename?: 'NftTokensConnection';
+  edges: Array<GqlNftTokenEdge>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type GqlNftWallet = {
+  __typename?: 'NftWallet';
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
+  id: Scalars['ID']['output'];
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+  user: GqlUser;
+  walletAddress: Scalars['String']['output'];
+};
+
+export type GqlOpportunitiesConnection = {
+  __typename?: 'OpportunitiesConnection';
+  edges: Array<GqlOpportunityEdge>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type GqlOpportunity = {
+  __typename?: 'Opportunity';
+  articles?: Maybe<Array<GqlArticle>>;
+  body?: Maybe<Scalars['String']['output']>;
+  capacity?: Maybe<Scalars['Int']['output']>;
+  category: GqlOpportunityCategory;
+  community?: Maybe<GqlCommunity>;
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
+  createdByUser?: Maybe<GqlUser>;
+  description: Scalars['String']['output'];
+  earliestReservableAt?: Maybe<Scalars['Datetime']['output']>;
+  feeRequired?: Maybe<Scalars['Int']['output']>;
+  id: Scalars['ID']['output'];
+  images?: Maybe<Array<Scalars['String']['output']>>;
+  isReservableWithTicket?: Maybe<Scalars['Boolean']['output']>;
+  place?: Maybe<GqlPlace>;
+  pointsRequired?: Maybe<Scalars['Int']['output']>;
+  pointsToEarn?: Maybe<Scalars['Int']['output']>;
+  publishStatus: GqlPublishStatus;
+  requireApproval: Scalars['Boolean']['output'];
+  requiredUtilities?: Maybe<Array<GqlUtility>>;
+  slots?: Maybe<Array<GqlOpportunitySlot>>;
+  title: Scalars['String']['output'];
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+};
+
+
+export type GqlOpportunitySlotsArgs = {
+  filter?: InputMaybe<GqlOpportunitySlotFilterInput>;
+  sort?: InputMaybe<GqlOpportunitySlotSortInput>;
+};
+
+export const GqlOpportunityCategory = {
+  Activity: 'ACTIVITY',
+  Event: 'EVENT',
+  Quest: 'QUEST'
+} as const;
+
+export type GqlOpportunityCategory = typeof GqlOpportunityCategory[keyof typeof GqlOpportunityCategory];
+export type GqlOpportunityCreateInput = {
+  body?: InputMaybe<Scalars['String']['input']>;
+  category: GqlOpportunityCategory;
+  createdBy?: InputMaybe<Scalars['ID']['input']>;
+  description: Scalars['String']['input'];
+  feeRequired?: InputMaybe<Scalars['Int']['input']>;
+  images?: InputMaybe<Array<GqlImageInput>>;
+  placeId?: InputMaybe<Scalars['ID']['input']>;
+  pointsRequired?: InputMaybe<Scalars['Int']['input']>;
+  pointsToEarn?: InputMaybe<Scalars['Int']['input']>;
+  publishStatus: GqlPublishStatus;
+  relatedArticleIds?: InputMaybe<Array<Scalars['ID']['input']>>;
+  requireApproval: Scalars['Boolean']['input'];
+  requiredUtilityIds?: InputMaybe<Array<Scalars['ID']['input']>>;
+  slots?: InputMaybe<Array<GqlOpportunitySlotCreateInput>>;
+  title: Scalars['String']['input'];
+};
+
+export type GqlOpportunityCreatePayload = GqlOpportunityCreateSuccess;
+
+export type GqlOpportunityCreateSuccess = {
+  __typename?: 'OpportunityCreateSuccess';
+  opportunity: GqlOpportunity;
+};
+
+export type GqlOpportunityDeletePayload = GqlOpportunityDeleteSuccess;
+
+export type GqlOpportunityDeleteSuccess = {
+  __typename?: 'OpportunityDeleteSuccess';
+  opportunityId: Scalars['ID']['output'];
+};
+
+export type GqlOpportunityEdge = GqlEdge & {
+  __typename?: 'OpportunityEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlOpportunity>;
+};
+
+export type GqlOpportunityFilterInput = {
+  and?: InputMaybe<Array<GqlOpportunityFilterInput>>;
+  articleIds?: InputMaybe<Array<Scalars['ID']['input']>>;
+  category?: InputMaybe<GqlOpportunityCategory>;
+  cityCodes?: InputMaybe<Array<Scalars['ID']['input']>>;
+  communityIds?: InputMaybe<Array<Scalars['ID']['input']>>;
+  createdByUserIds?: InputMaybe<Array<Scalars['ID']['input']>>;
+  isReservableWithPoint?: InputMaybe<Scalars['Boolean']['input']>;
+  isReservableWithTicket?: InputMaybe<Scalars['Boolean']['input']>;
+  keyword?: InputMaybe<Scalars['String']['input']>;
+  not?: InputMaybe<GqlOpportunityFilterInput>;
+  or?: InputMaybe<Array<GqlOpportunityFilterInput>>;
+  placeIds?: InputMaybe<Array<Scalars['ID']['input']>>;
+  publishStatus?: InputMaybe<Array<GqlPublishStatus>>;
+  requiredUtilityIds?: InputMaybe<Array<Scalars['ID']['input']>>;
+  slotDateRange?: InputMaybe<GqlDateTimeRangeFilter>;
+  slotHostingStatus?: InputMaybe<Array<GqlOpportunitySlotHostingStatus>>;
+  slotRemainingCapacity?: InputMaybe<Scalars['Int']['input']>;
+  stateCodes?: InputMaybe<Array<Scalars['ID']['input']>>;
+};
+
+export type GqlOpportunitySetPublishStatusInput = {
+  publishStatus: GqlPublishStatus;
+};
+
+export type GqlOpportunitySetPublishStatusPayload = GqlOpportunitySetPublishStatusSuccess;
+
+export type GqlOpportunitySetPublishStatusSuccess = {
+  __typename?: 'OpportunitySetPublishStatusSuccess';
+  opportunity: GqlOpportunity;
+};
+
+export type GqlOpportunitySlot = {
+  __typename?: 'OpportunitySlot';
+  capacity?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
+  endsAt: Scalars['Datetime']['output'];
+  hostingStatus: GqlOpportunitySlotHostingStatus;
+  id: Scalars['ID']['output'];
+  isFullyEvaluated?: Maybe<Scalars['Boolean']['output']>;
+  numEvaluated?: Maybe<Scalars['Int']['output']>;
+  numParticipants?: Maybe<Scalars['Int']['output']>;
+  opportunity?: Maybe<GqlOpportunity>;
+  remainingCapacity?: Maybe<Scalars['Int']['output']>;
+  reservations?: Maybe<Array<GqlReservation>>;
+  startsAt: Scalars['Datetime']['output'];
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+  vcIssuanceRequests?: Maybe<Array<GqlVcIssuanceRequest>>;
+};
+
+export type GqlOpportunitySlotCreateInput = {
+  capacity: Scalars['Int']['input'];
+  endsAt: Scalars['Datetime']['input'];
+  startsAt: Scalars['Datetime']['input'];
+};
+
+export type GqlOpportunitySlotCreatePayload = GqlOpportunitySlotCreateSuccess;
+
+export type GqlOpportunitySlotCreateSuccess = {
+  __typename?: 'OpportunitySlotCreateSuccess';
+  slot: GqlOpportunitySlot;
+};
+
+export type GqlOpportunitySlotEdge = GqlEdge & {
+  __typename?: 'OpportunitySlotEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlOpportunitySlot>;
+};
+
+export type GqlOpportunitySlotFilterInput = {
+  dateRange?: InputMaybe<GqlDateTimeRangeFilter>;
+  hostingStatus?: InputMaybe<Array<GqlOpportunitySlotHostingStatus>>;
+  opportunityIds?: InputMaybe<Array<Scalars['ID']['input']>>;
+  ownerId?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export const GqlOpportunitySlotHostingStatus = {
+  Cancelled: 'CANCELLED',
+  Completed: 'COMPLETED',
+  Scheduled: 'SCHEDULED'
+} as const;
+
+export type GqlOpportunitySlotHostingStatus = typeof GqlOpportunitySlotHostingStatus[keyof typeof GqlOpportunitySlotHostingStatus];
+export type GqlOpportunitySlotSetHostingStatusInput = {
+  capacity?: InputMaybe<Scalars['Int']['input']>;
+  comment?: InputMaybe<Scalars['String']['input']>;
+  createdBy?: InputMaybe<Scalars['ID']['input']>;
+  endsAt?: InputMaybe<Scalars['Datetime']['input']>;
+  startsAt?: InputMaybe<Scalars['Datetime']['input']>;
+  status: GqlOpportunitySlotHostingStatus;
+};
+
+export type GqlOpportunitySlotSetHostingStatusPayload = GqlOpportunitySlotSetHostingStatusSuccess;
+
+export type GqlOpportunitySlotSetHostingStatusSuccess = {
+  __typename?: 'OpportunitySlotSetHostingStatusSuccess';
+  slot: GqlOpportunitySlot;
+};
+
+export type GqlOpportunitySlotSortInput = {
+  createdAt?: InputMaybe<GqlSortDirection>;
+  endsAt?: InputMaybe<GqlSortDirection>;
+  startsAt?: InputMaybe<GqlSortDirection>;
+};
+
+export type GqlOpportunitySlotUpdateInput = {
+  capacity?: InputMaybe<Scalars['Int']['input']>;
+  endsAt: Scalars['Datetime']['input'];
+  id: Scalars['ID']['input'];
+  startsAt: Scalars['Datetime']['input'];
+};
+
+export type GqlOpportunitySlotsBulkUpdateInput = {
+  create?: InputMaybe<Array<GqlOpportunitySlotCreateInput>>;
+  delete?: InputMaybe<Array<Scalars['ID']['input']>>;
+  opportunityId: Scalars['ID']['input'];
+  update?: InputMaybe<Array<GqlOpportunitySlotUpdateInput>>;
+};
+
+export type GqlOpportunitySlotsBulkUpdatePayload = GqlOpportunitySlotsBulkUpdateSuccess;
+
+export type GqlOpportunitySlotsBulkUpdateSuccess = {
+  __typename?: 'OpportunitySlotsBulkUpdateSuccess';
+  slots: Array<GqlOpportunitySlot>;
+};
+
+export type GqlOpportunitySlotsConnection = {
+  __typename?: 'OpportunitySlotsConnection';
+  edges?: Maybe<Array<Maybe<GqlOpportunitySlotEdge>>>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type GqlOpportunitySortInput = {
+  createdAt?: InputMaybe<GqlSortDirection>;
+  earliestSlotStartsAt?: InputMaybe<GqlSortDirection>;
+};
+
+export type GqlOpportunityUpdateContentInput = {
+  body?: InputMaybe<Scalars['String']['input']>;
+  category: GqlOpportunityCategory;
+  createdBy?: InputMaybe<Scalars['ID']['input']>;
+  description: Scalars['String']['input'];
+  feeRequired?: InputMaybe<Scalars['Int']['input']>;
+  images?: InputMaybe<Array<GqlImageInput>>;
+  placeId?: InputMaybe<Scalars['ID']['input']>;
+  pointsRequired?: InputMaybe<Scalars['Int']['input']>;
+  pointsToEarn?: InputMaybe<Scalars['Int']['input']>;
+  publishStatus: GqlPublishStatus;
+  relatedArticleIds?: InputMaybe<Array<Scalars['ID']['input']>>;
+  requireApproval: Scalars['Boolean']['input'];
+  requiredUtilityIds?: InputMaybe<Array<Scalars['ID']['input']>>;
+  title: Scalars['String']['input'];
+};
+
+export type GqlOpportunityUpdateContentPayload = GqlOpportunityUpdateContentSuccess;
+
+export type GqlOpportunityUpdateContentSuccess = {
+  __typename?: 'OpportunityUpdateContentSuccess';
+  opportunity: GqlOpportunity;
+};
+
+export type GqlPageInfo = {
+  __typename?: 'PageInfo';
+  endCursor?: Maybe<Scalars['String']['output']>;
+  hasNextPage: Scalars['Boolean']['output'];
+  hasPreviousPage: Scalars['Boolean']['output'];
+  startCursor?: Maybe<Scalars['String']['output']>;
+};
+
+export type GqlPaging = {
+  __typename?: 'Paging';
+  skip: Scalars['Int']['output'];
+  take: Scalars['Int']['output'];
+};
+
+export type GqlParticipation = {
+  __typename?: 'Participation';
+  community?: Maybe<GqlCommunity>;
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  evaluation?: Maybe<GqlEvaluation>;
+  id: Scalars['ID']['output'];
+  images?: Maybe<Array<Scalars['String']['output']>>;
+  opportunitySlot?: Maybe<GqlOpportunitySlot>;
+  reason: GqlParticipationStatusReason;
+  reservation?: Maybe<GqlReservation>;
+  source?: Maybe<GqlSource>;
+  status: GqlParticipationStatus;
+  statusHistories?: Maybe<Array<GqlParticipationStatusHistory>>;
+  ticketStatusHistories?: Maybe<Array<GqlTicketStatusHistory>>;
+  transactions?: Maybe<Array<GqlTransaction>>;
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+  user?: Maybe<GqlUser>;
+};
+
+export type GqlParticipationBulkCreateInput = {
+  description?: InputMaybe<Scalars['String']['input']>;
+  slotId: Scalars['ID']['input'];
+  userIds: Array<Scalars['ID']['input']>;
+};
+
+export type GqlParticipationBulkCreatePayload = GqlParticipationBulkCreateSuccess;
+
+export type GqlParticipationBulkCreateSuccess = {
+  __typename?: 'ParticipationBulkCreateSuccess';
+  participations: Array<GqlParticipation>;
+};
+
+export type GqlParticipationCreatePersonalRecordInput = {
+  description?: InputMaybe<Scalars['String']['input']>;
+  images?: InputMaybe<Array<GqlImageInput>>;
+};
+
+export type GqlParticipationCreatePersonalRecordPayload = GqlParticipationCreatePersonalRecordSuccess;
+
+export type GqlParticipationCreatePersonalRecordSuccess = {
+  __typename?: 'ParticipationCreatePersonalRecordSuccess';
+  participation: GqlParticipation;
+};
+
+export type GqlParticipationDeletePayload = GqlParticipationDeleteSuccess;
+
+export type GqlParticipationDeleteSuccess = {
+  __typename?: 'ParticipationDeleteSuccess';
+  participationId: Scalars['ID']['output'];
+};
+
+export type GqlParticipationEdge = GqlEdge & {
+  __typename?: 'ParticipationEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlParticipation>;
+};
+
+export type GqlParticipationFilterInput = {
+  categories?: InputMaybe<Array<Scalars['String']['input']>>;
+  cityCodes?: InputMaybe<Array<Scalars['ID']['input']>>;
+  communityId?: InputMaybe<Scalars['ID']['input']>;
+  dateFrom?: InputMaybe<Scalars['Datetime']['input']>;
+  dateTo?: InputMaybe<Scalars['Datetime']['input']>;
+  opportunityId?: InputMaybe<Scalars['ID']['input']>;
+  opportunitySlotId?: InputMaybe<Scalars['ID']['input']>;
+  reservationId?: InputMaybe<Scalars['ID']['input']>;
+  stateCodes?: InputMaybe<Array<Scalars['ID']['input']>>;
+  status?: InputMaybe<GqlParticipationStatus>;
+  userIds?: InputMaybe<Array<Scalars['ID']['input']>>;
+};
+
+export type GqlParticipationSortInput = {
+  createdAt?: InputMaybe<GqlSortDirection>;
+  startsAt?: InputMaybe<GqlSortDirection>;
+  updatedAt?: InputMaybe<GqlSortDirection>;
+};
+
+export const GqlParticipationStatus = {
+  NotParticipating: 'NOT_PARTICIPATING',
+  Participated: 'PARTICIPATED',
+  Participating: 'PARTICIPATING',
+  Pending: 'PENDING'
+} as const;
+
+export type GqlParticipationStatus = typeof GqlParticipationStatus[keyof typeof GqlParticipationStatus];
+export type GqlParticipationStatusHistoriesConnection = {
+  __typename?: 'ParticipationStatusHistoriesConnection';
+  edges: Array<GqlParticipationStatusHistoryEdge>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type GqlParticipationStatusHistory = {
+  __typename?: 'ParticipationStatusHistory';
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
+  createdByUser?: Maybe<GqlUser>;
+  id: Scalars['ID']['output'];
+  participation?: Maybe<GqlParticipation>;
+  reason: GqlParticipationStatusReason;
+  status: GqlParticipationStatus;
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+};
+
+export type GqlParticipationStatusHistoryEdge = GqlEdge & {
+  __typename?: 'ParticipationStatusHistoryEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlParticipationStatusHistory>;
+};
+
+export type GqlParticipationStatusHistoryFilterInput = {
+  createdById?: InputMaybe<Scalars['ID']['input']>;
+  participationId?: InputMaybe<Scalars['ID']['input']>;
+  status?: InputMaybe<GqlParticipationStatus>;
+};
+
+export type GqlParticipationStatusHistorySortInput = {
+  createdAt?: InputMaybe<GqlSortDirection>;
+};
+
+export const GqlParticipationStatusReason = {
+  OpportunityCanceled: 'OPPORTUNITY_CANCELED',
+  PersonalRecord: 'PERSONAL_RECORD',
+  ReservationAccepted: 'RESERVATION_ACCEPTED',
+  ReservationApplied: 'RESERVATION_APPLIED',
+  ReservationCanceled: 'RESERVATION_CANCELED',
+  ReservationJoined: 'RESERVATION_JOINED',
+  ReservationRejected: 'RESERVATION_REJECTED'
+} as const;
+
+export type GqlParticipationStatusReason = typeof GqlParticipationStatusReason[keyof typeof GqlParticipationStatusReason];
+export const GqlParticipationType = {
+  Hosted: 'HOSTED',
+  Participated: 'PARTICIPATED'
+} as const;
+
+export type GqlParticipationType = typeof GqlParticipationType[keyof typeof GqlParticipationType];
+export type GqlParticipationsConnection = {
+  __typename?: 'ParticipationsConnection';
+  edges: Array<GqlParticipationEdge>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export const GqlPhoneUserStatus = {
+  ExistingDifferentCommunity: 'EXISTING_DIFFERENT_COMMUNITY',
+  ExistingSameCommunity: 'EXISTING_SAME_COMMUNITY',
+  NewUser: 'NEW_USER'
+} as const;
+
+export type GqlPhoneUserStatus = typeof GqlPhoneUserStatus[keyof typeof GqlPhoneUserStatus];
+export type GqlPlace = {
+  __typename?: 'Place';
+  accumulatedParticipants?: Maybe<Scalars['Int']['output']>;
+  address: Scalars['String']['output'];
+  city?: Maybe<GqlCity>;
+  community?: Maybe<GqlCommunity>;
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
+  currentPublicOpportunityCount?: Maybe<Scalars['Int']['output']>;
+  googlePlaceId?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  image?: Maybe<Scalars['String']['output']>;
+  isManual?: Maybe<Scalars['Boolean']['output']>;
+  latitude: Scalars['Decimal']['output'];
+  longitude: Scalars['Decimal']['output'];
+  mapLocation?: Maybe<Scalars['JSON']['output']>;
+  name: Scalars['String']['output'];
+  opportunities?: Maybe<Array<GqlOpportunity>>;
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+};
+
+export type GqlPlaceCreateInput = {
+  address: Scalars['String']['input'];
+  cityCode: Scalars['ID']['input'];
+  communityId: Scalars['ID']['input'];
+  googlePlaceId?: InputMaybe<Scalars['String']['input']>;
+  isManual: Scalars['Boolean']['input'];
+  latitude: Scalars['Decimal']['input'];
+  longitude: Scalars['Decimal']['input'];
+  mapLocation?: InputMaybe<Scalars['JSON']['input']>;
+  name: Scalars['String']['input'];
+  opportunityIds?: InputMaybe<Array<Scalars['ID']['input']>>;
+};
+
+export type GqlPlaceCreatePayload = GqlPlaceCreateSuccess;
+
+export type GqlPlaceCreateSuccess = {
+  __typename?: 'PlaceCreateSuccess';
+  place: GqlPlace;
+};
+
+export type GqlPlaceDeletePayload = GqlPlaceDeleteSuccess;
+
+export type GqlPlaceDeleteSuccess = {
+  __typename?: 'PlaceDeleteSuccess';
+  id: Scalars['ID']['output'];
+};
+
+export type GqlPlaceEdge = GqlEdge & {
+  __typename?: 'PlaceEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlPlace>;
+};
+
+export type GqlPlaceFilterInput = {
+  cityCode?: InputMaybe<Scalars['ID']['input']>;
+  communityId?: InputMaybe<Scalars['ID']['input']>;
+  keyword?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type GqlPlaceSortInput = {
+  createdAt?: InputMaybe<GqlSortDirection>;
+};
+
+export type GqlPlaceUpdateInput = {
+  address: Scalars['String']['input'];
+  cityCode: Scalars['ID']['input'];
+  googlePlaceId?: InputMaybe<Scalars['String']['input']>;
+  id: Scalars['ID']['input'];
+  isManual: Scalars['Boolean']['input'];
+  latitude: Scalars['Decimal']['input'];
+  longitude: Scalars['Decimal']['input'];
+  mapLocation?: InputMaybe<Scalars['JSON']['input']>;
+  name: Scalars['String']['input'];
+  opportunityIds?: InputMaybe<Array<Scalars['ID']['input']>>;
+};
+
+export type GqlPlaceUpdatePayload = GqlPlaceUpdateSuccess;
+
+export type GqlPlaceUpdateSuccess = {
+  __typename?: 'PlaceUpdateSuccess';
+  place: GqlPlace;
+};
+
+export type GqlPlacesConnection = {
+  __typename?: 'PlacesConnection';
+  edges?: Maybe<Array<Maybe<GqlPlaceEdge>>>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type GqlPortfolio = {
+  __typename?: 'Portfolio';
+  category: GqlPortfolioCategory;
+  date: Scalars['Datetime']['output'];
+  evaluationStatus?: Maybe<GqlEvaluationStatus>;
+  id: Scalars['ID']['output'];
+  participants?: Maybe<Array<GqlUser>>;
+  place?: Maybe<GqlPlace>;
+  reservationStatus?: Maybe<GqlReservationStatus>;
+  source: GqlPortfolioSource;
+  thumbnailUrl?: Maybe<Scalars['String']['output']>;
+  title: Scalars['String']['output'];
+};
+
+export const GqlPortfolioCategory = {
+  Activity: 'ACTIVITY',
+  ActivityReport: 'ACTIVITY_REPORT',
+  Event: 'EVENT',
+  Interview: 'INTERVIEW',
+  Quest: 'QUEST'
+} as const;
+
+export type GqlPortfolioCategory = typeof GqlPortfolioCategory[keyof typeof GqlPortfolioCategory];
+export type GqlPortfolioEdge = GqlEdge & {
+  __typename?: 'PortfolioEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlPortfolio>;
+};
+
+export type GqlPortfolioFilterInput = {
+  communityIds?: InputMaybe<Array<Scalars['ID']['input']>>;
+  dateRange?: InputMaybe<GqlDateTimeRangeFilter>;
+  keyword?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type GqlPortfolioSortInput = {
+  date?: InputMaybe<GqlSortDirection>;
+};
+
+export const GqlPortfolioSource = {
+  Article: 'ARTICLE',
+  Opportunity: 'OPPORTUNITY'
+} as const;
+
+export type GqlPortfolioSource = typeof GqlPortfolioSource[keyof typeof GqlPortfolioSource];
+export type GqlPortfoliosConnection = {
+  __typename?: 'PortfoliosConnection';
+  edges: Array<GqlPortfolioEdge>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type GqlPublishReportPayload = GqlPublishReportSuccess;
+
+export type GqlPublishReportSuccess = {
+  __typename?: 'PublishReportSuccess';
+  report: GqlReport;
+};
+
+export const GqlPublishStatus = {
+  CommunityInternal: 'COMMUNITY_INTERNAL',
+  Private: 'PRIVATE',
+  Public: 'PUBLIC'
+} as const;
+
+export type GqlPublishStatus = typeof GqlPublishStatus[keyof typeof GqlPublishStatus];
+export type GqlQuery = {
+  __typename?: 'Query';
+  /**
+   * Single-community analytics detail: summary card, stage distribution,
+   * trailing-window trends, cohort retention, and a paginated member list.
+   * Intended for answering "what are kibotcha's numbers?" in an external
+   * report conversation.
+   */
+  analyticsCommunity: GqlAnalyticsCommunityPayload;
+  /**
+   * L1 dashboard: platform totals plus one row per community. Intended
+   * for the "is any community stalling?" scan. Community fan-out is
+   * served with N in-process calls (acceptable at today's community
+   * count — switch to a GROUP BY implementation once the platform
+   * exceeds ~20 communities).
+   */
+  analyticsDashboard: GqlAnalyticsDashboardPayload;
+  article?: Maybe<GqlArticle>;
+  articles: GqlArticlesConnection;
+  cities: GqlCitiesConnection;
+  communities: GqlCommunitiesConnection;
+  community?: Maybe<GqlCommunity>;
+  communityPortalConfig?: Maybe<GqlCommunityPortalConfig>;
+  currentUser?: Maybe<GqlCurrentUserPayload>;
+  echo: Scalars['String']['output'];
+  evaluation?: Maybe<GqlEvaluation>;
+  evaluationHistories: GqlEvaluationHistoriesConnection;
+  evaluationHistory?: Maybe<GqlEvaluationHistory>;
+  evaluations: GqlEvaluationsConnection;
+  incentiveGrant?: Maybe<GqlIncentiveGrant>;
+  incentiveGrants: GqlIncentiveGrantsConnection;
+  membership?: Maybe<GqlMembership>;
+  memberships: GqlMembershipsConnection;
+  /**
+   * ログインユーザーの投票資格確認。
+   * 投票画面（単一トピックにフォーカス）で利用する想定。
+   * 一覧画面では各ノードの VoteTopic.myEligibility を使う方が効率的。
+   */
+  myVoteEligibility: GqlMyVoteEligibility;
+  myWallet?: Maybe<GqlWallet>;
+  nftInstance?: Maybe<GqlNftInstance>;
+  nftInstances: GqlNftInstancesConnection;
+  nftToken?: Maybe<GqlNftToken>;
+  nftTokens: GqlNftTokensConnection;
+  opportunities: GqlOpportunitiesConnection;
+  opportunity?: Maybe<GqlOpportunity>;
+  opportunitySlot?: Maybe<GqlOpportunitySlot>;
+  opportunitySlots: GqlOpportunitySlotsConnection;
+  participation?: Maybe<GqlParticipation>;
+  participationStatusHistories: GqlParticipationStatusHistoriesConnection;
+  participationStatusHistory?: Maybe<GqlParticipationStatusHistory>;
+  participations: GqlParticipationsConnection;
+  place?: Maybe<GqlPlace>;
+  places: GqlPlacesConnection;
+  portfolios?: Maybe<Array<GqlPortfolio>>;
+  report?: Maybe<GqlReport>;
+  reportSummaries: GqlAdminReportSummaryConnection;
+  reportTemplate?: Maybe<GqlReportTemplate>;
+  reportTemplateFeedbackStats: GqlAdminTemplateFeedbackStats;
+  reportTemplateFeedbacks: GqlReportFeedbacksConnection;
+  reportTemplateStats: GqlReportTemplateStats;
+  reportTemplateStatsBreakdown: GqlReportTemplateStatsBreakdownConnection;
+  reportTemplates: Array<GqlReportTemplate>;
+  reports: GqlReportsConnection;
+  reportsAll: GqlReportsConnection;
+  reservation?: Maybe<GqlReservation>;
+  reservationHistories: GqlReservationHistoriesConnection;
+  reservationHistory?: Maybe<GqlReservationHistory>;
+  reservations: GqlReservationsConnection;
+  signupBonusConfig?: Maybe<GqlCommunitySignupBonusConfig>;
+  states: GqlStatesConnection;
+  ticket?: Maybe<GqlTicket>;
+  ticketClaimLink?: Maybe<GqlTicketClaimLink>;
+  ticketClaimLinks: GqlTicketClaimLinksConnection;
+  ticketIssuer?: Maybe<GqlTicketIssuer>;
+  ticketIssuers: GqlTicketIssuersConnection;
+  ticketStatusHistories: GqlTicketStatusHistoriesConnection;
+  ticketStatusHistory?: Maybe<GqlTicketStatusHistory>;
+  tickets: GqlTicketsConnection;
+  transaction?: Maybe<GqlTransaction>;
+  transactions: GqlTransactionsConnection;
+  user?: Maybe<GqlUser>;
+  /**
+   * 指定ユーザーの最新 UserDidAnchor を返却する。
+   * 存在しない場合は null。PENDING 状態でも返却される (§F)。
+   * 認証必須。
+   */
+  userDid?: Maybe<GqlUserDidAnchor>;
+  users: GqlUsersConnection;
+  utilities: GqlUtilitiesConnection;
+  utility?: Maybe<GqlUtility>;
+  /**
+   * 単一 VC issuance を id で取得。存在しない場合は null。
+   * 認証必須。
+   */
+  vcIssuance?: Maybe<GqlVcIssuance>;
+  vcIssuanceRequest?: Maybe<GqlVcIssuanceRequest>;
+  vcIssuanceRequests: GqlVcIssuanceRequestsConnection;
+  /**
+   * 指定ユーザーが保有する VC issuance 一覧を返却する。
+   * 認証必須。
+   */
+  vcIssuancesByUser: Array<GqlVcIssuance>;
+  /**
+   * Verify transactions against the Cardano blockchain.
+   * - Retrieves Merkle proofs for specified transactions
+   * - Recalculates root hash using proofs
+   * - Compares with Cardano blockchain metadata
+   * - Returns data integrity verification results
+   */
+  verifyTransactions?: Maybe<Array<GqlTransactionVerificationResult>>;
+  /** 投票テーマ詳細（myBallot / myEligibility はフィールドリゾルバー経由で解決）。 */
+  voteTopic?: Maybe<GqlVoteTopic>;
+  /**
+   * コミュニティの投票テーマ一覧（カーソルページネーション）。
+   * 各ノードの myBallot / myEligibility は DataLoader 経由で解決され、N+1 は発生しない。
+   */
+  voteTopics: GqlVoteTopicsConnection;
+  wallet?: Maybe<GqlWallet>;
+  wallets: GqlWalletsConnection;
+};
+
+
+export type GqlQueryAnalyticsCommunityArgs = {
+  input: GqlAnalyticsCommunityInput;
+};
+
+
+export type GqlQueryAnalyticsDashboardArgs = {
+  input?: InputMaybe<GqlAnalyticsDashboardInput>;
+};
+
+
+export type GqlQueryArticleArgs = {
+  id: Scalars['ID']['input'];
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlQueryArticlesArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlArticleFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlArticleSortInput>;
+};
+
+
+export type GqlQueryCitiesArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlCitiesInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlCitiesSortInput>;
+};
+
+
+export type GqlQueryCommunitiesArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlCommunityFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlCommunitySortInput>;
+};
+
+
+export type GqlQueryCommunityArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryCommunityPortalConfigArgs = {
+  communityId: Scalars['String']['input'];
+};
+
+
+export type GqlQueryEvaluationArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryEvaluationHistoriesArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlEvaluationHistoryFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlEvaluationHistorySortInput>;
+};
+
+
+export type GqlQueryEvaluationHistoryArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryEvaluationsArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlEvaluationFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlEvaluationSortInput>;
+};
+
+
+export type GqlQueryIncentiveGrantArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryIncentiveGrantsArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlIncentiveGrantFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlIncentiveGrantSortInput>;
+};
+
+
+export type GqlQueryMembershipArgs = {
+  communityId: Scalars['ID']['input'];
+  userId: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryMembershipsArgs = {
+  cursor?: InputMaybe<GqlMembershipCursorInput>;
+  filter?: InputMaybe<GqlMembershipFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlMembershipSortInput>;
+};
+
+
+export type GqlQueryMyVoteEligibilityArgs = {
+  topicId: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryNftInstanceArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryNftInstancesArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlNftInstanceFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlNftInstanceSortInput>;
+};
+
+
+export type GqlQueryNftTokenArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryNftTokensArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlNftTokenFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlNftTokenSortInput>;
+};
+
+
+export type GqlQueryOpportunitiesArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlOpportunityFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlOpportunitySortInput>;
+};
+
+
+export type GqlQueryOpportunityArgs = {
+  id: Scalars['ID']['input'];
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlQueryOpportunitySlotArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryOpportunitySlotsArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlOpportunitySlotFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlOpportunitySlotSortInput>;
+};
+
+
+export type GqlQueryParticipationArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryParticipationStatusHistoriesArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlParticipationStatusHistoryFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlParticipationStatusHistorySortInput>;
+};
+
+
+export type GqlQueryParticipationStatusHistoryArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryParticipationsArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlParticipationFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlParticipationSortInput>;
+};
+
+
+export type GqlQueryPlaceArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryPlacesArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlPlaceFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlPlaceSortInput>;
+};
+
+
+export type GqlQueryPortfoliosArgs = {
+  filter?: InputMaybe<GqlPortfolioFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlPortfolioSortInput>;
+};
+
+
+export type GqlQueryReportArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryReportSummariesArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type GqlQueryReportTemplateArgs = {
+  communityId?: InputMaybe<Scalars['ID']['input']>;
+  variant: GqlReportVariant;
+};
+
+
+export type GqlQueryReportTemplateFeedbackStatsArgs = {
+  kind?: InputMaybe<GqlReportTemplateKind>;
+  variant: GqlReportVariant;
+  version?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type GqlQueryReportTemplateFeedbacksArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  feedbackType?: InputMaybe<GqlReportFeedbackType>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  kind?: InputMaybe<GqlReportTemplateKind>;
+  maxRating?: InputMaybe<Scalars['Int']['input']>;
+  variant: GqlReportVariant;
+  version?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type GqlQueryReportTemplateStatsArgs = {
+  variant: GqlReportVariant;
+  version?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type GqlQueryReportTemplateStatsBreakdownArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  includeInactive?: InputMaybe<Scalars['Boolean']['input']>;
+  kind?: InputMaybe<GqlReportTemplateKind>;
+  variant: GqlReportVariant;
+  version?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type GqlQueryReportTemplatesArgs = {
+  communityId?: InputMaybe<Scalars['ID']['input']>;
+  includeInactive?: InputMaybe<Scalars['Boolean']['input']>;
+  kind?: InputMaybe<GqlReportTemplateKind>;
+  variant: GqlReportVariant;
+};
+
+
+export type GqlQueryReportsArgs = {
+  communityId: Scalars['ID']['input'];
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+  status?: InputMaybe<GqlReportStatus>;
+  variant?: InputMaybe<GqlReportVariant>;
+};
+
+
+export type GqlQueryReportsAllArgs = {
+  communityId?: InputMaybe<Scalars['ID']['input']>;
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  publishedAfter?: InputMaybe<Scalars['Datetime']['input']>;
+  publishedBefore?: InputMaybe<Scalars['Datetime']['input']>;
+  status?: InputMaybe<GqlReportStatus>;
+  variant?: InputMaybe<GqlReportVariant>;
+};
+
+
+export type GqlQueryReservationArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryReservationHistoriesArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlReservationHistoryFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlReservationHistorySortInput>;
+};
+
+
+export type GqlQueryReservationHistoryArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryReservationsArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlReservationFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlReservationSortInput>;
+};
+
+
+export type GqlQuerySignupBonusConfigArgs = {
+  communityId: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryStatesArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlStatesInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type GqlQueryTicketArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryTicketClaimLinkArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryTicketClaimLinksArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlTicketClaimLinkFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlTicketClaimLinkSortInput>;
+};
+
+
+export type GqlQueryTicketIssuerArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryTicketIssuersArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlTicketIssuerFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlTicketIssuerSortInput>;
+};
+
+
+export type GqlQueryTicketStatusHistoriesArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlTicketStatusHistoryFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlTicketStatusHistorySortInput>;
+};
+
+
+export type GqlQueryTicketStatusHistoryArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryTicketsArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlTicketFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlTicketSortInput>;
+};
+
+
+export type GqlQueryTransactionArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryTransactionsArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlTransactionFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlTransactionSortInput>;
+};
+
+
+export type GqlQueryUserArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryUserDidArgs = {
+  userId: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryUsersArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlUserFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlUserSortInput>;
+};
+
+
+export type GqlQueryUtilitiesArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlUtilityFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlUtilitySortInput>;
+};
+
+
+export type GqlQueryUtilityArgs = {
+  id: Scalars['ID']['input'];
+  permission?: InputMaybe<GqlCheckCommunityPermissionInput>;
+};
+
+
+export type GqlQueryVcIssuanceArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryVcIssuanceRequestArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryVcIssuanceRequestsArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlVcIssuanceRequestFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlVcIssuanceRequestSortInput>;
+};
+
+
+export type GqlQueryVcIssuancesByUserArgs = {
+  userId: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryVerifyTransactionsArgs = {
+  txIds: Array<Scalars['ID']['input']>;
+};
+
+
+export type GqlQueryVoteTopicArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryVoteTopicsArgs = {
+  communityId: Scalars['ID']['input'];
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type GqlQueryWalletArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type GqlQueryWalletsArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlWalletFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlWalletSortInput>;
+};
+
+export type GqlRejectReportPayload = GqlRejectReportSuccess;
+
+export type GqlRejectReportSuccess = {
+  __typename?: 'RejectReportSuccess';
+  report: GqlReport;
+};
+
+export type GqlReport = {
+  __typename?: 'Report';
+  cacheReadTokens?: Maybe<Scalars['Int']['output']>;
+  community: GqlCommunity;
+  createdAt: Scalars['Datetime']['output'];
+  feedbacks: GqlReportFeedbacksConnection;
+  finalContent?: Maybe<Scalars['String']['output']>;
+  generatedByUser?: Maybe<GqlUser>;
+  id: Scalars['ID']['output'];
+  inputTokens?: Maybe<Scalars['Int']['output']>;
+  model?: Maybe<Scalars['String']['output']>;
+  myFeedback?: Maybe<GqlReportFeedback>;
+  outputMarkdown?: Maybe<Scalars['String']['output']>;
+  outputTokens?: Maybe<Scalars['Int']['output']>;
+  parentRun?: Maybe<GqlReport>;
+  periodFrom: Scalars['Datetime']['output'];
+  periodTo: Scalars['Datetime']['output'];
+  publishedAt?: Maybe<Scalars['Datetime']['output']>;
+  publishedByUser?: Maybe<GqlUser>;
+  regenerateCount: Scalars['Int']['output'];
+  regenerations: Array<GqlReport>;
+  skipReason?: Maybe<Scalars['String']['output']>;
+  status: GqlReportStatus;
+  targetUser?: Maybe<GqlUser>;
+  template?: Maybe<GqlReportTemplate>;
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+  variant: GqlReportVariant;
+};
+
+
+export type GqlReportFeedbacksArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type GqlReportEdge = GqlEdge & {
+  __typename?: 'ReportEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlReport>;
+};
+
+export type GqlReportFeedback = {
+  __typename?: 'ReportFeedback';
+  comment?: Maybe<Scalars['String']['output']>;
+  createdAt: Scalars['Datetime']['output'];
+  feedbackType?: Maybe<GqlReportFeedbackType>;
+  id: Scalars['ID']['output'];
+  rating: Scalars['Int']['output'];
+  report: GqlReport;
+  reportId: Scalars['ID']['output'];
+  sectionKey?: Maybe<Scalars['String']['output']>;
+  user: GqlUser;
+};
+
+export type GqlReportFeedbackEdge = GqlEdge & {
+  __typename?: 'ReportFeedbackEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlReportFeedback>;
+};
+
+export type GqlReportFeedbackRatingBucket = {
+  __typename?: 'ReportFeedbackRatingBucket';
+  count: Scalars['Int']['output'];
+  rating: Scalars['Int']['output'];
+};
+
+export const GqlReportFeedbackType = {
+  Accuracy: 'ACCURACY',
+  Other: 'OTHER',
+  Quality: 'QUALITY',
+  Structure: 'STRUCTURE',
+  Tone: 'TONE'
+} as const;
+
+export type GqlReportFeedbackType = typeof GqlReportFeedbackType[keyof typeof GqlReportFeedbackType];
+export type GqlReportFeedbacksConnection = {
+  __typename?: 'ReportFeedbacksConnection';
+  edges?: Maybe<Array<Maybe<GqlReportFeedbackEdge>>>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export const GqlReportStatus = {
+  Approved: 'APPROVED',
+  Draft: 'DRAFT',
+  Published: 'PUBLISHED',
+  Rejected: 'REJECTED',
+  Skipped: 'SKIPPED',
+  Superseded: 'SUPERSEDED'
+} as const;
+
+export type GqlReportStatus = typeof GqlReportStatus[keyof typeof GqlReportStatus];
+export type GqlReportTemplate = {
+  __typename?: 'ReportTemplate';
+  community?: Maybe<GqlCommunity>;
+  communityContext?: Maybe<Scalars['String']['output']>;
+  createdAt: Scalars['Datetime']['output'];
+  experimentKey?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  isActive: Scalars['Boolean']['output'];
+  isEnabled: Scalars['Boolean']['output'];
+  kind: GqlReportTemplateKind;
+  maxTokens: Scalars['Int']['output'];
+  model: Scalars['String']['output'];
+  scope: GqlReportTemplateScope;
+  stopSequences: Array<Scalars['String']['output']>;
+  systemPrompt: Scalars['String']['output'];
+  temperature?: Maybe<Scalars['Float']['output']>;
+  trafficWeight: Scalars['Int']['output'];
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+  updatedByUser?: Maybe<GqlUser>;
+  userPromptTemplate: Scalars['String']['output'];
+  variant: GqlReportVariant;
+  version: Scalars['Int']['output'];
+};
+
+export const GqlReportTemplateKind = {
+  Generation: 'GENERATION',
+  Judge: 'JUDGE'
+} as const;
+
+export type GqlReportTemplateKind = typeof GqlReportTemplateKind[keyof typeof GqlReportTemplateKind];
+export const GqlReportTemplateScope = {
+  Community: 'COMMUNITY',
+  System: 'SYSTEM'
+} as const;
+
+export type GqlReportTemplateScope = typeof GqlReportTemplateScope[keyof typeof GqlReportTemplateScope];
+export type GqlReportTemplateStats = {
+  __typename?: 'ReportTemplateStats';
+  avgJudgeScore?: Maybe<Scalars['Float']['output']>;
+  avgRating?: Maybe<Scalars['Float']['output']>;
+  correlationWarning: Scalars['Boolean']['output'];
+  feedbackCount: Scalars['Int']['output'];
+  judgeHumanCorrelation?: Maybe<Scalars['Float']['output']>;
+  variant: GqlReportVariant;
+  version?: Maybe<Scalars['Int']['output']>;
+};
+
+export type GqlReportTemplateStatsBreakdownConnection = {
+  __typename?: 'ReportTemplateStatsBreakdownConnection';
+  edges?: Maybe<Array<Maybe<GqlReportTemplateStatsBreakdownEdge>>>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type GqlReportTemplateStatsBreakdownEdge = GqlEdge & {
+  __typename?: 'ReportTemplateStatsBreakdownEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlReportTemplateStatsBreakdownRow>;
+};
+
+export type GqlReportTemplateStatsBreakdownRow = {
+  __typename?: 'ReportTemplateStatsBreakdownRow';
+  avgJudgeScore?: Maybe<Scalars['Float']['output']>;
+  avgRating?: Maybe<Scalars['Float']['output']>;
+  correlationWarning: Scalars['Boolean']['output'];
+  experimentKey?: Maybe<Scalars['String']['output']>;
+  feedbackCount: Scalars['Int']['output'];
+  isActive: Scalars['Boolean']['output'];
+  isEnabled: Scalars['Boolean']['output'];
+  judgeHumanCorrelation?: Maybe<Scalars['Float']['output']>;
+  kind: GqlReportTemplateKind;
+  scope: GqlReportTemplateScope;
+  templateId: Scalars['ID']['output'];
+  trafficWeight: Scalars['Int']['output'];
+  version: Scalars['Int']['output'];
+};
+
+export const GqlReportVariant = {
+  GrantApplication: 'GRANT_APPLICATION',
+  MediaPr: 'MEDIA_PR',
+  MemberNewsletter: 'MEMBER_NEWSLETTER',
+  PersonalRecap: 'PERSONAL_RECAP',
+  WeeklySummary: 'WEEKLY_SUMMARY'
+} as const;
+
+export type GqlReportVariant = typeof GqlReportVariant[keyof typeof GqlReportVariant];
+export type GqlReportsConnection = {
+  __typename?: 'ReportsConnection';
+  edges?: Maybe<Array<Maybe<GqlReportEdge>>>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type GqlReservation = {
+  __typename?: 'Reservation';
+  comment?: Maybe<Scalars['String']['output']>;
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
+  createdByUser?: Maybe<GqlUser>;
+  histories?: Maybe<Array<GqlReservationHistory>>;
+  id: Scalars['ID']['output'];
+  opportunitySlot?: Maybe<GqlOpportunitySlot>;
+  participantCountWithPoint?: Maybe<Scalars['Int']['output']>;
+  participations?: Maybe<Array<GqlParticipation>>;
+  status: GqlReservationStatus;
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+};
+
+export type GqlReservationCancelInput = {
+  paymentMethod: GqlReservationPaymentMethod;
+  ticketIdsIfExists?: InputMaybe<Array<Scalars['ID']['input']>>;
+};
+
+export type GqlReservationCreateInput = {
+  comment?: InputMaybe<Scalars['String']['input']>;
+  opportunitySlotId: Scalars['ID']['input'];
+  otherUserIds?: InputMaybe<Array<Scalars['ID']['input']>>;
+  participantCountWithPoint?: InputMaybe<Scalars['Int']['input']>;
+  paymentMethod: GqlReservationPaymentMethod;
+  ticketIdsIfNeed?: InputMaybe<Array<Scalars['ID']['input']>>;
+  totalParticipantCount: Scalars['Int']['input'];
+};
+
+export type GqlReservationCreatePayload = GqlReservationCreateSuccess;
+
+export type GqlReservationCreateSuccess = {
+  __typename?: 'ReservationCreateSuccess';
+  reservation: GqlReservation;
+};
+
+export type GqlReservationEdge = GqlEdge & {
+  __typename?: 'ReservationEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlReservation>;
+};
+
+export type GqlReservationFilterInput = {
+  and?: InputMaybe<Array<GqlReservationFilterInput>>;
+  communityId?: InputMaybe<Scalars['ID']['input']>;
+  createdByUserId?: InputMaybe<Scalars['ID']['input']>;
+  evaluationStatus?: InputMaybe<GqlEvaluationStatus>;
+  hostingStatus?: InputMaybe<Array<GqlOpportunitySlotHostingStatus>>;
+  not?: InputMaybe<Array<GqlReservationFilterInput>>;
+  opportunityId?: InputMaybe<Scalars['ID']['input']>;
+  opportunityOwnerId?: InputMaybe<Scalars['ID']['input']>;
+  opportunitySlotId?: InputMaybe<Scalars['ID']['input']>;
+  or?: InputMaybe<Array<GqlReservationFilterInput>>;
+  participationStatus?: InputMaybe<Array<GqlParticipationStatus>>;
+  reservationStatus?: InputMaybe<Array<GqlReservationStatus>>;
+};
+
+export type GqlReservationHistoriesConnection = {
+  __typename?: 'ReservationHistoriesConnection';
+  edges: Array<GqlReservationHistoryEdge>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type GqlReservationHistory = {
+  __typename?: 'ReservationHistory';
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
+  createdByUser?: Maybe<GqlUser>;
+  id: Scalars['ID']['output'];
+  reservation: GqlReservation;
+  status: GqlReservationStatus;
+};
+
+export type GqlReservationHistoryEdge = GqlEdge & {
+  __typename?: 'ReservationHistoryEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlReservationHistory>;
+};
+
+export type GqlReservationHistoryFilterInput = {
+  createdByUserId?: InputMaybe<Scalars['ID']['input']>;
+  reservationId?: InputMaybe<Scalars['ID']['input']>;
+  status?: InputMaybe<GqlReservationStatus>;
+};
+
+export type GqlReservationHistorySortInput = {
+  createdAt?: InputMaybe<GqlSortDirection>;
+};
+
+export const GqlReservationPaymentMethod = {
+  Fee: 'FEE',
+  Ticket: 'TICKET'
+} as const;
+
+export type GqlReservationPaymentMethod = typeof GqlReservationPaymentMethod[keyof typeof GqlReservationPaymentMethod];
+export type GqlReservationRejectInput = {
+  comment?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type GqlReservationSetStatusPayload = GqlReservationSetStatusSuccess;
+
+export type GqlReservationSetStatusSuccess = {
+  __typename?: 'ReservationSetStatusSuccess';
+  reservation: GqlReservation;
+};
+
+export type GqlReservationSortInput = {
+  createdAt?: InputMaybe<GqlSortDirection>;
+  updatedAt?: InputMaybe<GqlSortDirection>;
+};
+
+export const GqlReservationStatus = {
+  Accepted: 'ACCEPTED',
+  Applied: 'APPLIED',
+  Canceled: 'CANCELED',
+  Rejected: 'REJECTED'
+} as const;
+
+export type GqlReservationStatus = typeof GqlReservationStatus[keyof typeof GqlReservationStatus];
+export type GqlReservationsConnection = {
+  __typename?: 'ReservationsConnection';
+  edges: Array<GqlReservationEdge>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type GqlRevokeUserVcInput = {
+  /** Revoke 理由 (audit log 用、任意)。 */
+  reason?: InputMaybe<Scalars['String']['input']>;
+  /** Revoke 対象の VC issuance id。 */
+  vcId: Scalars['ID']['input'];
+};
+
+export const GqlRole = {
+  Manager: 'MANAGER',
+  Member: 'MEMBER',
+  Owner: 'OWNER'
+} as const;
+
+export type GqlRole = typeof GqlRole[keyof typeof GqlRole];
+export const GqlSortDirection = {
+  Asc: 'asc',
+  Desc: 'desc'
+} as const;
+
+export type GqlSortDirection = typeof GqlSortDirection[keyof typeof GqlSortDirection];
+export const GqlSource = {
+  External: 'EXTERNAL',
+  Internal: 'INTERNAL'
+} as const;
+
+export type GqlSource = typeof GqlSource[keyof typeof GqlSource];
+export type GqlState = {
+  __typename?: 'State';
+  code: Scalars['ID']['output'];
+  countryCode: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+};
+
+export type GqlStateEdge = GqlEdge & {
+  __typename?: 'StateEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlState>;
+};
+
+export type GqlStatesConnection = {
+  __typename?: 'StatesConnection';
+  edges: Array<GqlStateEdge>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type GqlStatesInput = {
+  name?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type GqlStorePhoneAuthTokenInput = {
+  authToken: Scalars['String']['input'];
+  expiresIn: Scalars['Int']['input'];
+  phoneUid: Scalars['String']['input'];
+  refreshToken: Scalars['String']['input'];
+};
+
+export type GqlStorePhoneAuthTokenPayload = {
+  __typename?: 'StorePhoneAuthTokenPayload';
+  expiresAt?: Maybe<Scalars['Datetime']['output']>;
+  success: Scalars['Boolean']['output'];
+};
+
+export type GqlSubmitReportFeedbackInput = {
+  comment?: InputMaybe<Scalars['String']['input']>;
+  feedbackType?: InputMaybe<GqlReportFeedbackType>;
+  rating: Scalars['Int']['input'];
+  reportId: Scalars['ID']['input'];
+  sectionKey?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type GqlSubmitReportFeedbackPayload = GqlSubmitReportFeedbackSuccess;
+
+export type GqlSubmitReportFeedbackSuccess = {
+  __typename?: 'SubmitReportFeedbackSuccess';
+  feedback: GqlReportFeedback;
+};
+
+export const GqlSysRole = {
+  SysAdmin: 'SYS_ADMIN',
+  User: 'USER'
+} as const;
+
+export type GqlSysRole = typeof GqlSysRole[keyof typeof GqlSysRole];
+export type GqlTicket = {
+  __typename?: 'Ticket';
+  claimLink?: Maybe<GqlTicketClaimLink>;
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
+  id: Scalars['ID']['output'];
+  reason: GqlTicketStatusReason;
+  status: GqlTicketStatus;
+  ticketStatusHistories?: Maybe<Array<GqlTicketStatusHistory>>;
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+  utility?: Maybe<GqlUtility>;
+  wallet?: Maybe<GqlWallet>;
+};
+
+export type GqlTicketClaimInput = {
+  ticketClaimLinkId: Scalars['ID']['input'];
+};
+
+export type GqlTicketClaimLink = {
+  __typename?: 'TicketClaimLink';
+  claimedAt?: Maybe<Scalars['Datetime']['output']>;
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
+  id: Scalars['ID']['output'];
+  issuer?: Maybe<GqlTicketIssuer>;
+  /** Max number of tickets a user can claim using this link */
+  qty: Scalars['Int']['output'];
+  status: GqlClaimLinkStatus;
+  tickets?: Maybe<Array<GqlTicket>>;
+};
+
+export type GqlTicketClaimLinkEdge = GqlEdge & {
+  __typename?: 'TicketClaimLinkEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlTicketClaimLink>;
+};
+
+export type GqlTicketClaimLinkFilterInput = {
+  hasAvailableTickets?: InputMaybe<Scalars['Boolean']['input']>;
+  issuedTo?: InputMaybe<Scalars['ID']['input']>;
+  issuerId?: InputMaybe<Scalars['ID']['input']>;
+  status?: InputMaybe<GqlClaimLinkStatus>;
+};
+
+export type GqlTicketClaimLinkSortInput = {
+  createdAt?: InputMaybe<GqlSortDirection>;
+  status?: InputMaybe<GqlSortDirection>;
+};
+
+export type GqlTicketClaimLinksConnection = {
+  __typename?: 'TicketClaimLinksConnection';
+  edges?: Maybe<Array<Maybe<GqlTicketClaimLinkEdge>>>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type GqlTicketClaimPayload = GqlTicketClaimSuccess;
+
+export type GqlTicketClaimSuccess = {
+  __typename?: 'TicketClaimSuccess';
+  tickets: Array<GqlTicket>;
+};
+
+export type GqlTicketEdge = GqlEdge & {
+  __typename?: 'TicketEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlTicket>;
+};
+
+export type GqlTicketFilterInput = {
+  ownerId?: InputMaybe<Scalars['ID']['input']>;
+  status?: InputMaybe<GqlTicketStatus>;
+  utilityId?: InputMaybe<Scalars['ID']['input']>;
+  walletId?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type GqlTicketIssueInput = {
+  qtyToBeIssued: Scalars['Int']['input'];
+  utilityId: Scalars['ID']['input'];
+};
+
+export type GqlTicketIssuePayload = GqlTicketIssueSuccess;
+
+export type GqlTicketIssueSuccess = {
+  __typename?: 'TicketIssueSuccess';
+  issue: GqlTicketIssuer;
+};
+
+export type GqlTicketIssuer = {
+  __typename?: 'TicketIssuer';
+  claimLink?: Maybe<GqlTicketClaimLink>;
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
+  id: Scalars['ID']['output'];
+  owner?: Maybe<GqlUser>;
+  /** Maximum number of tickets claimable from this link */
+  qtyToBeIssued: Scalars['Int']['output'];
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+  utility?: Maybe<GqlUtility>;
+};
+
+export type GqlTicketIssuerEdge = GqlEdge & {
+  __typename?: 'TicketIssuerEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlTicketIssuer>;
+};
+
+export type GqlTicketIssuerFilterInput = {
+  ownerId?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type GqlTicketIssuerSortInput = {
+  createdAt?: InputMaybe<GqlSortDirection>;
+};
+
+export type GqlTicketIssuersConnection = {
+  __typename?: 'TicketIssuersConnection';
+  edges?: Maybe<Array<Maybe<GqlTicketIssuerEdge>>>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type GqlTicketPurchaseInput = {
+  communityId: Scalars['ID']['input'];
+  pointsRequired: Scalars['Int']['input'];
+  utilityId: Scalars['ID']['input'];
+  walletId: Scalars['ID']['input'];
+};
+
+export type GqlTicketPurchasePayload = GqlTicketPurchaseSuccess;
+
+export type GqlTicketPurchaseSuccess = {
+  __typename?: 'TicketPurchaseSuccess';
+  ticket: GqlTicket;
+};
+
+export type GqlTicketRefundInput = {
+  communityId: Scalars['ID']['input'];
+  pointsRequired: Scalars['Int']['input'];
+  walletId: Scalars['ID']['input'];
+};
+
+export type GqlTicketRefundPayload = GqlTicketRefundSuccess;
+
+export type GqlTicketRefundSuccess = {
+  __typename?: 'TicketRefundSuccess';
+  ticket: GqlTicket;
+};
+
+export type GqlTicketSortInput = {
+  createdAt?: InputMaybe<GqlSortDirection>;
+  status?: InputMaybe<GqlSortDirection>;
+};
+
+export const GqlTicketStatus = {
+  Available: 'AVAILABLE',
+  Disabled: 'DISABLED'
+} as const;
+
+export type GqlTicketStatus = typeof GqlTicketStatus[keyof typeof GqlTicketStatus];
+export type GqlTicketStatusHistoriesConnection = {
+  __typename?: 'TicketStatusHistoriesConnection';
+  edges?: Maybe<Array<Maybe<GqlTicketStatusHistoryEdge>>>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type GqlTicketStatusHistory = {
+  __typename?: 'TicketStatusHistory';
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
+  createdByUser?: Maybe<GqlUser>;
+  id: Scalars['ID']['output'];
+  reason: GqlTicketStatusReason;
+  status: GqlTicketStatus;
+  ticket?: Maybe<GqlTicket>;
+  transaction?: Maybe<GqlTransaction>;
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+};
+
+export type GqlTicketStatusHistoryEdge = GqlEdge & {
+  __typename?: 'TicketStatusHistoryEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlTicketStatusHistory>;
+};
+
+export type GqlTicketStatusHistoryFilterInput = {
+  createdById?: InputMaybe<Scalars['ID']['input']>;
+  reason?: InputMaybe<GqlTicketStatusReason>;
+  status?: InputMaybe<GqlTicketStatus>;
+  ticketId?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type GqlTicketStatusHistorySortInput = {
+  createdAt?: InputMaybe<GqlSortDirection>;
+};
+
+export const GqlTicketStatusReason = {
+  Canceled: 'CANCELED',
+  Expired: 'EXPIRED',
+  Gifted: 'GIFTED',
+  Purchased: 'PURCHASED',
+  Refunded: 'REFUNDED',
+  Reserved: 'RESERVED',
+  Used: 'USED'
+} as const;
+
+export type GqlTicketStatusReason = typeof GqlTicketStatusReason[keyof typeof GqlTicketStatusReason];
+export type GqlTicketUsePayload = GqlTicketUseSuccess;
+
+export type GqlTicketUseSuccess = {
+  __typename?: 'TicketUseSuccess';
+  ticket: GqlTicket;
+};
+
+export type GqlTicketsConnection = {
+  __typename?: 'TicketsConnection';
+  edges?: Maybe<Array<Maybe<GqlTicketEdge>>>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type GqlTransaction = {
+  __typename?: 'Transaction';
+  /**
+   * ポイントの旅のステップを返します（最大10段階）。
+   * 再帰CTEによる単一クエリで取得しますが、循環・異常データ対策のため深さ上限を10としています。
+   * transactions などのリスト取得で chain を要求すると、各 Transaction ごとにこのクエリが実行されるため高コストになりえます。
+   * transaction(id) での単体取得時のみ使用し、深さだけ必要な場合は chainDepth を使用してください。
+   */
+  chain?: Maybe<GqlTransactionChain>;
+  chainDepth?: Maybe<Scalars['Int']['output']>;
+  comment?: Maybe<Scalars['String']['output']>;
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
+  createdByUser?: Maybe<GqlUser>;
+  fromPointChange?: Maybe<Scalars['Int']['output']>;
+  fromWallet?: Maybe<GqlWallet>;
+  id: Scalars['ID']['output'];
+  images?: Maybe<Array<Scalars['String']['output']>>;
+  participation?: Maybe<GqlParticipation>;
+  reason: GqlTransactionReason;
+  reservation?: Maybe<GqlReservation>;
+  ticketStatusHistories?: Maybe<Array<GqlTicketStatusHistory>>;
+  toPointChange?: Maybe<Scalars['Int']['output']>;
+  toWallet?: Maybe<GqlWallet>;
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+};
+
+/**
+ * ポイントの旅（chain）の全体像。
+ * depth はチェーンの長さ（ステップ数）、steps は古い順（起点→現在）に並ぶ。
+ */
+export type GqlTransactionChain = {
+  __typename?: 'TransactionChain';
+  depth: Scalars['Int']['output'];
+  steps: Array<GqlTransactionChainStep>;
+};
+
+/**
+ * 参加者がコミュニティ（COMMUNITY wallet の所有者）である場合の表現。
+ * id は Community.id。GRANT / ONBOARDING のような、community wallet から
+ * 発行される transaction の起点ステップで登場する。
+ */
+export type GqlTransactionChainCommunity = GqlTransactionChainParticipant & {
+  __typename?: 'TransactionChainCommunity';
+  bio?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  image?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+};
+
+/**
+ * chain の 1 ステップに登場する参加者（User または Community）。
+ * 共通フィールドを束ねた interface。実体の判別は __typename で行う。
+ */
+export type GqlTransactionChainParticipant = {
+  bio?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  image?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+};
+
+/**
+ * chain の1ステップ。ある transaction（ポイントの移動 1回分）に対応する。
+ * from が送信元、to が送信先。どちらも User または Community を表す
+ * TransactionChainParticipant interface で、__typename で判別できる。
+ */
+export type GqlTransactionChainStep = {
+  __typename?: 'TransactionChainStep';
+  createdAt: Scalars['Datetime']['output'];
+  /**
+   * 送信元の参加者。
+   * - GRANT / ONBOARDING の起点ステップでは TransactionChainCommunity（community wallet 発）
+   * - それ以外のステップは TransactionChainUser
+   * - ウォレットが削除済み（退会済みユーザー等）の場合は null
+   */
+  from?: Maybe<GqlTransactionChainParticipant>;
+  id: Scalars['ID']['output'];
+  points: Scalars['Int']['output'];
+  reason: GqlTransactionReason;
+  /**
+   * 送信先の参加者。
+   * 現状の業務ロジックでは常に TransactionChainUser（MEMBER wallet 宛）。
+   * ウォレットが削除済みの場合は null。
+   */
+  to?: Maybe<GqlTransactionChainParticipant>;
+};
+
+/**
+ * 参加者がユーザー（MEMBER wallet の所有者）である場合の表現。
+ * id は User.id。
+ */
+export type GqlTransactionChainUser = GqlTransactionChainParticipant & {
+  __typename?: 'TransactionChainUser';
+  bio?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  image?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+};
+
+export type GqlTransactionDonateSelfPointInput = {
+  comment?: InputMaybe<Scalars['String']['input']>;
+  communityId: Scalars['ID']['input'];
+  images?: InputMaybe<Array<GqlImageInput>>;
+  toUserId: Scalars['ID']['input'];
+  transferPoints: Scalars['Int']['input'];
+};
+
+export type GqlTransactionDonateSelfPointPayload = GqlTransactionDonateSelfPointSuccess;
+
+export type GqlTransactionDonateSelfPointSuccess = {
+  __typename?: 'TransactionDonateSelfPointSuccess';
+  transaction: GqlTransaction;
+};
+
+export type GqlTransactionEdge = GqlEdge & {
+  __typename?: 'TransactionEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlTransaction>;
+};
+
+export type GqlTransactionFilterInput = {
+  and?: InputMaybe<Array<GqlTransactionFilterInput>>;
+  communityId?: InputMaybe<Scalars['ID']['input']>;
+  fromDidValue?: InputMaybe<Scalars['String']['input']>;
+  fromUserId?: InputMaybe<Scalars['ID']['input']>;
+  fromUserName?: InputMaybe<Scalars['String']['input']>;
+  fromWalletId?: InputMaybe<Scalars['ID']['input']>;
+  fromWalletType?: InputMaybe<GqlWalletType>;
+  not?: InputMaybe<GqlTransactionFilterInput>;
+  or?: InputMaybe<Array<GqlTransactionFilterInput>>;
+  reason?: InputMaybe<GqlTransactionReason>;
+  toDidValue?: InputMaybe<Scalars['String']['input']>;
+  toUserId?: InputMaybe<Scalars['ID']['input']>;
+  toUserName?: InputMaybe<Scalars['String']['input']>;
+  toWalletId?: InputMaybe<Scalars['ID']['input']>;
+  toWalletType?: InputMaybe<GqlWalletType>;
+};
+
+export type GqlTransactionGrantCommunityPointInput = {
+  comment?: InputMaybe<Scalars['String']['input']>;
+  images?: InputMaybe<Array<GqlImageInput>>;
+  toUserId: Scalars['ID']['input'];
+  transferPoints: Scalars['Int']['input'];
+};
+
+export type GqlTransactionGrantCommunityPointPayload = GqlTransactionGrantCommunityPointSuccess;
+
+export type GqlTransactionGrantCommunityPointSuccess = {
+  __typename?: 'TransactionGrantCommunityPointSuccess';
+  transaction: GqlTransaction;
+};
+
+export type GqlTransactionIssueCommunityPointInput = {
+  comment?: InputMaybe<Scalars['String']['input']>;
+  images?: InputMaybe<Array<GqlImageInput>>;
+  transferPoints: Scalars['Int']['input'];
+};
+
+export type GqlTransactionIssueCommunityPointPayload = GqlTransactionIssueCommunityPointSuccess;
+
+export type GqlTransactionIssueCommunityPointSuccess = {
+  __typename?: 'TransactionIssueCommunityPointSuccess';
+  transaction: GqlTransaction;
+};
+
+export const GqlTransactionReason = {
+  Donation: 'DONATION',
+  Grant: 'GRANT',
+  Onboarding: 'ONBOARDING',
+  OpportunityReservationCanceled: 'OPPORTUNITY_RESERVATION_CANCELED',
+  OpportunityReservationCreated: 'OPPORTUNITY_RESERVATION_CREATED',
+  OpportunityReservationRejected: 'OPPORTUNITY_RESERVATION_REJECTED',
+  PointIssued: 'POINT_ISSUED',
+  PointReward: 'POINT_REWARD',
+  TicketPurchased: 'TICKET_PURCHASED',
+  TicketRefunded: 'TICKET_REFUNDED'
+} as const;
+
+export type GqlTransactionReason = typeof GqlTransactionReason[keyof typeof GqlTransactionReason];
+export type GqlTransactionSortInput = {
+  createdAt?: InputMaybe<GqlSortDirection>;
+};
+
+export type GqlTransactionUpdateMetadataInput = {
+  comment?: InputMaybe<Scalars['String']['input']>;
+  images?: InputMaybe<Array<GqlImageInput>>;
+};
+
+export type GqlTransactionUpdateMetadataPayload = GqlTransactionUpdateMetadataSuccess;
+
+export type GqlTransactionUpdateMetadataSuccess = {
+  __typename?: 'TransactionUpdateMetadataSuccess';
+  transaction: GqlTransaction;
+};
+
+export type GqlTransactionVerificationResult = {
+  __typename?: 'TransactionVerificationResult';
+  label: Scalars['Int']['output'];
+  rootHash: Scalars['String']['output'];
+  status: GqlVerificationStatus;
+  transactionHash: Scalars['String']['output'];
+  txId: Scalars['ID']['output'];
+};
+
+export type GqlTransactionsConnection = {
+  __typename?: 'TransactionsConnection';
+  edges?: Maybe<Array<Maybe<GqlTransactionEdge>>>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type GqlUpdateReportTemplateInput = {
+  communityContext?: InputMaybe<Scalars['String']['input']>;
+  experimentKey?: InputMaybe<Scalars['String']['input']>;
+  isActive?: InputMaybe<Scalars['Boolean']['input']>;
+  isEnabled?: InputMaybe<Scalars['Boolean']['input']>;
+  maxTokens: Scalars['Int']['input'];
+  model: Scalars['String']['input'];
+  stopSequences?: InputMaybe<Array<Scalars['String']['input']>>;
+  systemPrompt: Scalars['String']['input'];
+  temperature?: InputMaybe<Scalars['Float']['input']>;
+  trafficWeight?: InputMaybe<Scalars['Int']['input']>;
+  userPromptTemplate: Scalars['String']['input'];
+};
+
+export type GqlUpdateReportTemplatePayload = GqlUpdateReportTemplateSuccess;
+
+export type GqlUpdateReportTemplateSuccess = {
+  __typename?: 'UpdateReportTemplateSuccess';
+  reportTemplate: GqlReportTemplate;
+};
+
+export type GqlUpdateSignupBonusConfigInput = {
+  bonusPoint: Scalars['Int']['input'];
+  isEnabled: Scalars['Boolean']['input'];
+  message?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type GqlUser = {
+  __typename?: 'User';
+  articlesAboutMe?: Maybe<Array<GqlArticle>>;
+  articlesWrittenByMe?: Maybe<Array<GqlArticle>>;
+  bio?: Maybe<Scalars['String']['output']>;
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
+  currentPrefecture?: Maybe<GqlCurrentPrefecture>;
+  didIssuanceRequests?: Maybe<Array<GqlDidIssuanceRequest>>;
+  evaluationCreatedByMe?: Maybe<Array<GqlEvaluationHistory>>;
+  evaluations?: Maybe<Array<GqlEvaluation>>;
+  id: Scalars['ID']['output'];
+  identities?: Maybe<Array<GqlIdentity>>;
+  image?: Maybe<Scalars['String']['output']>;
+  membershipChangedByMe?: Maybe<Array<GqlMembershipHistory>>;
+  memberships?: Maybe<Array<GqlMembership>>;
+  name: Scalars['String']['output'];
+  nftInstances?: Maybe<GqlNftInstancesConnection>;
+  nftWallet?: Maybe<GqlNftWallet>;
+  opportunitiesCreatedByMe?: Maybe<Array<GqlOpportunity>>;
+  participationStatusChangedByMe?: Maybe<Array<GqlParticipationStatusHistory>>;
+  participations?: Maybe<Array<GqlParticipation>>;
+  phoneNumber?: Maybe<Scalars['String']['output']>;
+  portfolios?: Maybe<Array<GqlPortfolio>>;
+  preferredLanguage?: Maybe<GqlLanguage>;
+  reservationStatusChangedByMe?: Maybe<Array<GqlReservationHistory>>;
+  reservations?: Maybe<Array<GqlReservation>>;
+  slug?: Maybe<Scalars['String']['output']>;
+  sysRole?: Maybe<GqlSysRole>;
+  ticketStatusChangedByMe?: Maybe<Array<GqlTicketStatusHistory>>;
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+  urlFacebook?: Maybe<Scalars['String']['output']>;
+  urlInstagram?: Maybe<Scalars['String']['output']>;
+  urlTiktok?: Maybe<Scalars['String']['output']>;
+  urlWebsite?: Maybe<Scalars['String']['output']>;
+  urlX?: Maybe<Scalars['String']['output']>;
+  urlYoutube?: Maybe<Scalars['String']['output']>;
+  wallets?: Maybe<Array<GqlWallet>>;
+};
+
+
+export type GqlUserNftInstancesArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlNftInstanceFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlNftInstanceSortInput>;
+};
+
+
+export type GqlUserPortfoliosArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<GqlPortfolioFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlPortfolioSortInput>;
+};
+
+export type GqlUserDeletePayload = {
+  __typename?: 'UserDeletePayload';
+  userId?: Maybe<Scalars['ID']['output']>;
+};
+
+/**
+ * ユーザー DID の chain anchor 1 件を表す。
+ * PENDING 状態でも返却される（§F: PENDING も resolver で配信）。
+ * chainTxHash / chainOpIndex / confirmedAt は CONFIRMED で初めて埋まる。
+ */
+export type GqlUserDidAnchor = {
+  __typename?: 'UserDidAnchor';
+  chainOpIndex?: Maybe<Scalars['Int']['output']>;
+  chainTxHash?: Maybe<Scalars['String']['output']>;
+  confirmedAt?: Maybe<Scalars['Datetime']['output']>;
+  createdAt: Scalars['Datetime']['output'];
+  did: Scalars['String']['output'];
+  documentHash: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  network: GqlChainNetwork;
+  operation: GqlDidOperation;
+  status: GqlAnchorStatus;
+  /**
+   * この DID anchor の所有ユーザー。
+   * Field resolver + 共通 `ctx.loaders.user` (DataLoader) 経由で解決される
+   * (§5.2.1 / Phase 1.5)。
+   *
+   * ユーザーが論理削除 / hard-delete されても anchor 行は履歴として残る
+   * ため、参照先 user が存在しないケースでは `null` を返す
+   * (deletion-safe; nullable)。
+   */
+  user?: Maybe<GqlUser>;
+};
+
+export type GqlUserEdge = GqlEdge & {
+  __typename?: 'UserEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlUser>;
+};
+
+export type GqlUserFilterInput = {
+  ids?: InputMaybe<Array<Scalars['ID']['input']>>;
+  keywords?: InputMaybe<Array<Scalars['String']['input']>>;
+  sysRole?: InputMaybe<GqlSysRole>;
+};
+
+export type GqlUserSignUpInput = {
+  currentPrefecture: GqlCurrentPrefecture;
+  image?: InputMaybe<GqlImageInput>;
+  lineRefreshToken?: InputMaybe<Scalars['String']['input']>;
+  lineTokenExpiresAt?: InputMaybe<Scalars['String']['input']>;
+  name: Scalars['String']['input'];
+  phoneAccessToken?: InputMaybe<Scalars['String']['input']>;
+  phoneNumber?: InputMaybe<Scalars['String']['input']>;
+  phoneRefreshToken?: InputMaybe<Scalars['String']['input']>;
+  phoneTokenExpiresAt?: InputMaybe<Scalars['String']['input']>;
+  phoneUid?: InputMaybe<Scalars['String']['input']>;
+  preferredLanguage?: InputMaybe<GqlLanguage>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type GqlUserSortInput = {
+  createdAt?: InputMaybe<GqlSortDirection>;
+};
+
+export type GqlUserUpdateProfileInput = {
+  bio?: InputMaybe<Scalars['String']['input']>;
+  currentPrefecture?: InputMaybe<GqlCurrentPrefecture>;
+  image?: InputMaybe<GqlImageInput>;
+  name: Scalars['String']['input'];
+  preferredLanguage?: InputMaybe<GqlLanguage>;
+  slug: Scalars['String']['input'];
+  urlFacebook?: InputMaybe<Scalars['String']['input']>;
+  urlInstagram?: InputMaybe<Scalars['String']['input']>;
+  urlTiktok?: InputMaybe<Scalars['String']['input']>;
+  urlWebsite?: InputMaybe<Scalars['String']['input']>;
+  urlX?: InputMaybe<Scalars['String']['input']>;
+  urlYoutube?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type GqlUserUpdateProfilePayload = GqlUserUpdateProfileSuccess;
+
+export type GqlUserUpdateProfileSuccess = {
+  __typename?: 'UserUpdateProfileSuccess';
+  user?: Maybe<GqlUser>;
+};
+
+export type GqlUsersConnection = {
+  __typename?: 'UsersConnection';
+  edges?: Maybe<Array<Maybe<GqlUserEdge>>>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type GqlUtilitiesConnection = {
+  __typename?: 'UtilitiesConnection';
+  edges?: Maybe<Array<Maybe<GqlUtilityEdge>>>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type GqlUtility = {
+  __typename?: 'Utility';
+  community?: Maybe<GqlCommunity>;
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  images?: Maybe<Array<Scalars['String']['output']>>;
+  name?: Maybe<Scalars['String']['output']>;
+  owner?: Maybe<GqlUser>;
+  pointsRequired: Scalars['Int']['output'];
+  publishStatus: GqlPublishStatus;
+  requiredForOpportunities?: Maybe<Array<GqlOpportunity>>;
+  ticketIssuers?: Maybe<Array<GqlTicketIssuer>>;
+  tickets?: Maybe<Array<GqlTicket>>;
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+};
+
+export type GqlUtilityCreateInput = {
+  description?: InputMaybe<Scalars['String']['input']>;
+  images?: InputMaybe<Array<GqlImageInput>>;
+  name: Scalars['String']['input'];
+  pointsRequired: Scalars['Int']['input'];
+  requiredForOpportunityIds?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
+export type GqlUtilityCreatePayload = GqlUtilityCreateSuccess;
+
+export type GqlUtilityCreateSuccess = {
+  __typename?: 'UtilityCreateSuccess';
+  utility: GqlUtility;
+};
+
+export type GqlUtilityDeletePayload = GqlUtilityDeleteSuccess;
+
+export type GqlUtilityDeleteSuccess = {
+  __typename?: 'UtilityDeleteSuccess';
+  utilityId: Scalars['String']['output'];
+};
+
+export type GqlUtilityEdge = GqlEdge & {
+  __typename?: 'UtilityEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlUtility>;
+};
+
+export type GqlUtilityFilterInput = {
+  and?: InputMaybe<Array<GqlUtilityFilterInput>>;
+  communityIds?: InputMaybe<Array<Scalars['ID']['input']>>;
+  not?: InputMaybe<GqlUtilityFilterInput>;
+  or?: InputMaybe<Array<GqlUtilityFilterInput>>;
+  ownerIds?: InputMaybe<Array<Scalars['ID']['input']>>;
+  publishStatus?: InputMaybe<Array<GqlPublishStatus>>;
+};
+
+export type GqlUtilitySetPublishStatusInput = {
+  publishStatus: GqlPublishStatus;
+};
+
+export type GqlUtilitySetPublishStatusPayload = GqlUtilitySetPublishStatusSuccess;
+
+export type GqlUtilitySetPublishStatusSuccess = {
+  __typename?: 'UtilitySetPublishStatusSuccess';
+  utility: GqlUtility;
+};
+
+export type GqlUtilitySortInput = {
+  createdAt?: InputMaybe<GqlSortDirection>;
+  pointsRequired?: InputMaybe<GqlSortDirection>;
+};
+
+export type GqlUtilityUpdateInfoInput = {
+  description?: InputMaybe<Scalars['String']['input']>;
+  images?: InputMaybe<Array<GqlImageInput>>;
+  name: Scalars['String']['input'];
+  pointsRequired: Scalars['Int']['input'];
+};
+
+export type GqlUtilityUpdateInfoPayload = GqlUtilityUpdateInfoSuccess;
+
+export type GqlUtilityUpdateInfoSuccess = {
+  __typename?: 'UtilityUpdateInfoSuccess';
+  utility: GqlUtility;
+};
+
+export const GqlValueType = {
+  Float: 'FLOAT',
+  Int: 'INT'
+} as const;
+
+export type GqlValueType = typeof GqlValueType[keyof typeof GqlValueType];
+/**
+ * VC のシリアライゼーション形式 (§4.1)。
+ * Phase 1 は INTERNAL_JWT のみ (§5.2.2)。
+ * IDENTUS_VC_PRISM は legacy 互換のため列挙のみ保持。
+ */
+export const GqlVcFormat = {
+  IdentusVcPrism: 'IDENTUS_VC_PRISM',
+  InternalJwt: 'INTERNAL_JWT'
+} as const;
+
+export type GqlVcFormat = typeof GqlVcFormat[keyof typeof GqlVcFormat];
+/**
+ * civicship が発行した内部 VC (§5.2.2)。
+ * 本体は anchor 待ちなしで COMPLETED として配信される。
+ * chain anchor の状態は別フィールドで管理されており、検証側はそれを参照する。
+ */
+export type GqlVcIssuance = {
+  __typename?: 'VcIssuance';
+  createdAt: Scalars['Datetime']['output'];
+  /**
+   * この VC が紐付く Evaluation (任意)。
+   * evaluationId が null のとき、または Evaluation が削除済みのときは null。
+   * Field resolver + 共通 `ctx.loaders.evaluation` (DataLoader) 経由で解決される。
+   */
+  evaluation?: Maybe<GqlEvaluation>;
+  evaluationId?: Maybe<Scalars['ID']['output']>;
+  id: Scalars['ID']['output'];
+  issuerDid: Scalars['String']['output'];
+  revokedAt?: Maybe<Scalars['Datetime']['output']>;
+  status: GqlVcIssuanceStatus;
+  statusListCredential?: Maybe<Scalars['String']['output']>;
+  statusListIndex?: Maybe<Scalars['Int']['output']>;
+  subjectDid: Scalars['String']['output'];
+  /**
+   * この VC の所有ユーザー。
+   * Field resolver + 共通 `ctx.loaders.user` (DataLoader) 経由で解決される
+   * (§5.2.2 / Phase 1.5)。
+   *
+   * ユーザーが論理削除 / hard-delete されても VC 行は履歴 / revocation 確認用
+   * として残るため、参照先 user が存在しないケースでは `null` を返す
+   * (deletion-safe; nullable)。
+   */
+  user?: Maybe<GqlUser>;
+  userId: Scalars['ID']['output'];
+  vcFormat: GqlVcFormat;
+  vcJwt: Scalars['String']['output'];
+};
+
+export type GqlVcIssuanceRequest = {
+  __typename?: 'VcIssuanceRequest';
+  completedAt?: Maybe<Scalars['Datetime']['output']>;
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
+  evaluation?: Maybe<GqlEvaluation>;
+  id: Scalars['ID']['output'];
+  processedAt?: Maybe<Scalars['Datetime']['output']>;
+  requestedAt?: Maybe<Scalars['Datetime']['output']>;
+  status: GqlVcIssuanceStatus;
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+  user?: Maybe<GqlUser>;
+};
+
+export type GqlVcIssuanceRequestEdge = GqlEdge & {
+  __typename?: 'VcIssuanceRequestEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlVcIssuanceRequest>;
+};
+
+export type GqlVcIssuanceRequestFilterInput = {
+  evaluationId?: InputMaybe<Scalars['ID']['input']>;
+  status?: InputMaybe<GqlVcIssuanceStatus>;
+  userIds?: InputMaybe<Array<Scalars['ID']['input']>>;
+};
+
+export type GqlVcIssuanceRequestSortInput = {
+  createdAt?: InputMaybe<GqlSortDirection>;
+  updatedAt?: InputMaybe<GqlSortDirection>;
+};
+
+export type GqlVcIssuanceRequestsConnection = {
+  __typename?: 'VcIssuanceRequestsConnection';
+  edges: Array<GqlVcIssuanceRequestEdge>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+/** VC issuance のライフサイクル状態 (§4.1)。 */
+export const GqlVcIssuanceStatus = {
+  Completed: 'COMPLETED',
+  Failed: 'FAILED',
+  InProgress: 'IN_PROGRESS',
+  Pending: 'PENDING',
+  Processing: 'PROCESSING'
+} as const;
+
+export type GqlVcIssuanceStatus = typeof GqlVcIssuanceStatus[keyof typeof GqlVcIssuanceStatus];
+export const GqlVerificationStatus = {
+  Error: 'ERROR',
+  NotVerified: 'NOT_VERIFIED',
+  Pending: 'PENDING',
+  Verified: 'VERIFIED'
+} as const;
+
+export type GqlVerificationStatus = typeof GqlVerificationStatus[keyof typeof GqlVerificationStatus];
+/**
+ * 個々の投票レコード。同一 (userId, topicId) に対し常に 1 レコード。
+ * 再投票は upsert で上書きされるため**投票履歴は保持されない**。
+ * 投票の取消（withdraw）は現時点で未サポート。
+ */
+export type GqlVoteBallot = {
+  __typename?: 'VoteBallot';
+  createdAt: Scalars['Datetime']['output'];
+  id: Scalars['ID']['output'];
+  option: GqlVoteOption;
+  /**
+   * 投票時点の power **スナップショット**。
+   * NFT_COUNT ポリシーの場合、投票後に NFT 保有数が変化しても本フィールドは変わらない
+   * （現時点の power は MyVoteEligibility.currentPower を参照）。
+   */
+  power: Scalars['Int']['output'];
+  /** 再投票（upsert）時に現在時刻で更新される。初回投票時は null。 */
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+};
+
+export type GqlVoteCastInput = {
+  optionId: Scalars['ID']['input'];
+  topicId: Scalars['ID']['input'];
+};
+
+export type GqlVoteCastPayload = GqlVoteCastSuccess;
+
+export type GqlVoteCastSuccess = {
+  __typename?: 'VoteCastSuccess';
+  ballot: GqlVoteBallot;
+};
+
+/**
+ * 誰が投票できるか（資格ゲート）。
+ * VotePowerPolicy（何票持つか）とは**独立に設定される**が、両方が NFT 系
+ * （Gate.type=NFT かつ PowerPolicy.type=NFT_COUNT）の場合に限り、参照する
+ * **nftTokenId は一致していなければならない**（バックエンドで検証、違反時は
+ * `VALIDATION_ERROR`）。異なる token を指定した場合、A 保有者のうち B 非保有者が
+ * eligible=true / currentPower=0 になる「投票しても効かない」状態が生じる設定ミスを防ぐため。
+ *
+ * 許容される組み合わせ:
+ * - Gate=NFT(A) + Policy=NFT_COUNT(A)  典型的
+ * - Gate=MEMBERSHIP + Policy=NFT_COUNT(A)  メンバー内で NFT ホルダーのみ重み付け（非ホルダーは power=0）
+ * - Gate=NFT(A) + Policy=FLAT  A 保有者は一律 1 票
+ * - Gate=MEMBERSHIP + Policy=FLAT  全員 1 票
+ */
+export type GqlVoteGate = {
+  __typename?: 'VoteGate';
+  id: Scalars['ID']['output'];
+  /** type=NFT のときの参照 NftToken */
+  nftToken?: Maybe<GqlNftToken>;
+  /** type=MEMBERSHIP のときに要求する最低ロール（未指定時は MEMBER 以上） */
+  requiredRole?: Maybe<GqlRole>;
+  type: GqlVoteGateType;
+};
+
+export type GqlVoteGateInput = {
+  /** type=NFT のとき必須。MEMBERSHIP のときは無視される。 */
+  nftTokenId?: InputMaybe<Scalars['ID']['input']>;
+  /** type=MEMBERSHIP のときに任意指定（未指定時は MEMBER 以上で可）。NFT のときは無視される。 */
+  requiredRole?: InputMaybe<GqlRole>;
+  type: GqlVoteGateType;
+};
+
+export const GqlVoteGateType = {
+  Membership: 'MEMBERSHIP',
+  Nft: 'NFT'
+} as const;
+
+export type GqlVoteGateType = typeof GqlVoteGateType[keyof typeof GqlVoteGateType];
+/**
+ * 投票選択肢。
+ * voteCount / totalPower は投票・再投票時にトランザクション内で直接更新される**非正規化カラム**で、
+ * 集計コストを O(1) に抑える。PowerPolicy=FLAT のとき voteCount == totalPower、
+ * NFT_COUNT では乖離する。一般的には勝敗判定に totalPower、参加者数表示に voteCount を使う。
+ */
+export type GqlVoteOption = {
+  __typename?: 'VoteOption';
+  id: Scalars['ID']['output'];
+  label: Scalars['String']['output'];
+  /**
+   * 作成時（VoteOptionInput）に指定した値がそのまま保持される。
+   * VoteTopic.options は本フィールドの昇順で返るため、UI 側で追加のソートは不要。
+   */
+  orderIndex: Scalars['Int']['output'];
+  /** 票の重み合計（= Σ power）。endsAt 到達前は一般ユーザーに null（管理者は常に実値を参照可）。 */
+  totalPower?: Maybe<Scalars['Int']['output']>;
+  /** 投票した**人数**。endsAt 到達前は一般ユーザーに null（管理者は常に実値を参照可）。 */
+  voteCount?: Maybe<Scalars['Int']['output']>;
+};
+
+export type GqlVoteOptionInput = {
+  label: Scalars['String']['input'];
+  /** 0 以上の整数。オプション間で重複不可。 */
+  orderIndex: Scalars['Int']['input'];
+};
+
+/**
+ * 投票の重み（1 人が何票持つか）を決めるポリシー。
+ * VoteGate（投票可能か）とは独立に設定される。
+ */
+export type GqlVotePowerPolicy = {
+  __typename?: 'VotePowerPolicy';
+  id: Scalars['ID']['output'];
+  /** type=NFT_COUNT のときに参照する NftToken（保有数を power とする） */
+  nftToken?: Maybe<GqlNftToken>;
+  type: GqlVotePowerPolicyType;
+};
+
+export type GqlVotePowerPolicyInput = {
+  /** type=NFT_COUNT のとき必須。FLAT のときは無視される。 */
+  nftTokenId?: InputMaybe<Scalars['ID']['input']>;
+  type: GqlVotePowerPolicyType;
+};
+
+export const GqlVotePowerPolicyType = {
+  Flat: 'FLAT',
+  NftCount: 'NFT_COUNT'
+} as const;
+
+export type GqlVotePowerPolicyType = typeof GqlVotePowerPolicyType[keyof typeof GqlVotePowerPolicyType];
+export type GqlVoteTopic = {
+  __typename?: 'VoteTopic';
+  community: GqlCommunity;
+  createdAt: Scalars['Datetime']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  endsAt: Scalars['Datetime']['output'];
+  gate: GqlVoteGate;
+  id: Scalars['ID']['output'];
+  /**
+   * ログインユーザーの投票（未ログイン・未投票は null）。
+   * MyVoteEligibility.myBallot と同じ値を返すため、一覧画面ではこちらを利用することを推奨
+   * （投票画面のように資格情報も必要な場合は myEligibility.myBallot を使う）。
+   */
+  myBallot?: Maybe<GqlVoteBallot>;
+  /** ログインユーザーの投票資格情報（未ログインは null）。 */
+  myEligibility?: Maybe<GqlMyVoteEligibility>;
+  /** 投票選択肢。orderIndex 昇順で返る（UI 側でのソートは不要）。 */
+  options: Array<GqlVoteOption>;
+  /**
+   * 現在フェーズ。**レスポンス時点でサーバ時刻から計算される値**であり DB カラムではない。
+   * 詳細は VoteTopicPhase の説明を参照。
+   */
+  phase: GqlVoteTopicPhase;
+  powerPolicy: GqlVotePowerPolicy;
+  startsAt: Scalars['Datetime']['output'];
+  title: Scalars['String']['output'];
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+};
+
+export type GqlVoteTopicCreateInput = {
+  communityId: Scalars['ID']['input'];
+  description?: InputMaybe<Scalars['String']['input']>;
+  endsAt: Scalars['Datetime']['input'];
+  gate: GqlVoteGateInput;
+  options: Array<GqlVoteOptionInput>;
+  powerPolicy: GqlVotePowerPolicyInput;
+  startsAt: Scalars['Datetime']['input'];
+  title: Scalars['String']['input'];
+};
+
+export type GqlVoteTopicCreatePayload = GqlVoteTopicCreateSuccess;
+
+export type GqlVoteTopicCreateSuccess = {
+  __typename?: 'VoteTopicCreateSuccess';
+  voteTopic: GqlVoteTopic;
+};
+
+export type GqlVoteTopicDeletePayload = GqlVoteTopicDeleteSuccess;
+
+export type GqlVoteTopicDeleteSuccess = {
+  __typename?: 'VoteTopicDeleteSuccess';
+  voteTopicId: Scalars['ID']['output'];
+};
+
+export type GqlVoteTopicEdge = {
+  __typename?: 'VoteTopicEdge';
+  cursor: Scalars['String']['output'];
+  node: GqlVoteTopic;
+};
+
+/**
+ * 投票テーマの現在フェーズ。
+ * startsAt / endsAt と現在時刻から**レスポンス時点で**計算される値で、DB カラムではない。
+ * 長時間開いたままの画面（カウントダウン等）ではクライアント側で古くなるため、
+ * 精密な期間判定には startsAt / endsAt を直接比較すること。一覧表示などでは phase を利用して構わない。
+ */
+export const GqlVoteTopicPhase = {
+  Closed: 'CLOSED',
+  Open: 'OPEN',
+  Upcoming: 'UPCOMING'
+} as const;
+
+export type GqlVoteTopicPhase = typeof GqlVoteTopicPhase[keyof typeof GqlVoteTopicPhase];
+/**
+ * voteTopicUpdate 用の入力。**既存の全フィールドを置き換える**（部分更新は未サポート）。
+ * options は delete → create で全量置換される。gate / powerPolicy も同様に再生成されるため、
+ * 既存の id 値は保持されない点に注意。UPCOMING フェーズ限定で呼ばれるため、投票は存在しない前提。
+ */
+export type GqlVoteTopicUpdateInput = {
+  description?: InputMaybe<Scalars['String']['input']>;
+  endsAt: Scalars['Datetime']['input'];
+  gate: GqlVoteGateInput;
+  options: Array<GqlVoteOptionInput>;
+  powerPolicy: GqlVotePowerPolicyInput;
+  startsAt: Scalars['Datetime']['input'];
+  title: Scalars['String']['input'];
+};
+
+export type GqlVoteTopicUpdatePayload = GqlVoteTopicUpdateSuccess;
+
+export type GqlVoteTopicUpdateSuccess = {
+  __typename?: 'VoteTopicUpdateSuccess';
+  voteTopic: GqlVoteTopic;
+};
+
+export type GqlVoteTopicsConnection = {
+  __typename?: 'VoteTopicsConnection';
+  edges: Array<GqlVoteTopicEdge>;
+  nodes: Array<GqlVoteTopic>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type GqlWallet = {
+  __typename?: 'Wallet';
+  accumulatedPointView?: Maybe<GqlAccumulatedPointView>;
+  community?: Maybe<GqlCommunity>;
+  createdAt?: Maybe<Scalars['Datetime']['output']>;
+  currentPointView?: Maybe<GqlCurrentPointView>;
+  id: Scalars['ID']['output'];
+  tickets?: Maybe<Array<GqlTicket>>;
+  /** @deprecated Use transactionsConnection for pagination support */
+  transactions?: Maybe<Array<GqlTransaction>>;
+  transactionsConnection?: Maybe<GqlTransactionsConnection>;
+  type: GqlWalletType;
+  updatedAt?: Maybe<Scalars['Datetime']['output']>;
+  user?: Maybe<GqlUser>;
+};
+
+
+export type GqlWalletTransactionsConnectionArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<GqlTransactionSortInput>;
+};
+
+export type GqlWalletEdge = GqlEdge & {
+  __typename?: 'WalletEdge';
+  cursor: Scalars['String']['output'];
+  node?: Maybe<GqlWallet>;
+};
+
+export type GqlWalletFilterInput = {
+  communityId?: InputMaybe<Scalars['ID']['input']>;
+  type?: InputMaybe<GqlWalletType>;
+  userId?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type GqlWalletSortInput = {
+  createdAt?: InputMaybe<GqlSortDirection>;
+};
+
+export const GqlWalletType = {
+  Community: 'COMMUNITY',
+  Member: 'MEMBER'
+} as const;
+
+export type GqlWalletType = typeof GqlWalletType[keyof typeof GqlWalletType];
+export type GqlWalletsConnection = {
+  __typename?: 'WalletsConnection';
+  edges?: Maybe<Array<Maybe<GqlWalletEdge>>>;
+  pageInfo: GqlPageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type WithIndex<TObject> = TObject & Record<string, any>;
+export type ResolversObject<TObject> = WithIndex<TObject>;
+
+export type ResolverTypeWrapper<T> = Promise<T> | T;
+
+
+export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> = ResolverFn<TResult, TParent, TContext, TArgs> | ResolverWithResolve<TResult, TParent, TContext, TArgs>;
+
+export type ResolverFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Promise<TResult> | TResult;
+
+export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => AsyncIterable<TResult> | Promise<AsyncIterable<TResult>>;
+
+export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
+  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
+}
+
+export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+}
+
+export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
+  | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
+  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+
+export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
+  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
+
+export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
+  parent: TParent,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
+
+export type IsTypeOfResolverFn<T = {}, TContext = {}> = (obj: T, context: TContext, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
+
+export type NextResolverFn<T> = () => Promise<T>;
+
+export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
+  next: NextResolverFn<TResult>,
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+/** Mapping of union types */
+export type GqlResolversUnionTypes<_RefType extends Record<string, unknown>> = ResolversObject<{
+  ApproveReportPayload: ( Omit<GqlApproveReportSuccess, 'report'> & { report: _RefType['Report'] } );
+  ArticleCreatePayload: ( Omit<GqlArticleCreateSuccess, 'article'> & { article: _RefType['Article'] } );
+  ArticleDeletePayload: ( GqlArticleDeleteSuccess );
+  ArticleUpdateContentPayload: ( Omit<GqlArticleUpdateContentSuccess, 'article'> & { article: _RefType['Article'] } );
+  CommunityCreatePayload: ( Omit<GqlCommunityCreateSuccess, 'community'> & { community: _RefType['Community'] } );
+  CommunityDeletePayload: ( GqlCommunityDeleteSuccess );
+  CommunityUpdateProfilePayload: ( Omit<GqlCommunityUpdateProfileSuccess, 'community'> & { community: _RefType['Community'] } );
+  EvaluationBulkCreatePayload: ( Omit<GqlEvaluationBulkCreateSuccess, 'evaluations'> & { evaluations: Array<_RefType['Evaluation']> } );
+  GenerateReportPayload: ( Omit<GqlGenerateReportSuccess, 'report'> & { report: _RefType['Report'] } );
+  IncentiveGrantRetryPayload: ( Omit<GqlIncentiveGrantRetrySuccess, 'incentiveGrant' | 'transaction'> & { incentiveGrant: _RefType['IncentiveGrant'], transaction?: Maybe<_RefType['Transaction']> } );
+  MembershipInvitePayload: ( Omit<GqlMembershipInviteSuccess, 'membership'> & { membership: _RefType['Membership'] } );
+  MembershipRemovePayload: ( GqlMembershipRemoveSuccess );
+  MembershipSetInvitationStatusPayload: ( Omit<GqlMembershipSetInvitationStatusSuccess, 'membership'> & { membership: _RefType['Membership'] } );
+  MembershipSetRolePayload: ( Omit<GqlMembershipSetRoleSuccess, 'membership'> & { membership: _RefType['Membership'] } );
+  MembershipWithdrawPayload: ( GqlMembershipWithdrawSuccess );
+  OpportunityCreatePayload: ( Omit<GqlOpportunityCreateSuccess, 'opportunity'> & { opportunity: _RefType['Opportunity'] } );
+  OpportunityDeletePayload: ( GqlOpportunityDeleteSuccess );
+  OpportunitySetPublishStatusPayload: ( Omit<GqlOpportunitySetPublishStatusSuccess, 'opportunity'> & { opportunity: _RefType['Opportunity'] } );
+  OpportunitySlotCreatePayload: ( Omit<GqlOpportunitySlotCreateSuccess, 'slot'> & { slot: _RefType['OpportunitySlot'] } );
+  OpportunitySlotSetHostingStatusPayload: ( Omit<GqlOpportunitySlotSetHostingStatusSuccess, 'slot'> & { slot: _RefType['OpportunitySlot'] } );
+  OpportunitySlotsBulkUpdatePayload: ( Omit<GqlOpportunitySlotsBulkUpdateSuccess, 'slots'> & { slots: Array<_RefType['OpportunitySlot']> } );
+  OpportunityUpdateContentPayload: ( Omit<GqlOpportunityUpdateContentSuccess, 'opportunity'> & { opportunity: _RefType['Opportunity'] } );
+  ParticipationBulkCreatePayload: ( Omit<GqlParticipationBulkCreateSuccess, 'participations'> & { participations: Array<_RefType['Participation']> } );
+  ParticipationCreatePersonalRecordPayload: ( Omit<GqlParticipationCreatePersonalRecordSuccess, 'participation'> & { participation: _RefType['Participation'] } );
+  ParticipationDeletePayload: ( GqlParticipationDeleteSuccess );
+  PlaceCreatePayload: ( Omit<GqlPlaceCreateSuccess, 'place'> & { place: _RefType['Place'] } );
+  PlaceDeletePayload: ( GqlPlaceDeleteSuccess );
+  PlaceUpdatePayload: ( Omit<GqlPlaceUpdateSuccess, 'place'> & { place: _RefType['Place'] } );
+  PublishReportPayload: ( Omit<GqlPublishReportSuccess, 'report'> & { report: _RefType['Report'] } );
+  RejectReportPayload: ( Omit<GqlRejectReportSuccess, 'report'> & { report: _RefType['Report'] } );
+  ReservationCreatePayload: ( Omit<GqlReservationCreateSuccess, 'reservation'> & { reservation: _RefType['Reservation'] } );
+  ReservationSetStatusPayload: ( Omit<GqlReservationSetStatusSuccess, 'reservation'> & { reservation: _RefType['Reservation'] } );
+  SubmitReportFeedbackPayload: ( Omit<GqlSubmitReportFeedbackSuccess, 'feedback'> & { feedback: _RefType['ReportFeedback'] } );
+  TicketClaimPayload: ( Omit<GqlTicketClaimSuccess, 'tickets'> & { tickets: Array<_RefType['Ticket']> } );
+  TicketIssuePayload: ( Omit<GqlTicketIssueSuccess, 'issue'> & { issue: _RefType['TicketIssuer'] } );
+  TicketPurchasePayload: ( Omit<GqlTicketPurchaseSuccess, 'ticket'> & { ticket: _RefType['Ticket'] } );
+  TicketRefundPayload: ( Omit<GqlTicketRefundSuccess, 'ticket'> & { ticket: _RefType['Ticket'] } );
+  TicketUsePayload: ( Omit<GqlTicketUseSuccess, 'ticket'> & { ticket: _RefType['Ticket'] } );
+  TransactionDonateSelfPointPayload: ( Omit<GqlTransactionDonateSelfPointSuccess, 'transaction'> & { transaction: _RefType['Transaction'] } );
+  TransactionGrantCommunityPointPayload: ( Omit<GqlTransactionGrantCommunityPointSuccess, 'transaction'> & { transaction: _RefType['Transaction'] } );
+  TransactionIssueCommunityPointPayload: ( Omit<GqlTransactionIssueCommunityPointSuccess, 'transaction'> & { transaction: _RefType['Transaction'] } );
+  TransactionUpdateMetadataPayload: ( Omit<GqlTransactionUpdateMetadataSuccess, 'transaction'> & { transaction: _RefType['Transaction'] } );
+  UpdateReportTemplatePayload: ( Omit<GqlUpdateReportTemplateSuccess, 'reportTemplate'> & { reportTemplate: _RefType['ReportTemplate'] } );
+  UserUpdateProfilePayload: ( Omit<GqlUserUpdateProfileSuccess, 'user'> & { user?: Maybe<_RefType['User']> } );
+  UtilityCreatePayload: ( Omit<GqlUtilityCreateSuccess, 'utility'> & { utility: _RefType['Utility'] } );
+  UtilityDeletePayload: ( GqlUtilityDeleteSuccess );
+  UtilitySetPublishStatusPayload: ( Omit<GqlUtilitySetPublishStatusSuccess, 'utility'> & { utility: _RefType['Utility'] } );
+  UtilityUpdateInfoPayload: ( Omit<GqlUtilityUpdateInfoSuccess, 'utility'> & { utility: _RefType['Utility'] } );
+  VoteCastPayload: ( GqlVoteCastSuccess );
+  VoteTopicCreatePayload: ( Omit<GqlVoteTopicCreateSuccess, 'voteTopic'> & { voteTopic: _RefType['VoteTopic'] } );
+  VoteTopicDeletePayload: ( GqlVoteTopicDeleteSuccess );
+  VoteTopicUpdatePayload: ( Omit<GqlVoteTopicUpdateSuccess, 'voteTopic'> & { voteTopic: _RefType['VoteTopic'] } );
+}>;
+
+/** Mapping of interface types */
+export type GqlResolversInterfaceTypes<_RefType extends Record<string, unknown>> = ResolversObject<{
+  Edge: ( Omit<GqlAdminReportSummaryEdge, 'node'> & { node?: Maybe<_RefType['AdminReportSummaryRow']> } ) | ( Omit<GqlArticleEdge, 'node'> & { node?: Maybe<_RefType['Article']> } ) | ( Omit<GqlCityEdge, 'node'> & { node?: Maybe<_RefType['City']> } ) | ( Omit<GqlCommunityEdge, 'node'> & { node?: Maybe<_RefType['Community']> } ) | ( Omit<GqlEvaluationEdge, 'node'> & { node?: Maybe<_RefType['Evaluation']> } ) | ( Omit<GqlEvaluationHistoryEdge, 'node'> & { node?: Maybe<_RefType['EvaluationHistory']> } ) | ( Omit<GqlIncentiveGrantEdge, 'node'> & { node?: Maybe<_RefType['IncentiveGrant']> } ) | ( Omit<GqlMembershipEdge, 'node'> & { node?: Maybe<_RefType['Membership']> } ) | ( Omit<GqlNftInstanceEdge, 'node'> & { node: _RefType['NftInstance'] } ) | ( Omit<GqlNftTokenEdge, 'node'> & { node: _RefType['NftToken'] } ) | ( Omit<GqlOpportunityEdge, 'node'> & { node?: Maybe<_RefType['Opportunity']> } ) | ( Omit<GqlOpportunitySlotEdge, 'node'> & { node?: Maybe<_RefType['OpportunitySlot']> } ) | ( Omit<GqlParticipationEdge, 'node'> & { node?: Maybe<_RefType['Participation']> } ) | ( Omit<GqlParticipationStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['ParticipationStatusHistory']> } ) | ( Omit<GqlPlaceEdge, 'node'> & { node?: Maybe<_RefType['Place']> } ) | ( Omit<GqlPortfolioEdge, 'node'> & { node?: Maybe<_RefType['Portfolio']> } ) | ( Omit<GqlReportEdge, 'node'> & { node?: Maybe<_RefType['Report']> } ) | ( Omit<GqlReportFeedbackEdge, 'node'> & { node?: Maybe<_RefType['ReportFeedback']> } ) | ( GqlReportTemplateStatsBreakdownEdge ) | ( Omit<GqlReservationEdge, 'node'> & { node?: Maybe<_RefType['Reservation']> } ) | ( Omit<GqlReservationHistoryEdge, 'node'> & { node?: Maybe<_RefType['ReservationHistory']> } ) | ( Omit<GqlStateEdge, 'node'> & { node?: Maybe<_RefType['State']> } ) | ( Omit<GqlTicketClaimLinkEdge, 'node'> & { node?: Maybe<_RefType['TicketClaimLink']> } ) | ( Omit<GqlTicketEdge, 'node'> & { node?: Maybe<_RefType['Ticket']> } ) | ( Omit<GqlTicketIssuerEdge, 'node'> & { node?: Maybe<_RefType['TicketIssuer']> } ) | ( Omit<GqlTicketStatusHistoryEdge, 'node'> & { node?: Maybe<_RefType['TicketStatusHistory']> } ) | ( Omit<GqlTransactionEdge, 'node'> & { node?: Maybe<_RefType['Transaction']> } ) | ( Omit<GqlUserEdge, 'node'> & { node?: Maybe<_RefType['User']> } ) | ( Omit<GqlUtilityEdge, 'node'> & { node?: Maybe<_RefType['Utility']> } ) | ( Omit<GqlVcIssuanceRequestEdge, 'node'> & { node?: Maybe<_RefType['VcIssuanceRequest']> } ) | ( Omit<GqlWalletEdge, 'node'> & { node?: Maybe<_RefType['Wallet']> } );
+  TransactionChainParticipant: ( GqlTransactionChainCommunity ) | ( GqlTransactionChainUser );
+}>;
+
+/** Mapping between all available schema types and the resolvers types */
+export type GqlResolversTypes = ResolversObject<{
+  AccumulatedPointView: ResolverTypeWrapper<AccumulatedPointView>;
+  AdminReportSummaryConnection: ResolverTypeWrapper<Omit<GqlAdminReportSummaryConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['AdminReportSummaryEdge']>>> }>;
+  AdminReportSummaryEdge: ResolverTypeWrapper<Omit<GqlAdminReportSummaryEdge, 'node'> & { node?: Maybe<GqlResolversTypes['AdminReportSummaryRow']> }>;
+  AdminReportSummaryRow: ResolverTypeWrapper<Omit<GqlAdminReportSummaryRow, 'community' | 'lastPublishedReport'> & { community: GqlResolversTypes['Community'], lastPublishedReport?: Maybe<GqlResolversTypes['Report']> }>;
+  AdminTemplateFeedbackStats: ResolverTypeWrapper<GqlAdminTemplateFeedbackStats>;
+  AnalyticsChainDepthBucket: ResolverTypeWrapper<GqlAnalyticsChainDepthBucket>;
+  AnalyticsCohortFunnelPoint: ResolverTypeWrapper<GqlAnalyticsCohortFunnelPoint>;
+  AnalyticsCohortRetentionPoint: ResolverTypeWrapper<GqlAnalyticsCohortRetentionPoint>;
+  AnalyticsCommunityAlerts: ResolverTypeWrapper<GqlAnalyticsCommunityAlerts>;
+  AnalyticsCommunityInput: GqlAnalyticsCommunityInput;
+  AnalyticsCommunityOverview: ResolverTypeWrapper<GqlAnalyticsCommunityOverview>;
+  AnalyticsCommunityPayload: ResolverTypeWrapper<GqlAnalyticsCommunityPayload>;
+  AnalyticsCommunitySummaryCard: ResolverTypeWrapper<GqlAnalyticsCommunitySummaryCard>;
+  AnalyticsDashboardInput: GqlAnalyticsDashboardInput;
+  AnalyticsDashboardPayload: ResolverTypeWrapper<GqlAnalyticsDashboardPayload>;
+  AnalyticsLatestCohort: ResolverTypeWrapper<GqlAnalyticsLatestCohort>;
+  AnalyticsMemberList: ResolverTypeWrapper<GqlAnalyticsMemberList>;
+  AnalyticsMemberRow: ResolverTypeWrapper<GqlAnalyticsMemberRow>;
+  AnalyticsMonthlyActivityPoint: ResolverTypeWrapper<GqlAnalyticsMonthlyActivityPoint>;
+  AnalyticsPlatformSummary: ResolverTypeWrapper<GqlAnalyticsPlatformSummary>;
+  AnalyticsRetentionTrendPoint: ResolverTypeWrapper<GqlAnalyticsRetentionTrendPoint>;
+  AnalyticsSegmentCounts: ResolverTypeWrapper<GqlAnalyticsSegmentCounts>;
+  AnalyticsSegmentThresholdsInput: GqlAnalyticsSegmentThresholdsInput;
+  AnalyticsSortOrder: GqlAnalyticsSortOrder;
+  AnalyticsStageBucket: ResolverTypeWrapper<GqlAnalyticsStageBucket>;
+  AnalyticsStageDistribution: ResolverTypeWrapper<GqlAnalyticsStageDistribution>;
+  AnalyticsTenureDistribution: ResolverTypeWrapper<GqlAnalyticsTenureDistribution>;
+  AnalyticsTenureHistogramBucket: ResolverTypeWrapper<GqlAnalyticsTenureHistogramBucket>;
+  AnalyticsUserListFilter: GqlAnalyticsUserListFilter;
+  AnalyticsUserListSort: GqlAnalyticsUserListSort;
+  AnalyticsUserSortField: GqlAnalyticsUserSortField;
+  AnalyticsWeeklyRetention: ResolverTypeWrapper<GqlAnalyticsWeeklyRetention>;
+  AnalyticsWindowActivity: ResolverTypeWrapper<GqlAnalyticsWindowActivity>;
+  AnchorStatus: GqlAnchorStatus;
+  ApproveReportPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['ApproveReportPayload']>;
+  ApproveReportSuccess: ResolverTypeWrapper<Omit<GqlApproveReportSuccess, 'report'> & { report: GqlResolversTypes['Report'] }>;
+  Article: ResolverTypeWrapper<Article>;
+  ArticleCategory: GqlArticleCategory;
+  ArticleCreateInput: GqlArticleCreateInput;
+  ArticleCreatePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['ArticleCreatePayload']>;
+  ArticleCreateSuccess: ResolverTypeWrapper<Omit<GqlArticleCreateSuccess, 'article'> & { article: GqlResolversTypes['Article'] }>;
+  ArticleDeletePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['ArticleDeletePayload']>;
+  ArticleDeleteSuccess: ResolverTypeWrapper<GqlArticleDeleteSuccess>;
+  ArticleEdge: ResolverTypeWrapper<Omit<GqlArticleEdge, 'node'> & { node?: Maybe<GqlResolversTypes['Article']> }>;
+  ArticleFilterInput: GqlArticleFilterInput;
+  ArticleSortInput: GqlArticleSortInput;
+  ArticleUpdateContentInput: GqlArticleUpdateContentInput;
+  ArticleUpdateContentPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['ArticleUpdateContentPayload']>;
+  ArticleUpdateContentSuccess: ResolverTypeWrapper<Omit<GqlArticleUpdateContentSuccess, 'article'> & { article: GqlResolversTypes['Article'] }>;
+  ArticlesConnection: ResolverTypeWrapper<Omit<GqlArticlesConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['ArticleEdge']>>> }>;
+  AuthZDirectiveCompositeRulesInput: GqlAuthZDirectiveCompositeRulesInput;
+  AuthZDirectiveDeepCompositeRulesInput: GqlAuthZDirectiveDeepCompositeRulesInput;
+  AuthZRules: GqlAuthZRules;
+  BigInt: ResolverTypeWrapper<Scalars['BigInt']['output']>;
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
+  ChainNetwork: GqlChainNetwork;
+  CheckCommunityPermissionInput: GqlCheckCommunityPermissionInput;
+  CheckIsSelfPermissionInput: GqlCheckIsSelfPermissionInput;
+  CheckOpportunityPermissionInput: GqlCheckOpportunityPermissionInput;
+  CitiesConnection: ResolverTypeWrapper<Omit<GqlCitiesConnection, 'edges'> & { edges: Array<GqlResolversTypes['CityEdge']> }>;
+  CitiesInput: GqlCitiesInput;
+  CitiesSortInput: GqlCitiesSortInput;
+  City: ResolverTypeWrapper<City>;
+  CityEdge: ResolverTypeWrapper<Omit<GqlCityEdge, 'node'> & { node?: Maybe<GqlResolversTypes['City']> }>;
+  ClaimLinkStatus: GqlClaimLinkStatus;
+  CommonDocumentOverrides: ResolverTypeWrapper<GqlCommonDocumentOverrides>;
+  CommonDocumentOverridesInput: GqlCommonDocumentOverridesInput;
+  CommunitiesConnection: ResolverTypeWrapper<Omit<GqlCommunitiesConnection, 'edges'> & { edges?: Maybe<Array<GqlResolversTypes['CommunityEdge']>> }>;
+  Community: ResolverTypeWrapper<Community>;
+  CommunityConfig: ResolverTypeWrapper<GqlCommunityConfig>;
+  CommunityConfigInput: GqlCommunityConfigInput;
+  CommunityCreateInput: GqlCommunityCreateInput;
+  CommunityCreatePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['CommunityCreatePayload']>;
+  CommunityCreateSuccess: ResolverTypeWrapper<Omit<GqlCommunityCreateSuccess, 'community'> & { community: GqlResolversTypes['Community'] }>;
+  CommunityDeletePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['CommunityDeletePayload']>;
+  CommunityDeleteSuccess: ResolverTypeWrapper<GqlCommunityDeleteSuccess>;
+  CommunityDocument: ResolverTypeWrapper<GqlCommunityDocument>;
+  CommunityDocumentInput: GqlCommunityDocumentInput;
+  CommunityEdge: ResolverTypeWrapper<Omit<GqlCommunityEdge, 'node'> & { node?: Maybe<GqlResolversTypes['Community']> }>;
+  CommunityFilterInput: GqlCommunityFilterInput;
+  CommunityFirebaseConfig: ResolverTypeWrapper<GqlCommunityFirebaseConfig>;
+  CommunityLineConfig: ResolverTypeWrapper<GqlCommunityLineConfig>;
+  CommunityLineConfigInput: GqlCommunityLineConfigInput;
+  CommunityLineRichMenuConfig: ResolverTypeWrapper<GqlCommunityLineRichMenuConfig>;
+  CommunityLineRichMenuConfigInput: GqlCommunityLineRichMenuConfigInput;
+  CommunityPortalConfig: ResolverTypeWrapper<GqlCommunityPortalConfig>;
+  CommunityPortalConfigInput: GqlCommunityPortalConfigInput;
+  CommunitySignupBonusConfig: ResolverTypeWrapper<GqlCommunitySignupBonusConfig>;
+  CommunitySortInput: GqlCommunitySortInput;
+  CommunityUpdateProfileInput: GqlCommunityUpdateProfileInput;
+  CommunityUpdateProfilePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['CommunityUpdateProfilePayload']>;
+  CommunityUpdateProfileSuccess: ResolverTypeWrapper<Omit<GqlCommunityUpdateProfileSuccess, 'community'> & { community: GqlResolversTypes['Community'] }>;
+  CreateUserDidInput: GqlCreateUserDidInput;
+  CurrentPointView: ResolverTypeWrapper<CurrentPointView>;
+  CurrentPrefecture: GqlCurrentPrefecture;
+  CurrentUserPayload: ResolverTypeWrapper<Omit<GqlCurrentUserPayload, 'user'> & { user?: Maybe<GqlResolversTypes['User']> }>;
+  DateTimeRangeFilter: GqlDateTimeRangeFilter;
+  Datetime: ResolverTypeWrapper<Scalars['Datetime']['output']>;
+  Decimal: ResolverTypeWrapper<Scalars['Decimal']['output']>;
+  DidIssuanceRequest: ResolverTypeWrapper<GqlDidIssuanceRequest>;
+  DidIssuanceStatus: GqlDidIssuanceStatus;
+  DidOperation: GqlDidOperation;
+  Edge: ResolverTypeWrapper<GqlResolversInterfaceTypes<GqlResolversTypes>['Edge']>;
+  Error: ResolverTypeWrapper<GqlError>;
+  ErrorCode: GqlErrorCode;
+  Evaluation: ResolverTypeWrapper<Omit<GqlEvaluation, 'evaluator' | 'histories' | 'participation' | 'vcIssuanceRequest'> & { evaluator?: Maybe<GqlResolversTypes['User']>, histories?: Maybe<Array<GqlResolversTypes['EvaluationHistory']>>, participation?: Maybe<GqlResolversTypes['Participation']>, vcIssuanceRequest?: Maybe<GqlResolversTypes['VcIssuanceRequest']> }>;
+  EvaluationBulkCreateInput: GqlEvaluationBulkCreateInput;
+  EvaluationBulkCreatePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['EvaluationBulkCreatePayload']>;
+  EvaluationBulkCreateSuccess: ResolverTypeWrapper<Omit<GqlEvaluationBulkCreateSuccess, 'evaluations'> & { evaluations: Array<GqlResolversTypes['Evaluation']> }>;
+  EvaluationCreateInput: GqlEvaluationCreateInput;
+  EvaluationEdge: ResolverTypeWrapper<Omit<GqlEvaluationEdge, 'node'> & { node?: Maybe<GqlResolversTypes['Evaluation']> }>;
+  EvaluationFilterInput: GqlEvaluationFilterInput;
+  EvaluationHistoriesConnection: ResolverTypeWrapper<Omit<GqlEvaluationHistoriesConnection, 'edges'> & { edges: Array<GqlResolversTypes['EvaluationHistoryEdge']> }>;
+  EvaluationHistory: ResolverTypeWrapper<Omit<GqlEvaluationHistory, 'createdByUser' | 'evaluation'> & { createdByUser?: Maybe<GqlResolversTypes['User']>, evaluation?: Maybe<GqlResolversTypes['Evaluation']> }>;
+  EvaluationHistoryEdge: ResolverTypeWrapper<Omit<GqlEvaluationHistoryEdge, 'node'> & { node?: Maybe<GqlResolversTypes['EvaluationHistory']> }>;
+  EvaluationHistoryFilterInput: GqlEvaluationHistoryFilterInput;
+  EvaluationHistorySortInput: GqlEvaluationHistorySortInput;
+  EvaluationItem: GqlEvaluationItem;
+  EvaluationSortInput: GqlEvaluationSortInput;
+  EvaluationStatus: GqlEvaluationStatus;
+  EvaluationsConnection: ResolverTypeWrapper<Omit<GqlEvaluationsConnection, 'edges'> & { edges: Array<GqlResolversTypes['EvaluationEdge']> }>;
+  Float: ResolverTypeWrapper<Scalars['Float']['output']>;
+  GenerateReportInput: GqlGenerateReportInput;
+  GenerateReportPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['GenerateReportPayload']>;
+  GenerateReportSuccess: ResolverTypeWrapper<Omit<GqlGenerateReportSuccess, 'report'> & { report: GqlResolversTypes['Report'] }>;
+  ID: ResolverTypeWrapper<Scalars['ID']['output']>;
+  Identity: ResolverTypeWrapper<Omit<GqlIdentity, 'user'> & { user?: Maybe<GqlResolversTypes['User']> }>;
+  IdentityCheckPhoneUserInput: GqlIdentityCheckPhoneUserInput;
+  IdentityCheckPhoneUserPayload: ResolverTypeWrapper<Omit<GqlIdentityCheckPhoneUserPayload, 'membership' | 'user'> & { membership?: Maybe<GqlResolversTypes['Membership']>, user?: Maybe<GqlResolversTypes['User']> }>;
+  IdentityPlatform: GqlIdentityPlatform;
+  ImageInput: GqlImageInput;
+  IncentiveGrant: ResolverTypeWrapper<Omit<GqlIncentiveGrant, 'community' | 'transaction' | 'user'> & { community?: Maybe<GqlResolversTypes['Community']>, transaction?: Maybe<GqlResolversTypes['Transaction']>, user?: Maybe<GqlResolversTypes['User']> }>;
+  IncentiveGrantEdge: ResolverTypeWrapper<Omit<GqlIncentiveGrantEdge, 'node'> & { node?: Maybe<GqlResolversTypes['IncentiveGrant']> }>;
+  IncentiveGrantFailureCode: GqlIncentiveGrantFailureCode;
+  IncentiveGrantFilterInput: GqlIncentiveGrantFilterInput;
+  IncentiveGrantRetryInput: GqlIncentiveGrantRetryInput;
+  IncentiveGrantRetryPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['IncentiveGrantRetryPayload']>;
+  IncentiveGrantRetrySuccess: ResolverTypeWrapper<Omit<GqlIncentiveGrantRetrySuccess, 'incentiveGrant' | 'transaction'> & { incentiveGrant: GqlResolversTypes['IncentiveGrant'], transaction?: Maybe<GqlResolversTypes['Transaction']> }>;
+  IncentiveGrantSortInput: GqlIncentiveGrantSortInput;
+  IncentiveGrantStatus: GqlIncentiveGrantStatus;
+  IncentiveGrantType: GqlIncentiveGrantType;
+  IncentiveGrantsConnection: ResolverTypeWrapper<Omit<GqlIncentiveGrantsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['IncentiveGrantEdge']>>> }>;
+  Int: ResolverTypeWrapper<Scalars['Int']['output']>;
+  IssueVcInput: GqlIssueVcInput;
+  JSON: ResolverTypeWrapper<Scalars['JSON']['output']>;
+  Language: GqlLanguage;
+  LineRichMenuType: GqlLineRichMenuType;
+  LinkPhoneAuthInput: GqlLinkPhoneAuthInput;
+  LinkPhoneAuthPayload: ResolverTypeWrapper<Omit<GqlLinkPhoneAuthPayload, 'user'> & { user?: Maybe<GqlResolversTypes['User']> }>;
+  Membership: ResolverTypeWrapper<Membership>;
+  MembershipCursorInput: GqlMembershipCursorInput;
+  MembershipEdge: ResolverTypeWrapper<Omit<GqlMembershipEdge, 'node'> & { node?: Maybe<GqlResolversTypes['Membership']> }>;
+  MembershipFilterInput: GqlMembershipFilterInput;
+  MembershipHistory: ResolverTypeWrapper<MembershipHistory>;
+  MembershipInviteInput: GqlMembershipInviteInput;
+  MembershipInvitePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['MembershipInvitePayload']>;
+  MembershipInviteSuccess: ResolverTypeWrapper<Omit<GqlMembershipInviteSuccess, 'membership'> & { membership: GqlResolversTypes['Membership'] }>;
+  MembershipRemoveInput: GqlMembershipRemoveInput;
+  MembershipRemovePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['MembershipRemovePayload']>;
+  MembershipRemoveSuccess: ResolverTypeWrapper<GqlMembershipRemoveSuccess>;
+  MembershipSetInvitationStatusInput: GqlMembershipSetInvitationStatusInput;
+  MembershipSetInvitationStatusPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['MembershipSetInvitationStatusPayload']>;
+  MembershipSetInvitationStatusSuccess: ResolverTypeWrapper<Omit<GqlMembershipSetInvitationStatusSuccess, 'membership'> & { membership: GqlResolversTypes['Membership'] }>;
+  MembershipSetRoleInput: GqlMembershipSetRoleInput;
+  MembershipSetRolePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['MembershipSetRolePayload']>;
+  MembershipSetRoleSuccess: ResolverTypeWrapper<Omit<GqlMembershipSetRoleSuccess, 'membership'> & { membership: GqlResolversTypes['Membership'] }>;
+  MembershipSortInput: GqlMembershipSortInput;
+  MembershipStatus: GqlMembershipStatus;
+  MembershipStatusReason: GqlMembershipStatusReason;
+  MembershipWithdrawInput: GqlMembershipWithdrawInput;
+  MembershipWithdrawPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['MembershipWithdrawPayload']>;
+  MembershipWithdrawSuccess: ResolverTypeWrapper<GqlMembershipWithdrawSuccess>;
+  MembershipsConnection: ResolverTypeWrapper<Omit<GqlMembershipsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['MembershipEdge']>>> }>;
+  Mutation: ResolverTypeWrapper<{}>;
+  MyVoteEligibility: ResolverTypeWrapper<GqlMyVoteEligibility>;
+  NestedPlaceConnectOrCreateInput: GqlNestedPlaceConnectOrCreateInput;
+  NestedPlaceCreateInput: GqlNestedPlaceCreateInput;
+  NestedPlacesBulkConnectOrCreateInput: GqlNestedPlacesBulkConnectOrCreateInput;
+  NestedPlacesBulkUpdateInput: GqlNestedPlacesBulkUpdateInput;
+  NftInstance: ResolverTypeWrapper<Omit<GqlNftInstance, 'community' | 'nftToken' | 'nftWallet'> & { community?: Maybe<GqlResolversTypes['Community']>, nftToken?: Maybe<GqlResolversTypes['NftToken']>, nftWallet?: Maybe<GqlResolversTypes['NftWallet']> }>;
+  NftInstanceEdge: ResolverTypeWrapper<Omit<GqlNftInstanceEdge, 'node'> & { node: GqlResolversTypes['NftInstance'] }>;
+  NftInstanceFilterInput: GqlNftInstanceFilterInput;
+  NftInstanceSortInput: GqlNftInstanceSortInput;
+  NftInstancesConnection: ResolverTypeWrapper<Omit<GqlNftInstancesConnection, 'edges'> & { edges: Array<GqlResolversTypes['NftInstanceEdge']> }>;
+  NftToken: ResolverTypeWrapper<Omit<GqlNftToken, 'community'> & { community?: Maybe<GqlResolversTypes['Community']> }>;
+  NftTokenEdge: ResolverTypeWrapper<Omit<GqlNftTokenEdge, 'node'> & { node: GqlResolversTypes['NftToken'] }>;
+  NftTokenFilterInput: GqlNftTokenFilterInput;
+  NftTokenSortInput: GqlNftTokenSortInput;
+  NftTokensConnection: ResolverTypeWrapper<Omit<GqlNftTokensConnection, 'edges'> & { edges: Array<GqlResolversTypes['NftTokenEdge']> }>;
+  NftWallet: ResolverTypeWrapper<Omit<GqlNftWallet, 'user'> & { user: GqlResolversTypes['User'] }>;
+  OpportunitiesConnection: ResolverTypeWrapper<Omit<GqlOpportunitiesConnection, 'edges'> & { edges: Array<GqlResolversTypes['OpportunityEdge']> }>;
+  Opportunity: ResolverTypeWrapper<Opportunity>;
+  OpportunityCategory: GqlOpportunityCategory;
+  OpportunityCreateInput: GqlOpportunityCreateInput;
+  OpportunityCreatePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['OpportunityCreatePayload']>;
+  OpportunityCreateSuccess: ResolverTypeWrapper<Omit<GqlOpportunityCreateSuccess, 'opportunity'> & { opportunity: GqlResolversTypes['Opportunity'] }>;
+  OpportunityDeletePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['OpportunityDeletePayload']>;
+  OpportunityDeleteSuccess: ResolverTypeWrapper<GqlOpportunityDeleteSuccess>;
+  OpportunityEdge: ResolverTypeWrapper<Omit<GqlOpportunityEdge, 'node'> & { node?: Maybe<GqlResolversTypes['Opportunity']> }>;
+  OpportunityFilterInput: GqlOpportunityFilterInput;
+  OpportunitySetPublishStatusInput: GqlOpportunitySetPublishStatusInput;
+  OpportunitySetPublishStatusPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['OpportunitySetPublishStatusPayload']>;
+  OpportunitySetPublishStatusSuccess: ResolverTypeWrapper<Omit<GqlOpportunitySetPublishStatusSuccess, 'opportunity'> & { opportunity: GqlResolversTypes['Opportunity'] }>;
+  OpportunitySlot: ResolverTypeWrapper<OpportunitySlot>;
+  OpportunitySlotCreateInput: GqlOpportunitySlotCreateInput;
+  OpportunitySlotCreatePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['OpportunitySlotCreatePayload']>;
+  OpportunitySlotCreateSuccess: ResolverTypeWrapper<Omit<GqlOpportunitySlotCreateSuccess, 'slot'> & { slot: GqlResolversTypes['OpportunitySlot'] }>;
+  OpportunitySlotEdge: ResolverTypeWrapper<Omit<GqlOpportunitySlotEdge, 'node'> & { node?: Maybe<GqlResolversTypes['OpportunitySlot']> }>;
+  OpportunitySlotFilterInput: GqlOpportunitySlotFilterInput;
+  OpportunitySlotHostingStatus: GqlOpportunitySlotHostingStatus;
+  OpportunitySlotSetHostingStatusInput: GqlOpportunitySlotSetHostingStatusInput;
+  OpportunitySlotSetHostingStatusPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['OpportunitySlotSetHostingStatusPayload']>;
+  OpportunitySlotSetHostingStatusSuccess: ResolverTypeWrapper<Omit<GqlOpportunitySlotSetHostingStatusSuccess, 'slot'> & { slot: GqlResolversTypes['OpportunitySlot'] }>;
+  OpportunitySlotSortInput: GqlOpportunitySlotSortInput;
+  OpportunitySlotUpdateInput: GqlOpportunitySlotUpdateInput;
+  OpportunitySlotsBulkUpdateInput: GqlOpportunitySlotsBulkUpdateInput;
+  OpportunitySlotsBulkUpdatePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['OpportunitySlotsBulkUpdatePayload']>;
+  OpportunitySlotsBulkUpdateSuccess: ResolverTypeWrapper<Omit<GqlOpportunitySlotsBulkUpdateSuccess, 'slots'> & { slots: Array<GqlResolversTypes['OpportunitySlot']> }>;
+  OpportunitySlotsConnection: ResolverTypeWrapper<Omit<GqlOpportunitySlotsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['OpportunitySlotEdge']>>> }>;
+  OpportunitySortInput: GqlOpportunitySortInput;
+  OpportunityUpdateContentInput: GqlOpportunityUpdateContentInput;
+  OpportunityUpdateContentPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['OpportunityUpdateContentPayload']>;
+  OpportunityUpdateContentSuccess: ResolverTypeWrapper<Omit<GqlOpportunityUpdateContentSuccess, 'opportunity'> & { opportunity: GqlResolversTypes['Opportunity'] }>;
+  PageInfo: ResolverTypeWrapper<GqlPageInfo>;
+  Paging: ResolverTypeWrapper<GqlPaging>;
+  Participation: ResolverTypeWrapper<Participation>;
+  ParticipationBulkCreateInput: GqlParticipationBulkCreateInput;
+  ParticipationBulkCreatePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['ParticipationBulkCreatePayload']>;
+  ParticipationBulkCreateSuccess: ResolverTypeWrapper<Omit<GqlParticipationBulkCreateSuccess, 'participations'> & { participations: Array<GqlResolversTypes['Participation']> }>;
+  ParticipationCreatePersonalRecordInput: GqlParticipationCreatePersonalRecordInput;
+  ParticipationCreatePersonalRecordPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['ParticipationCreatePersonalRecordPayload']>;
+  ParticipationCreatePersonalRecordSuccess: ResolverTypeWrapper<Omit<GqlParticipationCreatePersonalRecordSuccess, 'participation'> & { participation: GqlResolversTypes['Participation'] }>;
+  ParticipationDeletePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['ParticipationDeletePayload']>;
+  ParticipationDeleteSuccess: ResolverTypeWrapper<GqlParticipationDeleteSuccess>;
+  ParticipationEdge: ResolverTypeWrapper<Omit<GqlParticipationEdge, 'node'> & { node?: Maybe<GqlResolversTypes['Participation']> }>;
+  ParticipationFilterInput: GqlParticipationFilterInput;
+  ParticipationSortInput: GqlParticipationSortInput;
+  ParticipationStatus: GqlParticipationStatus;
+  ParticipationStatusHistoriesConnection: ResolverTypeWrapper<Omit<GqlParticipationStatusHistoriesConnection, 'edges'> & { edges: Array<GqlResolversTypes['ParticipationStatusHistoryEdge']> }>;
+  ParticipationStatusHistory: ResolverTypeWrapper<ParticipationStatusHistory>;
+  ParticipationStatusHistoryEdge: ResolverTypeWrapper<Omit<GqlParticipationStatusHistoryEdge, 'node'> & { node?: Maybe<GqlResolversTypes['ParticipationStatusHistory']> }>;
+  ParticipationStatusHistoryFilterInput: GqlParticipationStatusHistoryFilterInput;
+  ParticipationStatusHistorySortInput: GqlParticipationStatusHistorySortInput;
+  ParticipationStatusReason: GqlParticipationStatusReason;
+  ParticipationType: GqlParticipationType;
+  ParticipationsConnection: ResolverTypeWrapper<Omit<GqlParticipationsConnection, 'edges'> & { edges: Array<GqlResolversTypes['ParticipationEdge']> }>;
+  PhoneUserStatus: GqlPhoneUserStatus;
+  Place: ResolverTypeWrapper<Place>;
+  PlaceCreateInput: GqlPlaceCreateInput;
+  PlaceCreatePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['PlaceCreatePayload']>;
+  PlaceCreateSuccess: ResolverTypeWrapper<Omit<GqlPlaceCreateSuccess, 'place'> & { place: GqlResolversTypes['Place'] }>;
+  PlaceDeletePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['PlaceDeletePayload']>;
+  PlaceDeleteSuccess: ResolverTypeWrapper<GqlPlaceDeleteSuccess>;
+  PlaceEdge: ResolverTypeWrapper<Omit<GqlPlaceEdge, 'node'> & { node?: Maybe<GqlResolversTypes['Place']> }>;
+  PlaceFilterInput: GqlPlaceFilterInput;
+  PlaceSortInput: GqlPlaceSortInput;
+  PlaceUpdateInput: GqlPlaceUpdateInput;
+  PlaceUpdatePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['PlaceUpdatePayload']>;
+  PlaceUpdateSuccess: ResolverTypeWrapper<Omit<GqlPlaceUpdateSuccess, 'place'> & { place: GqlResolversTypes['Place'] }>;
+  PlacesConnection: ResolverTypeWrapper<Omit<GqlPlacesConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['PlaceEdge']>>> }>;
+  Portfolio: ResolverTypeWrapper<Omit<GqlPortfolio, 'participants' | 'place'> & { participants?: Maybe<Array<GqlResolversTypes['User']>>, place?: Maybe<GqlResolversTypes['Place']> }>;
+  PortfolioCategory: GqlPortfolioCategory;
+  PortfolioEdge: ResolverTypeWrapper<Omit<GqlPortfolioEdge, 'node'> & { node?: Maybe<GqlResolversTypes['Portfolio']> }>;
+  PortfolioFilterInput: GqlPortfolioFilterInput;
+  PortfolioSortInput: GqlPortfolioSortInput;
+  PortfolioSource: GqlPortfolioSource;
+  PortfoliosConnection: ResolverTypeWrapper<Omit<GqlPortfoliosConnection, 'edges'> & { edges: Array<GqlResolversTypes['PortfolioEdge']> }>;
+  PublishReportPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['PublishReportPayload']>;
+  PublishReportSuccess: ResolverTypeWrapper<Omit<GqlPublishReportSuccess, 'report'> & { report: GqlResolversTypes['Report'] }>;
+  PublishStatus: GqlPublishStatus;
+  Query: ResolverTypeWrapper<{}>;
+  RejectReportPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['RejectReportPayload']>;
+  RejectReportSuccess: ResolverTypeWrapper<Omit<GqlRejectReportSuccess, 'report'> & { report: GqlResolversTypes['Report'] }>;
+  Report: ResolverTypeWrapper<Omit<GqlReport, 'community' | 'feedbacks' | 'generatedByUser' | 'myFeedback' | 'parentRun' | 'publishedByUser' | 'regenerations' | 'targetUser' | 'template'> & { community: GqlResolversTypes['Community'], feedbacks: GqlResolversTypes['ReportFeedbacksConnection'], generatedByUser?: Maybe<GqlResolversTypes['User']>, myFeedback?: Maybe<GqlResolversTypes['ReportFeedback']>, parentRun?: Maybe<GqlResolversTypes['Report']>, publishedByUser?: Maybe<GqlResolversTypes['User']>, regenerations: Array<GqlResolversTypes['Report']>, targetUser?: Maybe<GqlResolversTypes['User']>, template?: Maybe<GqlResolversTypes['ReportTemplate']> }>;
+  ReportEdge: ResolverTypeWrapper<Omit<GqlReportEdge, 'node'> & { node?: Maybe<GqlResolversTypes['Report']> }>;
+  ReportFeedback: ResolverTypeWrapper<Omit<GqlReportFeedback, 'report' | 'user'> & { report: GqlResolversTypes['Report'], user: GqlResolversTypes['User'] }>;
+  ReportFeedbackEdge: ResolverTypeWrapper<Omit<GqlReportFeedbackEdge, 'node'> & { node?: Maybe<GqlResolversTypes['ReportFeedback']> }>;
+  ReportFeedbackRatingBucket: ResolverTypeWrapper<GqlReportFeedbackRatingBucket>;
+  ReportFeedbackType: GqlReportFeedbackType;
+  ReportFeedbacksConnection: ResolverTypeWrapper<Omit<GqlReportFeedbacksConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['ReportFeedbackEdge']>>> }>;
+  ReportStatus: GqlReportStatus;
+  ReportTemplate: ResolverTypeWrapper<Omit<GqlReportTemplate, 'community' | 'updatedByUser'> & { community?: Maybe<GqlResolversTypes['Community']>, updatedByUser?: Maybe<GqlResolversTypes['User']> }>;
+  ReportTemplateKind: GqlReportTemplateKind;
+  ReportTemplateScope: GqlReportTemplateScope;
+  ReportTemplateStats: ResolverTypeWrapper<GqlReportTemplateStats>;
+  ReportTemplateStatsBreakdownConnection: ResolverTypeWrapper<GqlReportTemplateStatsBreakdownConnection>;
+  ReportTemplateStatsBreakdownEdge: ResolverTypeWrapper<GqlReportTemplateStatsBreakdownEdge>;
+  ReportTemplateStatsBreakdownRow: ResolverTypeWrapper<GqlReportTemplateStatsBreakdownRow>;
+  ReportVariant: GqlReportVariant;
+  ReportsConnection: ResolverTypeWrapper<Omit<GqlReportsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['ReportEdge']>>> }>;
+  Reservation: ResolverTypeWrapper<Omit<GqlReservation, 'createdByUser' | 'histories' | 'opportunitySlot' | 'participations'> & { createdByUser?: Maybe<GqlResolversTypes['User']>, histories?: Maybe<Array<GqlResolversTypes['ReservationHistory']>>, opportunitySlot?: Maybe<GqlResolversTypes['OpportunitySlot']>, participations?: Maybe<Array<GqlResolversTypes['Participation']>> }>;
+  ReservationCancelInput: GqlReservationCancelInput;
+  ReservationCreateInput: GqlReservationCreateInput;
+  ReservationCreatePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['ReservationCreatePayload']>;
+  ReservationCreateSuccess: ResolverTypeWrapper<Omit<GqlReservationCreateSuccess, 'reservation'> & { reservation: GqlResolversTypes['Reservation'] }>;
+  ReservationEdge: ResolverTypeWrapper<Omit<GqlReservationEdge, 'node'> & { node?: Maybe<GqlResolversTypes['Reservation']> }>;
+  ReservationFilterInput: GqlReservationFilterInput;
+  ReservationHistoriesConnection: ResolverTypeWrapper<Omit<GqlReservationHistoriesConnection, 'edges'> & { edges: Array<GqlResolversTypes['ReservationHistoryEdge']> }>;
+  ReservationHistory: ResolverTypeWrapper<Omit<GqlReservationHistory, 'createdByUser' | 'reservation'> & { createdByUser?: Maybe<GqlResolversTypes['User']>, reservation: GqlResolversTypes['Reservation'] }>;
+  ReservationHistoryEdge: ResolverTypeWrapper<Omit<GqlReservationHistoryEdge, 'node'> & { node?: Maybe<GqlResolversTypes['ReservationHistory']> }>;
+  ReservationHistoryFilterInput: GqlReservationHistoryFilterInput;
+  ReservationHistorySortInput: GqlReservationHistorySortInput;
+  ReservationPaymentMethod: GqlReservationPaymentMethod;
+  ReservationRejectInput: GqlReservationRejectInput;
+  ReservationSetStatusPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['ReservationSetStatusPayload']>;
+  ReservationSetStatusSuccess: ResolverTypeWrapper<Omit<GqlReservationSetStatusSuccess, 'reservation'> & { reservation: GqlResolversTypes['Reservation'] }>;
+  ReservationSortInput: GqlReservationSortInput;
+  ReservationStatus: GqlReservationStatus;
+  ReservationsConnection: ResolverTypeWrapper<Omit<GqlReservationsConnection, 'edges'> & { edges: Array<GqlResolversTypes['ReservationEdge']> }>;
+  RevokeUserVcInput: GqlRevokeUserVcInput;
+  Role: GqlRole;
+  SortDirection: GqlSortDirection;
+  Source: GqlSource;
+  State: ResolverTypeWrapper<State>;
+  StateEdge: ResolverTypeWrapper<Omit<GqlStateEdge, 'node'> & { node?: Maybe<GqlResolversTypes['State']> }>;
+  StatesConnection: ResolverTypeWrapper<Omit<GqlStatesConnection, 'edges'> & { edges: Array<GqlResolversTypes['StateEdge']> }>;
+  StatesInput: GqlStatesInput;
+  StorePhoneAuthTokenInput: GqlStorePhoneAuthTokenInput;
+  StorePhoneAuthTokenPayload: ResolverTypeWrapper<GqlStorePhoneAuthTokenPayload>;
+  String: ResolverTypeWrapper<Scalars['String']['output']>;
+  SubmitReportFeedbackInput: GqlSubmitReportFeedbackInput;
+  SubmitReportFeedbackPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['SubmitReportFeedbackPayload']>;
+  SubmitReportFeedbackSuccess: ResolverTypeWrapper<Omit<GqlSubmitReportFeedbackSuccess, 'feedback'> & { feedback: GqlResolversTypes['ReportFeedback'] }>;
+  SysRole: GqlSysRole;
+  Ticket: ResolverTypeWrapper<Ticket>;
+  TicketClaimInput: GqlTicketClaimInput;
+  TicketClaimLink: ResolverTypeWrapper<TicketClaimLink>;
+  TicketClaimLinkEdge: ResolverTypeWrapper<Omit<GqlTicketClaimLinkEdge, 'node'> & { node?: Maybe<GqlResolversTypes['TicketClaimLink']> }>;
+  TicketClaimLinkFilterInput: GqlTicketClaimLinkFilterInput;
+  TicketClaimLinkSortInput: GqlTicketClaimLinkSortInput;
+  TicketClaimLinksConnection: ResolverTypeWrapper<Omit<GqlTicketClaimLinksConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['TicketClaimLinkEdge']>>> }>;
+  TicketClaimPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['TicketClaimPayload']>;
+  TicketClaimSuccess: ResolverTypeWrapper<Omit<GqlTicketClaimSuccess, 'tickets'> & { tickets: Array<GqlResolversTypes['Ticket']> }>;
+  TicketEdge: ResolverTypeWrapper<Omit<GqlTicketEdge, 'node'> & { node?: Maybe<GqlResolversTypes['Ticket']> }>;
+  TicketFilterInput: GqlTicketFilterInput;
+  TicketIssueInput: GqlTicketIssueInput;
+  TicketIssuePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['TicketIssuePayload']>;
+  TicketIssueSuccess: ResolverTypeWrapper<Omit<GqlTicketIssueSuccess, 'issue'> & { issue: GqlResolversTypes['TicketIssuer'] }>;
+  TicketIssuer: ResolverTypeWrapper<TicketIssuer>;
+  TicketIssuerEdge: ResolverTypeWrapper<Omit<GqlTicketIssuerEdge, 'node'> & { node?: Maybe<GqlResolversTypes['TicketIssuer']> }>;
+  TicketIssuerFilterInput: GqlTicketIssuerFilterInput;
+  TicketIssuerSortInput: GqlTicketIssuerSortInput;
+  TicketIssuersConnection: ResolverTypeWrapper<Omit<GqlTicketIssuersConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['TicketIssuerEdge']>>> }>;
+  TicketPurchaseInput: GqlTicketPurchaseInput;
+  TicketPurchasePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['TicketPurchasePayload']>;
+  TicketPurchaseSuccess: ResolverTypeWrapper<Omit<GqlTicketPurchaseSuccess, 'ticket'> & { ticket: GqlResolversTypes['Ticket'] }>;
+  TicketRefundInput: GqlTicketRefundInput;
+  TicketRefundPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['TicketRefundPayload']>;
+  TicketRefundSuccess: ResolverTypeWrapper<Omit<GqlTicketRefundSuccess, 'ticket'> & { ticket: GqlResolversTypes['Ticket'] }>;
+  TicketSortInput: GqlTicketSortInput;
+  TicketStatus: GqlTicketStatus;
+  TicketStatusHistoriesConnection: ResolverTypeWrapper<Omit<GqlTicketStatusHistoriesConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['TicketStatusHistoryEdge']>>> }>;
+  TicketStatusHistory: ResolverTypeWrapper<TicketStatusHistory>;
+  TicketStatusHistoryEdge: ResolverTypeWrapper<Omit<GqlTicketStatusHistoryEdge, 'node'> & { node?: Maybe<GqlResolversTypes['TicketStatusHistory']> }>;
+  TicketStatusHistoryFilterInput: GqlTicketStatusHistoryFilterInput;
+  TicketStatusHistorySortInput: GqlTicketStatusHistorySortInput;
+  TicketStatusReason: GqlTicketStatusReason;
+  TicketUsePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['TicketUsePayload']>;
+  TicketUseSuccess: ResolverTypeWrapper<Omit<GqlTicketUseSuccess, 'ticket'> & { ticket: GqlResolversTypes['Ticket'] }>;
+  TicketsConnection: ResolverTypeWrapper<Omit<GqlTicketsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['TicketEdge']>>> }>;
+  Transaction: ResolverTypeWrapper<Transaction>;
+  TransactionChain: ResolverTypeWrapper<Omit<GqlTransactionChain, 'steps'> & { steps: Array<GqlResolversTypes['TransactionChainStep']> }>;
+  TransactionChainCommunity: ResolverTypeWrapper<GqlTransactionChainCommunity>;
+  TransactionChainParticipant: ResolverTypeWrapper<GqlResolversInterfaceTypes<GqlResolversTypes>['TransactionChainParticipant']>;
+  TransactionChainStep: ResolverTypeWrapper<Omit<GqlTransactionChainStep, 'from' | 'to'> & { from?: Maybe<GqlResolversTypes['TransactionChainParticipant']>, to?: Maybe<GqlResolversTypes['TransactionChainParticipant']> }>;
+  TransactionChainUser: ResolverTypeWrapper<GqlTransactionChainUser>;
+  TransactionDonateSelfPointInput: GqlTransactionDonateSelfPointInput;
+  TransactionDonateSelfPointPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['TransactionDonateSelfPointPayload']>;
+  TransactionDonateSelfPointSuccess: ResolverTypeWrapper<Omit<GqlTransactionDonateSelfPointSuccess, 'transaction'> & { transaction: GqlResolversTypes['Transaction'] }>;
+  TransactionEdge: ResolverTypeWrapper<Omit<GqlTransactionEdge, 'node'> & { node?: Maybe<GqlResolversTypes['Transaction']> }>;
+  TransactionFilterInput: GqlTransactionFilterInput;
+  TransactionGrantCommunityPointInput: GqlTransactionGrantCommunityPointInput;
+  TransactionGrantCommunityPointPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['TransactionGrantCommunityPointPayload']>;
+  TransactionGrantCommunityPointSuccess: ResolverTypeWrapper<Omit<GqlTransactionGrantCommunityPointSuccess, 'transaction'> & { transaction: GqlResolversTypes['Transaction'] }>;
+  TransactionIssueCommunityPointInput: GqlTransactionIssueCommunityPointInput;
+  TransactionIssueCommunityPointPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['TransactionIssueCommunityPointPayload']>;
+  TransactionIssueCommunityPointSuccess: ResolverTypeWrapper<Omit<GqlTransactionIssueCommunityPointSuccess, 'transaction'> & { transaction: GqlResolversTypes['Transaction'] }>;
+  TransactionReason: GqlTransactionReason;
+  TransactionSortInput: GqlTransactionSortInput;
+  TransactionUpdateMetadataInput: GqlTransactionUpdateMetadataInput;
+  TransactionUpdateMetadataPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['TransactionUpdateMetadataPayload']>;
+  TransactionUpdateMetadataSuccess: ResolverTypeWrapper<Omit<GqlTransactionUpdateMetadataSuccess, 'transaction'> & { transaction: GqlResolversTypes['Transaction'] }>;
+  TransactionVerificationResult: ResolverTypeWrapper<GqlTransactionVerificationResult>;
+  TransactionsConnection: ResolverTypeWrapper<Omit<GqlTransactionsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['TransactionEdge']>>> }>;
+  UpdateReportTemplateInput: GqlUpdateReportTemplateInput;
+  UpdateReportTemplatePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['UpdateReportTemplatePayload']>;
+  UpdateReportTemplateSuccess: ResolverTypeWrapper<Omit<GqlUpdateReportTemplateSuccess, 'reportTemplate'> & { reportTemplate: GqlResolversTypes['ReportTemplate'] }>;
+  UpdateSignupBonusConfigInput: GqlUpdateSignupBonusConfigInput;
+  Upload: ResolverTypeWrapper<Scalars['Upload']['output']>;
+  User: ResolverTypeWrapper<User>;
+  UserDeletePayload: ResolverTypeWrapper<GqlUserDeletePayload>;
+  UserDidAnchor: ResolverTypeWrapper<Omit<GqlUserDidAnchor, 'user'> & { user?: Maybe<GqlResolversTypes['User']> }>;
+  UserEdge: ResolverTypeWrapper<Omit<GqlUserEdge, 'node'> & { node?: Maybe<GqlResolversTypes['User']> }>;
+  UserFilterInput: GqlUserFilterInput;
+  UserSignUpInput: GqlUserSignUpInput;
+  UserSortInput: GqlUserSortInput;
+  UserUpdateProfileInput: GqlUserUpdateProfileInput;
+  UserUpdateProfilePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['UserUpdateProfilePayload']>;
+  UserUpdateProfileSuccess: ResolverTypeWrapper<Omit<GqlUserUpdateProfileSuccess, 'user'> & { user?: Maybe<GqlResolversTypes['User']> }>;
+  UsersConnection: ResolverTypeWrapper<Omit<GqlUsersConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['UserEdge']>>> }>;
+  UtilitiesConnection: ResolverTypeWrapper<Omit<GqlUtilitiesConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['UtilityEdge']>>> }>;
+  Utility: ResolverTypeWrapper<Utility>;
+  UtilityCreateInput: GqlUtilityCreateInput;
+  UtilityCreatePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['UtilityCreatePayload']>;
+  UtilityCreateSuccess: ResolverTypeWrapper<Omit<GqlUtilityCreateSuccess, 'utility'> & { utility: GqlResolversTypes['Utility'] }>;
+  UtilityDeletePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['UtilityDeletePayload']>;
+  UtilityDeleteSuccess: ResolverTypeWrapper<GqlUtilityDeleteSuccess>;
+  UtilityEdge: ResolverTypeWrapper<Omit<GqlUtilityEdge, 'node'> & { node?: Maybe<GqlResolversTypes['Utility']> }>;
+  UtilityFilterInput: GqlUtilityFilterInput;
+  UtilitySetPublishStatusInput: GqlUtilitySetPublishStatusInput;
+  UtilitySetPublishStatusPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['UtilitySetPublishStatusPayload']>;
+  UtilitySetPublishStatusSuccess: ResolverTypeWrapper<Omit<GqlUtilitySetPublishStatusSuccess, 'utility'> & { utility: GqlResolversTypes['Utility'] }>;
+  UtilitySortInput: GqlUtilitySortInput;
+  UtilityUpdateInfoInput: GqlUtilityUpdateInfoInput;
+  UtilityUpdateInfoPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['UtilityUpdateInfoPayload']>;
+  UtilityUpdateInfoSuccess: ResolverTypeWrapper<Omit<GqlUtilityUpdateInfoSuccess, 'utility'> & { utility: GqlResolversTypes['Utility'] }>;
+  ValueType: GqlValueType;
+  VcFormat: GqlVcFormat;
+  VcIssuance: ResolverTypeWrapper<Omit<GqlVcIssuance, 'evaluation' | 'user'> & { evaluation?: Maybe<GqlResolversTypes['Evaluation']>, user?: Maybe<GqlResolversTypes['User']> }>;
+  VcIssuanceRequest: ResolverTypeWrapper<Omit<GqlVcIssuanceRequest, 'evaluation' | 'user'> & { evaluation?: Maybe<GqlResolversTypes['Evaluation']>, user?: Maybe<GqlResolversTypes['User']> }>;
+  VcIssuanceRequestEdge: ResolverTypeWrapper<Omit<GqlVcIssuanceRequestEdge, 'node'> & { node?: Maybe<GqlResolversTypes['VcIssuanceRequest']> }>;
+  VcIssuanceRequestFilterInput: GqlVcIssuanceRequestFilterInput;
+  VcIssuanceRequestSortInput: GqlVcIssuanceRequestSortInput;
+  VcIssuanceRequestsConnection: ResolverTypeWrapper<Omit<GqlVcIssuanceRequestsConnection, 'edges'> & { edges: Array<GqlResolversTypes['VcIssuanceRequestEdge']> }>;
+  VcIssuanceStatus: GqlVcIssuanceStatus;
+  VerificationStatus: GqlVerificationStatus;
+  VoteBallot: ResolverTypeWrapper<GqlVoteBallot>;
+  VoteCastInput: GqlVoteCastInput;
+  VoteCastPayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['VoteCastPayload']>;
+  VoteCastSuccess: ResolverTypeWrapper<GqlVoteCastSuccess>;
+  VoteGate: ResolverTypeWrapper<Omit<GqlVoteGate, 'nftToken'> & { nftToken?: Maybe<GqlResolversTypes['NftToken']> }>;
+  VoteGateInput: GqlVoteGateInput;
+  VoteGateType: GqlVoteGateType;
+  VoteOption: ResolverTypeWrapper<GqlVoteOption>;
+  VoteOptionInput: GqlVoteOptionInput;
+  VotePowerPolicy: ResolverTypeWrapper<Omit<GqlVotePowerPolicy, 'nftToken'> & { nftToken?: Maybe<GqlResolversTypes['NftToken']> }>;
+  VotePowerPolicyInput: GqlVotePowerPolicyInput;
+  VotePowerPolicyType: GqlVotePowerPolicyType;
+  VoteTopic: ResolverTypeWrapper<Omit<GqlVoteTopic, 'community' | 'gate' | 'powerPolicy'> & { community: GqlResolversTypes['Community'], gate: GqlResolversTypes['VoteGate'], powerPolicy: GqlResolversTypes['VotePowerPolicy'] }>;
+  VoteTopicCreateInput: GqlVoteTopicCreateInput;
+  VoteTopicCreatePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['VoteTopicCreatePayload']>;
+  VoteTopicCreateSuccess: ResolverTypeWrapper<Omit<GqlVoteTopicCreateSuccess, 'voteTopic'> & { voteTopic: GqlResolversTypes['VoteTopic'] }>;
+  VoteTopicDeletePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['VoteTopicDeletePayload']>;
+  VoteTopicDeleteSuccess: ResolverTypeWrapper<GqlVoteTopicDeleteSuccess>;
+  VoteTopicEdge: ResolverTypeWrapper<Omit<GqlVoteTopicEdge, 'node'> & { node: GqlResolversTypes['VoteTopic'] }>;
+  VoteTopicPhase: GqlVoteTopicPhase;
+  VoteTopicUpdateInput: GqlVoteTopicUpdateInput;
+  VoteTopicUpdatePayload: ResolverTypeWrapper<GqlResolversUnionTypes<GqlResolversTypes>['VoteTopicUpdatePayload']>;
+  VoteTopicUpdateSuccess: ResolverTypeWrapper<Omit<GqlVoteTopicUpdateSuccess, 'voteTopic'> & { voteTopic: GqlResolversTypes['VoteTopic'] }>;
+  VoteTopicsConnection: ResolverTypeWrapper<Omit<GqlVoteTopicsConnection, 'edges' | 'nodes'> & { edges: Array<GqlResolversTypes['VoteTopicEdge']>, nodes: Array<GqlResolversTypes['VoteTopic']> }>;
+  Wallet: ResolverTypeWrapper<Wallet>;
+  WalletEdge: ResolverTypeWrapper<Omit<GqlWalletEdge, 'node'> & { node?: Maybe<GqlResolversTypes['Wallet']> }>;
+  WalletFilterInput: GqlWalletFilterInput;
+  WalletSortInput: GqlWalletSortInput;
+  WalletType: GqlWalletType;
+  WalletsConnection: ResolverTypeWrapper<Omit<GqlWalletsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversTypes['WalletEdge']>>> }>;
+}>;
+
+/** Mapping between all available schema types and the resolvers parents */
+export type GqlResolversParentTypes = ResolversObject<{
+  AccumulatedPointView: AccumulatedPointView;
+  AdminReportSummaryConnection: Omit<GqlAdminReportSummaryConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['AdminReportSummaryEdge']>>> };
+  AdminReportSummaryEdge: Omit<GqlAdminReportSummaryEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['AdminReportSummaryRow']> };
+  AdminReportSummaryRow: Omit<GqlAdminReportSummaryRow, 'community' | 'lastPublishedReport'> & { community: GqlResolversParentTypes['Community'], lastPublishedReport?: Maybe<GqlResolversParentTypes['Report']> };
+  AdminTemplateFeedbackStats: GqlAdminTemplateFeedbackStats;
+  AnalyticsChainDepthBucket: GqlAnalyticsChainDepthBucket;
+  AnalyticsCohortFunnelPoint: GqlAnalyticsCohortFunnelPoint;
+  AnalyticsCohortRetentionPoint: GqlAnalyticsCohortRetentionPoint;
+  AnalyticsCommunityAlerts: GqlAnalyticsCommunityAlerts;
+  AnalyticsCommunityInput: GqlAnalyticsCommunityInput;
+  AnalyticsCommunityOverview: GqlAnalyticsCommunityOverview;
+  AnalyticsCommunityPayload: GqlAnalyticsCommunityPayload;
+  AnalyticsCommunitySummaryCard: GqlAnalyticsCommunitySummaryCard;
+  AnalyticsDashboardInput: GqlAnalyticsDashboardInput;
+  AnalyticsDashboardPayload: GqlAnalyticsDashboardPayload;
+  AnalyticsLatestCohort: GqlAnalyticsLatestCohort;
+  AnalyticsMemberList: GqlAnalyticsMemberList;
+  AnalyticsMemberRow: GqlAnalyticsMemberRow;
+  AnalyticsMonthlyActivityPoint: GqlAnalyticsMonthlyActivityPoint;
+  AnalyticsPlatformSummary: GqlAnalyticsPlatformSummary;
+  AnalyticsRetentionTrendPoint: GqlAnalyticsRetentionTrendPoint;
+  AnalyticsSegmentCounts: GqlAnalyticsSegmentCounts;
+  AnalyticsSegmentThresholdsInput: GqlAnalyticsSegmentThresholdsInput;
+  AnalyticsStageBucket: GqlAnalyticsStageBucket;
+  AnalyticsStageDistribution: GqlAnalyticsStageDistribution;
+  AnalyticsTenureDistribution: GqlAnalyticsTenureDistribution;
+  AnalyticsTenureHistogramBucket: GqlAnalyticsTenureHistogramBucket;
+  AnalyticsUserListFilter: GqlAnalyticsUserListFilter;
+  AnalyticsUserListSort: GqlAnalyticsUserListSort;
+  AnalyticsWeeklyRetention: GqlAnalyticsWeeklyRetention;
+  AnalyticsWindowActivity: GqlAnalyticsWindowActivity;
+  ApproveReportPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['ApproveReportPayload'];
+  ApproveReportSuccess: Omit<GqlApproveReportSuccess, 'report'> & { report: GqlResolversParentTypes['Report'] };
+  Article: Article;
+  ArticleCreateInput: GqlArticleCreateInput;
+  ArticleCreatePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['ArticleCreatePayload'];
+  ArticleCreateSuccess: Omit<GqlArticleCreateSuccess, 'article'> & { article: GqlResolversParentTypes['Article'] };
+  ArticleDeletePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['ArticleDeletePayload'];
+  ArticleDeleteSuccess: GqlArticleDeleteSuccess;
+  ArticleEdge: Omit<GqlArticleEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['Article']> };
+  ArticleFilterInput: GqlArticleFilterInput;
+  ArticleSortInput: GqlArticleSortInput;
+  ArticleUpdateContentInput: GqlArticleUpdateContentInput;
+  ArticleUpdateContentPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['ArticleUpdateContentPayload'];
+  ArticleUpdateContentSuccess: Omit<GqlArticleUpdateContentSuccess, 'article'> & { article: GqlResolversParentTypes['Article'] };
+  ArticlesConnection: Omit<GqlArticlesConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['ArticleEdge']>>> };
+  AuthZDirectiveCompositeRulesInput: GqlAuthZDirectiveCompositeRulesInput;
+  AuthZDirectiveDeepCompositeRulesInput: GqlAuthZDirectiveDeepCompositeRulesInput;
+  BigInt: Scalars['BigInt']['output'];
+  Boolean: Scalars['Boolean']['output'];
+  CheckCommunityPermissionInput: GqlCheckCommunityPermissionInput;
+  CheckIsSelfPermissionInput: GqlCheckIsSelfPermissionInput;
+  CheckOpportunityPermissionInput: GqlCheckOpportunityPermissionInput;
+  CitiesConnection: Omit<GqlCitiesConnection, 'edges'> & { edges: Array<GqlResolversParentTypes['CityEdge']> };
+  CitiesInput: GqlCitiesInput;
+  CitiesSortInput: GqlCitiesSortInput;
+  City: City;
+  CityEdge: Omit<GqlCityEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['City']> };
+  CommonDocumentOverrides: GqlCommonDocumentOverrides;
+  CommonDocumentOverridesInput: GqlCommonDocumentOverridesInput;
+  CommunitiesConnection: Omit<GqlCommunitiesConnection, 'edges'> & { edges?: Maybe<Array<GqlResolversParentTypes['CommunityEdge']>> };
+  Community: Community;
+  CommunityConfig: GqlCommunityConfig;
+  CommunityConfigInput: GqlCommunityConfigInput;
+  CommunityCreateInput: GqlCommunityCreateInput;
+  CommunityCreatePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['CommunityCreatePayload'];
+  CommunityCreateSuccess: Omit<GqlCommunityCreateSuccess, 'community'> & { community: GqlResolversParentTypes['Community'] };
+  CommunityDeletePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['CommunityDeletePayload'];
+  CommunityDeleteSuccess: GqlCommunityDeleteSuccess;
+  CommunityDocument: GqlCommunityDocument;
+  CommunityDocumentInput: GqlCommunityDocumentInput;
+  CommunityEdge: Omit<GqlCommunityEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['Community']> };
+  CommunityFilterInput: GqlCommunityFilterInput;
+  CommunityFirebaseConfig: GqlCommunityFirebaseConfig;
+  CommunityLineConfig: GqlCommunityLineConfig;
+  CommunityLineConfigInput: GqlCommunityLineConfigInput;
+  CommunityLineRichMenuConfig: GqlCommunityLineRichMenuConfig;
+  CommunityLineRichMenuConfigInput: GqlCommunityLineRichMenuConfigInput;
+  CommunityPortalConfig: GqlCommunityPortalConfig;
+  CommunityPortalConfigInput: GqlCommunityPortalConfigInput;
+  CommunitySignupBonusConfig: GqlCommunitySignupBonusConfig;
+  CommunitySortInput: GqlCommunitySortInput;
+  CommunityUpdateProfileInput: GqlCommunityUpdateProfileInput;
+  CommunityUpdateProfilePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['CommunityUpdateProfilePayload'];
+  CommunityUpdateProfileSuccess: Omit<GqlCommunityUpdateProfileSuccess, 'community'> & { community: GqlResolversParentTypes['Community'] };
+  CreateUserDidInput: GqlCreateUserDidInput;
+  CurrentPointView: CurrentPointView;
+  CurrentUserPayload: Omit<GqlCurrentUserPayload, 'user'> & { user?: Maybe<GqlResolversParentTypes['User']> };
+  DateTimeRangeFilter: GqlDateTimeRangeFilter;
+  Datetime: Scalars['Datetime']['output'];
+  Decimal: Scalars['Decimal']['output'];
+  DidIssuanceRequest: GqlDidIssuanceRequest;
+  Edge: GqlResolversInterfaceTypes<GqlResolversParentTypes>['Edge'];
+  Error: GqlError;
+  Evaluation: Omit<GqlEvaluation, 'evaluator' | 'histories' | 'participation' | 'vcIssuanceRequest'> & { evaluator?: Maybe<GqlResolversParentTypes['User']>, histories?: Maybe<Array<GqlResolversParentTypes['EvaluationHistory']>>, participation?: Maybe<GqlResolversParentTypes['Participation']>, vcIssuanceRequest?: Maybe<GqlResolversParentTypes['VcIssuanceRequest']> };
+  EvaluationBulkCreateInput: GqlEvaluationBulkCreateInput;
+  EvaluationBulkCreatePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['EvaluationBulkCreatePayload'];
+  EvaluationBulkCreateSuccess: Omit<GqlEvaluationBulkCreateSuccess, 'evaluations'> & { evaluations: Array<GqlResolversParentTypes['Evaluation']> };
+  EvaluationCreateInput: GqlEvaluationCreateInput;
+  EvaluationEdge: Omit<GqlEvaluationEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['Evaluation']> };
+  EvaluationFilterInput: GqlEvaluationFilterInput;
+  EvaluationHistoriesConnection: Omit<GqlEvaluationHistoriesConnection, 'edges'> & { edges: Array<GqlResolversParentTypes['EvaluationHistoryEdge']> };
+  EvaluationHistory: Omit<GqlEvaluationHistory, 'createdByUser' | 'evaluation'> & { createdByUser?: Maybe<GqlResolversParentTypes['User']>, evaluation?: Maybe<GqlResolversParentTypes['Evaluation']> };
+  EvaluationHistoryEdge: Omit<GqlEvaluationHistoryEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['EvaluationHistory']> };
+  EvaluationHistoryFilterInput: GqlEvaluationHistoryFilterInput;
+  EvaluationHistorySortInput: GqlEvaluationHistorySortInput;
+  EvaluationItem: GqlEvaluationItem;
+  EvaluationSortInput: GqlEvaluationSortInput;
+  EvaluationsConnection: Omit<GqlEvaluationsConnection, 'edges'> & { edges: Array<GqlResolversParentTypes['EvaluationEdge']> };
+  Float: Scalars['Float']['output'];
+  GenerateReportInput: GqlGenerateReportInput;
+  GenerateReportPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['GenerateReportPayload'];
+  GenerateReportSuccess: Omit<GqlGenerateReportSuccess, 'report'> & { report: GqlResolversParentTypes['Report'] };
+  ID: Scalars['ID']['output'];
+  Identity: Omit<GqlIdentity, 'user'> & { user?: Maybe<GqlResolversParentTypes['User']> };
+  IdentityCheckPhoneUserInput: GqlIdentityCheckPhoneUserInput;
+  IdentityCheckPhoneUserPayload: Omit<GqlIdentityCheckPhoneUserPayload, 'membership' | 'user'> & { membership?: Maybe<GqlResolversParentTypes['Membership']>, user?: Maybe<GqlResolversParentTypes['User']> };
+  ImageInput: GqlImageInput;
+  IncentiveGrant: Omit<GqlIncentiveGrant, 'community' | 'transaction' | 'user'> & { community?: Maybe<GqlResolversParentTypes['Community']>, transaction?: Maybe<GqlResolversParentTypes['Transaction']>, user?: Maybe<GqlResolversParentTypes['User']> };
+  IncentiveGrantEdge: Omit<GqlIncentiveGrantEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['IncentiveGrant']> };
+  IncentiveGrantFilterInput: GqlIncentiveGrantFilterInput;
+  IncentiveGrantRetryInput: GqlIncentiveGrantRetryInput;
+  IncentiveGrantRetryPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['IncentiveGrantRetryPayload'];
+  IncentiveGrantRetrySuccess: Omit<GqlIncentiveGrantRetrySuccess, 'incentiveGrant' | 'transaction'> & { incentiveGrant: GqlResolversParentTypes['IncentiveGrant'], transaction?: Maybe<GqlResolversParentTypes['Transaction']> };
+  IncentiveGrantSortInput: GqlIncentiveGrantSortInput;
+  IncentiveGrantsConnection: Omit<GqlIncentiveGrantsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['IncentiveGrantEdge']>>> };
+  Int: Scalars['Int']['output'];
+  IssueVcInput: GqlIssueVcInput;
+  JSON: Scalars['JSON']['output'];
+  LinkPhoneAuthInput: GqlLinkPhoneAuthInput;
+  LinkPhoneAuthPayload: Omit<GqlLinkPhoneAuthPayload, 'user'> & { user?: Maybe<GqlResolversParentTypes['User']> };
+  Membership: Membership;
+  MembershipCursorInput: GqlMembershipCursorInput;
+  MembershipEdge: Omit<GqlMembershipEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['Membership']> };
+  MembershipFilterInput: GqlMembershipFilterInput;
+  MembershipHistory: MembershipHistory;
+  MembershipInviteInput: GqlMembershipInviteInput;
+  MembershipInvitePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['MembershipInvitePayload'];
+  MembershipInviteSuccess: Omit<GqlMembershipInviteSuccess, 'membership'> & { membership: GqlResolversParentTypes['Membership'] };
+  MembershipRemoveInput: GqlMembershipRemoveInput;
+  MembershipRemovePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['MembershipRemovePayload'];
+  MembershipRemoveSuccess: GqlMembershipRemoveSuccess;
+  MembershipSetInvitationStatusInput: GqlMembershipSetInvitationStatusInput;
+  MembershipSetInvitationStatusPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['MembershipSetInvitationStatusPayload'];
+  MembershipSetInvitationStatusSuccess: Omit<GqlMembershipSetInvitationStatusSuccess, 'membership'> & { membership: GqlResolversParentTypes['Membership'] };
+  MembershipSetRoleInput: GqlMembershipSetRoleInput;
+  MembershipSetRolePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['MembershipSetRolePayload'];
+  MembershipSetRoleSuccess: Omit<GqlMembershipSetRoleSuccess, 'membership'> & { membership: GqlResolversParentTypes['Membership'] };
+  MembershipSortInput: GqlMembershipSortInput;
+  MembershipWithdrawInput: GqlMembershipWithdrawInput;
+  MembershipWithdrawPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['MembershipWithdrawPayload'];
+  MembershipWithdrawSuccess: GqlMembershipWithdrawSuccess;
+  MembershipsConnection: Omit<GqlMembershipsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['MembershipEdge']>>> };
+  Mutation: {};
+  MyVoteEligibility: GqlMyVoteEligibility;
+  NestedPlaceConnectOrCreateInput: GqlNestedPlaceConnectOrCreateInput;
+  NestedPlaceCreateInput: GqlNestedPlaceCreateInput;
+  NestedPlacesBulkConnectOrCreateInput: GqlNestedPlacesBulkConnectOrCreateInput;
+  NestedPlacesBulkUpdateInput: GqlNestedPlacesBulkUpdateInput;
+  NftInstance: Omit<GqlNftInstance, 'community' | 'nftToken' | 'nftWallet'> & { community?: Maybe<GqlResolversParentTypes['Community']>, nftToken?: Maybe<GqlResolversParentTypes['NftToken']>, nftWallet?: Maybe<GqlResolversParentTypes['NftWallet']> };
+  NftInstanceEdge: Omit<GqlNftInstanceEdge, 'node'> & { node: GqlResolversParentTypes['NftInstance'] };
+  NftInstanceFilterInput: GqlNftInstanceFilterInput;
+  NftInstanceSortInput: GqlNftInstanceSortInput;
+  NftInstancesConnection: Omit<GqlNftInstancesConnection, 'edges'> & { edges: Array<GqlResolversParentTypes['NftInstanceEdge']> };
+  NftToken: Omit<GqlNftToken, 'community'> & { community?: Maybe<GqlResolversParentTypes['Community']> };
+  NftTokenEdge: Omit<GqlNftTokenEdge, 'node'> & { node: GqlResolversParentTypes['NftToken'] };
+  NftTokenFilterInput: GqlNftTokenFilterInput;
+  NftTokenSortInput: GqlNftTokenSortInput;
+  NftTokensConnection: Omit<GqlNftTokensConnection, 'edges'> & { edges: Array<GqlResolversParentTypes['NftTokenEdge']> };
+  NftWallet: Omit<GqlNftWallet, 'user'> & { user: GqlResolversParentTypes['User'] };
+  OpportunitiesConnection: Omit<GqlOpportunitiesConnection, 'edges'> & { edges: Array<GqlResolversParentTypes['OpportunityEdge']> };
+  Opportunity: Opportunity;
+  OpportunityCreateInput: GqlOpportunityCreateInput;
+  OpportunityCreatePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['OpportunityCreatePayload'];
+  OpportunityCreateSuccess: Omit<GqlOpportunityCreateSuccess, 'opportunity'> & { opportunity: GqlResolversParentTypes['Opportunity'] };
+  OpportunityDeletePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['OpportunityDeletePayload'];
+  OpportunityDeleteSuccess: GqlOpportunityDeleteSuccess;
+  OpportunityEdge: Omit<GqlOpportunityEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['Opportunity']> };
+  OpportunityFilterInput: GqlOpportunityFilterInput;
+  OpportunitySetPublishStatusInput: GqlOpportunitySetPublishStatusInput;
+  OpportunitySetPublishStatusPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['OpportunitySetPublishStatusPayload'];
+  OpportunitySetPublishStatusSuccess: Omit<GqlOpportunitySetPublishStatusSuccess, 'opportunity'> & { opportunity: GqlResolversParentTypes['Opportunity'] };
+  OpportunitySlot: OpportunitySlot;
+  OpportunitySlotCreateInput: GqlOpportunitySlotCreateInput;
+  OpportunitySlotCreatePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['OpportunitySlotCreatePayload'];
+  OpportunitySlotCreateSuccess: Omit<GqlOpportunitySlotCreateSuccess, 'slot'> & { slot: GqlResolversParentTypes['OpportunitySlot'] };
+  OpportunitySlotEdge: Omit<GqlOpportunitySlotEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['OpportunitySlot']> };
+  OpportunitySlotFilterInput: GqlOpportunitySlotFilterInput;
+  OpportunitySlotSetHostingStatusInput: GqlOpportunitySlotSetHostingStatusInput;
+  OpportunitySlotSetHostingStatusPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['OpportunitySlotSetHostingStatusPayload'];
+  OpportunitySlotSetHostingStatusSuccess: Omit<GqlOpportunitySlotSetHostingStatusSuccess, 'slot'> & { slot: GqlResolversParentTypes['OpportunitySlot'] };
+  OpportunitySlotSortInput: GqlOpportunitySlotSortInput;
+  OpportunitySlotUpdateInput: GqlOpportunitySlotUpdateInput;
+  OpportunitySlotsBulkUpdateInput: GqlOpportunitySlotsBulkUpdateInput;
+  OpportunitySlotsBulkUpdatePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['OpportunitySlotsBulkUpdatePayload'];
+  OpportunitySlotsBulkUpdateSuccess: Omit<GqlOpportunitySlotsBulkUpdateSuccess, 'slots'> & { slots: Array<GqlResolversParentTypes['OpportunitySlot']> };
+  OpportunitySlotsConnection: Omit<GqlOpportunitySlotsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['OpportunitySlotEdge']>>> };
+  OpportunitySortInput: GqlOpportunitySortInput;
+  OpportunityUpdateContentInput: GqlOpportunityUpdateContentInput;
+  OpportunityUpdateContentPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['OpportunityUpdateContentPayload'];
+  OpportunityUpdateContentSuccess: Omit<GqlOpportunityUpdateContentSuccess, 'opportunity'> & { opportunity: GqlResolversParentTypes['Opportunity'] };
+  PageInfo: GqlPageInfo;
+  Paging: GqlPaging;
+  Participation: Participation;
+  ParticipationBulkCreateInput: GqlParticipationBulkCreateInput;
+  ParticipationBulkCreatePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['ParticipationBulkCreatePayload'];
+  ParticipationBulkCreateSuccess: Omit<GqlParticipationBulkCreateSuccess, 'participations'> & { participations: Array<GqlResolversParentTypes['Participation']> };
+  ParticipationCreatePersonalRecordInput: GqlParticipationCreatePersonalRecordInput;
+  ParticipationCreatePersonalRecordPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['ParticipationCreatePersonalRecordPayload'];
+  ParticipationCreatePersonalRecordSuccess: Omit<GqlParticipationCreatePersonalRecordSuccess, 'participation'> & { participation: GqlResolversParentTypes['Participation'] };
+  ParticipationDeletePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['ParticipationDeletePayload'];
+  ParticipationDeleteSuccess: GqlParticipationDeleteSuccess;
+  ParticipationEdge: Omit<GqlParticipationEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['Participation']> };
+  ParticipationFilterInput: GqlParticipationFilterInput;
+  ParticipationSortInput: GqlParticipationSortInput;
+  ParticipationStatusHistoriesConnection: Omit<GqlParticipationStatusHistoriesConnection, 'edges'> & { edges: Array<GqlResolversParentTypes['ParticipationStatusHistoryEdge']> };
+  ParticipationStatusHistory: ParticipationStatusHistory;
+  ParticipationStatusHistoryEdge: Omit<GqlParticipationStatusHistoryEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['ParticipationStatusHistory']> };
+  ParticipationStatusHistoryFilterInput: GqlParticipationStatusHistoryFilterInput;
+  ParticipationStatusHistorySortInput: GqlParticipationStatusHistorySortInput;
+  ParticipationsConnection: Omit<GqlParticipationsConnection, 'edges'> & { edges: Array<GqlResolversParentTypes['ParticipationEdge']> };
+  Place: Place;
+  PlaceCreateInput: GqlPlaceCreateInput;
+  PlaceCreatePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['PlaceCreatePayload'];
+  PlaceCreateSuccess: Omit<GqlPlaceCreateSuccess, 'place'> & { place: GqlResolversParentTypes['Place'] };
+  PlaceDeletePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['PlaceDeletePayload'];
+  PlaceDeleteSuccess: GqlPlaceDeleteSuccess;
+  PlaceEdge: Omit<GqlPlaceEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['Place']> };
+  PlaceFilterInput: GqlPlaceFilterInput;
+  PlaceSortInput: GqlPlaceSortInput;
+  PlaceUpdateInput: GqlPlaceUpdateInput;
+  PlaceUpdatePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['PlaceUpdatePayload'];
+  PlaceUpdateSuccess: Omit<GqlPlaceUpdateSuccess, 'place'> & { place: GqlResolversParentTypes['Place'] };
+  PlacesConnection: Omit<GqlPlacesConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['PlaceEdge']>>> };
+  Portfolio: Omit<GqlPortfolio, 'participants' | 'place'> & { participants?: Maybe<Array<GqlResolversParentTypes['User']>>, place?: Maybe<GqlResolversParentTypes['Place']> };
+  PortfolioEdge: Omit<GqlPortfolioEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['Portfolio']> };
+  PortfolioFilterInput: GqlPortfolioFilterInput;
+  PortfolioSortInput: GqlPortfolioSortInput;
+  PortfoliosConnection: Omit<GqlPortfoliosConnection, 'edges'> & { edges: Array<GqlResolversParentTypes['PortfolioEdge']> };
+  PublishReportPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['PublishReportPayload'];
+  PublishReportSuccess: Omit<GqlPublishReportSuccess, 'report'> & { report: GqlResolversParentTypes['Report'] };
+  Query: {};
+  RejectReportPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['RejectReportPayload'];
+  RejectReportSuccess: Omit<GqlRejectReportSuccess, 'report'> & { report: GqlResolversParentTypes['Report'] };
+  Report: Omit<GqlReport, 'community' | 'feedbacks' | 'generatedByUser' | 'myFeedback' | 'parentRun' | 'publishedByUser' | 'regenerations' | 'targetUser' | 'template'> & { community: GqlResolversParentTypes['Community'], feedbacks: GqlResolversParentTypes['ReportFeedbacksConnection'], generatedByUser?: Maybe<GqlResolversParentTypes['User']>, myFeedback?: Maybe<GqlResolversParentTypes['ReportFeedback']>, parentRun?: Maybe<GqlResolversParentTypes['Report']>, publishedByUser?: Maybe<GqlResolversParentTypes['User']>, regenerations: Array<GqlResolversParentTypes['Report']>, targetUser?: Maybe<GqlResolversParentTypes['User']>, template?: Maybe<GqlResolversParentTypes['ReportTemplate']> };
+  ReportEdge: Omit<GqlReportEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['Report']> };
+  ReportFeedback: Omit<GqlReportFeedback, 'report' | 'user'> & { report: GqlResolversParentTypes['Report'], user: GqlResolversParentTypes['User'] };
+  ReportFeedbackEdge: Omit<GqlReportFeedbackEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['ReportFeedback']> };
+  ReportFeedbackRatingBucket: GqlReportFeedbackRatingBucket;
+  ReportFeedbacksConnection: Omit<GqlReportFeedbacksConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['ReportFeedbackEdge']>>> };
+  ReportTemplate: Omit<GqlReportTemplate, 'community' | 'updatedByUser'> & { community?: Maybe<GqlResolversParentTypes['Community']>, updatedByUser?: Maybe<GqlResolversParentTypes['User']> };
+  ReportTemplateStats: GqlReportTemplateStats;
+  ReportTemplateStatsBreakdownConnection: GqlReportTemplateStatsBreakdownConnection;
+  ReportTemplateStatsBreakdownEdge: GqlReportTemplateStatsBreakdownEdge;
+  ReportTemplateStatsBreakdownRow: GqlReportTemplateStatsBreakdownRow;
+  ReportsConnection: Omit<GqlReportsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['ReportEdge']>>> };
+  Reservation: Omit<GqlReservation, 'createdByUser' | 'histories' | 'opportunitySlot' | 'participations'> & { createdByUser?: Maybe<GqlResolversParentTypes['User']>, histories?: Maybe<Array<GqlResolversParentTypes['ReservationHistory']>>, opportunitySlot?: Maybe<GqlResolversParentTypes['OpportunitySlot']>, participations?: Maybe<Array<GqlResolversParentTypes['Participation']>> };
+  ReservationCancelInput: GqlReservationCancelInput;
+  ReservationCreateInput: GqlReservationCreateInput;
+  ReservationCreatePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['ReservationCreatePayload'];
+  ReservationCreateSuccess: Omit<GqlReservationCreateSuccess, 'reservation'> & { reservation: GqlResolversParentTypes['Reservation'] };
+  ReservationEdge: Omit<GqlReservationEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['Reservation']> };
+  ReservationFilterInput: GqlReservationFilterInput;
+  ReservationHistoriesConnection: Omit<GqlReservationHistoriesConnection, 'edges'> & { edges: Array<GqlResolversParentTypes['ReservationHistoryEdge']> };
+  ReservationHistory: Omit<GqlReservationHistory, 'createdByUser' | 'reservation'> & { createdByUser?: Maybe<GqlResolversParentTypes['User']>, reservation: GqlResolversParentTypes['Reservation'] };
+  ReservationHistoryEdge: Omit<GqlReservationHistoryEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['ReservationHistory']> };
+  ReservationHistoryFilterInput: GqlReservationHistoryFilterInput;
+  ReservationHistorySortInput: GqlReservationHistorySortInput;
+  ReservationRejectInput: GqlReservationRejectInput;
+  ReservationSetStatusPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['ReservationSetStatusPayload'];
+  ReservationSetStatusSuccess: Omit<GqlReservationSetStatusSuccess, 'reservation'> & { reservation: GqlResolversParentTypes['Reservation'] };
+  ReservationSortInput: GqlReservationSortInput;
+  ReservationsConnection: Omit<GqlReservationsConnection, 'edges'> & { edges: Array<GqlResolversParentTypes['ReservationEdge']> };
+  RevokeUserVcInput: GqlRevokeUserVcInput;
+  State: State;
+  StateEdge: Omit<GqlStateEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['State']> };
+  StatesConnection: Omit<GqlStatesConnection, 'edges'> & { edges: Array<GqlResolversParentTypes['StateEdge']> };
+  StatesInput: GqlStatesInput;
+  StorePhoneAuthTokenInput: GqlStorePhoneAuthTokenInput;
+  StorePhoneAuthTokenPayload: GqlStorePhoneAuthTokenPayload;
+  String: Scalars['String']['output'];
+  SubmitReportFeedbackInput: GqlSubmitReportFeedbackInput;
+  SubmitReportFeedbackPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['SubmitReportFeedbackPayload'];
+  SubmitReportFeedbackSuccess: Omit<GqlSubmitReportFeedbackSuccess, 'feedback'> & { feedback: GqlResolversParentTypes['ReportFeedback'] };
+  Ticket: Ticket;
+  TicketClaimInput: GqlTicketClaimInput;
+  TicketClaimLink: TicketClaimLink;
+  TicketClaimLinkEdge: Omit<GqlTicketClaimLinkEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['TicketClaimLink']> };
+  TicketClaimLinkFilterInput: GqlTicketClaimLinkFilterInput;
+  TicketClaimLinkSortInput: GqlTicketClaimLinkSortInput;
+  TicketClaimLinksConnection: Omit<GqlTicketClaimLinksConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['TicketClaimLinkEdge']>>> };
+  TicketClaimPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['TicketClaimPayload'];
+  TicketClaimSuccess: Omit<GqlTicketClaimSuccess, 'tickets'> & { tickets: Array<GqlResolversParentTypes['Ticket']> };
+  TicketEdge: Omit<GqlTicketEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['Ticket']> };
+  TicketFilterInput: GqlTicketFilterInput;
+  TicketIssueInput: GqlTicketIssueInput;
+  TicketIssuePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['TicketIssuePayload'];
+  TicketIssueSuccess: Omit<GqlTicketIssueSuccess, 'issue'> & { issue: GqlResolversParentTypes['TicketIssuer'] };
+  TicketIssuer: TicketIssuer;
+  TicketIssuerEdge: Omit<GqlTicketIssuerEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['TicketIssuer']> };
+  TicketIssuerFilterInput: GqlTicketIssuerFilterInput;
+  TicketIssuerSortInput: GqlTicketIssuerSortInput;
+  TicketIssuersConnection: Omit<GqlTicketIssuersConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['TicketIssuerEdge']>>> };
+  TicketPurchaseInput: GqlTicketPurchaseInput;
+  TicketPurchasePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['TicketPurchasePayload'];
+  TicketPurchaseSuccess: Omit<GqlTicketPurchaseSuccess, 'ticket'> & { ticket: GqlResolversParentTypes['Ticket'] };
+  TicketRefundInput: GqlTicketRefundInput;
+  TicketRefundPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['TicketRefundPayload'];
+  TicketRefundSuccess: Omit<GqlTicketRefundSuccess, 'ticket'> & { ticket: GqlResolversParentTypes['Ticket'] };
+  TicketSortInput: GqlTicketSortInput;
+  TicketStatusHistoriesConnection: Omit<GqlTicketStatusHistoriesConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['TicketStatusHistoryEdge']>>> };
+  TicketStatusHistory: TicketStatusHistory;
+  TicketStatusHistoryEdge: Omit<GqlTicketStatusHistoryEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['TicketStatusHistory']> };
+  TicketStatusHistoryFilterInput: GqlTicketStatusHistoryFilterInput;
+  TicketStatusHistorySortInput: GqlTicketStatusHistorySortInput;
+  TicketUsePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['TicketUsePayload'];
+  TicketUseSuccess: Omit<GqlTicketUseSuccess, 'ticket'> & { ticket: GqlResolversParentTypes['Ticket'] };
+  TicketsConnection: Omit<GqlTicketsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['TicketEdge']>>> };
+  Transaction: Transaction;
+  TransactionChain: Omit<GqlTransactionChain, 'steps'> & { steps: Array<GqlResolversParentTypes['TransactionChainStep']> };
+  TransactionChainCommunity: GqlTransactionChainCommunity;
+  TransactionChainParticipant: GqlResolversInterfaceTypes<GqlResolversParentTypes>['TransactionChainParticipant'];
+  TransactionChainStep: Omit<GqlTransactionChainStep, 'from' | 'to'> & { from?: Maybe<GqlResolversParentTypes['TransactionChainParticipant']>, to?: Maybe<GqlResolversParentTypes['TransactionChainParticipant']> };
+  TransactionChainUser: GqlTransactionChainUser;
+  TransactionDonateSelfPointInput: GqlTransactionDonateSelfPointInput;
+  TransactionDonateSelfPointPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['TransactionDonateSelfPointPayload'];
+  TransactionDonateSelfPointSuccess: Omit<GqlTransactionDonateSelfPointSuccess, 'transaction'> & { transaction: GqlResolversParentTypes['Transaction'] };
+  TransactionEdge: Omit<GqlTransactionEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['Transaction']> };
+  TransactionFilterInput: GqlTransactionFilterInput;
+  TransactionGrantCommunityPointInput: GqlTransactionGrantCommunityPointInput;
+  TransactionGrantCommunityPointPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['TransactionGrantCommunityPointPayload'];
+  TransactionGrantCommunityPointSuccess: Omit<GqlTransactionGrantCommunityPointSuccess, 'transaction'> & { transaction: GqlResolversParentTypes['Transaction'] };
+  TransactionIssueCommunityPointInput: GqlTransactionIssueCommunityPointInput;
+  TransactionIssueCommunityPointPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['TransactionIssueCommunityPointPayload'];
+  TransactionIssueCommunityPointSuccess: Omit<GqlTransactionIssueCommunityPointSuccess, 'transaction'> & { transaction: GqlResolversParentTypes['Transaction'] };
+  TransactionSortInput: GqlTransactionSortInput;
+  TransactionUpdateMetadataInput: GqlTransactionUpdateMetadataInput;
+  TransactionUpdateMetadataPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['TransactionUpdateMetadataPayload'];
+  TransactionUpdateMetadataSuccess: Omit<GqlTransactionUpdateMetadataSuccess, 'transaction'> & { transaction: GqlResolversParentTypes['Transaction'] };
+  TransactionVerificationResult: GqlTransactionVerificationResult;
+  TransactionsConnection: Omit<GqlTransactionsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['TransactionEdge']>>> };
+  UpdateReportTemplateInput: GqlUpdateReportTemplateInput;
+  UpdateReportTemplatePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['UpdateReportTemplatePayload'];
+  UpdateReportTemplateSuccess: Omit<GqlUpdateReportTemplateSuccess, 'reportTemplate'> & { reportTemplate: GqlResolversParentTypes['ReportTemplate'] };
+  UpdateSignupBonusConfigInput: GqlUpdateSignupBonusConfigInput;
+  Upload: Scalars['Upload']['output'];
+  User: User;
+  UserDeletePayload: GqlUserDeletePayload;
+  UserDidAnchor: Omit<GqlUserDidAnchor, 'user'> & { user?: Maybe<GqlResolversParentTypes['User']> };
+  UserEdge: Omit<GqlUserEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['User']> };
+  UserFilterInput: GqlUserFilterInput;
+  UserSignUpInput: GqlUserSignUpInput;
+  UserSortInput: GqlUserSortInput;
+  UserUpdateProfileInput: GqlUserUpdateProfileInput;
+  UserUpdateProfilePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['UserUpdateProfilePayload'];
+  UserUpdateProfileSuccess: Omit<GqlUserUpdateProfileSuccess, 'user'> & { user?: Maybe<GqlResolversParentTypes['User']> };
+  UsersConnection: Omit<GqlUsersConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['UserEdge']>>> };
+  UtilitiesConnection: Omit<GqlUtilitiesConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['UtilityEdge']>>> };
+  Utility: Utility;
+  UtilityCreateInput: GqlUtilityCreateInput;
+  UtilityCreatePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['UtilityCreatePayload'];
+  UtilityCreateSuccess: Omit<GqlUtilityCreateSuccess, 'utility'> & { utility: GqlResolversParentTypes['Utility'] };
+  UtilityDeletePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['UtilityDeletePayload'];
+  UtilityDeleteSuccess: GqlUtilityDeleteSuccess;
+  UtilityEdge: Omit<GqlUtilityEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['Utility']> };
+  UtilityFilterInput: GqlUtilityFilterInput;
+  UtilitySetPublishStatusInput: GqlUtilitySetPublishStatusInput;
+  UtilitySetPublishStatusPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['UtilitySetPublishStatusPayload'];
+  UtilitySetPublishStatusSuccess: Omit<GqlUtilitySetPublishStatusSuccess, 'utility'> & { utility: GqlResolversParentTypes['Utility'] };
+  UtilitySortInput: GqlUtilitySortInput;
+  UtilityUpdateInfoInput: GqlUtilityUpdateInfoInput;
+  UtilityUpdateInfoPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['UtilityUpdateInfoPayload'];
+  UtilityUpdateInfoSuccess: Omit<GqlUtilityUpdateInfoSuccess, 'utility'> & { utility: GqlResolversParentTypes['Utility'] };
+  VcIssuance: Omit<GqlVcIssuance, 'evaluation' | 'user'> & { evaluation?: Maybe<GqlResolversParentTypes['Evaluation']>, user?: Maybe<GqlResolversParentTypes['User']> };
+  VcIssuanceRequest: Omit<GqlVcIssuanceRequest, 'evaluation' | 'user'> & { evaluation?: Maybe<GqlResolversParentTypes['Evaluation']>, user?: Maybe<GqlResolversParentTypes['User']> };
+  VcIssuanceRequestEdge: Omit<GqlVcIssuanceRequestEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['VcIssuanceRequest']> };
+  VcIssuanceRequestFilterInput: GqlVcIssuanceRequestFilterInput;
+  VcIssuanceRequestSortInput: GqlVcIssuanceRequestSortInput;
+  VcIssuanceRequestsConnection: Omit<GqlVcIssuanceRequestsConnection, 'edges'> & { edges: Array<GqlResolversParentTypes['VcIssuanceRequestEdge']> };
+  VoteBallot: GqlVoteBallot;
+  VoteCastInput: GqlVoteCastInput;
+  VoteCastPayload: GqlResolversUnionTypes<GqlResolversParentTypes>['VoteCastPayload'];
+  VoteCastSuccess: GqlVoteCastSuccess;
+  VoteGate: Omit<GqlVoteGate, 'nftToken'> & { nftToken?: Maybe<GqlResolversParentTypes['NftToken']> };
+  VoteGateInput: GqlVoteGateInput;
+  VoteOption: GqlVoteOption;
+  VoteOptionInput: GqlVoteOptionInput;
+  VotePowerPolicy: Omit<GqlVotePowerPolicy, 'nftToken'> & { nftToken?: Maybe<GqlResolversParentTypes['NftToken']> };
+  VotePowerPolicyInput: GqlVotePowerPolicyInput;
+  VoteTopic: Omit<GqlVoteTopic, 'community' | 'gate' | 'powerPolicy'> & { community: GqlResolversParentTypes['Community'], gate: GqlResolversParentTypes['VoteGate'], powerPolicy: GqlResolversParentTypes['VotePowerPolicy'] };
+  VoteTopicCreateInput: GqlVoteTopicCreateInput;
+  VoteTopicCreatePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['VoteTopicCreatePayload'];
+  VoteTopicCreateSuccess: Omit<GqlVoteTopicCreateSuccess, 'voteTopic'> & { voteTopic: GqlResolversParentTypes['VoteTopic'] };
+  VoteTopicDeletePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['VoteTopicDeletePayload'];
+  VoteTopicDeleteSuccess: GqlVoteTopicDeleteSuccess;
+  VoteTopicEdge: Omit<GqlVoteTopicEdge, 'node'> & { node: GqlResolversParentTypes['VoteTopic'] };
+  VoteTopicUpdateInput: GqlVoteTopicUpdateInput;
+  VoteTopicUpdatePayload: GqlResolversUnionTypes<GqlResolversParentTypes>['VoteTopicUpdatePayload'];
+  VoteTopicUpdateSuccess: Omit<GqlVoteTopicUpdateSuccess, 'voteTopic'> & { voteTopic: GqlResolversParentTypes['VoteTopic'] };
+  VoteTopicsConnection: Omit<GqlVoteTopicsConnection, 'edges' | 'nodes'> & { edges: Array<GqlResolversParentTypes['VoteTopicEdge']>, nodes: Array<GqlResolversParentTypes['VoteTopic']> };
+  Wallet: Wallet;
+  WalletEdge: Omit<GqlWalletEdge, 'node'> & { node?: Maybe<GqlResolversParentTypes['Wallet']> };
+  WalletFilterInput: GqlWalletFilterInput;
+  WalletSortInput: GqlWalletSortInput;
+  WalletsConnection: Omit<GqlWalletsConnection, 'edges'> & { edges?: Maybe<Array<Maybe<GqlResolversParentTypes['WalletEdge']>>> };
+}>;
+
+export type GqlAuthzDirectiveArgs = {
+  compositeRules?: Maybe<Array<Maybe<GqlAuthZDirectiveCompositeRulesInput>>>;
+  deepCompositeRules?: Maybe<Array<Maybe<GqlAuthZDirectiveDeepCompositeRulesInput>>>;
+  rules?: Maybe<Array<Maybe<GqlAuthZRules>>>;
+};
+
+export type GqlAuthzDirectiveResolver<Result, Parent, ContextType = any, Args = GqlAuthzDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+
+export type GqlRequireRoleDirectiveArgs = {
+  role: GqlRole;
+};
+
+export type GqlRequireRoleDirectiveResolver<Result, Parent, ContextType = any, Args = GqlRequireRoleDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+
+export type GqlAccumulatedPointViewResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AccumulatedPointView'] = GqlResolversParentTypes['AccumulatedPointView']> = ResolversObject<{
+  accumulatedPoint?: Resolver<GqlResolversTypes['BigInt'], ParentType, ContextType>;
+  walletId?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAdminReportSummaryConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AdminReportSummaryConnection'] = GqlResolversParentTypes['AdminReportSummaryConnection']> = ResolversObject<{
+  edges?: Resolver<Maybe<Array<Maybe<GqlResolversTypes['AdminReportSummaryEdge']>>>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAdminReportSummaryEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AdminReportSummaryEdge'] = GqlResolversParentTypes['AdminReportSummaryEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['AdminReportSummaryRow']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAdminReportSummaryRowResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AdminReportSummaryRow'] = GqlResolversParentTypes['AdminReportSummaryRow']> = ResolversObject<{
+  community?: Resolver<GqlResolversTypes['Community'], ParentType, ContextType>;
+  daysSinceLastPublish?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  lastPublishedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  lastPublishedReport?: Resolver<Maybe<GqlResolversTypes['Report']>, ParentType, ContextType>;
+  publishedCountLast90Days?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAdminTemplateFeedbackStatsResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AdminTemplateFeedbackStats'] = GqlResolversParentTypes['AdminTemplateFeedbackStats']> = ResolversObject<{
+  avgRating?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  ratingDistribution?: Resolver<Array<GqlResolversTypes['ReportFeedbackRatingBucket']>, ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAnalyticsChainDepthBucketResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AnalyticsChainDepthBucket'] = GqlResolversParentTypes['AnalyticsChainDepthBucket']> = ResolversObject<{
+  count?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  depth?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAnalyticsCohortFunnelPointResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AnalyticsCohortFunnelPoint'] = GqlResolversParentTypes['AnalyticsCohortFunnelPoint']> = ResolversObject<{
+  acquired?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  activatedD30?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  cohortMonth?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  habitual?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  repeated?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAnalyticsCohortRetentionPointResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AnalyticsCohortRetentionPoint'] = GqlResolversParentTypes['AnalyticsCohortRetentionPoint']> = ResolversObject<{
+  cohortMonth?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  cohortSize?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  retentionM1?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  retentionM3?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  retentionM6?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAnalyticsCommunityAlertsResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AnalyticsCommunityAlerts'] = GqlResolversParentTypes['AnalyticsCommunityAlerts']> = ResolversObject<{
+  activeDrop?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  churnSpike?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  noNewMembers?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAnalyticsCommunityOverviewResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AnalyticsCommunityOverview'] = GqlResolversParentTypes['AnalyticsCommunityOverview']> = ResolversObject<{
+  communityId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  communityName?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  dormantCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  hubMemberCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  latestCohort?: Resolver<GqlResolversTypes['AnalyticsLatestCohort'], ParentType, ContextType>;
+  segmentCounts?: Resolver<GqlResolversTypes['AnalyticsSegmentCounts'], ParentType, ContextType>;
+  tenureDistribution?: Resolver<GqlResolversTypes['AnalyticsTenureDistribution'], ParentType, ContextType>;
+  totalMembers?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  weeklyRetention?: Resolver<GqlResolversTypes['AnalyticsWeeklyRetention'], ParentType, ContextType>;
+  windowActivity?: Resolver<GqlResolversTypes['AnalyticsWindowActivity'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAnalyticsCommunityPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AnalyticsCommunityPayload'] = GqlResolversParentTypes['AnalyticsCommunityPayload']> = ResolversObject<{
+  alerts?: Resolver<GqlResolversTypes['AnalyticsCommunityAlerts'], ParentType, ContextType>;
+  asOf?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  chainDepthDistribution?: Resolver<Array<GqlResolversTypes['AnalyticsChainDepthBucket']>, ParentType, ContextType>;
+  cohortFunnel?: Resolver<Array<GqlResolversTypes['AnalyticsCohortFunnelPoint']>, ParentType, ContextType>;
+  cohortRetention?: Resolver<Array<GqlResolversTypes['AnalyticsCohortRetentionPoint']>, ParentType, ContextType>;
+  communityId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  communityName?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  dormantCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  memberList?: Resolver<GqlResolversTypes['AnalyticsMemberList'], ParentType, ContextType>;
+  monthlyActivityTrend?: Resolver<Array<GqlResolversTypes['AnalyticsMonthlyActivityPoint']>, ParentType, ContextType>;
+  retentionTrend?: Resolver<Array<GqlResolversTypes['AnalyticsRetentionTrendPoint']>, ParentType, ContextType>;
+  stages?: Resolver<GqlResolversTypes['AnalyticsStageDistribution'], ParentType, ContextType>;
+  summary?: Resolver<GqlResolversTypes['AnalyticsCommunitySummaryCard'], ParentType, ContextType>;
+  windowMonths?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAnalyticsCommunitySummaryCardResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AnalyticsCommunitySummaryCard'] = GqlResolversParentTypes['AnalyticsCommunitySummaryCard']> = ResolversObject<{
+  communityActivityRate?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  communityActivityRate3mAvg?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  communityId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  communityName?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  dataFrom?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  dataTo?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  growthRateActivity?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  maxChainDepthAllTime?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  tier2Count?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  tier2Pct?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  totalDonationPointsAllTime?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  totalMembers?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAnalyticsDashboardPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AnalyticsDashboardPayload'] = GqlResolversParentTypes['AnalyticsDashboardPayload']> = ResolversObject<{
+  asOf?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  communities?: Resolver<Array<GqlResolversTypes['AnalyticsCommunityOverview']>, ParentType, ContextType>;
+  platform?: Resolver<GqlResolversTypes['AnalyticsPlatformSummary'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAnalyticsLatestCohortResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AnalyticsLatestCohort'] = GqlResolversParentTypes['AnalyticsLatestCohort']> = ResolversObject<{
+  activeAtM1?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  size?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAnalyticsMemberListResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AnalyticsMemberList'] = GqlResolversParentTypes['AnalyticsMemberList']> = ResolversObject<{
+  hasNextPage?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  nextCursor?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  users?: Resolver<Array<GqlResolversTypes['AnalyticsMemberRow']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAnalyticsMemberRowResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AnalyticsMemberRow'] = GqlResolversParentTypes['AnalyticsMemberRow']> = ResolversObject<{
+  daysIn?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  donationInDays?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  donationInMonths?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  donationOutDays?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  donationOutMonths?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  lastDonationAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  monthsIn?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  name?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  totalPointsIn?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  totalPointsOut?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  uniqueDonationRecipients?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  uniqueDonationSenders?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  userId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  userSendRate?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAnalyticsMonthlyActivityPointResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AnalyticsMonthlyActivityPoint'] = GqlResolversParentTypes['AnalyticsMonthlyActivityPoint']> = ResolversObject<{
+  chainPct?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  communityActivityRate?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  donationPointsSum?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  dormantCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  hubMemberCount?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  month?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  newMembers?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  returnedMembers?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  senderCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAnalyticsPlatformSummaryResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AnalyticsPlatformSummary'] = GqlResolversParentTypes['AnalyticsPlatformSummary']> = ResolversObject<{
+  communitiesCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  latestMonthDonationPoints?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  totalMembers?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAnalyticsRetentionTrendPointResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AnalyticsRetentionTrendPoint'] = GqlResolversParentTypes['AnalyticsRetentionTrendPoint']> = ResolversObject<{
+  churnedSenders?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  communityActivityRate?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  newMembers?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  retainedSenders?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  returnedSenders?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  week?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAnalyticsSegmentCountsResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AnalyticsSegmentCounts'] = GqlResolversParentTypes['AnalyticsSegmentCounts']> = ResolversObject<{
+  activeCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  passiveCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  tier1Count?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  tier2Count?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  total?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAnalyticsStageBucketResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AnalyticsStageBucket'] = GqlResolversParentTypes['AnalyticsStageBucket']> = ResolversObject<{
+  avgMonthsIn?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  avgSendRate?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  count?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  pct?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  pointsContributionPct?: Resolver<GqlResolversTypes['Float'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAnalyticsStageDistributionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AnalyticsStageDistribution'] = GqlResolversParentTypes['AnalyticsStageDistribution']> = ResolversObject<{
+  habitual?: Resolver<GqlResolversTypes['AnalyticsStageBucket'], ParentType, ContextType>;
+  latent?: Resolver<GqlResolversTypes['AnalyticsStageBucket'], ParentType, ContextType>;
+  occasional?: Resolver<GqlResolversTypes['AnalyticsStageBucket'], ParentType, ContextType>;
+  regular?: Resolver<GqlResolversTypes['AnalyticsStageBucket'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAnalyticsTenureDistributionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AnalyticsTenureDistribution'] = GqlResolversParentTypes['AnalyticsTenureDistribution']> = ResolversObject<{
+  gte12Months?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  lt1Month?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  m1to3Months?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  m3to12Months?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  monthlyHistogram?: Resolver<Array<GqlResolversTypes['AnalyticsTenureHistogramBucket']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAnalyticsTenureHistogramBucketResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AnalyticsTenureHistogramBucket'] = GqlResolversParentTypes['AnalyticsTenureHistogramBucket']> = ResolversObject<{
+  count?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  monthsIn?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAnalyticsWeeklyRetentionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AnalyticsWeeklyRetention'] = GqlResolversParentTypes['AnalyticsWeeklyRetention']> = ResolversObject<{
+  churnedSenders?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  retainedSenders?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlAnalyticsWindowActivityResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['AnalyticsWindowActivity'] = GqlResolversParentTypes['AnalyticsWindowActivity']> = ResolversObject<{
+  newMemberCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  newMemberCountPrev?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  retainedSenders?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  senderCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  senderCountPrev?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlApproveReportPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ApproveReportPayload'] = GqlResolversParentTypes['ApproveReportPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'ApproveReportSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlApproveReportSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ApproveReportSuccess'] = GqlResolversParentTypes['ApproveReportSuccess']> = ResolversObject<{
+  report?: Resolver<GqlResolversTypes['Report'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlArticleResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Article'] = GqlResolversParentTypes['Article']> = ResolversObject<{
+  authors?: Resolver<Maybe<Array<GqlResolversTypes['User']>>, ParentType, ContextType>;
+  body?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  category?: Resolver<GqlResolversTypes['ArticleCategory'], ParentType, ContextType>;
+  community?: Resolver<Maybe<GqlResolversTypes['Community']>, ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  introduction?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  opportunities?: Resolver<Maybe<Array<GqlResolversTypes['Opportunity']>>, ParentType, ContextType>;
+  publishStatus?: Resolver<GqlResolversTypes['PublishStatus'], ParentType, ContextType>;
+  publishedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  relatedUsers?: Resolver<Maybe<Array<GqlResolversTypes['User']>>, ParentType, ContextType>;
+  thumbnail?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  title?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlArticleCreatePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ArticleCreatePayload'] = GqlResolversParentTypes['ArticleCreatePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'ArticleCreateSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlArticleCreateSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ArticleCreateSuccess'] = GqlResolversParentTypes['ArticleCreateSuccess']> = ResolversObject<{
+  article?: Resolver<GqlResolversTypes['Article'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlArticleDeletePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ArticleDeletePayload'] = GqlResolversParentTypes['ArticleDeletePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'ArticleDeleteSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlArticleDeleteSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ArticleDeleteSuccess'] = GqlResolversParentTypes['ArticleDeleteSuccess']> = ResolversObject<{
+  articleId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlArticleEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ArticleEdge'] = GqlResolversParentTypes['ArticleEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['Article']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlArticleUpdateContentPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ArticleUpdateContentPayload'] = GqlResolversParentTypes['ArticleUpdateContentPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'ArticleUpdateContentSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlArticleUpdateContentSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ArticleUpdateContentSuccess'] = GqlResolversParentTypes['ArticleUpdateContentSuccess']> = ResolversObject<{
+  article?: Resolver<GqlResolversTypes['Article'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlArticlesConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ArticlesConnection'] = GqlResolversParentTypes['ArticlesConnection']> = ResolversObject<{
+  edges?: Resolver<Maybe<Array<Maybe<GqlResolversTypes['ArticleEdge']>>>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export interface GqlBigIntScalarConfig extends GraphQLScalarTypeConfig<GqlResolversTypes['BigInt'], any> {
+  name: 'BigInt';
+}
+
+export type GqlCitiesConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CitiesConnection'] = GqlResolversParentTypes['CitiesConnection']> = ResolversObject<{
+  edges?: Resolver<Array<GqlResolversTypes['CityEdge']>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlCityResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['City'] = GqlResolversParentTypes['City']> = ResolversObject<{
+  code?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  name?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  state?: Resolver<Maybe<GqlResolversTypes['State']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlCityEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CityEdge'] = GqlResolversParentTypes['CityEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['City']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlCommonDocumentOverridesResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CommonDocumentOverrides'] = GqlResolversParentTypes['CommonDocumentOverrides']> = ResolversObject<{
+  privacy?: Resolver<Maybe<GqlResolversTypes['CommunityDocument']>, ParentType, ContextType>;
+  terms?: Resolver<Maybe<GqlResolversTypes['CommunityDocument']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlCommunitiesConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CommunitiesConnection'] = GqlResolversParentTypes['CommunitiesConnection']> = ResolversObject<{
+  edges?: Resolver<Maybe<Array<GqlResolversTypes['CommunityEdge']>>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlCommunityResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Community'] = GqlResolversParentTypes['Community']> = ResolversObject<{
+  articles?: Resolver<Maybe<Array<GqlResolversTypes['Article']>>, ParentType, ContextType>;
+  bio?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  config?: Resolver<Maybe<GqlResolversTypes['CommunityConfig']>, ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  establishedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  image?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  memberships?: Resolver<Maybe<Array<GqlResolversTypes['Membership']>>, ParentType, ContextType>;
+  name?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  opportunities?: Resolver<Maybe<Array<GqlResolversTypes['Opportunity']>>, ParentType, ContextType>;
+  participations?: Resolver<Maybe<Array<GqlResolversTypes['Participation']>>, ParentType, ContextType>;
+  places?: Resolver<Maybe<Array<GqlResolversTypes['Place']>>, ParentType, ContextType>;
+  pointName?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  utilities?: Resolver<Maybe<Array<GqlResolversTypes['Utility']>>, ParentType, ContextType>;
+  wallets?: Resolver<Maybe<Array<GqlResolversTypes['Wallet']>>, ParentType, ContextType>;
+  website?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlCommunityConfigResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CommunityConfig'] = GqlResolversParentTypes['CommunityConfig']> = ResolversObject<{
+  firebaseConfig?: Resolver<Maybe<GqlResolversTypes['CommunityFirebaseConfig']>, ParentType, ContextType>;
+  lineConfig?: Resolver<Maybe<GqlResolversTypes['CommunityLineConfig']>, ParentType, ContextType>;
+  signupBonusConfig?: Resolver<Maybe<GqlResolversTypes['CommunitySignupBonusConfig']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlCommunityCreatePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CommunityCreatePayload'] = GqlResolversParentTypes['CommunityCreatePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'CommunityCreateSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlCommunityCreateSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CommunityCreateSuccess'] = GqlResolversParentTypes['CommunityCreateSuccess']> = ResolversObject<{
+  community?: Resolver<GqlResolversTypes['Community'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlCommunityDeletePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CommunityDeletePayload'] = GqlResolversParentTypes['CommunityDeletePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'CommunityDeleteSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlCommunityDeleteSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CommunityDeleteSuccess'] = GqlResolversParentTypes['CommunityDeleteSuccess']> = ResolversObject<{
+  communityId?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlCommunityDocumentResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CommunityDocument'] = GqlResolversParentTypes['CommunityDocument']> = ResolversObject<{
+  id?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  order?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  path?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  title?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  type?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlCommunityEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CommunityEdge'] = GqlResolversParentTypes['CommunityEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['Community']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlCommunityFirebaseConfigResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CommunityFirebaseConfig'] = GqlResolversParentTypes['CommunityFirebaseConfig']> = ResolversObject<{
+  tenantId?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlCommunityLineConfigResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CommunityLineConfig'] = GqlResolversParentTypes['CommunityLineConfig']> = ResolversObject<{
+  accessToken?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  channelId?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  channelSecret?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  liffAppId?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  liffBaseUrl?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  liffId?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  richMenus?: Resolver<Maybe<Array<GqlResolversTypes['CommunityLineRichMenuConfig']>>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlCommunityLineRichMenuConfigResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CommunityLineRichMenuConfig'] = GqlResolversParentTypes['CommunityLineRichMenuConfig']> = ResolversObject<{
+  richMenuId?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  type?: Resolver<GqlResolversTypes['LineRichMenuType'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlCommunityPortalConfigResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CommunityPortalConfig'] = GqlResolversParentTypes['CommunityPortalConfig']> = ResolversObject<{
+  adminRootPath?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  commonDocumentOverrides?: Resolver<Maybe<GqlResolversTypes['CommonDocumentOverrides']>, ParentType, ContextType>;
+  communityId?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  description?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  documents?: Resolver<Maybe<Array<GqlResolversTypes['CommunityDocument']>>, ParentType, ContextType>;
+  domain?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  enableFeatures?: Resolver<Array<GqlResolversTypes['String']>, ParentType, ContextType>;
+  faviconPrefix?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  firebaseTenantId?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  liffAppId?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  liffBaseUrl?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  liffId?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  logoPath?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  ogImagePath?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  regionKey?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  regionName?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  rootPath?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  shortDescription?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  squareLogoPath?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  title?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  tokenName?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlCommunitySignupBonusConfigResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CommunitySignupBonusConfig'] = GqlResolversParentTypes['CommunitySignupBonusConfig']> = ResolversObject<{
+  bonusPoint?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  isEnabled?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  message?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlCommunityUpdateProfilePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CommunityUpdateProfilePayload'] = GqlResolversParentTypes['CommunityUpdateProfilePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'CommunityUpdateProfileSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlCommunityUpdateProfileSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CommunityUpdateProfileSuccess'] = GqlResolversParentTypes['CommunityUpdateProfileSuccess']> = ResolversObject<{
+  community?: Resolver<GqlResolversTypes['Community'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlCurrentPointViewResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CurrentPointView'] = GqlResolversParentTypes['CurrentPointView']> = ResolversObject<{
+  currentPoint?: Resolver<GqlResolversTypes['BigInt'], ParentType, ContextType>;
+  walletId?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlCurrentUserPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['CurrentUserPayload'] = GqlResolversParentTypes['CurrentUserPayload']> = ResolversObject<{
+  user?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export interface GqlDatetimeScalarConfig extends GraphQLScalarTypeConfig<GqlResolversTypes['Datetime'], any> {
+  name: 'Datetime';
+}
+
+export interface GqlDecimalScalarConfig extends GraphQLScalarTypeConfig<GqlResolversTypes['Decimal'], any> {
+  name: 'Decimal';
+}
+
+export type GqlDidIssuanceRequestResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['DidIssuanceRequest'] = GqlResolversParentTypes['DidIssuanceRequest']> = ResolversObject<{
+  completedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  didValue?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  processedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  requestedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  status?: Resolver<GqlResolversTypes['DidIssuanceStatus'], ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Edge'] = GqlResolversParentTypes['Edge']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'AdminReportSummaryEdge' | 'ArticleEdge' | 'CityEdge' | 'CommunityEdge' | 'EvaluationEdge' | 'EvaluationHistoryEdge' | 'IncentiveGrantEdge' | 'MembershipEdge' | 'NftInstanceEdge' | 'NftTokenEdge' | 'OpportunityEdge' | 'OpportunitySlotEdge' | 'ParticipationEdge' | 'ParticipationStatusHistoryEdge' | 'PlaceEdge' | 'PortfolioEdge' | 'ReportEdge' | 'ReportFeedbackEdge' | 'ReportTemplateStatsBreakdownEdge' | 'ReservationEdge' | 'ReservationHistoryEdge' | 'StateEdge' | 'TicketClaimLinkEdge' | 'TicketEdge' | 'TicketIssuerEdge' | 'TicketStatusHistoryEdge' | 'TransactionEdge' | 'UserEdge' | 'UtilityEdge' | 'VcIssuanceRequestEdge' | 'WalletEdge', ParentType, ContextType>;
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+}>;
+
+export type GqlErrorResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Error'] = GqlResolversParentTypes['Error']> = ResolversObject<{
+  code?: Resolver<GqlResolversTypes['ErrorCode'], ParentType, ContextType>;
+  message?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlEvaluationResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Evaluation'] = GqlResolversParentTypes['Evaluation']> = ResolversObject<{
+  comment?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  credentialUrl?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  evaluator?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  histories?: Resolver<Maybe<Array<GqlResolversTypes['EvaluationHistory']>>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  issuedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  participation?: Resolver<Maybe<GqlResolversTypes['Participation']>, ParentType, ContextType>;
+  status?: Resolver<GqlResolversTypes['EvaluationStatus'], ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  vcIssuanceRequest?: Resolver<Maybe<GqlResolversTypes['VcIssuanceRequest']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlEvaluationBulkCreatePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['EvaluationBulkCreatePayload'] = GqlResolversParentTypes['EvaluationBulkCreatePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'EvaluationBulkCreateSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlEvaluationBulkCreateSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['EvaluationBulkCreateSuccess'] = GqlResolversParentTypes['EvaluationBulkCreateSuccess']> = ResolversObject<{
+  evaluations?: Resolver<Array<GqlResolversTypes['Evaluation']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlEvaluationEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['EvaluationEdge'] = GqlResolversParentTypes['EvaluationEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['Evaluation']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlEvaluationHistoriesConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['EvaluationHistoriesConnection'] = GqlResolversParentTypes['EvaluationHistoriesConnection']> = ResolversObject<{
+  edges?: Resolver<Array<GqlResolversTypes['EvaluationHistoryEdge']>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlEvaluationHistoryResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['EvaluationHistory'] = GqlResolversParentTypes['EvaluationHistory']> = ResolversObject<{
+  comment?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  createdByUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  evaluation?: Resolver<Maybe<GqlResolversTypes['Evaluation']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  status?: Resolver<GqlResolversTypes['EvaluationStatus'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlEvaluationHistoryEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['EvaluationHistoryEdge'] = GqlResolversParentTypes['EvaluationHistoryEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['EvaluationHistory']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlEvaluationsConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['EvaluationsConnection'] = GqlResolversParentTypes['EvaluationsConnection']> = ResolversObject<{
+  edges?: Resolver<Array<GqlResolversTypes['EvaluationEdge']>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlGenerateReportPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['GenerateReportPayload'] = GqlResolversParentTypes['GenerateReportPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'GenerateReportSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlGenerateReportSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['GenerateReportSuccess'] = GqlResolversParentTypes['GenerateReportSuccess']> = ResolversObject<{
+  report?: Resolver<GqlResolversTypes['Report'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlIdentityResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Identity'] = GqlResolversParentTypes['Identity']> = ResolversObject<{
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  platform?: Resolver<Maybe<GqlResolversTypes['IdentityPlatform']>, ParentType, ContextType>;
+  uid?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  user?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlIdentityCheckPhoneUserPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['IdentityCheckPhoneUserPayload'] = GqlResolversParentTypes['IdentityCheckPhoneUserPayload']> = ResolversObject<{
+  membership?: Resolver<Maybe<GqlResolversTypes['Membership']>, ParentType, ContextType>;
+  status?: Resolver<GqlResolversTypes['PhoneUserStatus'], ParentType, ContextType>;
+  user?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlIncentiveGrantResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['IncentiveGrant'] = GqlResolversParentTypes['IncentiveGrant']> = ResolversObject<{
+  attemptCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  community?: Resolver<Maybe<GqlResolversTypes['Community']>, ParentType, ContextType>;
+  createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  failureCode?: Resolver<Maybe<GqlResolversTypes['IncentiveGrantFailureCode']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  lastAttemptedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  lastError?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  sourceId?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  status?: Resolver<GqlResolversTypes['IncentiveGrantStatus'], ParentType, ContextType>;
+  transaction?: Resolver<Maybe<GqlResolversTypes['Transaction']>, ParentType, ContextType>;
+  type?: Resolver<GqlResolversTypes['IncentiveGrantType'], ParentType, ContextType>;
+  updatedAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  user?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlIncentiveGrantEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['IncentiveGrantEdge'] = GqlResolversParentTypes['IncentiveGrantEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['IncentiveGrant']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlIncentiveGrantRetryPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['IncentiveGrantRetryPayload'] = GqlResolversParentTypes['IncentiveGrantRetryPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'IncentiveGrantRetrySuccess', ParentType, ContextType>;
+}>;
+
+export type GqlIncentiveGrantRetrySuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['IncentiveGrantRetrySuccess'] = GqlResolversParentTypes['IncentiveGrantRetrySuccess']> = ResolversObject<{
+  incentiveGrant?: Resolver<GqlResolversTypes['IncentiveGrant'], ParentType, ContextType>;
+  transaction?: Resolver<Maybe<GqlResolversTypes['Transaction']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlIncentiveGrantsConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['IncentiveGrantsConnection'] = GqlResolversParentTypes['IncentiveGrantsConnection']> = ResolversObject<{
+  edges?: Resolver<Maybe<Array<Maybe<GqlResolversTypes['IncentiveGrantEdge']>>>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export interface GqlJsonScalarConfig extends GraphQLScalarTypeConfig<GqlResolversTypes['JSON'], any> {
+  name: 'JSON';
+}
+
+export type GqlLinkPhoneAuthPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['LinkPhoneAuthPayload'] = GqlResolversParentTypes['LinkPhoneAuthPayload']> = ResolversObject<{
+  success?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  user?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlMembershipResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Membership'] = GqlResolversParentTypes['Membership']> = ResolversObject<{
+  bio?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  community?: Resolver<Maybe<GqlResolversTypes['Community']>, ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  headline?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  histories?: Resolver<Maybe<Array<GqlResolversTypes['MembershipHistory']>>, ParentType, ContextType>;
+  reason?: Resolver<GqlResolversTypes['MembershipStatusReason'], ParentType, ContextType>;
+  role?: Resolver<GqlResolversTypes['Role'], ParentType, ContextType>;
+  status?: Resolver<GqlResolversTypes['MembershipStatus'], ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  user?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlMembershipEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['MembershipEdge'] = GqlResolversParentTypes['MembershipEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['Membership']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlMembershipHistoryResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['MembershipHistory'] = GqlResolversParentTypes['MembershipHistory']> = ResolversObject<{
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  createdByUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  membership?: Resolver<GqlResolversTypes['Membership'], ParentType, ContextType>;
+  reason?: Resolver<GqlResolversTypes['MembershipStatusReason'], ParentType, ContextType>;
+  role?: Resolver<GqlResolversTypes['Role'], ParentType, ContextType>;
+  status?: Resolver<GqlResolversTypes['MembershipStatus'], ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlMembershipInvitePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['MembershipInvitePayload'] = GqlResolversParentTypes['MembershipInvitePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'MembershipInviteSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlMembershipInviteSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['MembershipInviteSuccess'] = GqlResolversParentTypes['MembershipInviteSuccess']> = ResolversObject<{
+  membership?: Resolver<GqlResolversTypes['Membership'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlMembershipRemovePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['MembershipRemovePayload'] = GqlResolversParentTypes['MembershipRemovePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'MembershipRemoveSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlMembershipRemoveSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['MembershipRemoveSuccess'] = GqlResolversParentTypes['MembershipRemoveSuccess']> = ResolversObject<{
+  communityId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  userId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlMembershipSetInvitationStatusPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['MembershipSetInvitationStatusPayload'] = GqlResolversParentTypes['MembershipSetInvitationStatusPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'MembershipSetInvitationStatusSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlMembershipSetInvitationStatusSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['MembershipSetInvitationStatusSuccess'] = GqlResolversParentTypes['MembershipSetInvitationStatusSuccess']> = ResolversObject<{
+  membership?: Resolver<GqlResolversTypes['Membership'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlMembershipSetRolePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['MembershipSetRolePayload'] = GqlResolversParentTypes['MembershipSetRolePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'MembershipSetRoleSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlMembershipSetRoleSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['MembershipSetRoleSuccess'] = GqlResolversParentTypes['MembershipSetRoleSuccess']> = ResolversObject<{
+  membership?: Resolver<GqlResolversTypes['Membership'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlMembershipWithdrawPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['MembershipWithdrawPayload'] = GqlResolversParentTypes['MembershipWithdrawPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'MembershipWithdrawSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlMembershipWithdrawSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['MembershipWithdrawSuccess'] = GqlResolversParentTypes['MembershipWithdrawSuccess']> = ResolversObject<{
+  communityId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  userId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlMembershipsConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['MembershipsConnection'] = GqlResolversParentTypes['MembershipsConnection']> = ResolversObject<{
+  edges?: Resolver<Maybe<Array<Maybe<GqlResolversTypes['MembershipEdge']>>>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlMutationResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Mutation'] = GqlResolversParentTypes['Mutation']> = ResolversObject<{
+  approveReport?: Resolver<Maybe<GqlResolversTypes['ApproveReportPayload']>, ParentType, ContextType, RequireFields<GqlMutationApproveReportArgs, 'id'>>;
+  articleCreate?: Resolver<Maybe<GqlResolversTypes['ArticleCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationArticleCreateArgs, 'input'>>;
+  articleDelete?: Resolver<Maybe<GqlResolversTypes['ArticleDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationArticleDeleteArgs, 'id'>>;
+  articleUpdateContent?: Resolver<Maybe<GqlResolversTypes['ArticleUpdateContentPayload']>, ParentType, ContextType, RequireFields<GqlMutationArticleUpdateContentArgs, 'id' | 'input'>>;
+  communityCreate?: Resolver<Maybe<GqlResolversTypes['CommunityCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationCommunityCreateArgs, 'input'>>;
+  communityDelete?: Resolver<Maybe<GqlResolversTypes['CommunityDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationCommunityDeleteArgs, 'id'>>;
+  communityUpdateProfile?: Resolver<Maybe<GqlResolversTypes['CommunityUpdateProfilePayload']>, ParentType, ContextType, RequireFields<GqlMutationCommunityUpdateProfileArgs, 'id' | 'input'>>;
+  createUserDid?: Resolver<GqlResolversTypes['UserDidAnchor'], ParentType, ContextType, RequireFields<GqlMutationCreateUserDidArgs, 'input' | 'permission'>>;
+  deactivateUserDid?: Resolver<GqlResolversTypes['UserDidAnchor'], ParentType, ContextType, RequireFields<GqlMutationDeactivateUserDidArgs, 'permission' | 'userId'>>;
+  evaluationBulkCreate?: Resolver<Maybe<GqlResolversTypes['EvaluationBulkCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationEvaluationBulkCreateArgs, 'input'>>;
+  generateReport?: Resolver<Maybe<GqlResolversTypes['GenerateReportPayload']>, ParentType, ContextType, RequireFields<GqlMutationGenerateReportArgs, 'input'>>;
+  identityCheckPhoneUser?: Resolver<GqlResolversTypes['IdentityCheckPhoneUserPayload'], ParentType, ContextType, RequireFields<GqlMutationIdentityCheckPhoneUserArgs, 'input'>>;
+  incentiveGrantRetry?: Resolver<Maybe<GqlResolversTypes['IncentiveGrantRetryPayload']>, ParentType, ContextType, RequireFields<GqlMutationIncentiveGrantRetryArgs, 'input'>>;
+  issueVc?: Resolver<GqlResolversTypes['VcIssuance'], ParentType, ContextType, RequireFields<GqlMutationIssueVcArgs, 'input'>>;
+  linkPhoneAuth?: Resolver<Maybe<GqlResolversTypes['LinkPhoneAuthPayload']>, ParentType, ContextType, RequireFields<GqlMutationLinkPhoneAuthArgs, 'input' | 'permission'>>;
+  membershipAcceptMyInvitation?: Resolver<Maybe<GqlResolversTypes['MembershipSetInvitationStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationMembershipAcceptMyInvitationArgs, 'input' | 'permission'>>;
+  membershipAssignManager?: Resolver<Maybe<GqlResolversTypes['MembershipSetRolePayload']>, ParentType, ContextType, RequireFields<GqlMutationMembershipAssignManagerArgs, 'input'>>;
+  membershipAssignMember?: Resolver<Maybe<GqlResolversTypes['MembershipSetRolePayload']>, ParentType, ContextType, RequireFields<GqlMutationMembershipAssignMemberArgs, 'input'>>;
+  membershipAssignOwner?: Resolver<Maybe<GqlResolversTypes['MembershipSetRolePayload']>, ParentType, ContextType, RequireFields<GqlMutationMembershipAssignOwnerArgs, 'input'>>;
+  membershipCancelInvitation?: Resolver<Maybe<GqlResolversTypes['MembershipSetInvitationStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationMembershipCancelInvitationArgs, 'input'>>;
+  membershipDenyMyInvitation?: Resolver<Maybe<GqlResolversTypes['MembershipSetInvitationStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationMembershipDenyMyInvitationArgs, 'input' | 'permission'>>;
+  membershipInvite?: Resolver<Maybe<GqlResolversTypes['MembershipInvitePayload']>, ParentType, ContextType, RequireFields<GqlMutationMembershipInviteArgs, 'input'>>;
+  membershipRemove?: Resolver<Maybe<GqlResolversTypes['MembershipRemovePayload']>, ParentType, ContextType, RequireFields<GqlMutationMembershipRemoveArgs, 'input'>>;
+  membershipWithdraw?: Resolver<Maybe<GqlResolversTypes['MembershipWithdrawPayload']>, ParentType, ContextType, RequireFields<GqlMutationMembershipWithdrawArgs, 'input' | 'permission'>>;
+  mutationEcho?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  opportunityCreate?: Resolver<Maybe<GqlResolversTypes['OpportunityCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationOpportunityCreateArgs, 'input'>>;
+  opportunityDelete?: Resolver<Maybe<GqlResolversTypes['OpportunityDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationOpportunityDeleteArgs, 'id' | 'permission'>>;
+  opportunitySetPublishStatus?: Resolver<Maybe<GqlResolversTypes['OpportunitySetPublishStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationOpportunitySetPublishStatusArgs, 'id' | 'input' | 'permission'>>;
+  opportunitySlotCreate?: Resolver<Maybe<GqlResolversTypes['OpportunitySlotCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationOpportunitySlotCreateArgs, 'input' | 'opportunityId' | 'permission'>>;
+  opportunitySlotSetHostingStatus?: Resolver<Maybe<GqlResolversTypes['OpportunitySlotSetHostingStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationOpportunitySlotSetHostingStatusArgs, 'id' | 'input' | 'permission'>>;
+  opportunitySlotsBulkUpdate?: Resolver<Maybe<GqlResolversTypes['OpportunitySlotsBulkUpdatePayload']>, ParentType, ContextType, RequireFields<GqlMutationOpportunitySlotsBulkUpdateArgs, 'input' | 'permission'>>;
+  opportunityUpdateContent?: Resolver<Maybe<GqlResolversTypes['OpportunityUpdateContentPayload']>, ParentType, ContextType, RequireFields<GqlMutationOpportunityUpdateContentArgs, 'id' | 'input' | 'permission'>>;
+  participationBulkCreate?: Resolver<Maybe<GqlResolversTypes['ParticipationBulkCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationParticipationBulkCreateArgs, 'input'>>;
+  participationCreatePersonalRecord?: Resolver<Maybe<GqlResolversTypes['ParticipationCreatePersonalRecordPayload']>, ParentType, ContextType, RequireFields<GqlMutationParticipationCreatePersonalRecordArgs, 'input'>>;
+  participationDeletePersonalRecord?: Resolver<Maybe<GqlResolversTypes['ParticipationDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationParticipationDeletePersonalRecordArgs, 'id' | 'permission'>>;
+  placeCreate?: Resolver<Maybe<GqlResolversTypes['PlaceCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationPlaceCreateArgs, 'input'>>;
+  placeDelete?: Resolver<Maybe<GqlResolversTypes['PlaceDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationPlaceDeleteArgs, 'id'>>;
+  placeUpdate?: Resolver<Maybe<GqlResolversTypes['PlaceUpdatePayload']>, ParentType, ContextType, RequireFields<GqlMutationPlaceUpdateArgs, 'id' | 'input'>>;
+  publishReport?: Resolver<Maybe<GqlResolversTypes['PublishReportPayload']>, ParentType, ContextType, RequireFields<GqlMutationPublishReportArgs, 'finalContent' | 'id'>>;
+  rejectReport?: Resolver<Maybe<GqlResolversTypes['RejectReportPayload']>, ParentType, ContextType, RequireFields<GqlMutationRejectReportArgs, 'id'>>;
+  reservationAccept?: Resolver<Maybe<GqlResolversTypes['ReservationSetStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationReservationAcceptArgs, 'id' | 'permission'>>;
+  reservationCancel?: Resolver<Maybe<GqlResolversTypes['ReservationSetStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationReservationCancelArgs, 'id' | 'input' | 'permission'>>;
+  reservationCreate?: Resolver<Maybe<GqlResolversTypes['ReservationCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationReservationCreateArgs, 'input'>>;
+  reservationJoin?: Resolver<Maybe<GqlResolversTypes['ReservationSetStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationReservationJoinArgs, 'id'>>;
+  reservationReject?: Resolver<Maybe<GqlResolversTypes['ReservationSetStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationReservationRejectArgs, 'id' | 'input' | 'permission'>>;
+  revokeUserVc?: Resolver<GqlResolversTypes['VcIssuance'], ParentType, ContextType, RequireFields<GqlMutationRevokeUserVcArgs, 'input'>>;
+  storePhoneAuthToken?: Resolver<Maybe<GqlResolversTypes['StorePhoneAuthTokenPayload']>, ParentType, ContextType, RequireFields<GqlMutationStorePhoneAuthTokenArgs, 'input' | 'permission'>>;
+  submitReportFeedback?: Resolver<Maybe<GqlResolversTypes['SubmitReportFeedbackPayload']>, ParentType, ContextType, RequireFields<GqlMutationSubmitReportFeedbackArgs, 'input'>>;
+  ticketClaim?: Resolver<Maybe<GqlResolversTypes['TicketClaimPayload']>, ParentType, ContextType, RequireFields<GqlMutationTicketClaimArgs, 'input'>>;
+  ticketIssue?: Resolver<Maybe<GqlResolversTypes['TicketIssuePayload']>, ParentType, ContextType, RequireFields<GqlMutationTicketIssueArgs, 'input'>>;
+  ticketPurchase?: Resolver<Maybe<GqlResolversTypes['TicketPurchasePayload']>, ParentType, ContextType, RequireFields<GqlMutationTicketPurchaseArgs, 'input'>>;
+  ticketRefund?: Resolver<Maybe<GqlResolversTypes['TicketRefundPayload']>, ParentType, ContextType, RequireFields<GqlMutationTicketRefundArgs, 'id' | 'input' | 'permission'>>;
+  ticketUse?: Resolver<Maybe<GqlResolversTypes['TicketUsePayload']>, ParentType, ContextType, RequireFields<GqlMutationTicketUseArgs, 'id' | 'permission'>>;
+  transactionDonateSelfPoint?: Resolver<Maybe<GqlResolversTypes['TransactionDonateSelfPointPayload']>, ParentType, ContextType, RequireFields<GqlMutationTransactionDonateSelfPointArgs, 'input' | 'permission'>>;
+  transactionGrantCommunityPoint?: Resolver<Maybe<GqlResolversTypes['TransactionGrantCommunityPointPayload']>, ParentType, ContextType, RequireFields<GqlMutationTransactionGrantCommunityPointArgs, 'input'>>;
+  transactionIssueCommunityPoint?: Resolver<Maybe<GqlResolversTypes['TransactionIssueCommunityPointPayload']>, ParentType, ContextType, RequireFields<GqlMutationTransactionIssueCommunityPointArgs, 'input'>>;
+  transactionUpdateMetadata?: Resolver<Maybe<GqlResolversTypes['TransactionUpdateMetadataPayload']>, ParentType, ContextType, RequireFields<GqlMutationTransactionUpdateMetadataArgs, 'id' | 'input'>>;
+  updatePortalConfig?: Resolver<GqlResolversTypes['CommunityPortalConfig'], ParentType, ContextType, RequireFields<GqlMutationUpdatePortalConfigArgs, 'input'>>;
+  updateReportTemplate?: Resolver<Maybe<GqlResolversTypes['UpdateReportTemplatePayload']>, ParentType, ContextType, RequireFields<GqlMutationUpdateReportTemplateArgs, 'input' | 'variant'>>;
+  updateSignupBonusConfig?: Resolver<GqlResolversTypes['CommunitySignupBonusConfig'], ParentType, ContextType, RequireFields<GqlMutationUpdateSignupBonusConfigArgs, 'input'>>;
+  userDeleteMe?: Resolver<Maybe<GqlResolversTypes['UserDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationUserDeleteMeArgs, 'permission'>>;
+  userSignUp?: Resolver<Maybe<GqlResolversTypes['CurrentUserPayload']>, ParentType, ContextType, RequireFields<GqlMutationUserSignUpArgs, 'input'>>;
+  userUpdateMyProfile?: Resolver<Maybe<GqlResolversTypes['UserUpdateProfilePayload']>, ParentType, ContextType, RequireFields<GqlMutationUserUpdateMyProfileArgs, 'input' | 'permission'>>;
+  utilityCreate?: Resolver<Maybe<GqlResolversTypes['UtilityCreatePayload']>, ParentType, ContextType, RequireFields<GqlMutationUtilityCreateArgs, 'input'>>;
+  utilityDelete?: Resolver<Maybe<GqlResolversTypes['UtilityDeletePayload']>, ParentType, ContextType, RequireFields<GqlMutationUtilityDeleteArgs, 'id'>>;
+  utilitySetPublishStatus?: Resolver<Maybe<GqlResolversTypes['UtilitySetPublishStatusPayload']>, ParentType, ContextType, RequireFields<GqlMutationUtilitySetPublishStatusArgs, 'id' | 'input'>>;
+  utilityUpdateInfo?: Resolver<Maybe<GqlResolversTypes['UtilityUpdateInfoPayload']>, ParentType, ContextType, RequireFields<GqlMutationUtilityUpdateInfoArgs, 'id' | 'input'>>;
+  voteCast?: Resolver<GqlResolversTypes['VoteCastPayload'], ParentType, ContextType, RequireFields<GqlMutationVoteCastArgs, 'input'>>;
+  voteTopicCreate?: Resolver<GqlResolversTypes['VoteTopicCreatePayload'], ParentType, ContextType, RequireFields<GqlMutationVoteTopicCreateArgs, 'input'>>;
+  voteTopicDelete?: Resolver<GqlResolversTypes['VoteTopicDeletePayload'], ParentType, ContextType, RequireFields<GqlMutationVoteTopicDeleteArgs, 'id'>>;
+  voteTopicUpdate?: Resolver<GqlResolversTypes['VoteTopicUpdatePayload'], ParentType, ContextType, RequireFields<GqlMutationVoteTopicUpdateArgs, 'id' | 'input'>>;
+}>;
+
+export type GqlMyVoteEligibilityResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['MyVoteEligibility'] = GqlResolversParentTypes['MyVoteEligibility']> = ResolversObject<{
+  currentPower?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  eligible?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  myBallot?: Resolver<Maybe<GqlResolversTypes['VoteBallot']>, ParentType, ContextType>;
+  reason?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlNftInstanceResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['NftInstance'] = GqlResolversParentTypes['NftInstance']> = ResolversObject<{
+  community?: Resolver<Maybe<GqlResolversTypes['Community']>, ParentType, ContextType>;
+  createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  description?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  imageUrl?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  instanceId?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  json?: Resolver<Maybe<GqlResolversTypes['JSON']>, ParentType, ContextType>;
+  name?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  nftToken?: Resolver<Maybe<GqlResolversTypes['NftToken']>, ParentType, ContextType>;
+  nftWallet?: Resolver<Maybe<GqlResolversTypes['NftWallet']>, ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlNftInstanceEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['NftInstanceEdge'] = GqlResolversParentTypes['NftInstanceEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<GqlResolversTypes['NftInstance'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlNftInstancesConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['NftInstancesConnection'] = GqlResolversParentTypes['NftInstancesConnection']> = ResolversObject<{
+  edges?: Resolver<Array<GqlResolversTypes['NftInstanceEdge']>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlNftTokenResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['NftToken'] = GqlResolversParentTypes['NftToken']> = ResolversObject<{
+  address?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  community?: Resolver<Maybe<GqlResolversTypes['Community']>, ParentType, ContextType>;
+  createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  json?: Resolver<Maybe<GqlResolversTypes['JSON']>, ParentType, ContextType>;
+  name?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  symbol?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  type?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlNftTokenEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['NftTokenEdge'] = GqlResolversParentTypes['NftTokenEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<GqlResolversTypes['NftToken'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlNftTokensConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['NftTokensConnection'] = GqlResolversParentTypes['NftTokensConnection']> = ResolversObject<{
+  edges?: Resolver<Array<GqlResolversTypes['NftTokenEdge']>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlNftWalletResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['NftWallet'] = GqlResolversParentTypes['NftWallet']> = ResolversObject<{
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  user?: Resolver<GqlResolversTypes['User'], ParentType, ContextType>;
+  walletAddress?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlOpportunitiesConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['OpportunitiesConnection'] = GqlResolversParentTypes['OpportunitiesConnection']> = ResolversObject<{
+  edges?: Resolver<Array<GqlResolversTypes['OpportunityEdge']>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlOpportunityResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Opportunity'] = GqlResolversParentTypes['Opportunity']> = ResolversObject<{
+  articles?: Resolver<Maybe<Array<GqlResolversTypes['Article']>>, ParentType, ContextType>;
+  body?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  capacity?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  category?: Resolver<GqlResolversTypes['OpportunityCategory'], ParentType, ContextType>;
+  community?: Resolver<Maybe<GqlResolversTypes['Community']>, ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  createdByUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  description?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  earliestReservableAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  feeRequired?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  images?: Resolver<Maybe<Array<GqlResolversTypes['String']>>, ParentType, ContextType>;
+  isReservableWithTicket?: Resolver<Maybe<GqlResolversTypes['Boolean']>, ParentType, ContextType>;
+  place?: Resolver<Maybe<GqlResolversTypes['Place']>, ParentType, ContextType>;
+  pointsRequired?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  pointsToEarn?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  publishStatus?: Resolver<GqlResolversTypes['PublishStatus'], ParentType, ContextType>;
+  requireApproval?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  requiredUtilities?: Resolver<Maybe<Array<GqlResolversTypes['Utility']>>, ParentType, ContextType>;
+  slots?: Resolver<Maybe<Array<GqlResolversTypes['OpportunitySlot']>>, ParentType, ContextType, Partial<GqlOpportunitySlotsArgs>>;
+  title?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlOpportunityCreatePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['OpportunityCreatePayload'] = GqlResolversParentTypes['OpportunityCreatePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'OpportunityCreateSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlOpportunityCreateSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['OpportunityCreateSuccess'] = GqlResolversParentTypes['OpportunityCreateSuccess']> = ResolversObject<{
+  opportunity?: Resolver<GqlResolversTypes['Opportunity'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlOpportunityDeletePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['OpportunityDeletePayload'] = GqlResolversParentTypes['OpportunityDeletePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'OpportunityDeleteSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlOpportunityDeleteSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['OpportunityDeleteSuccess'] = GqlResolversParentTypes['OpportunityDeleteSuccess']> = ResolversObject<{
+  opportunityId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlOpportunityEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['OpportunityEdge'] = GqlResolversParentTypes['OpportunityEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['Opportunity']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlOpportunitySetPublishStatusPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['OpportunitySetPublishStatusPayload'] = GqlResolversParentTypes['OpportunitySetPublishStatusPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'OpportunitySetPublishStatusSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlOpportunitySetPublishStatusSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['OpportunitySetPublishStatusSuccess'] = GqlResolversParentTypes['OpportunitySetPublishStatusSuccess']> = ResolversObject<{
+  opportunity?: Resolver<GqlResolversTypes['Opportunity'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlOpportunitySlotResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['OpportunitySlot'] = GqlResolversParentTypes['OpportunitySlot']> = ResolversObject<{
+  capacity?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  endsAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  hostingStatus?: Resolver<GqlResolversTypes['OpportunitySlotHostingStatus'], ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  isFullyEvaluated?: Resolver<Maybe<GqlResolversTypes['Boolean']>, ParentType, ContextType>;
+  numEvaluated?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  numParticipants?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  opportunity?: Resolver<Maybe<GqlResolversTypes['Opportunity']>, ParentType, ContextType>;
+  remainingCapacity?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  reservations?: Resolver<Maybe<Array<GqlResolversTypes['Reservation']>>, ParentType, ContextType>;
+  startsAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  vcIssuanceRequests?: Resolver<Maybe<Array<GqlResolversTypes['VcIssuanceRequest']>>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlOpportunitySlotCreatePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['OpportunitySlotCreatePayload'] = GqlResolversParentTypes['OpportunitySlotCreatePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'OpportunitySlotCreateSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlOpportunitySlotCreateSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['OpportunitySlotCreateSuccess'] = GqlResolversParentTypes['OpportunitySlotCreateSuccess']> = ResolversObject<{
+  slot?: Resolver<GqlResolversTypes['OpportunitySlot'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlOpportunitySlotEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['OpportunitySlotEdge'] = GqlResolversParentTypes['OpportunitySlotEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['OpportunitySlot']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlOpportunitySlotSetHostingStatusPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['OpportunitySlotSetHostingStatusPayload'] = GqlResolversParentTypes['OpportunitySlotSetHostingStatusPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'OpportunitySlotSetHostingStatusSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlOpportunitySlotSetHostingStatusSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['OpportunitySlotSetHostingStatusSuccess'] = GqlResolversParentTypes['OpportunitySlotSetHostingStatusSuccess']> = ResolversObject<{
+  slot?: Resolver<GqlResolversTypes['OpportunitySlot'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlOpportunitySlotsBulkUpdatePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['OpportunitySlotsBulkUpdatePayload'] = GqlResolversParentTypes['OpportunitySlotsBulkUpdatePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'OpportunitySlotsBulkUpdateSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlOpportunitySlotsBulkUpdateSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['OpportunitySlotsBulkUpdateSuccess'] = GqlResolversParentTypes['OpportunitySlotsBulkUpdateSuccess']> = ResolversObject<{
+  slots?: Resolver<Array<GqlResolversTypes['OpportunitySlot']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlOpportunitySlotsConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['OpportunitySlotsConnection'] = GqlResolversParentTypes['OpportunitySlotsConnection']> = ResolversObject<{
+  edges?: Resolver<Maybe<Array<Maybe<GqlResolversTypes['OpportunitySlotEdge']>>>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlOpportunityUpdateContentPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['OpportunityUpdateContentPayload'] = GqlResolversParentTypes['OpportunityUpdateContentPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'OpportunityUpdateContentSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlOpportunityUpdateContentSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['OpportunityUpdateContentSuccess'] = GqlResolversParentTypes['OpportunityUpdateContentSuccess']> = ResolversObject<{
+  opportunity?: Resolver<GqlResolversTypes['Opportunity'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlPageInfoResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['PageInfo'] = GqlResolversParentTypes['PageInfo']> = ResolversObject<{
+  endCursor?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  hasNextPage?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  hasPreviousPage?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  startCursor?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlPagingResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Paging'] = GqlResolversParentTypes['Paging']> = ResolversObject<{
+  skip?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  take?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlParticipationResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Participation'] = GqlResolversParentTypes['Participation']> = ResolversObject<{
+  community?: Resolver<Maybe<GqlResolversTypes['Community']>, ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  description?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  evaluation?: Resolver<Maybe<GqlResolversTypes['Evaluation']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  images?: Resolver<Maybe<Array<GqlResolversTypes['String']>>, ParentType, ContextType>;
+  opportunitySlot?: Resolver<Maybe<GqlResolversTypes['OpportunitySlot']>, ParentType, ContextType>;
+  reason?: Resolver<GqlResolversTypes['ParticipationStatusReason'], ParentType, ContextType>;
+  reservation?: Resolver<Maybe<GqlResolversTypes['Reservation']>, ParentType, ContextType>;
+  source?: Resolver<Maybe<GqlResolversTypes['Source']>, ParentType, ContextType>;
+  status?: Resolver<GqlResolversTypes['ParticipationStatus'], ParentType, ContextType>;
+  statusHistories?: Resolver<Maybe<Array<GqlResolversTypes['ParticipationStatusHistory']>>, ParentType, ContextType>;
+  ticketStatusHistories?: Resolver<Maybe<Array<GqlResolversTypes['TicketStatusHistory']>>, ParentType, ContextType>;
+  transactions?: Resolver<Maybe<Array<GqlResolversTypes['Transaction']>>, ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  user?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlParticipationBulkCreatePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ParticipationBulkCreatePayload'] = GqlResolversParentTypes['ParticipationBulkCreatePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'ParticipationBulkCreateSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlParticipationBulkCreateSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ParticipationBulkCreateSuccess'] = GqlResolversParentTypes['ParticipationBulkCreateSuccess']> = ResolversObject<{
+  participations?: Resolver<Array<GqlResolversTypes['Participation']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlParticipationCreatePersonalRecordPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ParticipationCreatePersonalRecordPayload'] = GqlResolversParentTypes['ParticipationCreatePersonalRecordPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'ParticipationCreatePersonalRecordSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlParticipationCreatePersonalRecordSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ParticipationCreatePersonalRecordSuccess'] = GqlResolversParentTypes['ParticipationCreatePersonalRecordSuccess']> = ResolversObject<{
+  participation?: Resolver<GqlResolversTypes['Participation'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlParticipationDeletePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ParticipationDeletePayload'] = GqlResolversParentTypes['ParticipationDeletePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'ParticipationDeleteSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlParticipationDeleteSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ParticipationDeleteSuccess'] = GqlResolversParentTypes['ParticipationDeleteSuccess']> = ResolversObject<{
+  participationId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlParticipationEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ParticipationEdge'] = GqlResolversParentTypes['ParticipationEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['Participation']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlParticipationStatusHistoriesConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ParticipationStatusHistoriesConnection'] = GqlResolversParentTypes['ParticipationStatusHistoriesConnection']> = ResolversObject<{
+  edges?: Resolver<Array<GqlResolversTypes['ParticipationStatusHistoryEdge']>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlParticipationStatusHistoryResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ParticipationStatusHistory'] = GqlResolversParentTypes['ParticipationStatusHistory']> = ResolversObject<{
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  createdByUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  participation?: Resolver<Maybe<GqlResolversTypes['Participation']>, ParentType, ContextType>;
+  reason?: Resolver<GqlResolversTypes['ParticipationStatusReason'], ParentType, ContextType>;
+  status?: Resolver<GqlResolversTypes['ParticipationStatus'], ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlParticipationStatusHistoryEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ParticipationStatusHistoryEdge'] = GqlResolversParentTypes['ParticipationStatusHistoryEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['ParticipationStatusHistory']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlParticipationsConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ParticipationsConnection'] = GqlResolversParentTypes['ParticipationsConnection']> = ResolversObject<{
+  edges?: Resolver<Array<GqlResolversTypes['ParticipationEdge']>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlPlaceResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Place'] = GqlResolversParentTypes['Place']> = ResolversObject<{
+  accumulatedParticipants?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  address?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  city?: Resolver<Maybe<GqlResolversTypes['City']>, ParentType, ContextType>;
+  community?: Resolver<Maybe<GqlResolversTypes['Community']>, ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  currentPublicOpportunityCount?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  googlePlaceId?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  image?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  isManual?: Resolver<Maybe<GqlResolversTypes['Boolean']>, ParentType, ContextType>;
+  latitude?: Resolver<GqlResolversTypes['Decimal'], ParentType, ContextType>;
+  longitude?: Resolver<GqlResolversTypes['Decimal'], ParentType, ContextType>;
+  mapLocation?: Resolver<Maybe<GqlResolversTypes['JSON']>, ParentType, ContextType>;
+  name?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  opportunities?: Resolver<Maybe<Array<GqlResolversTypes['Opportunity']>>, ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlPlaceCreatePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['PlaceCreatePayload'] = GqlResolversParentTypes['PlaceCreatePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'PlaceCreateSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlPlaceCreateSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['PlaceCreateSuccess'] = GqlResolversParentTypes['PlaceCreateSuccess']> = ResolversObject<{
+  place?: Resolver<GqlResolversTypes['Place'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlPlaceDeletePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['PlaceDeletePayload'] = GqlResolversParentTypes['PlaceDeletePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'PlaceDeleteSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlPlaceDeleteSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['PlaceDeleteSuccess'] = GqlResolversParentTypes['PlaceDeleteSuccess']> = ResolversObject<{
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlPlaceEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['PlaceEdge'] = GqlResolversParentTypes['PlaceEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['Place']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlPlaceUpdatePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['PlaceUpdatePayload'] = GqlResolversParentTypes['PlaceUpdatePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'PlaceUpdateSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlPlaceUpdateSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['PlaceUpdateSuccess'] = GqlResolversParentTypes['PlaceUpdateSuccess']> = ResolversObject<{
+  place?: Resolver<GqlResolversTypes['Place'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlPlacesConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['PlacesConnection'] = GqlResolversParentTypes['PlacesConnection']> = ResolversObject<{
+  edges?: Resolver<Maybe<Array<Maybe<GqlResolversTypes['PlaceEdge']>>>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlPortfolioResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Portfolio'] = GqlResolversParentTypes['Portfolio']> = ResolversObject<{
+  category?: Resolver<GqlResolversTypes['PortfolioCategory'], ParentType, ContextType>;
+  date?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  evaluationStatus?: Resolver<Maybe<GqlResolversTypes['EvaluationStatus']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  participants?: Resolver<Maybe<Array<GqlResolversTypes['User']>>, ParentType, ContextType>;
+  place?: Resolver<Maybe<GqlResolversTypes['Place']>, ParentType, ContextType>;
+  reservationStatus?: Resolver<Maybe<GqlResolversTypes['ReservationStatus']>, ParentType, ContextType>;
+  source?: Resolver<GqlResolversTypes['PortfolioSource'], ParentType, ContextType>;
+  thumbnailUrl?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  title?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlPortfolioEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['PortfolioEdge'] = GqlResolversParentTypes['PortfolioEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['Portfolio']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlPortfoliosConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['PortfoliosConnection'] = GqlResolversParentTypes['PortfoliosConnection']> = ResolversObject<{
+  edges?: Resolver<Array<GqlResolversTypes['PortfolioEdge']>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlPublishReportPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['PublishReportPayload'] = GqlResolversParentTypes['PublishReportPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'PublishReportSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlPublishReportSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['PublishReportSuccess'] = GqlResolversParentTypes['PublishReportSuccess']> = ResolversObject<{
+  report?: Resolver<GqlResolversTypes['Report'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlQueryResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Query'] = GqlResolversParentTypes['Query']> = ResolversObject<{
+  analyticsCommunity?: Resolver<GqlResolversTypes['AnalyticsCommunityPayload'], ParentType, ContextType, RequireFields<GqlQueryAnalyticsCommunityArgs, 'input'>>;
+  analyticsDashboard?: Resolver<GqlResolversTypes['AnalyticsDashboardPayload'], ParentType, ContextType, Partial<GqlQueryAnalyticsDashboardArgs>>;
+  article?: Resolver<Maybe<GqlResolversTypes['Article']>, ParentType, ContextType, RequireFields<GqlQueryArticleArgs, 'id'>>;
+  articles?: Resolver<GqlResolversTypes['ArticlesConnection'], ParentType, ContextType, Partial<GqlQueryArticlesArgs>>;
+  cities?: Resolver<GqlResolversTypes['CitiesConnection'], ParentType, ContextType, Partial<GqlQueryCitiesArgs>>;
+  communities?: Resolver<GqlResolversTypes['CommunitiesConnection'], ParentType, ContextType, Partial<GqlQueryCommunitiesArgs>>;
+  community?: Resolver<Maybe<GqlResolversTypes['Community']>, ParentType, ContextType, RequireFields<GqlQueryCommunityArgs, 'id'>>;
+  communityPortalConfig?: Resolver<Maybe<GqlResolversTypes['CommunityPortalConfig']>, ParentType, ContextType, RequireFields<GqlQueryCommunityPortalConfigArgs, 'communityId'>>;
+  currentUser?: Resolver<Maybe<GqlResolversTypes['CurrentUserPayload']>, ParentType, ContextType>;
+  echo?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  evaluation?: Resolver<Maybe<GqlResolversTypes['Evaluation']>, ParentType, ContextType, RequireFields<GqlQueryEvaluationArgs, 'id'>>;
+  evaluationHistories?: Resolver<GqlResolversTypes['EvaluationHistoriesConnection'], ParentType, ContextType, Partial<GqlQueryEvaluationHistoriesArgs>>;
+  evaluationHistory?: Resolver<Maybe<GqlResolversTypes['EvaluationHistory']>, ParentType, ContextType, RequireFields<GqlQueryEvaluationHistoryArgs, 'id'>>;
+  evaluations?: Resolver<GqlResolversTypes['EvaluationsConnection'], ParentType, ContextType, Partial<GqlQueryEvaluationsArgs>>;
+  incentiveGrant?: Resolver<Maybe<GqlResolversTypes['IncentiveGrant']>, ParentType, ContextType, RequireFields<GqlQueryIncentiveGrantArgs, 'id'>>;
+  incentiveGrants?: Resolver<GqlResolversTypes['IncentiveGrantsConnection'], ParentType, ContextType, Partial<GqlQueryIncentiveGrantsArgs>>;
+  membership?: Resolver<Maybe<GqlResolversTypes['Membership']>, ParentType, ContextType, RequireFields<GqlQueryMembershipArgs, 'communityId' | 'userId'>>;
+  memberships?: Resolver<GqlResolversTypes['MembershipsConnection'], ParentType, ContextType, Partial<GqlQueryMembershipsArgs>>;
+  myVoteEligibility?: Resolver<GqlResolversTypes['MyVoteEligibility'], ParentType, ContextType, RequireFields<GqlQueryMyVoteEligibilityArgs, 'topicId'>>;
+  myWallet?: Resolver<Maybe<GqlResolversTypes['Wallet']>, ParentType, ContextType>;
+  nftInstance?: Resolver<Maybe<GqlResolversTypes['NftInstance']>, ParentType, ContextType, RequireFields<GqlQueryNftInstanceArgs, 'id'>>;
+  nftInstances?: Resolver<GqlResolversTypes['NftInstancesConnection'], ParentType, ContextType, Partial<GqlQueryNftInstancesArgs>>;
+  nftToken?: Resolver<Maybe<GqlResolversTypes['NftToken']>, ParentType, ContextType, RequireFields<GqlQueryNftTokenArgs, 'id'>>;
+  nftTokens?: Resolver<GqlResolversTypes['NftTokensConnection'], ParentType, ContextType, Partial<GqlQueryNftTokensArgs>>;
+  opportunities?: Resolver<GqlResolversTypes['OpportunitiesConnection'], ParentType, ContextType, Partial<GqlQueryOpportunitiesArgs>>;
+  opportunity?: Resolver<Maybe<GqlResolversTypes['Opportunity']>, ParentType, ContextType, RequireFields<GqlQueryOpportunityArgs, 'id'>>;
+  opportunitySlot?: Resolver<Maybe<GqlResolversTypes['OpportunitySlot']>, ParentType, ContextType, RequireFields<GqlQueryOpportunitySlotArgs, 'id'>>;
+  opportunitySlots?: Resolver<GqlResolversTypes['OpportunitySlotsConnection'], ParentType, ContextType, Partial<GqlQueryOpportunitySlotsArgs>>;
+  participation?: Resolver<Maybe<GqlResolversTypes['Participation']>, ParentType, ContextType, RequireFields<GqlQueryParticipationArgs, 'id'>>;
+  participationStatusHistories?: Resolver<GqlResolversTypes['ParticipationStatusHistoriesConnection'], ParentType, ContextType, Partial<GqlQueryParticipationStatusHistoriesArgs>>;
+  participationStatusHistory?: Resolver<Maybe<GqlResolversTypes['ParticipationStatusHistory']>, ParentType, ContextType, RequireFields<GqlQueryParticipationStatusHistoryArgs, 'id'>>;
+  participations?: Resolver<GqlResolversTypes['ParticipationsConnection'], ParentType, ContextType, Partial<GqlQueryParticipationsArgs>>;
+  place?: Resolver<Maybe<GqlResolversTypes['Place']>, ParentType, ContextType, RequireFields<GqlQueryPlaceArgs, 'id'>>;
+  places?: Resolver<GqlResolversTypes['PlacesConnection'], ParentType, ContextType, Partial<GqlQueryPlacesArgs>>;
+  portfolios?: Resolver<Maybe<Array<GqlResolversTypes['Portfolio']>>, ParentType, ContextType, Partial<GqlQueryPortfoliosArgs>>;
+  report?: Resolver<Maybe<GqlResolversTypes['Report']>, ParentType, ContextType, RequireFields<GqlQueryReportArgs, 'id'>>;
+  reportSummaries?: Resolver<GqlResolversTypes['AdminReportSummaryConnection'], ParentType, ContextType, Partial<GqlQueryReportSummariesArgs>>;
+  reportTemplate?: Resolver<Maybe<GqlResolversTypes['ReportTemplate']>, ParentType, ContextType, RequireFields<GqlQueryReportTemplateArgs, 'variant'>>;
+  reportTemplateFeedbackStats?: Resolver<GqlResolversTypes['AdminTemplateFeedbackStats'], ParentType, ContextType, RequireFields<GqlQueryReportTemplateFeedbackStatsArgs, 'kind' | 'variant'>>;
+  reportTemplateFeedbacks?: Resolver<GqlResolversTypes['ReportFeedbacksConnection'], ParentType, ContextType, RequireFields<GqlQueryReportTemplateFeedbacksArgs, 'first' | 'kind' | 'variant'>>;
+  reportTemplateStats?: Resolver<GqlResolversTypes['ReportTemplateStats'], ParentType, ContextType, RequireFields<GqlQueryReportTemplateStatsArgs, 'variant'>>;
+  reportTemplateStatsBreakdown?: Resolver<GqlResolversTypes['ReportTemplateStatsBreakdownConnection'], ParentType, ContextType, RequireFields<GqlQueryReportTemplateStatsBreakdownArgs, 'first' | 'includeInactive' | 'kind' | 'variant'>>;
+  reportTemplates?: Resolver<Array<GqlResolversTypes['ReportTemplate']>, ParentType, ContextType, RequireFields<GqlQueryReportTemplatesArgs, 'includeInactive' | 'kind' | 'variant'>>;
+  reports?: Resolver<GqlResolversTypes['ReportsConnection'], ParentType, ContextType, RequireFields<GqlQueryReportsArgs, 'communityId'>>;
+  reportsAll?: Resolver<GqlResolversTypes['ReportsConnection'], ParentType, ContextType, Partial<GqlQueryReportsAllArgs>>;
+  reservation?: Resolver<Maybe<GqlResolversTypes['Reservation']>, ParentType, ContextType, RequireFields<GqlQueryReservationArgs, 'id'>>;
+  reservationHistories?: Resolver<GqlResolversTypes['ReservationHistoriesConnection'], ParentType, ContextType, Partial<GqlQueryReservationHistoriesArgs>>;
+  reservationHistory?: Resolver<Maybe<GqlResolversTypes['ReservationHistory']>, ParentType, ContextType, RequireFields<GqlQueryReservationHistoryArgs, 'id'>>;
+  reservations?: Resolver<GqlResolversTypes['ReservationsConnection'], ParentType, ContextType, Partial<GqlQueryReservationsArgs>>;
+  signupBonusConfig?: Resolver<Maybe<GqlResolversTypes['CommunitySignupBonusConfig']>, ParentType, ContextType, RequireFields<GqlQuerySignupBonusConfigArgs, 'communityId'>>;
+  states?: Resolver<GqlResolversTypes['StatesConnection'], ParentType, ContextType, Partial<GqlQueryStatesArgs>>;
+  ticket?: Resolver<Maybe<GqlResolversTypes['Ticket']>, ParentType, ContextType, RequireFields<GqlQueryTicketArgs, 'id'>>;
+  ticketClaimLink?: Resolver<Maybe<GqlResolversTypes['TicketClaimLink']>, ParentType, ContextType, RequireFields<GqlQueryTicketClaimLinkArgs, 'id'>>;
+  ticketClaimLinks?: Resolver<GqlResolversTypes['TicketClaimLinksConnection'], ParentType, ContextType, Partial<GqlQueryTicketClaimLinksArgs>>;
+  ticketIssuer?: Resolver<Maybe<GqlResolversTypes['TicketIssuer']>, ParentType, ContextType, RequireFields<GqlQueryTicketIssuerArgs, 'id'>>;
+  ticketIssuers?: Resolver<GqlResolversTypes['TicketIssuersConnection'], ParentType, ContextType, Partial<GqlQueryTicketIssuersArgs>>;
+  ticketStatusHistories?: Resolver<GqlResolversTypes['TicketStatusHistoriesConnection'], ParentType, ContextType, Partial<GqlQueryTicketStatusHistoriesArgs>>;
+  ticketStatusHistory?: Resolver<Maybe<GqlResolversTypes['TicketStatusHistory']>, ParentType, ContextType, RequireFields<GqlQueryTicketStatusHistoryArgs, 'id'>>;
+  tickets?: Resolver<GqlResolversTypes['TicketsConnection'], ParentType, ContextType, Partial<GqlQueryTicketsArgs>>;
+  transaction?: Resolver<Maybe<GqlResolversTypes['Transaction']>, ParentType, ContextType, RequireFields<GqlQueryTransactionArgs, 'id'>>;
+  transactions?: Resolver<GqlResolversTypes['TransactionsConnection'], ParentType, ContextType, Partial<GqlQueryTransactionsArgs>>;
+  user?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType, RequireFields<GqlQueryUserArgs, 'id'>>;
+  userDid?: Resolver<Maybe<GqlResolversTypes['UserDidAnchor']>, ParentType, ContextType, RequireFields<GqlQueryUserDidArgs, 'userId'>>;
+  users?: Resolver<GqlResolversTypes['UsersConnection'], ParentType, ContextType, Partial<GqlQueryUsersArgs>>;
+  utilities?: Resolver<GqlResolversTypes['UtilitiesConnection'], ParentType, ContextType, Partial<GqlQueryUtilitiesArgs>>;
+  utility?: Resolver<Maybe<GqlResolversTypes['Utility']>, ParentType, ContextType, RequireFields<GqlQueryUtilityArgs, 'id'>>;
+  vcIssuance?: Resolver<Maybe<GqlResolversTypes['VcIssuance']>, ParentType, ContextType, RequireFields<GqlQueryVcIssuanceArgs, 'id'>>;
+  vcIssuanceRequest?: Resolver<Maybe<GqlResolversTypes['VcIssuanceRequest']>, ParentType, ContextType, RequireFields<GqlQueryVcIssuanceRequestArgs, 'id'>>;
+  vcIssuanceRequests?: Resolver<GqlResolversTypes['VcIssuanceRequestsConnection'], ParentType, ContextType, Partial<GqlQueryVcIssuanceRequestsArgs>>;
+  vcIssuancesByUser?: Resolver<Array<GqlResolversTypes['VcIssuance']>, ParentType, ContextType, RequireFields<GqlQueryVcIssuancesByUserArgs, 'userId'>>;
+  verifyTransactions?: Resolver<Maybe<Array<GqlResolversTypes['TransactionVerificationResult']>>, ParentType, ContextType, RequireFields<GqlQueryVerifyTransactionsArgs, 'txIds'>>;
+  voteTopic?: Resolver<Maybe<GqlResolversTypes['VoteTopic']>, ParentType, ContextType, RequireFields<GqlQueryVoteTopicArgs, 'id'>>;
+  voteTopics?: Resolver<GqlResolversTypes['VoteTopicsConnection'], ParentType, ContextType, RequireFields<GqlQueryVoteTopicsArgs, 'communityId'>>;
+  wallet?: Resolver<Maybe<GqlResolversTypes['Wallet']>, ParentType, ContextType, RequireFields<GqlQueryWalletArgs, 'id'>>;
+  wallets?: Resolver<GqlResolversTypes['WalletsConnection'], ParentType, ContextType, Partial<GqlQueryWalletsArgs>>;
+}>;
+
+export type GqlRejectReportPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['RejectReportPayload'] = GqlResolversParentTypes['RejectReportPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'RejectReportSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlRejectReportSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['RejectReportSuccess'] = GqlResolversParentTypes['RejectReportSuccess']> = ResolversObject<{
+  report?: Resolver<GqlResolversTypes['Report'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReportResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Report'] = GqlResolversParentTypes['Report']> = ResolversObject<{
+  cacheReadTokens?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  community?: Resolver<GqlResolversTypes['Community'], ParentType, ContextType>;
+  createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  feedbacks?: Resolver<GqlResolversTypes['ReportFeedbacksConnection'], ParentType, ContextType, Partial<GqlReportFeedbacksArgs>>;
+  finalContent?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  generatedByUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  inputTokens?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  model?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  myFeedback?: Resolver<Maybe<GqlResolversTypes['ReportFeedback']>, ParentType, ContextType>;
+  outputMarkdown?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  outputTokens?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  parentRun?: Resolver<Maybe<GqlResolversTypes['Report']>, ParentType, ContextType>;
+  periodFrom?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  periodTo?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  publishedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  publishedByUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  regenerateCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  regenerations?: Resolver<Array<GqlResolversTypes['Report']>, ParentType, ContextType>;
+  skipReason?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  status?: Resolver<GqlResolversTypes['ReportStatus'], ParentType, ContextType>;
+  targetUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  template?: Resolver<Maybe<GqlResolversTypes['ReportTemplate']>, ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  variant?: Resolver<GqlResolversTypes['ReportVariant'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReportEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReportEdge'] = GqlResolversParentTypes['ReportEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['Report']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReportFeedbackResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReportFeedback'] = GqlResolversParentTypes['ReportFeedback']> = ResolversObject<{
+  comment?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  feedbackType?: Resolver<Maybe<GqlResolversTypes['ReportFeedbackType']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  rating?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  report?: Resolver<GqlResolversTypes['Report'], ParentType, ContextType>;
+  reportId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  sectionKey?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  user?: Resolver<GqlResolversTypes['User'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReportFeedbackEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReportFeedbackEdge'] = GqlResolversParentTypes['ReportFeedbackEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['ReportFeedback']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReportFeedbackRatingBucketResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReportFeedbackRatingBucket'] = GqlResolversParentTypes['ReportFeedbackRatingBucket']> = ResolversObject<{
+  count?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  rating?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReportFeedbacksConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReportFeedbacksConnection'] = GqlResolversParentTypes['ReportFeedbacksConnection']> = ResolversObject<{
+  edges?: Resolver<Maybe<Array<Maybe<GqlResolversTypes['ReportFeedbackEdge']>>>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReportTemplateResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReportTemplate'] = GqlResolversParentTypes['ReportTemplate']> = ResolversObject<{
+  community?: Resolver<Maybe<GqlResolversTypes['Community']>, ParentType, ContextType>;
+  communityContext?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  experimentKey?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  isActive?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  isEnabled?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  kind?: Resolver<GqlResolversTypes['ReportTemplateKind'], ParentType, ContextType>;
+  maxTokens?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  model?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  scope?: Resolver<GqlResolversTypes['ReportTemplateScope'], ParentType, ContextType>;
+  stopSequences?: Resolver<Array<GqlResolversTypes['String']>, ParentType, ContextType>;
+  systemPrompt?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  temperature?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  trafficWeight?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  updatedByUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  userPromptTemplate?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  variant?: Resolver<GqlResolversTypes['ReportVariant'], ParentType, ContextType>;
+  version?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReportTemplateStatsResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReportTemplateStats'] = GqlResolversParentTypes['ReportTemplateStats']> = ResolversObject<{
+  avgJudgeScore?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  avgRating?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  correlationWarning?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  feedbackCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  judgeHumanCorrelation?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  variant?: Resolver<GqlResolversTypes['ReportVariant'], ParentType, ContextType>;
+  version?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReportTemplateStatsBreakdownConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReportTemplateStatsBreakdownConnection'] = GqlResolversParentTypes['ReportTemplateStatsBreakdownConnection']> = ResolversObject<{
+  edges?: Resolver<Maybe<Array<Maybe<GqlResolversTypes['ReportTemplateStatsBreakdownEdge']>>>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReportTemplateStatsBreakdownEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReportTemplateStatsBreakdownEdge'] = GqlResolversParentTypes['ReportTemplateStatsBreakdownEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['ReportTemplateStatsBreakdownRow']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReportTemplateStatsBreakdownRowResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReportTemplateStatsBreakdownRow'] = GqlResolversParentTypes['ReportTemplateStatsBreakdownRow']> = ResolversObject<{
+  avgJudgeScore?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  avgRating?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  correlationWarning?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  experimentKey?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  feedbackCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  isActive?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  isEnabled?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  judgeHumanCorrelation?: Resolver<Maybe<GqlResolversTypes['Float']>, ParentType, ContextType>;
+  kind?: Resolver<GqlResolversTypes['ReportTemplateKind'], ParentType, ContextType>;
+  scope?: Resolver<GqlResolversTypes['ReportTemplateScope'], ParentType, ContextType>;
+  templateId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  trafficWeight?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  version?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReportsConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReportsConnection'] = GqlResolversParentTypes['ReportsConnection']> = ResolversObject<{
+  edges?: Resolver<Maybe<Array<Maybe<GqlResolversTypes['ReportEdge']>>>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReservationResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Reservation'] = GqlResolversParentTypes['Reservation']> = ResolversObject<{
+  comment?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  createdByUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  histories?: Resolver<Maybe<Array<GqlResolversTypes['ReservationHistory']>>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  opportunitySlot?: Resolver<Maybe<GqlResolversTypes['OpportunitySlot']>, ParentType, ContextType>;
+  participantCountWithPoint?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  participations?: Resolver<Maybe<Array<GqlResolversTypes['Participation']>>, ParentType, ContextType>;
+  status?: Resolver<GqlResolversTypes['ReservationStatus'], ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReservationCreatePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReservationCreatePayload'] = GqlResolversParentTypes['ReservationCreatePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'ReservationCreateSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlReservationCreateSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReservationCreateSuccess'] = GqlResolversParentTypes['ReservationCreateSuccess']> = ResolversObject<{
+  reservation?: Resolver<GqlResolversTypes['Reservation'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReservationEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReservationEdge'] = GqlResolversParentTypes['ReservationEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['Reservation']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReservationHistoriesConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReservationHistoriesConnection'] = GqlResolversParentTypes['ReservationHistoriesConnection']> = ResolversObject<{
+  edges?: Resolver<Array<GqlResolversTypes['ReservationHistoryEdge']>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReservationHistoryResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReservationHistory'] = GqlResolversParentTypes['ReservationHistory']> = ResolversObject<{
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  createdByUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  reservation?: Resolver<GqlResolversTypes['Reservation'], ParentType, ContextType>;
+  status?: Resolver<GqlResolversTypes['ReservationStatus'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReservationHistoryEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReservationHistoryEdge'] = GqlResolversParentTypes['ReservationHistoryEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['ReservationHistory']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReservationSetStatusPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReservationSetStatusPayload'] = GqlResolversParentTypes['ReservationSetStatusPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'ReservationSetStatusSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlReservationSetStatusSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReservationSetStatusSuccess'] = GqlResolversParentTypes['ReservationSetStatusSuccess']> = ResolversObject<{
+  reservation?: Resolver<GqlResolversTypes['Reservation'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlReservationsConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['ReservationsConnection'] = GqlResolversParentTypes['ReservationsConnection']> = ResolversObject<{
+  edges?: Resolver<Array<GqlResolversTypes['ReservationEdge']>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlStateResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['State'] = GqlResolversParentTypes['State']> = ResolversObject<{
+  code?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  countryCode?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  name?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlStateEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['StateEdge'] = GqlResolversParentTypes['StateEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['State']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlStatesConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['StatesConnection'] = GqlResolversParentTypes['StatesConnection']> = ResolversObject<{
+  edges?: Resolver<Array<GqlResolversTypes['StateEdge']>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlStorePhoneAuthTokenPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['StorePhoneAuthTokenPayload'] = GqlResolversParentTypes['StorePhoneAuthTokenPayload']> = ResolversObject<{
+  expiresAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  success?: Resolver<GqlResolversTypes['Boolean'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlSubmitReportFeedbackPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SubmitReportFeedbackPayload'] = GqlResolversParentTypes['SubmitReportFeedbackPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'SubmitReportFeedbackSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlSubmitReportFeedbackSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['SubmitReportFeedbackSuccess'] = GqlResolversParentTypes['SubmitReportFeedbackSuccess']> = ResolversObject<{
+  feedback?: Resolver<GqlResolversTypes['ReportFeedback'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTicketResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Ticket'] = GqlResolversParentTypes['Ticket']> = ResolversObject<{
+  claimLink?: Resolver<Maybe<GqlResolversTypes['TicketClaimLink']>, ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  reason?: Resolver<GqlResolversTypes['TicketStatusReason'], ParentType, ContextType>;
+  status?: Resolver<GqlResolversTypes['TicketStatus'], ParentType, ContextType>;
+  ticketStatusHistories?: Resolver<Maybe<Array<GqlResolversTypes['TicketStatusHistory']>>, ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  utility?: Resolver<Maybe<GqlResolversTypes['Utility']>, ParentType, ContextType>;
+  wallet?: Resolver<Maybe<GqlResolversTypes['Wallet']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTicketClaimLinkResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TicketClaimLink'] = GqlResolversParentTypes['TicketClaimLink']> = ResolversObject<{
+  claimedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  issuer?: Resolver<Maybe<GqlResolversTypes['TicketIssuer']>, ParentType, ContextType>;
+  qty?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  status?: Resolver<GqlResolversTypes['ClaimLinkStatus'], ParentType, ContextType>;
+  tickets?: Resolver<Maybe<Array<GqlResolversTypes['Ticket']>>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTicketClaimLinkEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TicketClaimLinkEdge'] = GqlResolversParentTypes['TicketClaimLinkEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['TicketClaimLink']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTicketClaimLinksConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TicketClaimLinksConnection'] = GqlResolversParentTypes['TicketClaimLinksConnection']> = ResolversObject<{
+  edges?: Resolver<Maybe<Array<Maybe<GqlResolversTypes['TicketClaimLinkEdge']>>>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTicketClaimPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TicketClaimPayload'] = GqlResolversParentTypes['TicketClaimPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'TicketClaimSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlTicketClaimSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TicketClaimSuccess'] = GqlResolversParentTypes['TicketClaimSuccess']> = ResolversObject<{
+  tickets?: Resolver<Array<GqlResolversTypes['Ticket']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTicketEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TicketEdge'] = GqlResolversParentTypes['TicketEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['Ticket']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTicketIssuePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TicketIssuePayload'] = GqlResolversParentTypes['TicketIssuePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'TicketIssueSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlTicketIssueSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TicketIssueSuccess'] = GqlResolversParentTypes['TicketIssueSuccess']> = ResolversObject<{
+  issue?: Resolver<GqlResolversTypes['TicketIssuer'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTicketIssuerResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TicketIssuer'] = GqlResolversParentTypes['TicketIssuer']> = ResolversObject<{
+  claimLink?: Resolver<Maybe<GqlResolversTypes['TicketClaimLink']>, ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  owner?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  qtyToBeIssued?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  utility?: Resolver<Maybe<GqlResolversTypes['Utility']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTicketIssuerEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TicketIssuerEdge'] = GqlResolversParentTypes['TicketIssuerEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['TicketIssuer']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTicketIssuersConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TicketIssuersConnection'] = GqlResolversParentTypes['TicketIssuersConnection']> = ResolversObject<{
+  edges?: Resolver<Maybe<Array<Maybe<GqlResolversTypes['TicketIssuerEdge']>>>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTicketPurchasePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TicketPurchasePayload'] = GqlResolversParentTypes['TicketPurchasePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'TicketPurchaseSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlTicketPurchaseSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TicketPurchaseSuccess'] = GqlResolversParentTypes['TicketPurchaseSuccess']> = ResolversObject<{
+  ticket?: Resolver<GqlResolversTypes['Ticket'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTicketRefundPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TicketRefundPayload'] = GqlResolversParentTypes['TicketRefundPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'TicketRefundSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlTicketRefundSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TicketRefundSuccess'] = GqlResolversParentTypes['TicketRefundSuccess']> = ResolversObject<{
+  ticket?: Resolver<GqlResolversTypes['Ticket'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTicketStatusHistoriesConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TicketStatusHistoriesConnection'] = GqlResolversParentTypes['TicketStatusHistoriesConnection']> = ResolversObject<{
+  edges?: Resolver<Maybe<Array<Maybe<GqlResolversTypes['TicketStatusHistoryEdge']>>>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTicketStatusHistoryResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TicketStatusHistory'] = GqlResolversParentTypes['TicketStatusHistory']> = ResolversObject<{
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  createdByUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  reason?: Resolver<GqlResolversTypes['TicketStatusReason'], ParentType, ContextType>;
+  status?: Resolver<GqlResolversTypes['TicketStatus'], ParentType, ContextType>;
+  ticket?: Resolver<Maybe<GqlResolversTypes['Ticket']>, ParentType, ContextType>;
+  transaction?: Resolver<Maybe<GqlResolversTypes['Transaction']>, ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTicketStatusHistoryEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TicketStatusHistoryEdge'] = GqlResolversParentTypes['TicketStatusHistoryEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['TicketStatusHistory']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTicketUsePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TicketUsePayload'] = GqlResolversParentTypes['TicketUsePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'TicketUseSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlTicketUseSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TicketUseSuccess'] = GqlResolversParentTypes['TicketUseSuccess']> = ResolversObject<{
+  ticket?: Resolver<GqlResolversTypes['Ticket'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTicketsConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TicketsConnection'] = GqlResolversParentTypes['TicketsConnection']> = ResolversObject<{
+  edges?: Resolver<Maybe<Array<Maybe<GqlResolversTypes['TicketEdge']>>>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTransactionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Transaction'] = GqlResolversParentTypes['Transaction']> = ResolversObject<{
+  chain?: Resolver<Maybe<GqlResolversTypes['TransactionChain']>, ParentType, ContextType>;
+  chainDepth?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  comment?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  createdByUser?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  fromPointChange?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  fromWallet?: Resolver<Maybe<GqlResolversTypes['Wallet']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  images?: Resolver<Maybe<Array<GqlResolversTypes['String']>>, ParentType, ContextType>;
+  participation?: Resolver<Maybe<GqlResolversTypes['Participation']>, ParentType, ContextType>;
+  reason?: Resolver<GqlResolversTypes['TransactionReason'], ParentType, ContextType>;
+  reservation?: Resolver<Maybe<GqlResolversTypes['Reservation']>, ParentType, ContextType>;
+  ticketStatusHistories?: Resolver<Maybe<Array<GqlResolversTypes['TicketStatusHistory']>>, ParentType, ContextType>;
+  toPointChange?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  toWallet?: Resolver<Maybe<GqlResolversTypes['Wallet']>, ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTransactionChainResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TransactionChain'] = GqlResolversParentTypes['TransactionChain']> = ResolversObject<{
+  depth?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  steps?: Resolver<Array<GqlResolversTypes['TransactionChainStep']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTransactionChainCommunityResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TransactionChainCommunity'] = GqlResolversParentTypes['TransactionChainCommunity']> = ResolversObject<{
+  bio?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  image?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTransactionChainParticipantResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TransactionChainParticipant'] = GqlResolversParentTypes['TransactionChainParticipant']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'TransactionChainCommunity' | 'TransactionChainUser', ParentType, ContextType>;
+  bio?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  image?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+}>;
+
+export type GqlTransactionChainStepResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TransactionChainStep'] = GqlResolversParentTypes['TransactionChainStep']> = ResolversObject<{
+  createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  from?: Resolver<Maybe<GqlResolversTypes['TransactionChainParticipant']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  points?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  reason?: Resolver<GqlResolversTypes['TransactionReason'], ParentType, ContextType>;
+  to?: Resolver<Maybe<GqlResolversTypes['TransactionChainParticipant']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTransactionChainUserResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TransactionChainUser'] = GqlResolversParentTypes['TransactionChainUser']> = ResolversObject<{
+  bio?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  image?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTransactionDonateSelfPointPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TransactionDonateSelfPointPayload'] = GqlResolversParentTypes['TransactionDonateSelfPointPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'TransactionDonateSelfPointSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlTransactionDonateSelfPointSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TransactionDonateSelfPointSuccess'] = GqlResolversParentTypes['TransactionDonateSelfPointSuccess']> = ResolversObject<{
+  transaction?: Resolver<GqlResolversTypes['Transaction'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTransactionEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TransactionEdge'] = GqlResolversParentTypes['TransactionEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['Transaction']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTransactionGrantCommunityPointPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TransactionGrantCommunityPointPayload'] = GqlResolversParentTypes['TransactionGrantCommunityPointPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'TransactionGrantCommunityPointSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlTransactionGrantCommunityPointSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TransactionGrantCommunityPointSuccess'] = GqlResolversParentTypes['TransactionGrantCommunityPointSuccess']> = ResolversObject<{
+  transaction?: Resolver<GqlResolversTypes['Transaction'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTransactionIssueCommunityPointPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TransactionIssueCommunityPointPayload'] = GqlResolversParentTypes['TransactionIssueCommunityPointPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'TransactionIssueCommunityPointSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlTransactionIssueCommunityPointSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TransactionIssueCommunityPointSuccess'] = GqlResolversParentTypes['TransactionIssueCommunityPointSuccess']> = ResolversObject<{
+  transaction?: Resolver<GqlResolversTypes['Transaction'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTransactionUpdateMetadataPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TransactionUpdateMetadataPayload'] = GqlResolversParentTypes['TransactionUpdateMetadataPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'TransactionUpdateMetadataSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlTransactionUpdateMetadataSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TransactionUpdateMetadataSuccess'] = GqlResolversParentTypes['TransactionUpdateMetadataSuccess']> = ResolversObject<{
+  transaction?: Resolver<GqlResolversTypes['Transaction'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTransactionVerificationResultResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TransactionVerificationResult'] = GqlResolversParentTypes['TransactionVerificationResult']> = ResolversObject<{
+  label?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  rootHash?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  status?: Resolver<GqlResolversTypes['VerificationStatus'], ParentType, ContextType>;
+  transactionHash?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  txId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlTransactionsConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['TransactionsConnection'] = GqlResolversParentTypes['TransactionsConnection']> = ResolversObject<{
+  edges?: Resolver<Maybe<Array<Maybe<GqlResolversTypes['TransactionEdge']>>>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlUpdateReportTemplatePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['UpdateReportTemplatePayload'] = GqlResolversParentTypes['UpdateReportTemplatePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'UpdateReportTemplateSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlUpdateReportTemplateSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['UpdateReportTemplateSuccess'] = GqlResolversParentTypes['UpdateReportTemplateSuccess']> = ResolversObject<{
+  reportTemplate?: Resolver<GqlResolversTypes['ReportTemplate'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export interface GqlUploadScalarConfig extends GraphQLScalarTypeConfig<GqlResolversTypes['Upload'], any> {
+  name: 'Upload';
+}
+
+export type GqlUserResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['User'] = GqlResolversParentTypes['User']> = ResolversObject<{
+  articlesAboutMe?: Resolver<Maybe<Array<GqlResolversTypes['Article']>>, ParentType, ContextType>;
+  articlesWrittenByMe?: Resolver<Maybe<Array<GqlResolversTypes['Article']>>, ParentType, ContextType>;
+  bio?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  currentPrefecture?: Resolver<Maybe<GqlResolversTypes['CurrentPrefecture']>, ParentType, ContextType>;
+  didIssuanceRequests?: Resolver<Maybe<Array<GqlResolversTypes['DidIssuanceRequest']>>, ParentType, ContextType>;
+  evaluationCreatedByMe?: Resolver<Maybe<Array<GqlResolversTypes['EvaluationHistory']>>, ParentType, ContextType>;
+  evaluations?: Resolver<Maybe<Array<GqlResolversTypes['Evaluation']>>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  identities?: Resolver<Maybe<Array<GqlResolversTypes['Identity']>>, ParentType, ContextType>;
+  image?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  membershipChangedByMe?: Resolver<Maybe<Array<GqlResolversTypes['MembershipHistory']>>, ParentType, ContextType>;
+  memberships?: Resolver<Maybe<Array<GqlResolversTypes['Membership']>>, ParentType, ContextType>;
+  name?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  nftInstances?: Resolver<Maybe<GqlResolversTypes['NftInstancesConnection']>, ParentType, ContextType, Partial<GqlUserNftInstancesArgs>>;
+  nftWallet?: Resolver<Maybe<GqlResolversTypes['NftWallet']>, ParentType, ContextType>;
+  opportunitiesCreatedByMe?: Resolver<Maybe<Array<GqlResolversTypes['Opportunity']>>, ParentType, ContextType>;
+  participationStatusChangedByMe?: Resolver<Maybe<Array<GqlResolversTypes['ParticipationStatusHistory']>>, ParentType, ContextType>;
+  participations?: Resolver<Maybe<Array<GqlResolversTypes['Participation']>>, ParentType, ContextType>;
+  phoneNumber?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  portfolios?: Resolver<Maybe<Array<GqlResolversTypes['Portfolio']>>, ParentType, ContextType, Partial<GqlUserPortfoliosArgs>>;
+  preferredLanguage?: Resolver<Maybe<GqlResolversTypes['Language']>, ParentType, ContextType>;
+  reservationStatusChangedByMe?: Resolver<Maybe<Array<GqlResolversTypes['ReservationHistory']>>, ParentType, ContextType>;
+  reservations?: Resolver<Maybe<Array<GqlResolversTypes['Reservation']>>, ParentType, ContextType>;
+  slug?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  sysRole?: Resolver<Maybe<GqlResolversTypes['SysRole']>, ParentType, ContextType>;
+  ticketStatusChangedByMe?: Resolver<Maybe<Array<GqlResolversTypes['TicketStatusHistory']>>, ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  urlFacebook?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  urlInstagram?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  urlTiktok?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  urlWebsite?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  urlX?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  urlYoutube?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  wallets?: Resolver<Maybe<Array<GqlResolversTypes['Wallet']>>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlUserDeletePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['UserDeletePayload'] = GqlResolversParentTypes['UserDeletePayload']> = ResolversObject<{
+  userId?: Resolver<Maybe<GqlResolversTypes['ID']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlUserDidAnchorResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['UserDidAnchor'] = GqlResolversParentTypes['UserDidAnchor']> = ResolversObject<{
+  chainOpIndex?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  chainTxHash?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  confirmedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  did?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  documentHash?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  network?: Resolver<GqlResolversTypes['ChainNetwork'], ParentType, ContextType>;
+  operation?: Resolver<GqlResolversTypes['DidOperation'], ParentType, ContextType>;
+  status?: Resolver<GqlResolversTypes['AnchorStatus'], ParentType, ContextType>;
+  user?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlUserEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['UserEdge'] = GqlResolversParentTypes['UserEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlUserUpdateProfilePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['UserUpdateProfilePayload'] = GqlResolversParentTypes['UserUpdateProfilePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'UserUpdateProfileSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlUserUpdateProfileSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['UserUpdateProfileSuccess'] = GqlResolversParentTypes['UserUpdateProfileSuccess']> = ResolversObject<{
+  user?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlUsersConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['UsersConnection'] = GqlResolversParentTypes['UsersConnection']> = ResolversObject<{
+  edges?: Resolver<Maybe<Array<Maybe<GqlResolversTypes['UserEdge']>>>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlUtilitiesConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['UtilitiesConnection'] = GqlResolversParentTypes['UtilitiesConnection']> = ResolversObject<{
+  edges?: Resolver<Maybe<Array<Maybe<GqlResolversTypes['UtilityEdge']>>>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlUtilityResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Utility'] = GqlResolversParentTypes['Utility']> = ResolversObject<{
+  community?: Resolver<Maybe<GqlResolversTypes['Community']>, ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  description?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  images?: Resolver<Maybe<Array<GqlResolversTypes['String']>>, ParentType, ContextType>;
+  name?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  owner?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  pointsRequired?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  publishStatus?: Resolver<GqlResolversTypes['PublishStatus'], ParentType, ContextType>;
+  requiredForOpportunities?: Resolver<Maybe<Array<GqlResolversTypes['Opportunity']>>, ParentType, ContextType>;
+  ticketIssuers?: Resolver<Maybe<Array<GqlResolversTypes['TicketIssuer']>>, ParentType, ContextType>;
+  tickets?: Resolver<Maybe<Array<GqlResolversTypes['Ticket']>>, ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlUtilityCreatePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['UtilityCreatePayload'] = GqlResolversParentTypes['UtilityCreatePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'UtilityCreateSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlUtilityCreateSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['UtilityCreateSuccess'] = GqlResolversParentTypes['UtilityCreateSuccess']> = ResolversObject<{
+  utility?: Resolver<GqlResolversTypes['Utility'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlUtilityDeletePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['UtilityDeletePayload'] = GqlResolversParentTypes['UtilityDeletePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'UtilityDeleteSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlUtilityDeleteSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['UtilityDeleteSuccess'] = GqlResolversParentTypes['UtilityDeleteSuccess']> = ResolversObject<{
+  utilityId?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlUtilityEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['UtilityEdge'] = GqlResolversParentTypes['UtilityEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['Utility']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlUtilitySetPublishStatusPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['UtilitySetPublishStatusPayload'] = GqlResolversParentTypes['UtilitySetPublishStatusPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'UtilitySetPublishStatusSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlUtilitySetPublishStatusSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['UtilitySetPublishStatusSuccess'] = GqlResolversParentTypes['UtilitySetPublishStatusSuccess']> = ResolversObject<{
+  utility?: Resolver<GqlResolversTypes['Utility'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlUtilityUpdateInfoPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['UtilityUpdateInfoPayload'] = GqlResolversParentTypes['UtilityUpdateInfoPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'UtilityUpdateInfoSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlUtilityUpdateInfoSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['UtilityUpdateInfoSuccess'] = GqlResolversParentTypes['UtilityUpdateInfoSuccess']> = ResolversObject<{
+  utility?: Resolver<GqlResolversTypes['Utility'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVcIssuanceResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VcIssuance'] = GqlResolversParentTypes['VcIssuance']> = ResolversObject<{
+  createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  evaluation?: Resolver<Maybe<GqlResolversTypes['Evaluation']>, ParentType, ContextType>;
+  evaluationId?: Resolver<Maybe<GqlResolversTypes['ID']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  issuerDid?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  revokedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  status?: Resolver<GqlResolversTypes['VcIssuanceStatus'], ParentType, ContextType>;
+  statusListCredential?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  statusListIndex?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  subjectDid?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  user?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  userId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  vcFormat?: Resolver<GqlResolversTypes['VcFormat'], ParentType, ContextType>;
+  vcJwt?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVcIssuanceRequestResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VcIssuanceRequest'] = GqlResolversParentTypes['VcIssuanceRequest']> = ResolversObject<{
+  completedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  evaluation?: Resolver<Maybe<GqlResolversTypes['Evaluation']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  processedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  requestedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  status?: Resolver<GqlResolversTypes['VcIssuanceStatus'], ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  user?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVcIssuanceRequestEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VcIssuanceRequestEdge'] = GqlResolversParentTypes['VcIssuanceRequestEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['VcIssuanceRequest']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVcIssuanceRequestsConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VcIssuanceRequestsConnection'] = GqlResolversParentTypes['VcIssuanceRequestsConnection']> = ResolversObject<{
+  edges?: Resolver<Array<GqlResolversTypes['VcIssuanceRequestEdge']>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVoteBallotResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VoteBallot'] = GqlResolversParentTypes['VoteBallot']> = ResolversObject<{
+  createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  option?: Resolver<GqlResolversTypes['VoteOption'], ParentType, ContextType>;
+  power?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVoteCastPayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VoteCastPayload'] = GqlResolversParentTypes['VoteCastPayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'VoteCastSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlVoteCastSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VoteCastSuccess'] = GqlResolversParentTypes['VoteCastSuccess']> = ResolversObject<{
+  ballot?: Resolver<GqlResolversTypes['VoteBallot'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVoteGateResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VoteGate'] = GqlResolversParentTypes['VoteGate']> = ResolversObject<{
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  nftToken?: Resolver<Maybe<GqlResolversTypes['NftToken']>, ParentType, ContextType>;
+  requiredRole?: Resolver<Maybe<GqlResolversTypes['Role']>, ParentType, ContextType>;
+  type?: Resolver<GqlResolversTypes['VoteGateType'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVoteOptionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VoteOption'] = GqlResolversParentTypes['VoteOption']> = ResolversObject<{
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  label?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  orderIndex?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  totalPower?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  voteCount?: Resolver<Maybe<GqlResolversTypes['Int']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVotePowerPolicyResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VotePowerPolicy'] = GqlResolversParentTypes['VotePowerPolicy']> = ResolversObject<{
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  nftToken?: Resolver<Maybe<GqlResolversTypes['NftToken']>, ParentType, ContextType>;
+  type?: Resolver<GqlResolversTypes['VotePowerPolicyType'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVoteTopicResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VoteTopic'] = GqlResolversParentTypes['VoteTopic']> = ResolversObject<{
+  community?: Resolver<GqlResolversTypes['Community'], ParentType, ContextType>;
+  createdAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  description?: Resolver<Maybe<GqlResolversTypes['String']>, ParentType, ContextType>;
+  endsAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  gate?: Resolver<GqlResolversTypes['VoteGate'], ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  myBallot?: Resolver<Maybe<GqlResolversTypes['VoteBallot']>, ParentType, ContextType>;
+  myEligibility?: Resolver<Maybe<GqlResolversTypes['MyVoteEligibility']>, ParentType, ContextType>;
+  options?: Resolver<Array<GqlResolversTypes['VoteOption']>, ParentType, ContextType>;
+  phase?: Resolver<GqlResolversTypes['VoteTopicPhase'], ParentType, ContextType>;
+  powerPolicy?: Resolver<GqlResolversTypes['VotePowerPolicy'], ParentType, ContextType>;
+  startsAt?: Resolver<GqlResolversTypes['Datetime'], ParentType, ContextType>;
+  title?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVoteTopicCreatePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VoteTopicCreatePayload'] = GqlResolversParentTypes['VoteTopicCreatePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'VoteTopicCreateSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlVoteTopicCreateSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VoteTopicCreateSuccess'] = GqlResolversParentTypes['VoteTopicCreateSuccess']> = ResolversObject<{
+  voteTopic?: Resolver<GqlResolversTypes['VoteTopic'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVoteTopicDeletePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VoteTopicDeletePayload'] = GqlResolversParentTypes['VoteTopicDeletePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'VoteTopicDeleteSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlVoteTopicDeleteSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VoteTopicDeleteSuccess'] = GqlResolversParentTypes['VoteTopicDeleteSuccess']> = ResolversObject<{
+  voteTopicId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVoteTopicEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VoteTopicEdge'] = GqlResolversParentTypes['VoteTopicEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<GqlResolversTypes['VoteTopic'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVoteTopicUpdatePayloadResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VoteTopicUpdatePayload'] = GqlResolversParentTypes['VoteTopicUpdatePayload']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'VoteTopicUpdateSuccess', ParentType, ContextType>;
+}>;
+
+export type GqlVoteTopicUpdateSuccessResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VoteTopicUpdateSuccess'] = GqlResolversParentTypes['VoteTopicUpdateSuccess']> = ResolversObject<{
+  voteTopic?: Resolver<GqlResolversTypes['VoteTopic'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlVoteTopicsConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['VoteTopicsConnection'] = GqlResolversParentTypes['VoteTopicsConnection']> = ResolversObject<{
+  edges?: Resolver<Array<GqlResolversTypes['VoteTopicEdge']>, ParentType, ContextType>;
+  nodes?: Resolver<Array<GqlResolversTypes['VoteTopic']>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlWalletResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['Wallet'] = GqlResolversParentTypes['Wallet']> = ResolversObject<{
+  accumulatedPointView?: Resolver<Maybe<GqlResolversTypes['AccumulatedPointView']>, ParentType, ContextType>;
+  community?: Resolver<Maybe<GqlResolversTypes['Community']>, ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  currentPointView?: Resolver<Maybe<GqlResolversTypes['CurrentPointView']>, ParentType, ContextType>;
+  id?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
+  tickets?: Resolver<Maybe<Array<GqlResolversTypes['Ticket']>>, ParentType, ContextType>;
+  transactions?: Resolver<Maybe<Array<GqlResolversTypes['Transaction']>>, ParentType, ContextType>;
+  transactionsConnection?: Resolver<Maybe<GqlResolversTypes['TransactionsConnection']>, ParentType, ContextType, Partial<GqlWalletTransactionsConnectionArgs>>;
+  type?: Resolver<GqlResolversTypes['WalletType'], ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<GqlResolversTypes['Datetime']>, ParentType, ContextType>;
+  user?: Resolver<Maybe<GqlResolversTypes['User']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlWalletEdgeResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['WalletEdge'] = GqlResolversParentTypes['WalletEdge']> = ResolversObject<{
+  cursor?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GqlResolversTypes['Wallet']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlWalletsConnectionResolvers<ContextType = any, ParentType extends GqlResolversParentTypes['WalletsConnection'] = GqlResolversParentTypes['WalletsConnection']> = ResolversObject<{
+  edges?: Resolver<Maybe<Array<Maybe<GqlResolversTypes['WalletEdge']>>>, ParentType, ContextType>;
+  pageInfo?: Resolver<GqlResolversTypes['PageInfo'], ParentType, ContextType>;
+  totalCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GqlResolvers<ContextType = any> = ResolversObject<{
+  AccumulatedPointView?: GqlAccumulatedPointViewResolvers<ContextType>;
+  AdminReportSummaryConnection?: GqlAdminReportSummaryConnectionResolvers<ContextType>;
+  AdminReportSummaryEdge?: GqlAdminReportSummaryEdgeResolvers<ContextType>;
+  AdminReportSummaryRow?: GqlAdminReportSummaryRowResolvers<ContextType>;
+  AdminTemplateFeedbackStats?: GqlAdminTemplateFeedbackStatsResolvers<ContextType>;
+  AnalyticsChainDepthBucket?: GqlAnalyticsChainDepthBucketResolvers<ContextType>;
+  AnalyticsCohortFunnelPoint?: GqlAnalyticsCohortFunnelPointResolvers<ContextType>;
+  AnalyticsCohortRetentionPoint?: GqlAnalyticsCohortRetentionPointResolvers<ContextType>;
+  AnalyticsCommunityAlerts?: GqlAnalyticsCommunityAlertsResolvers<ContextType>;
+  AnalyticsCommunityOverview?: GqlAnalyticsCommunityOverviewResolvers<ContextType>;
+  AnalyticsCommunityPayload?: GqlAnalyticsCommunityPayloadResolvers<ContextType>;
+  AnalyticsCommunitySummaryCard?: GqlAnalyticsCommunitySummaryCardResolvers<ContextType>;
+  AnalyticsDashboardPayload?: GqlAnalyticsDashboardPayloadResolvers<ContextType>;
+  AnalyticsLatestCohort?: GqlAnalyticsLatestCohortResolvers<ContextType>;
+  AnalyticsMemberList?: GqlAnalyticsMemberListResolvers<ContextType>;
+  AnalyticsMemberRow?: GqlAnalyticsMemberRowResolvers<ContextType>;
+  AnalyticsMonthlyActivityPoint?: GqlAnalyticsMonthlyActivityPointResolvers<ContextType>;
+  AnalyticsPlatformSummary?: GqlAnalyticsPlatformSummaryResolvers<ContextType>;
+  AnalyticsRetentionTrendPoint?: GqlAnalyticsRetentionTrendPointResolvers<ContextType>;
+  AnalyticsSegmentCounts?: GqlAnalyticsSegmentCountsResolvers<ContextType>;
+  AnalyticsStageBucket?: GqlAnalyticsStageBucketResolvers<ContextType>;
+  AnalyticsStageDistribution?: GqlAnalyticsStageDistributionResolvers<ContextType>;
+  AnalyticsTenureDistribution?: GqlAnalyticsTenureDistributionResolvers<ContextType>;
+  AnalyticsTenureHistogramBucket?: GqlAnalyticsTenureHistogramBucketResolvers<ContextType>;
+  AnalyticsWeeklyRetention?: GqlAnalyticsWeeklyRetentionResolvers<ContextType>;
+  AnalyticsWindowActivity?: GqlAnalyticsWindowActivityResolvers<ContextType>;
+  ApproveReportPayload?: GqlApproveReportPayloadResolvers<ContextType>;
+  ApproveReportSuccess?: GqlApproveReportSuccessResolvers<ContextType>;
+  Article?: GqlArticleResolvers<ContextType>;
+  ArticleCreatePayload?: GqlArticleCreatePayloadResolvers<ContextType>;
+  ArticleCreateSuccess?: GqlArticleCreateSuccessResolvers<ContextType>;
+  ArticleDeletePayload?: GqlArticleDeletePayloadResolvers<ContextType>;
+  ArticleDeleteSuccess?: GqlArticleDeleteSuccessResolvers<ContextType>;
+  ArticleEdge?: GqlArticleEdgeResolvers<ContextType>;
+  ArticleUpdateContentPayload?: GqlArticleUpdateContentPayloadResolvers<ContextType>;
+  ArticleUpdateContentSuccess?: GqlArticleUpdateContentSuccessResolvers<ContextType>;
+  ArticlesConnection?: GqlArticlesConnectionResolvers<ContextType>;
+  BigInt?: GraphQLScalarType;
+  CitiesConnection?: GqlCitiesConnectionResolvers<ContextType>;
+  City?: GqlCityResolvers<ContextType>;
+  CityEdge?: GqlCityEdgeResolvers<ContextType>;
+  CommonDocumentOverrides?: GqlCommonDocumentOverridesResolvers<ContextType>;
+  CommunitiesConnection?: GqlCommunitiesConnectionResolvers<ContextType>;
+  Community?: GqlCommunityResolvers<ContextType>;
+  CommunityConfig?: GqlCommunityConfigResolvers<ContextType>;
+  CommunityCreatePayload?: GqlCommunityCreatePayloadResolvers<ContextType>;
+  CommunityCreateSuccess?: GqlCommunityCreateSuccessResolvers<ContextType>;
+  CommunityDeletePayload?: GqlCommunityDeletePayloadResolvers<ContextType>;
+  CommunityDeleteSuccess?: GqlCommunityDeleteSuccessResolvers<ContextType>;
+  CommunityDocument?: GqlCommunityDocumentResolvers<ContextType>;
+  CommunityEdge?: GqlCommunityEdgeResolvers<ContextType>;
+  CommunityFirebaseConfig?: GqlCommunityFirebaseConfigResolvers<ContextType>;
+  CommunityLineConfig?: GqlCommunityLineConfigResolvers<ContextType>;
+  CommunityLineRichMenuConfig?: GqlCommunityLineRichMenuConfigResolvers<ContextType>;
+  CommunityPortalConfig?: GqlCommunityPortalConfigResolvers<ContextType>;
+  CommunitySignupBonusConfig?: GqlCommunitySignupBonusConfigResolvers<ContextType>;
+  CommunityUpdateProfilePayload?: GqlCommunityUpdateProfilePayloadResolvers<ContextType>;
+  CommunityUpdateProfileSuccess?: GqlCommunityUpdateProfileSuccessResolvers<ContextType>;
+  CurrentPointView?: GqlCurrentPointViewResolvers<ContextType>;
+  CurrentUserPayload?: GqlCurrentUserPayloadResolvers<ContextType>;
+  Datetime?: GraphQLScalarType;
+  Decimal?: GraphQLScalarType;
+  DidIssuanceRequest?: GqlDidIssuanceRequestResolvers<ContextType>;
+  Edge?: GqlEdgeResolvers<ContextType>;
+  Error?: GqlErrorResolvers<ContextType>;
+  Evaluation?: GqlEvaluationResolvers<ContextType>;
+  EvaluationBulkCreatePayload?: GqlEvaluationBulkCreatePayloadResolvers<ContextType>;
+  EvaluationBulkCreateSuccess?: GqlEvaluationBulkCreateSuccessResolvers<ContextType>;
+  EvaluationEdge?: GqlEvaluationEdgeResolvers<ContextType>;
+  EvaluationHistoriesConnection?: GqlEvaluationHistoriesConnectionResolvers<ContextType>;
+  EvaluationHistory?: GqlEvaluationHistoryResolvers<ContextType>;
+  EvaluationHistoryEdge?: GqlEvaluationHistoryEdgeResolvers<ContextType>;
+  EvaluationsConnection?: GqlEvaluationsConnectionResolvers<ContextType>;
+  GenerateReportPayload?: GqlGenerateReportPayloadResolvers<ContextType>;
+  GenerateReportSuccess?: GqlGenerateReportSuccessResolvers<ContextType>;
+  Identity?: GqlIdentityResolvers<ContextType>;
+  IdentityCheckPhoneUserPayload?: GqlIdentityCheckPhoneUserPayloadResolvers<ContextType>;
+  IncentiveGrant?: GqlIncentiveGrantResolvers<ContextType>;
+  IncentiveGrantEdge?: GqlIncentiveGrantEdgeResolvers<ContextType>;
+  IncentiveGrantRetryPayload?: GqlIncentiveGrantRetryPayloadResolvers<ContextType>;
+  IncentiveGrantRetrySuccess?: GqlIncentiveGrantRetrySuccessResolvers<ContextType>;
+  IncentiveGrantsConnection?: GqlIncentiveGrantsConnectionResolvers<ContextType>;
+  JSON?: GraphQLScalarType;
+  LinkPhoneAuthPayload?: GqlLinkPhoneAuthPayloadResolvers<ContextType>;
+  Membership?: GqlMembershipResolvers<ContextType>;
+  MembershipEdge?: GqlMembershipEdgeResolvers<ContextType>;
+  MembershipHistory?: GqlMembershipHistoryResolvers<ContextType>;
+  MembershipInvitePayload?: GqlMembershipInvitePayloadResolvers<ContextType>;
+  MembershipInviteSuccess?: GqlMembershipInviteSuccessResolvers<ContextType>;
+  MembershipRemovePayload?: GqlMembershipRemovePayloadResolvers<ContextType>;
+  MembershipRemoveSuccess?: GqlMembershipRemoveSuccessResolvers<ContextType>;
+  MembershipSetInvitationStatusPayload?: GqlMembershipSetInvitationStatusPayloadResolvers<ContextType>;
+  MembershipSetInvitationStatusSuccess?: GqlMembershipSetInvitationStatusSuccessResolvers<ContextType>;
+  MembershipSetRolePayload?: GqlMembershipSetRolePayloadResolvers<ContextType>;
+  MembershipSetRoleSuccess?: GqlMembershipSetRoleSuccessResolvers<ContextType>;
+  MembershipWithdrawPayload?: GqlMembershipWithdrawPayloadResolvers<ContextType>;
+  MembershipWithdrawSuccess?: GqlMembershipWithdrawSuccessResolvers<ContextType>;
+  MembershipsConnection?: GqlMembershipsConnectionResolvers<ContextType>;
+  Mutation?: GqlMutationResolvers<ContextType>;
+  MyVoteEligibility?: GqlMyVoteEligibilityResolvers<ContextType>;
+  NftInstance?: GqlNftInstanceResolvers<ContextType>;
+  NftInstanceEdge?: GqlNftInstanceEdgeResolvers<ContextType>;
+  NftInstancesConnection?: GqlNftInstancesConnectionResolvers<ContextType>;
+  NftToken?: GqlNftTokenResolvers<ContextType>;
+  NftTokenEdge?: GqlNftTokenEdgeResolvers<ContextType>;
+  NftTokensConnection?: GqlNftTokensConnectionResolvers<ContextType>;
+  NftWallet?: GqlNftWalletResolvers<ContextType>;
+  OpportunitiesConnection?: GqlOpportunitiesConnectionResolvers<ContextType>;
+  Opportunity?: GqlOpportunityResolvers<ContextType>;
+  OpportunityCreatePayload?: GqlOpportunityCreatePayloadResolvers<ContextType>;
+  OpportunityCreateSuccess?: GqlOpportunityCreateSuccessResolvers<ContextType>;
+  OpportunityDeletePayload?: GqlOpportunityDeletePayloadResolvers<ContextType>;
+  OpportunityDeleteSuccess?: GqlOpportunityDeleteSuccessResolvers<ContextType>;
+  OpportunityEdge?: GqlOpportunityEdgeResolvers<ContextType>;
+  OpportunitySetPublishStatusPayload?: GqlOpportunitySetPublishStatusPayloadResolvers<ContextType>;
+  OpportunitySetPublishStatusSuccess?: GqlOpportunitySetPublishStatusSuccessResolvers<ContextType>;
+  OpportunitySlot?: GqlOpportunitySlotResolvers<ContextType>;
+  OpportunitySlotCreatePayload?: GqlOpportunitySlotCreatePayloadResolvers<ContextType>;
+  OpportunitySlotCreateSuccess?: GqlOpportunitySlotCreateSuccessResolvers<ContextType>;
+  OpportunitySlotEdge?: GqlOpportunitySlotEdgeResolvers<ContextType>;
+  OpportunitySlotSetHostingStatusPayload?: GqlOpportunitySlotSetHostingStatusPayloadResolvers<ContextType>;
+  OpportunitySlotSetHostingStatusSuccess?: GqlOpportunitySlotSetHostingStatusSuccessResolvers<ContextType>;
+  OpportunitySlotsBulkUpdatePayload?: GqlOpportunitySlotsBulkUpdatePayloadResolvers<ContextType>;
+  OpportunitySlotsBulkUpdateSuccess?: GqlOpportunitySlotsBulkUpdateSuccessResolvers<ContextType>;
+  OpportunitySlotsConnection?: GqlOpportunitySlotsConnectionResolvers<ContextType>;
+  OpportunityUpdateContentPayload?: GqlOpportunityUpdateContentPayloadResolvers<ContextType>;
+  OpportunityUpdateContentSuccess?: GqlOpportunityUpdateContentSuccessResolvers<ContextType>;
+  PageInfo?: GqlPageInfoResolvers<ContextType>;
+  Paging?: GqlPagingResolvers<ContextType>;
+  Participation?: GqlParticipationResolvers<ContextType>;
+  ParticipationBulkCreatePayload?: GqlParticipationBulkCreatePayloadResolvers<ContextType>;
+  ParticipationBulkCreateSuccess?: GqlParticipationBulkCreateSuccessResolvers<ContextType>;
+  ParticipationCreatePersonalRecordPayload?: GqlParticipationCreatePersonalRecordPayloadResolvers<ContextType>;
+  ParticipationCreatePersonalRecordSuccess?: GqlParticipationCreatePersonalRecordSuccessResolvers<ContextType>;
+  ParticipationDeletePayload?: GqlParticipationDeletePayloadResolvers<ContextType>;
+  ParticipationDeleteSuccess?: GqlParticipationDeleteSuccessResolvers<ContextType>;
+  ParticipationEdge?: GqlParticipationEdgeResolvers<ContextType>;
+  ParticipationStatusHistoriesConnection?: GqlParticipationStatusHistoriesConnectionResolvers<ContextType>;
+  ParticipationStatusHistory?: GqlParticipationStatusHistoryResolvers<ContextType>;
+  ParticipationStatusHistoryEdge?: GqlParticipationStatusHistoryEdgeResolvers<ContextType>;
+  ParticipationsConnection?: GqlParticipationsConnectionResolvers<ContextType>;
+  Place?: GqlPlaceResolvers<ContextType>;
+  PlaceCreatePayload?: GqlPlaceCreatePayloadResolvers<ContextType>;
+  PlaceCreateSuccess?: GqlPlaceCreateSuccessResolvers<ContextType>;
+  PlaceDeletePayload?: GqlPlaceDeletePayloadResolvers<ContextType>;
+  PlaceDeleteSuccess?: GqlPlaceDeleteSuccessResolvers<ContextType>;
+  PlaceEdge?: GqlPlaceEdgeResolvers<ContextType>;
+  PlaceUpdatePayload?: GqlPlaceUpdatePayloadResolvers<ContextType>;
+  PlaceUpdateSuccess?: GqlPlaceUpdateSuccessResolvers<ContextType>;
+  PlacesConnection?: GqlPlacesConnectionResolvers<ContextType>;
+  Portfolio?: GqlPortfolioResolvers<ContextType>;
+  PortfolioEdge?: GqlPortfolioEdgeResolvers<ContextType>;
+  PortfoliosConnection?: GqlPortfoliosConnectionResolvers<ContextType>;
+  PublishReportPayload?: GqlPublishReportPayloadResolvers<ContextType>;
+  PublishReportSuccess?: GqlPublishReportSuccessResolvers<ContextType>;
+  Query?: GqlQueryResolvers<ContextType>;
+  RejectReportPayload?: GqlRejectReportPayloadResolvers<ContextType>;
+  RejectReportSuccess?: GqlRejectReportSuccessResolvers<ContextType>;
+  Report?: GqlReportResolvers<ContextType>;
+  ReportEdge?: GqlReportEdgeResolvers<ContextType>;
+  ReportFeedback?: GqlReportFeedbackResolvers<ContextType>;
+  ReportFeedbackEdge?: GqlReportFeedbackEdgeResolvers<ContextType>;
+  ReportFeedbackRatingBucket?: GqlReportFeedbackRatingBucketResolvers<ContextType>;
+  ReportFeedbacksConnection?: GqlReportFeedbacksConnectionResolvers<ContextType>;
+  ReportTemplate?: GqlReportTemplateResolvers<ContextType>;
+  ReportTemplateStats?: GqlReportTemplateStatsResolvers<ContextType>;
+  ReportTemplateStatsBreakdownConnection?: GqlReportTemplateStatsBreakdownConnectionResolvers<ContextType>;
+  ReportTemplateStatsBreakdownEdge?: GqlReportTemplateStatsBreakdownEdgeResolvers<ContextType>;
+  ReportTemplateStatsBreakdownRow?: GqlReportTemplateStatsBreakdownRowResolvers<ContextType>;
+  ReportsConnection?: GqlReportsConnectionResolvers<ContextType>;
+  Reservation?: GqlReservationResolvers<ContextType>;
+  ReservationCreatePayload?: GqlReservationCreatePayloadResolvers<ContextType>;
+  ReservationCreateSuccess?: GqlReservationCreateSuccessResolvers<ContextType>;
+  ReservationEdge?: GqlReservationEdgeResolvers<ContextType>;
+  ReservationHistoriesConnection?: GqlReservationHistoriesConnectionResolvers<ContextType>;
+  ReservationHistory?: GqlReservationHistoryResolvers<ContextType>;
+  ReservationHistoryEdge?: GqlReservationHistoryEdgeResolvers<ContextType>;
+  ReservationSetStatusPayload?: GqlReservationSetStatusPayloadResolvers<ContextType>;
+  ReservationSetStatusSuccess?: GqlReservationSetStatusSuccessResolvers<ContextType>;
+  ReservationsConnection?: GqlReservationsConnectionResolvers<ContextType>;
+  State?: GqlStateResolvers<ContextType>;
+  StateEdge?: GqlStateEdgeResolvers<ContextType>;
+  StatesConnection?: GqlStatesConnectionResolvers<ContextType>;
+  StorePhoneAuthTokenPayload?: GqlStorePhoneAuthTokenPayloadResolvers<ContextType>;
+  SubmitReportFeedbackPayload?: GqlSubmitReportFeedbackPayloadResolvers<ContextType>;
+  SubmitReportFeedbackSuccess?: GqlSubmitReportFeedbackSuccessResolvers<ContextType>;
+  Ticket?: GqlTicketResolvers<ContextType>;
+  TicketClaimLink?: GqlTicketClaimLinkResolvers<ContextType>;
+  TicketClaimLinkEdge?: GqlTicketClaimLinkEdgeResolvers<ContextType>;
+  TicketClaimLinksConnection?: GqlTicketClaimLinksConnectionResolvers<ContextType>;
+  TicketClaimPayload?: GqlTicketClaimPayloadResolvers<ContextType>;
+  TicketClaimSuccess?: GqlTicketClaimSuccessResolvers<ContextType>;
+  TicketEdge?: GqlTicketEdgeResolvers<ContextType>;
+  TicketIssuePayload?: GqlTicketIssuePayloadResolvers<ContextType>;
+  TicketIssueSuccess?: GqlTicketIssueSuccessResolvers<ContextType>;
+  TicketIssuer?: GqlTicketIssuerResolvers<ContextType>;
+  TicketIssuerEdge?: GqlTicketIssuerEdgeResolvers<ContextType>;
+  TicketIssuersConnection?: GqlTicketIssuersConnectionResolvers<ContextType>;
+  TicketPurchasePayload?: GqlTicketPurchasePayloadResolvers<ContextType>;
+  TicketPurchaseSuccess?: GqlTicketPurchaseSuccessResolvers<ContextType>;
+  TicketRefundPayload?: GqlTicketRefundPayloadResolvers<ContextType>;
+  TicketRefundSuccess?: GqlTicketRefundSuccessResolvers<ContextType>;
+  TicketStatusHistoriesConnection?: GqlTicketStatusHistoriesConnectionResolvers<ContextType>;
+  TicketStatusHistory?: GqlTicketStatusHistoryResolvers<ContextType>;
+  TicketStatusHistoryEdge?: GqlTicketStatusHistoryEdgeResolvers<ContextType>;
+  TicketUsePayload?: GqlTicketUsePayloadResolvers<ContextType>;
+  TicketUseSuccess?: GqlTicketUseSuccessResolvers<ContextType>;
+  TicketsConnection?: GqlTicketsConnectionResolvers<ContextType>;
+  Transaction?: GqlTransactionResolvers<ContextType>;
+  TransactionChain?: GqlTransactionChainResolvers<ContextType>;
+  TransactionChainCommunity?: GqlTransactionChainCommunityResolvers<ContextType>;
+  TransactionChainParticipant?: GqlTransactionChainParticipantResolvers<ContextType>;
+  TransactionChainStep?: GqlTransactionChainStepResolvers<ContextType>;
+  TransactionChainUser?: GqlTransactionChainUserResolvers<ContextType>;
+  TransactionDonateSelfPointPayload?: GqlTransactionDonateSelfPointPayloadResolvers<ContextType>;
+  TransactionDonateSelfPointSuccess?: GqlTransactionDonateSelfPointSuccessResolvers<ContextType>;
+  TransactionEdge?: GqlTransactionEdgeResolvers<ContextType>;
+  TransactionGrantCommunityPointPayload?: GqlTransactionGrantCommunityPointPayloadResolvers<ContextType>;
+  TransactionGrantCommunityPointSuccess?: GqlTransactionGrantCommunityPointSuccessResolvers<ContextType>;
+  TransactionIssueCommunityPointPayload?: GqlTransactionIssueCommunityPointPayloadResolvers<ContextType>;
+  TransactionIssueCommunityPointSuccess?: GqlTransactionIssueCommunityPointSuccessResolvers<ContextType>;
+  TransactionUpdateMetadataPayload?: GqlTransactionUpdateMetadataPayloadResolvers<ContextType>;
+  TransactionUpdateMetadataSuccess?: GqlTransactionUpdateMetadataSuccessResolvers<ContextType>;
+  TransactionVerificationResult?: GqlTransactionVerificationResultResolvers<ContextType>;
+  TransactionsConnection?: GqlTransactionsConnectionResolvers<ContextType>;
+  UpdateReportTemplatePayload?: GqlUpdateReportTemplatePayloadResolvers<ContextType>;
+  UpdateReportTemplateSuccess?: GqlUpdateReportTemplateSuccessResolvers<ContextType>;
+  Upload?: GraphQLScalarType;
+  User?: GqlUserResolvers<ContextType>;
+  UserDeletePayload?: GqlUserDeletePayloadResolvers<ContextType>;
+  UserDidAnchor?: GqlUserDidAnchorResolvers<ContextType>;
+  UserEdge?: GqlUserEdgeResolvers<ContextType>;
+  UserUpdateProfilePayload?: GqlUserUpdateProfilePayloadResolvers<ContextType>;
+  UserUpdateProfileSuccess?: GqlUserUpdateProfileSuccessResolvers<ContextType>;
+  UsersConnection?: GqlUsersConnectionResolvers<ContextType>;
+  UtilitiesConnection?: GqlUtilitiesConnectionResolvers<ContextType>;
+  Utility?: GqlUtilityResolvers<ContextType>;
+  UtilityCreatePayload?: GqlUtilityCreatePayloadResolvers<ContextType>;
+  UtilityCreateSuccess?: GqlUtilityCreateSuccessResolvers<ContextType>;
+  UtilityDeletePayload?: GqlUtilityDeletePayloadResolvers<ContextType>;
+  UtilityDeleteSuccess?: GqlUtilityDeleteSuccessResolvers<ContextType>;
+  UtilityEdge?: GqlUtilityEdgeResolvers<ContextType>;
+  UtilitySetPublishStatusPayload?: GqlUtilitySetPublishStatusPayloadResolvers<ContextType>;
+  UtilitySetPublishStatusSuccess?: GqlUtilitySetPublishStatusSuccessResolvers<ContextType>;
+  UtilityUpdateInfoPayload?: GqlUtilityUpdateInfoPayloadResolvers<ContextType>;
+  UtilityUpdateInfoSuccess?: GqlUtilityUpdateInfoSuccessResolvers<ContextType>;
+  VcIssuance?: GqlVcIssuanceResolvers<ContextType>;
+  VcIssuanceRequest?: GqlVcIssuanceRequestResolvers<ContextType>;
+  VcIssuanceRequestEdge?: GqlVcIssuanceRequestEdgeResolvers<ContextType>;
+  VcIssuanceRequestsConnection?: GqlVcIssuanceRequestsConnectionResolvers<ContextType>;
+  VoteBallot?: GqlVoteBallotResolvers<ContextType>;
+  VoteCastPayload?: GqlVoteCastPayloadResolvers<ContextType>;
+  VoteCastSuccess?: GqlVoteCastSuccessResolvers<ContextType>;
+  VoteGate?: GqlVoteGateResolvers<ContextType>;
+  VoteOption?: GqlVoteOptionResolvers<ContextType>;
+  VotePowerPolicy?: GqlVotePowerPolicyResolvers<ContextType>;
+  VoteTopic?: GqlVoteTopicResolvers<ContextType>;
+  VoteTopicCreatePayload?: GqlVoteTopicCreatePayloadResolvers<ContextType>;
+  VoteTopicCreateSuccess?: GqlVoteTopicCreateSuccessResolvers<ContextType>;
+  VoteTopicDeletePayload?: GqlVoteTopicDeletePayloadResolvers<ContextType>;
+  VoteTopicDeleteSuccess?: GqlVoteTopicDeleteSuccessResolvers<ContextType>;
+  VoteTopicEdge?: GqlVoteTopicEdgeResolvers<ContextType>;
+  VoteTopicUpdatePayload?: GqlVoteTopicUpdatePayloadResolvers<ContextType>;
+  VoteTopicUpdateSuccess?: GqlVoteTopicUpdateSuccessResolvers<ContextType>;
+  VoteTopicsConnection?: GqlVoteTopicsConnectionResolvers<ContextType>;
+  Wallet?: GqlWalletResolvers<ContextType>;
+  WalletEdge?: GqlWalletEdgeResolvers<ContextType>;
+  WalletsConnection?: GqlWalletsConnectionResolvers<ContextType>;
+}>;
+
+export type GqlDirectiveResolvers<ContextType = any> = ResolversObject<{
+  authz?: GqlAuthzDirectiveResolver<any, any, ContextType>;
+  requireRole?: GqlRequireRoleDirectiveResolver<any, any, ContextType>;
+}>;


### PR DESCRIPTION
## Summary

- `Mutation.revokeUserVc` を新設し、`IsAdmin` 限定で VC を revoke 可能に
- `StatusListService.revokeVc` に委譲して bitstring の revoked bit を立て、`t_vc_issuance_requests.revoked_at` を更新
- bit-flip / `revokedAt` stamp / re-read を同一 `ctx.issuer.public(ctx, …)` トランザクションで commit
- 整合性チェック: 冪等 (既 revoke は no-op で同一 snapshot を返す)、存在しない `vcId` は `NotFoundError`

## 設計上の注意

- 持続化される `status` 列は `COMPLETED` のまま (`VcIssuanceStatus.REVOKED` enum 値は schema PR `schema/phase1.5-revoke-and-index` で追加予定)。Verifier は StatusList JWT 側の bit を見るため、API 層では `revokedAt != null` で revoke を表現
- schema PR merge 後の follow-up commit で `status: REVOKED` への切り替えを想定 (`statusList/data/repository.ts` の `markVcRevoked` の TODO コメントと連携)

## Files

- `src/application/domain/credential/vcIssuance/schema/mutation.graphql` — `revokeUserVc` + `RevokeUserVcInput`
- `src/application/domain/credential/vcIssuance/usecase.ts` — `revokeUserVc` 追加 (+ `StatusListService` 注入)
- `src/application/domain/credential/vcIssuance/controller/resolver.ts` — `Mutation.revokeUserVc` 配線
- `src/application/domain/credential/vcIssuance/{service,data/{interface,repository}}.ts` — `findVcById` に optional `tx` を追加 (tx 内で in-progress writes を観測するため)
- 統合テスト: `src/__tests__/integration/vcIssuance/revokeUserVc.test.ts` (新規)
- 単体テスト: `src/__tests__/unit/application/domain/credential/vcIssuance/usecase.test.ts` (revoke ケース追加)

## Test plan

- [x] `pnpm test --testPathPattern '(domain/credential/(vcIssuance|statusList))' --runInBand` → 30/30 pass (3 suites)
- [x] `pnpm gql:generate` → `GqlMutationRevokeUserVcArgs` / `GqlRevokeUserVcInput` 生成確認
- [x] `pnpm exec eslint src/application/domain/credential/vcIssuance/ src/__tests__/.../revokeUserVc.test.ts src/__tests__/.../usecase.test.ts` clean
- [x] `pnpm exec tsc --noEmit` 既存 baseline (`@prisma/client/sql` / `@google-cloud/kms` 由来の TS2305/TS2307) のみで本 PR 由来のエラー無し
- [ ] (環境的に DB 接続不可のため未実行) `pnpm test --testPathPattern 'integration/vcIssuance' --runInBand` — 既存 `vcIssuance.test.ts` も同じ baseline エラーで失敗するため本 PR 影響なし

https://claude.ai/code/session_019MKzV6DsfsHA6dLJ99chU8

---
_Generated by [Claude Code](https://claude.ai/code/session_019MKzV6DsfsHA6dLJ99chU8)_