### PR TITLE
phase1.5(test): Phase 1 integration test を real DB で有効化

### DIFF
--- a/src/__tests__/helper/test-data-source-helper.ts
+++ b/src/__tests__/helper/test-data-source-helper.ts
@@ -23,7 +23,16 @@ export default class TestDataSourceHelper {
 
     await this.db.participationStatusHistory.deleteMany();
 
+    // Phase 1 (DID / VC internalization): anchors and StatusList rows must be
+    // cleaned up before users/evaluations because:
+    //   - UserDidAnchor.user is `onDelete: Restrict`
+    //   - VcIssuanceRequest references VcAnchor (FK; nullable but row-bound)
+    //   - StatusListCredential is independent but cleared for hygiene
+    await this.db.userDidAnchor.deleteMany();
     await this.db.vcIssuanceRequest.deleteMany();
+    await this.db.vcAnchor.deleteMany();
+    await this.db.transactionAnchor.deleteMany();
+    await this.db.statusListCredential.deleteMany();
     await this.db.didIssuanceRequest.deleteMany();
     await this.db.evaluation.deleteMany();
     await this.db.participation.deleteMany();

--- a/src/__tests__/integration/application/domain/account/userDid/repository.test.ts
+++ b/src/__tests__/integration/application/domain/account/userDid/repository.test.ts
@@ -1,20 +1,21 @@
 /**
- * Integration test skeleton for `UserDidAnchorRepository` (Phase 1 step 7
- * — strategy A cleanup).
+ * Integration tests for `UserDidAnchorRepository` (Phase 1.5).
  *
  * Background: the Phase 1 step 7 PR replaced the in-memory stub with a
  * Prisma-backed repository. The unit tests cover the call shape via
  * `useValue` mocks but do NOT exercise the actual SQL round-trip — that
- * coverage only comes from a real Postgres. This file is the placeholder
- * for that coverage; it ships as `describe.skip(...)` until the CI image
- * has the test database wired up (`pnpm container:up` + RLS migrations
- * applied).
+ * coverage only comes from a real Postgres. This file exercises the
+ * full `UserDidAnchor` round-trip against the test database.
  *
- * TODO(phase1.5): un-skip when CI provisions a PostgreSQL with the
- * UserDidAnchor table. The hand-rolled smoke test below covers the two
- * paths most likely to regress:
- *   1. `findLatestByUserId` returns the most recent row (orderBy desc).
- *   2. `createCreate` round-trips the canonical CreateUserDidAnchorInput.
+ * Coverage:
+ *   1. `findLatestByUserId` returns the most recent row by `createdAt DESC`.
+ *   2. `createCreate` / `createUpdate` / `createDeactivate` persist the
+ *      operation marker and the documentCbor / documentHash fields.
+ *   3. DEACTIVATE rows persist `documentCbor = null` (§E).
+ *   4. `network` is honoured per-row (CARDANO_PREPROD vs CARDANO_MAINNET).
+ *   5. The schema-level `previousAnchorId` column defaults to `null` for
+ *      every row created by the current repository surface (chain wiring
+ *      lands in a follow-up phase, this test pins the current contract).
  *
  * Design references:
  *   docs/report/did-vc-internalization.md §5.2.1
@@ -22,31 +23,181 @@
  */
 
 import "reflect-metadata";
+import { container } from "tsyringe";
+import { ChainNetwork, CurrentPrefecture, DidOperation } from "@prisma/client";
+import { registerProductionDependencies } from "@/application/provider";
+import TestDataSourceHelper from "@/__tests__/helper/test-data-source-helper";
+import { PrismaClientIssuer, prismaClient } from "@/infrastructure/prisma/client";
+import UserDidAnchorRepository from "@/application/domain/account/userDid/data/repository";
+import { IContext } from "@/types/server";
 
-describe.skip("UserDidAnchorRepository (integration)", () => {
-  // Intentionally not implemented yet — see file header. The Prisma
-  // schema for UserDidAnchor was introduced in PR #1094; this test will
-  // be wired up once the CI image runs migrations against a Postgres
-  // container.
-  //
-  // Sketch (kept as a comment so reviewers can see the intended shape):
-  //
-  //   beforeEach(async () => {
-  //     await TestDataSourceHelper.deleteAll();
-  //     container.reset();
-  //     registerProductionDependencies();
-  //   });
-  //
-  //   it("createCreate then findLatestByUserId returns the inserted row", async () => {
-  //     const ctx = buildPublicCtx();
-  //     const repo = container.resolve<import("@/application/domain/account/userDid/data/repository").default>(
-  //       "UserDidAnchorRepository",
-  //     );
-  //     await repo.createCreate(ctx, sampleCreateInput);
-  //     const latest = await repo.findLatestByUserId(sampleCreateInput.userId);
-  //     expect(latest?.did).toBe(sampleCreateInput.did);
-  //   });
-  it("placeholder — see TODO in file header", () => {
-    expect(true).toBe(true);
+describe("UserDidAnchorRepository (integration)", () => {
+  jest.setTimeout(30_000);
+  let repo: UserDidAnchorRepository;
+  let issuer: PrismaClientIssuer;
+  let userId: string;
+
+  beforeEach(async () => {
+    await TestDataSourceHelper.deleteAll();
+    container.reset();
+    registerProductionDependencies();
+    issuer = container.resolve(PrismaClientIssuer);
+    repo = container.resolve<UserDidAnchorRepository>("UserDidAnchorRepository");
+
+    const user = await TestDataSourceHelper.createUser({
+      name: "Test User",
+      slug: `user-${Date.now()}`,
+      currentPrefecture: CurrentPrefecture.KAGAWA,
+    });
+    userId = user.id;
+  });
+
+  afterAll(async () => {
+    await TestDataSourceHelper.disconnect();
+  });
+
+  function buildCtx(): IContext {
+    return { issuer } as unknown as IContext;
+  }
+
+  describe("findLatestByUserId", () => {
+    it("returns null when no anchor exists", async () => {
+      const result = await repo.findLatestByUserId(userId);
+      expect(result).toBeNull();
+    });
+
+    it("returns the most recent row ordered by createdAt DESC", async () => {
+      const ctx = buildCtx();
+      const cbor = new Uint8Array([1, 2, 3, 4]);
+
+      const first = await repo.createCreate(ctx, {
+        userId,
+        did: `did:web:api.civicship.app:users:${userId}`,
+        documentHash: "a".repeat(64),
+        documentCbor: cbor,
+        network: "CARDANO_PREPROD",
+      });
+
+      // Sleep a sliver so `createdAt` differs (Postgres timestamp resolution
+      // is microseconds, but separate `INSERT` statements can still land
+      // within the same micro-second on very fast machines).
+      await new Promise((r) => setTimeout(r, 10));
+
+      const second = await repo.createUpdate(ctx, {
+        userId,
+        did: `did:web:api.civicship.app:users:${userId}`,
+        documentHash: "b".repeat(64),
+        documentCbor: cbor,
+        network: "CARDANO_PREPROD",
+      });
+
+      const latest = await repo.findLatestByUserId(userId);
+      expect(latest).not.toBeNull();
+      expect(latest!.id).toBe(second.id);
+      expect(latest!.id).not.toBe(first.id);
+      expect(latest!.operation).toBe(DidOperation.UPDATE);
+    });
+  });
+
+  describe("createCreate / createUpdate / createDeactivate", () => {
+    it("persists CREATE with documentCbor + Blake2b hash + network", async () => {
+      const ctx = buildCtx();
+      const cbor = new Uint8Array([0xa1, 0x62, 0x69, 0x64, 0x60]);
+      const documentHash = "c".repeat(64);
+
+      const persisted = await repo.createCreate(ctx, {
+        userId,
+        did: `did:web:api.civicship.app:users:${userId}`,
+        documentHash,
+        documentCbor: cbor,
+        network: "CARDANO_PREPROD",
+      });
+
+      expect(persisted.id).toBeTruthy();
+      expect(persisted.operation).toBe(DidOperation.CREATE);
+      expect(persisted.documentHash).toBe(documentHash);
+      expect(persisted.network).toBe(ChainNetwork.CARDANO_PREPROD);
+
+      const row = await prismaClient.userDidAnchor.findUnique({
+        where: { id: persisted.id },
+      });
+      expect(row).not.toBeNull();
+      expect(row!.documentCbor).not.toBeNull();
+      expect(Array.from(row!.documentCbor!)).toEqual(Array.from(cbor));
+      expect(row!.previousAnchorId).toBeNull();
+    });
+
+    it("persists UPDATE with operation=UPDATE", async () => {
+      const ctx = buildCtx();
+      const cbor = new Uint8Array([1, 2, 3]);
+      const persisted = await repo.createUpdate(ctx, {
+        userId,
+        did: `did:web:api.civicship.app:users:${userId}`,
+        documentHash: "d".repeat(64),
+        documentCbor: cbor,
+      });
+
+      expect(persisted.operation).toBe(DidOperation.UPDATE);
+      // Default network falls back to mainnet.
+      expect(persisted.network).toBe(ChainNetwork.CARDANO_MAINNET);
+    });
+
+    it("persists DEACTIVATE with documentCbor = null (§E tombstone)", async () => {
+      const ctx = buildCtx();
+      const persisted = await repo.createDeactivate(ctx, {
+        userId,
+        did: `did:web:api.civicship.app:users:${userId}`,
+        documentHash: "e".repeat(64),
+        network: "CARDANO_PREPROD",
+      });
+
+      expect(persisted.operation).toBe(DidOperation.DEACTIVATE);
+
+      const row = await prismaClient.userDidAnchor.findUnique({
+        where: { id: persisted.id },
+      });
+      expect(row).not.toBeNull();
+      // §E: tombstones do not persist CBOR; the resolver reconstructs.
+      expect(row!.documentCbor).toBeNull();
+    });
+  });
+
+  describe("network selection", () => {
+    it("persists separate rows under CARDANO_PREPROD vs CARDANO_MAINNET", async () => {
+      const ctx = buildCtx();
+      const cbor = new Uint8Array([9, 9, 9]);
+
+      const preprod = await repo.createCreate(ctx, {
+        userId,
+        did: `did:web:api.civicship.app:users:${userId}`,
+        documentHash: "1".repeat(64),
+        documentCbor: cbor,
+        network: "CARDANO_PREPROD",
+      });
+
+      const mainnet = await repo.createUpdate(ctx, {
+        userId,
+        did: `did:web:api.civicship.app:users:${userId}`,
+        documentHash: "2".repeat(64),
+        documentCbor: cbor,
+        network: "CARDANO_MAINNET",
+      });
+
+      // Both are queryable; `findLatestByUserId` is network-agnostic, so we
+      // assert the schema-level partitioning by reading via Prisma directly.
+      const allForUser = await prismaClient.userDidAnchor.findMany({
+        where: { userId },
+        orderBy: { createdAt: "asc" },
+      });
+      expect(allForUser).toHaveLength(2);
+      const networks = allForUser.map((r) => r.network);
+      expect(networks).toContain(ChainNetwork.CARDANO_PREPROD);
+      expect(networks).toContain(ChainNetwork.CARDANO_MAINNET);
+
+      const preprodRow = allForUser.find((r) => r.id === preprod.id);
+      const mainnetRow = allForUser.find((r) => r.id === mainnet.id);
+      expect(preprodRow!.network).toBe(ChainNetwork.CARDANO_PREPROD);
+      expect(mainnetRow!.network).toBe(ChainNetwork.CARDANO_MAINNET);
+    });
   });
 });

--- a/src/__tests__/integration/application/domain/anchor/anchorBatch/repository.test.ts
+++ b/src/__tests__/integration/application/domain/anchor/anchorBatch/repository.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Integration tests for `AnchorBatchRepository` (Phase 1.5).
+ *
+ * Verifies the SQL round-trip for the weekly anchor batch surface:
+ *
+ *   - `findPendingAnchors` collates `transactionAnchor` / `vcAnchor` /
+ *     `userDidAnchor` rows in PENDING + batchId IS NULL.
+ *   - `claimPendingAnchors` performs a CAS update (PENDING + batchId IS NULL
+ *     → batchId = X). A second concurrent claim observes 0 rows.
+ *   - `markSubmitted` / `markConfirmed` / `markFailed` advance the state
+ *     machine and stamp side-channel columns (`chainTxHash`, `submittedAt`,
+ *     `confirmedAt`, `lastError`).
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.2.3 (anchor.repository.ts)
+ *   docs/report/did-vc-internalization.md §5.3.1 (idempotency / CAS)
+ */
+
+import "reflect-metadata";
+import { container } from "tsyringe";
+import {
+  AnchorStatus,
+  ChainNetwork,
+  CurrentPrefecture,
+  DidOperation,
+} from "@prisma/client";
+import { registerProductionDependencies } from "@/application/provider";
+import TestDataSourceHelper from "@/__tests__/helper/test-data-source-helper";
+import { PrismaClientIssuer, prismaClient } from "@/infrastructure/prisma/client";
+import AnchorBatchRepository from "@/application/domain/anchor/anchorBatch/data/repository";
+import { IContext } from "@/types/server";
+
+describe("AnchorBatchRepository (integration)", () => {
+  jest.setTimeout(30_000);
+  let repo: AnchorBatchRepository;
+  let issuer: PrismaClientIssuer;
+  let userId: string;
+
+  async function seedTransactionAnchor(): Promise<string> {
+    const row = await prismaClient.transactionAnchor.create({
+      data: {
+        periodStart: new Date("2026-05-01T00:00:00Z"),
+        periodEnd: new Date("2026-05-08T00:00:00Z"),
+        rootHash: "0".repeat(64),
+        leafIds: ["tx-leaf-1"],
+        leafCount: 1,
+        network: ChainNetwork.CARDANO_PREPROD,
+      },
+    });
+    return row.id;
+  }
+
+  async function seedVcAnchor(): Promise<string> {
+    const row = await prismaClient.vcAnchor.create({
+      data: {
+        periodStart: new Date("2026-05-01T00:00:00Z"),
+        periodEnd: new Date("2026-05-08T00:00:00Z"),
+        rootHash: "0".repeat(64),
+        leafIds: ["vc-leaf-1"],
+        leafCount: 1,
+        network: ChainNetwork.CARDANO_PREPROD,
+      },
+    });
+    return row.id;
+  }
+
+  async function seedUserDidAnchor(theUserId: string): Promise<string> {
+    const row = await prismaClient.userDidAnchor.create({
+      data: {
+        did: `did:web:api.civicship.app:users:${theUserId}`,
+        operation: DidOperation.CREATE,
+        documentHash: "f".repeat(64),
+        network: ChainNetwork.CARDANO_PREPROD,
+        user: { connect: { id: theUserId } },
+      },
+    });
+    return row.id;
+  }
+
+  beforeEach(async () => {
+    await TestDataSourceHelper.deleteAll();
+    container.reset();
+    registerProductionDependencies();
+    issuer = container.resolve(PrismaClientIssuer);
+    repo = container.resolve<AnchorBatchRepository>("AnchorBatchRepository");
+
+    const user = await TestDataSourceHelper.createUser({
+      name: "Anchor Test User",
+      slug: `anchor-${Date.now()}`,
+      currentPrefecture: CurrentPrefecture.KAGAWA,
+    });
+    userId = user.id;
+  });
+
+  afterAll(async () => {
+    await TestDataSourceHelper.disconnect();
+  });
+
+  function buildCtx(): IContext {
+    return { issuer } as unknown as IContext;
+  }
+
+  describe("findPendingAnchors", () => {
+    it("collates pending tx / vc / did anchors in a single call", async () => {
+      const txId = await seedTransactionAnchor();
+      const vcId = await seedVcAnchor();
+      const didId = await seedUserDidAnchor(userId);
+
+      const result = await repo.findPendingAnchors(buildCtx());
+      expect(result.transactionAnchors.map((a) => a.id)).toContain(txId);
+      expect(result.vcAnchors.map((a) => a.id)).toContain(vcId);
+      expect(result.userDidAnchors.map((a) => a.id)).toContain(didId);
+    });
+
+    it("ignores rows already claimed (batchId IS NOT NULL)", async () => {
+      const txId = await seedTransactionAnchor();
+      await prismaClient.transactionAnchor.update({
+        where: { id: txId },
+        data: { batchId: "claimed-batch" },
+      });
+
+      const result = await repo.findPendingAnchors(buildCtx());
+      expect(result.transactionAnchors.map((a) => a.id)).not.toContain(txId);
+    });
+  });
+
+  describe("claimPendingAnchors (CAS)", () => {
+    it("claims PENDING + batchId IS NULL rows by stamping batchId", async () => {
+      const txId = await seedTransactionAnchor();
+      const vcId = await seedVcAnchor();
+      const didId = await seedUserDidAnchor(userId);
+
+      const result = await repo.claimPendingAnchors(buildCtx(), {
+        batchId: "weekly-2026-05-01",
+        transactionAnchorIds: [txId],
+        vcAnchorIds: [vcId],
+        userDidAnchorIds: [didId],
+      });
+
+      expect(result.transactionAnchors).toBe(1);
+      expect(result.vcAnchors).toBe(1);
+      expect(result.userDidAnchors).toBe(1);
+
+      const tx = await prismaClient.transactionAnchor.findUnique({ where: { id: txId } });
+      const vc = await prismaClient.vcAnchor.findUnique({ where: { id: vcId } });
+      const did = await prismaClient.userDidAnchor.findUnique({ where: { id: didId } });
+      expect(tx!.batchId).toBe("weekly-2026-05-01");
+      expect(vc!.batchId).toBe("weekly-2026-05-01");
+      expect(did!.batchId).toBe("weekly-2026-05-01");
+    });
+
+    it("returns count=0 when a parallel claim already stamped the rows", async () => {
+      const txId = await seedTransactionAnchor();
+      const ctx = buildCtx();
+
+      // First claimer wins.
+      const winner = await repo.claimPendingAnchors(ctx, {
+        batchId: "winning-batch",
+        transactionAnchorIds: [txId],
+        vcAnchorIds: [],
+        userDidAnchorIds: [],
+      });
+      expect(winner.transactionAnchors).toBe(1);
+
+      // Second claimer (concurrent batch) sees the row already taken — the
+      // CAS guard `status: PENDING, batchId: null` no longer matches.
+      const loser = await repo.claimPendingAnchors(ctx, {
+        batchId: "losing-batch",
+        transactionAnchorIds: [txId],
+        vcAnchorIds: [],
+        userDidAnchorIds: [],
+      });
+      expect(loser.transactionAnchors).toBe(0);
+
+      const finalRow = await prismaClient.transactionAnchor.findUnique({
+        where: { id: txId },
+      });
+      expect(finalRow!.batchId).toBe("winning-batch");
+    });
+  });
+
+  describe("markSubmitted / markConfirmed / markFailed", () => {
+    it("markSubmitted advances all three anchor types to SUBMITTED with chainTxHash", async () => {
+      const ctx = buildCtx();
+      const txId = await seedTransactionAnchor();
+      const vcId = await seedVcAnchor();
+      const didId = await seedUserDidAnchor(userId);
+      await repo.claimPendingAnchors(ctx, {
+        batchId: "b1",
+        transactionAnchorIds: [txId],
+        vcAnchorIds: [vcId],
+        userDidAnchorIds: [didId],
+      });
+
+      await repo.markSubmitted(ctx, {
+        batchId: "b1",
+        chainTxHash: "deadbeef".repeat(8),
+        transactionAnchorIds: [txId],
+        vcAnchorIds: [vcId],
+        userDidAnchorIds: [didId],
+      });
+
+      const tx = await prismaClient.transactionAnchor.findUnique({ where: { id: txId } });
+      const vc = await prismaClient.vcAnchor.findUnique({ where: { id: vcId } });
+      const did = await prismaClient.userDidAnchor.findUnique({ where: { id: didId } });
+      expect(tx!.status).toBe(AnchorStatus.SUBMITTED);
+      expect(vc!.status).toBe(AnchorStatus.SUBMITTED);
+      expect(did!.status).toBe(AnchorStatus.SUBMITTED);
+      expect(tx!.chainTxHash).toBe("deadbeef".repeat(8));
+      expect(tx!.submittedAt).not.toBeNull();
+    });
+
+    it("markConfirmed advances to CONFIRMED with confirmedAt + blockHeight", async () => {
+      const ctx = buildCtx();
+      const txId = await seedTransactionAnchor();
+      const vcId = await seedVcAnchor();
+      const didId = await seedUserDidAnchor(userId);
+      await repo.claimPendingAnchors(ctx, {
+        batchId: "b2",
+        transactionAnchorIds: [txId],
+        vcAnchorIds: [vcId],
+        userDidAnchorIds: [didId],
+      });
+
+      await repo.markConfirmed(ctx, {
+        batchId: "b2",
+        blockHeight: 12345678,
+        transactionAnchorIds: [txId],
+        vcAnchorIds: [vcId],
+        userDidAnchorIds: [didId],
+      });
+
+      const tx = await prismaClient.transactionAnchor.findUnique({ where: { id: txId } });
+      const vc = await prismaClient.vcAnchor.findUnique({ where: { id: vcId } });
+      const did = await prismaClient.userDidAnchor.findUnique({ where: { id: didId } });
+      expect(tx!.status).toBe(AnchorStatus.CONFIRMED);
+      expect(vc!.status).toBe(AnchorStatus.CONFIRMED);
+      expect(did!.status).toBe(AnchorStatus.CONFIRMED);
+      expect(tx!.blockHeight).toBe(12345678);
+      expect(vc!.blockHeight).toBe(12345678);
+      // userDidAnchor schema has no blockHeight column — confirmedAt is the
+      // only confirmation marker.
+      expect(did!.confirmedAt).not.toBeNull();
+    });
+
+    it("markFailed advances to FAILED with lastError on tx / vc anchors", async () => {
+      const ctx = buildCtx();
+      const txId = await seedTransactionAnchor();
+      const vcId = await seedVcAnchor();
+      const didId = await seedUserDidAnchor(userId);
+      await repo.claimPendingAnchors(ctx, {
+        batchId: "b3",
+        transactionAnchorIds: [txId],
+        vcAnchorIds: [vcId],
+        userDidAnchorIds: [didId],
+      });
+
+      await repo.markFailed(ctx, {
+        batchId: "b3",
+        failureReason: "Cardano node unavailable",
+        transactionAnchorIds: [txId],
+        vcAnchorIds: [vcId],
+        userDidAnchorIds: [didId],
+      });
+
+      const tx = await prismaClient.transactionAnchor.findUnique({ where: { id: txId } });
+      const vc = await prismaClient.vcAnchor.findUnique({ where: { id: vcId } });
+      const did = await prismaClient.userDidAnchor.findUnique({ where: { id: didId } });
+      expect(tx!.status).toBe(AnchorStatus.FAILED);
+      expect(vc!.status).toBe(AnchorStatus.FAILED);
+      expect(did!.status).toBe(AnchorStatus.FAILED);
+      expect(tx!.lastError).toBe("Cardano node unavailable");
+      expect(vc!.lastError).toBe("Cardano node unavailable");
+    });
+  });
+
+  describe("getBatchTerminalStatus", () => {
+    it("returns null when no rows exist for batchId", async () => {
+      const status = await repo.getBatchTerminalStatus(buildCtx(), "missing-batch");
+      expect(status).toBeNull();
+    });
+
+    it("returns CONFIRMED when at least one tx-anchor in the batch is CONFIRMED", async () => {
+      const ctx = buildCtx();
+      const txId = await seedTransactionAnchor();
+      await repo.claimPendingAnchors(ctx, {
+        batchId: "terminal-batch",
+        transactionAnchorIds: [txId],
+        vcAnchorIds: [],
+        userDidAnchorIds: [],
+      });
+      await repo.markConfirmed(ctx, {
+        batchId: "terminal-batch",
+        blockHeight: 1,
+        transactionAnchorIds: [txId],
+        vcAnchorIds: [],
+        userDidAnchorIds: [],
+      });
+
+      const status = await repo.getBatchTerminalStatus(ctx, "terminal-batch");
+      expect(status).toBe(AnchorStatus.CONFIRMED);
+    });
+  });
+});

--- a/src/__tests__/integration/application/domain/credential/statusList/repository.test.ts
+++ b/src/__tests__/integration/application/domain/credential/statusList/repository.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Integration tests for `StatusListRepository` (Phase 1.5).
+ *
+ * Covers the persistence-layer atomicity properties that only surface
+ * against a real Postgres:
+ *
+ *   - `allocateSlot` issues an atomic `nextIndex: { increment: 1 }` UPDATE.
+ *     Concurrent allocations receive distinct indexes (no lost-update gap).
+ *   - Once a row is `frozen=true`, further allocations raise
+ *     `StatusListFrozenError` (mapped from Prisma P2025).
+ *   - `findMaxNumericListKey` returns `MAX(list_key::int)` for digit-only keys.
+ *   - Bootstrap → capacity → freeze flow round-trips through `create` /
+ *     `allocateSlot` / `findActive` (capacity reached forces rollover).
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §4.1   (StatusListCredential schema)
+ *   docs/report/did-vc-internalization.md §5.2.4 (Application service shape)
+ *   docs/report/did-vc-internalization.md §7     (Revocation lifecycle)
+ */
+
+import "reflect-metadata";
+import { container } from "tsyringe";
+import { registerProductionDependencies } from "@/application/provider";
+import TestDataSourceHelper from "@/__tests__/helper/test-data-source-helper";
+import { PrismaClientIssuer, prismaClient } from "@/infrastructure/prisma/client";
+import StatusListRepository from "@/application/domain/credential/statusList/data/repository";
+import { StatusListFrozenError } from "@/application/domain/credential/statusList/data/errors";
+import { IContext } from "@/types/server";
+
+describe("StatusListRepository (integration)", () => {
+  jest.setTimeout(30_000);
+  let repo: StatusListRepository;
+  let issuer: PrismaClientIssuer;
+
+  beforeEach(async () => {
+    await TestDataSourceHelper.deleteAll();
+    container.reset();
+    registerProductionDependencies();
+    issuer = container.resolve(PrismaClientIssuer);
+    repo = container.resolve<StatusListRepository>("StatusListRepository");
+  });
+
+  afterAll(async () => {
+    await TestDataSourceHelper.disconnect();
+  });
+
+  function buildCtx(): IContext {
+    return { issuer } as unknown as IContext;
+  }
+
+  async function bootstrap(listKey: string, capacity = 4) {
+    return repo.create(buildCtx(), {
+      listKey,
+      capacity,
+      encodedList: new Uint8Array(Math.ceil(capacity / 8)),
+      vcJwt: `bootstrap-jwt-${listKey}`,
+    });
+  }
+
+  describe("allocateSlot — atomic increment", () => {
+    it("returns sequential indexes for serial allocations", async () => {
+      const row = await bootstrap("1", 4);
+      const ctx = buildCtx();
+
+      const a = await repo.allocateSlot(ctx, row.id);
+      const b = await repo.allocateSlot(ctx, row.id);
+      expect(a.allocatedIndex).toBe(0);
+      expect(b.allocatedIndex).toBe(1);
+      expect(b.row.nextIndex).toBe(2);
+    });
+
+    it("returns distinct indexes for concurrent allocations (no lost-update)", async () => {
+      const row = await bootstrap("1", 8);
+      const ctx = buildCtx();
+
+      const [first, second] = await Promise.all([
+        repo.allocateSlot(ctx, row.id),
+        repo.allocateSlot(ctx, row.id),
+      ]);
+
+      // Postgres serializes the UPDATEs; both allocators must see distinct
+      // indexes (0 and 1 in some order).
+      expect(new Set([first.allocatedIndex, second.allocatedIndex])).toEqual(
+        new Set([0, 1]),
+      );
+    });
+
+    it("freezes the row on the final allocation (allocatedIndex == capacity-1)", async () => {
+      const row = await bootstrap("1", 2);
+      const ctx = buildCtx();
+
+      const a = await repo.allocateSlot(ctx, row.id);
+      const b = await repo.allocateSlot(ctx, row.id);
+      expect(a.allocatedIndex).toBe(0);
+      expect(b.allocatedIndex).toBe(1);
+      expect(b.row.frozen).toBe(true);
+    });
+
+    it("raises StatusListFrozenError after the row is frozen", async () => {
+      const row = await bootstrap("1", 1);
+      const ctx = buildCtx();
+
+      // First (and only) allocation freezes the row.
+      const a = await repo.allocateSlot(ctx, row.id);
+      expect(a.row.frozen).toBe(true);
+
+      await expect(repo.allocateSlot(ctx, row.id)).rejects.toBeInstanceOf(
+        StatusListFrozenError,
+      );
+    });
+  });
+
+  describe("findMaxNumericListKey", () => {
+    it("returns null for an empty table", async () => {
+      const max = await repo.findMaxNumericListKey(buildCtx());
+      expect(max).toBeNull();
+    });
+
+    it("returns MAX(list_key::int) over digit-only listKeys", async () => {
+      await bootstrap("1");
+      await bootstrap("2");
+      await bootstrap("10");
+      const max = await repo.findMaxNumericListKey(buildCtx());
+      expect(max).toBe(10);
+    });
+  });
+
+  describe("findActive", () => {
+    it("returns the latest non-frozen row by createdAt DESC", async () => {
+      const ctx = buildCtx();
+      const first = await bootstrap("1");
+      // Sleep so the second row's createdAt is strictly greater.
+      await new Promise((r) => setTimeout(r, 10));
+      const second = await bootstrap("2");
+
+      const active = await repo.findActive(ctx);
+      expect(active!.id).toBe(second.id);
+      expect(active!.id).not.toBe(first.id);
+    });
+
+    it("skips frozen rows (the frozen-list rotation case)", async () => {
+      const ctx = buildCtx();
+      const oldList = await bootstrap("1", 1);
+      // Drain the only slot so the row is frozen.
+      await repo.allocateSlot(ctx, oldList.id);
+
+      // Bootstrap the next list — `findActive` must surface this one,
+      // not the frozen "1".
+      await new Promise((r) => setTimeout(r, 10));
+      const newList = await bootstrap("2");
+
+      const active = await repo.findActive(ctx);
+      expect(active!.id).toBe(newList.id);
+
+      // Sanity check: the frozen row is still queryable directly.
+      const frozenRow = await prismaClient.statusListCredential.findUnique({
+        where: { id: oldList.id },
+      });
+      expect(frozenRow!.frozen).toBe(true);
+    });
+  });
+
+  describe("bootstrap → capacity → rollover flow", () => {
+    it("rolls over to a new list once capacity is reached", async () => {
+      const ctx = buildCtx();
+      const first = await bootstrap("1", 1);
+      const slot = await repo.allocateSlot(ctx, first.id);
+      expect(slot.allocatedIndex).toBe(0);
+      expect(slot.row.frozen).toBe(true);
+
+      // Find current MAX for next sequential bootstrap (mirrors the
+      // service-layer rollover path).
+      const maxBefore = await repo.findMaxNumericListKey(ctx);
+      expect(maxBefore).toBe(1);
+
+      const next = await bootstrap(String(maxBefore! + 1), 1);
+      const nextSlot = await repo.allocateSlot(ctx, next.id);
+      expect(nextSlot.allocatedIndex).toBe(0);
+      expect(nextSlot.row.listKey).toBe("2");
+    });
+  });
+});

--- a/src/__tests__/integration/application/domain/credential/vcIssuance/repository.test.ts
+++ b/src/__tests__/integration/application/domain/credential/vcIssuance/repository.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Integration tests for `VcIssuanceRepository` (Phase 1.5).
+ *
+ * Verifies the SQL round-trip for the redesigned (§5.2.2) VC issuance
+ * persistence path:
+ *
+ *   - `create` requires `evaluationId` (schema NOT NULL).
+ *   - `claims` is persisted as `{}` for INTERNAL_JWT (canonical claims live
+ *     in the JWT payload).
+ *   - `completedAt` is stamped when status is `COMPLETED` on insert.
+ *   - `findById` decodes `issuerDid` / `subjectDid` from the JWT payload.
+ *   - `findByUserId` returns rows ordered by `createdAt DESC`.
+ *   - `findById` returns `{ issuerDid: null, subjectDid: null }` (and warn
+ *     logs) when the JWT cannot be decoded.
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §4.1   (VcIssuanceRequest schema)
+ *   docs/report/did-vc-internalization.md §5.2.2 (Application service flow)
+ */
+
+import "reflect-metadata";
+import { container } from "tsyringe";
+import {
+  CurrentPrefecture,
+  EvaluationStatus,
+  ParticipationStatus,
+  ParticipationStatusReason,
+  Source,
+  VcFormat,
+  VcIssuanceStatus,
+} from "@prisma/client";
+import { registerProductionDependencies } from "@/application/provider";
+import TestDataSourceHelper from "@/__tests__/helper/test-data-source-helper";
+import { PrismaClientIssuer, prismaClient } from "@/infrastructure/prisma/client";
+import VcIssuanceRepository from "@/application/domain/credential/vcIssuance/data/repository";
+import logger from "@/infrastructure/logging";
+import { IContext } from "@/types/server";
+
+/**
+ * Encode a fake VC JWT with the given issuer / subject so that the
+ * repository's payload-decoder (`decodeIssuerSubjectFromJwt`) can recover
+ * the DIDs without a real signing key.
+ */
+function fakeVcJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "ES256K", typ: "JWT" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.sig`;
+}
+
+describe("VcIssuanceRepository (integration)", () => {
+  jest.setTimeout(30_000);
+  let repo: VcIssuanceRepository;
+  let issuer: PrismaClientIssuer;
+  let userId: string;
+
+  /** Build an Evaluation row (and the Participation it points at) for `userId`. */
+  async function createEvaluationFor(theUserId: string): Promise<string> {
+    const participation = await prismaClient.participation.create({
+      data: {
+        status: ParticipationStatus.PARTICIPATED,
+        reason: ParticipationStatusReason.PERSONAL_RECORD,
+        source: Source.INTERNAL,
+        user: { connect: { id: theUserId } },
+      },
+    });
+    const evaluation = await prismaClient.evaluation.create({
+      data: {
+        status: EvaluationStatus.PASSED,
+        participation: { connect: { id: participation.id } },
+        evaluator: { connect: { id: theUserId } },
+      },
+    });
+    return evaluation.id;
+  }
+
+  beforeEach(async () => {
+    await TestDataSourceHelper.deleteAll();
+    container.reset();
+    registerProductionDependencies();
+    issuer = container.resolve(PrismaClientIssuer);
+    repo = container.resolve<VcIssuanceRepository>("VcIssuanceRepository");
+
+    const user = await TestDataSourceHelper.createUser({
+      name: "VC Test User",
+      slug: `vc-user-${Date.now()}`,
+      currentPrefecture: CurrentPrefecture.KAGAWA,
+    });
+    userId = user.id;
+  });
+
+  afterAll(async () => {
+    await TestDataSourceHelper.disconnect();
+  });
+
+  function buildCtx(): IContext {
+    return { issuer } as unknown as IContext;
+  }
+
+  describe("create", () => {
+    it("throws when evaluationId is missing (schema NOT NULL)", async () => {
+      await expect(
+        repo.create(buildCtx(), {
+          userId,
+          // evaluationId intentionally omitted to cover the explicit guard
+          issuerDid: "did:web:api.civicship.app",
+          subjectDid: `did:web:api.civicship.app:users:${userId}`,
+          vcFormat: VcFormat.INTERNAL_JWT,
+          vcJwt: "h.p.s",
+          status: VcIssuanceStatus.COMPLETED,
+        }),
+      ).rejects.toThrow(/evaluationId/);
+    });
+
+    it("persists claims as `{}` for INTERNAL_JWT (canonical claims live in vcJwt)", async () => {
+      const ctx = buildCtx();
+      const evaluationId = await createEvaluationFor(userId);
+
+      const persisted = await repo.create(ctx, {
+        userId,
+        evaluationId,
+        issuerDid: "did:web:api.civicship.app",
+        subjectDid: `did:web:api.civicship.app:users:${userId}`,
+        vcFormat: VcFormat.INTERNAL_JWT,
+        vcJwt: fakeVcJwt({
+          issuer: "did:web:api.civicship.app",
+          credentialSubject: { id: `did:web:api.civicship.app:users:${userId}` },
+        }),
+        status: VcIssuanceStatus.COMPLETED,
+      });
+
+      const row = await prismaClient.vcIssuanceRequest.findUnique({
+        where: { id: persisted.id },
+      });
+      expect(row).not.toBeNull();
+      expect(row!.claims).toEqual({});
+      expect(row!.evaluationId).toBe(evaluationId);
+      expect(row!.vcFormat).toBe(VcFormat.INTERNAL_JWT);
+    });
+
+    it("stamps completedAt when status is COMPLETED", async () => {
+      const ctx = buildCtx();
+      const evaluationId = await createEvaluationFor(userId);
+      const before = new Date();
+
+      const persisted = await repo.create(ctx, {
+        userId,
+        evaluationId,
+        issuerDid: "did:web:api.civicship.app",
+        subjectDid: `did:web:api.civicship.app:users:${userId}`,
+        vcFormat: VcFormat.INTERNAL_JWT,
+        vcJwt: "h.p.s",
+        status: VcIssuanceStatus.COMPLETED,
+      });
+
+      expect(persisted.completedAt).not.toBeNull();
+      expect(persisted.completedAt!.getTime()).toBeGreaterThanOrEqual(before.getTime() - 1000);
+    });
+
+    it("leaves completedAt null when status is not COMPLETED", async () => {
+      const ctx = buildCtx();
+      const evaluationId = await createEvaluationFor(userId);
+
+      const persisted = await repo.create(ctx, {
+        userId,
+        evaluationId,
+        issuerDid: "did:web:api.civicship.app",
+        subjectDid: `did:web:api.civicship.app:users:${userId}`,
+        vcFormat: VcFormat.INTERNAL_JWT,
+        vcJwt: "h.p.s",
+        status: VcIssuanceStatus.PENDING,
+      });
+
+      expect(persisted.completedAt).toBeNull();
+    });
+  });
+
+  describe("findById", () => {
+    it("recovers issuerDid and subjectDid from the JWT payload", async () => {
+      const ctx = buildCtx();
+      const evaluationId = await createEvaluationFor(userId);
+      const subjectDid = `did:web:api.civicship.app:users:${userId}`;
+      const vcJwt = fakeVcJwt({
+        issuer: "did:web:api.civicship.app",
+        credentialSubject: { id: subjectDid },
+      });
+
+      const persisted = await repo.create(ctx, {
+        userId,
+        evaluationId,
+        issuerDid: "did:web:api.civicship.app",
+        subjectDid,
+        vcFormat: VcFormat.INTERNAL_JWT,
+        vcJwt,
+        status: VcIssuanceStatus.COMPLETED,
+      });
+
+      const fetched = await repo.findById(ctx, persisted.id);
+      expect(fetched).not.toBeNull();
+      expect(fetched!.issuerDid).toBe("did:web:api.civicship.app");
+      expect(fetched!.subjectDid).toBe(subjectDid);
+    });
+
+    it("returns null + warn-logs when the JWT cannot be decoded", async () => {
+      const ctx = buildCtx();
+      const evaluationId = await createEvaluationFor(userId);
+      const warnSpy = jest.spyOn(logger, "warn").mockImplementation(() => logger);
+
+      // Persist a row with a deliberately malformed JWT (only one segment).
+      const persisted = await repo.create(ctx, {
+        userId,
+        evaluationId,
+        issuerDid: "did:web:api.civicship.app",
+        subjectDid: `did:web:api.civicship.app:users:${userId}`,
+        vcFormat: VcFormat.INTERNAL_JWT,
+        vcJwt: "not-a-jwt",
+        status: VcIssuanceStatus.COMPLETED,
+      });
+
+      const fetched = await repo.findById(ctx, persisted.id);
+      expect(fetched).not.toBeNull();
+      expect(fetched!.issuerDid).toBeNull();
+      expect(fetched!.subjectDid).toBeNull();
+      expect(warnSpy).toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe("findByUserId", () => {
+    it("returns rows ordered by createdAt DESC", async () => {
+      const ctx = buildCtx();
+      const firstEvaluation = await createEvaluationFor(userId);
+      const first = await repo.create(ctx, {
+        userId,
+        evaluationId: firstEvaluation,
+        issuerDid: "did:web:api.civicship.app",
+        subjectDid: `did:web:api.civicship.app:users:${userId}`,
+        vcFormat: VcFormat.INTERNAL_JWT,
+        vcJwt: "h.p.s",
+        status: VcIssuanceStatus.COMPLETED,
+      });
+
+      // Schema enforces `evaluationId` UNIQUE, so seed a second user/evaluation
+      // pair to back the second VC issuance row owned by the same user. We
+      // reassign `userId` on the participation so all rows belong to `userId`.
+      const otherUser = await TestDataSourceHelper.createUser({
+        name: "Other User",
+        slug: `other-${Date.now()}`,
+        currentPrefecture: CurrentPrefecture.KAGAWA,
+      });
+      const participation = await prismaClient.participation.create({
+        data: {
+          status: ParticipationStatus.PARTICIPATED,
+          reason: ParticipationStatusReason.PERSONAL_RECORD,
+          source: Source.INTERNAL,
+          user: { connect: { id: otherUser.id } },
+        },
+      });
+      const secondEvaluation = await prismaClient.evaluation.create({
+        data: {
+          status: EvaluationStatus.PASSED,
+          participation: { connect: { id: participation.id } },
+          evaluator: { connect: { id: otherUser.id } },
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      const second = await repo.create(ctx, {
+        userId,
+        evaluationId: secondEvaluation.id,
+        issuerDid: "did:web:api.civicship.app",
+        subjectDid: `did:web:api.civicship.app:users:${userId}`,
+        vcFormat: VcFormat.INTERNAL_JWT,
+        vcJwt: "h.p.s",
+        status: VcIssuanceStatus.COMPLETED,
+      });
+
+      const rows = await repo.findByUserId(ctx, userId);
+      expect(rows.map((r) => r.id)).toEqual([second.id, first.id]);
+    });
+
+    it("returns empty array when no VCs exist", async () => {
+      const ctx = buildCtx();
+      const rows = await repo.findByUserId(ctx, userId);
+      expect(rows).toEqual([]);
+    });
+  });
+});

--- a/src/__tests__/integration/application/domain/credential/vcIssuance/repository.test.ts
+++ b/src/__tests__/integration/application/domain/credential/vcIssuance/repository.test.ts
@@ -98,17 +98,21 @@ describe("VcIssuanceRepository (integration)", () => {
 
   describe("create", () => {
     it("throws when evaluationId is missing (schema NOT NULL)", async () => {
-      await expect(
-        repo.create(buildCtx(), {
-          userId,
-          // evaluationId intentionally omitted to cover the explicit guard
-          issuerDid: "did:web:api.civicship.app",
-          subjectDid: `did:web:api.civicship.app:users:${userId}`,
-          vcFormat: VcFormat.INTERNAL_JWT,
-          vcJwt: "h.p.s",
-          status: VcIssuanceStatus.COMPLETED,
-        }),
-      ).rejects.toThrow(/evaluationId/);
+      // `evaluationId` is required by the input type but we deliberately
+      // omit it here to exercise the runtime guard. Cast to `any` so TS
+      // doesn't reject the missing-field shape at compile time.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const inputMissingEvaluationId: any = {
+        userId,
+        issuerDid: "did:web:api.civicship.app",
+        subjectDid: `did:web:api.civicship.app:users:${userId}`,
+        vcFormat: VcFormat.INTERNAL_JWT,
+        vcJwt: "h.p.s",
+        status: VcIssuanceStatus.COMPLETED,
+      };
+      await expect(repo.create(buildCtx(), inputMissingEvaluationId)).rejects.toThrow(
+        /evaluationId/,
+      );
     });
 
     it("persists claims as `{}` for INTERNAL_JWT (canonical claims live in vcJwt)", async () => {
@@ -153,7 +157,11 @@ describe("VcIssuanceRepository (integration)", () => {
       });
 
       expect(persisted.completedAt).not.toBeNull();
-      expect(persisted.completedAt!.getTime()).toBeGreaterThanOrEqual(before.getTime() - 1000);
+      // `before` is captured immediately above the `repo.create(...)` call,
+      // so `completedAt` must be on or after `before` — strict comparison
+      // catches stale-timestamp regressions that a `- 1000` buffer would
+      // hide.
+      expect(persisted.completedAt!.getTime()).toBeGreaterThanOrEqual(before.getTime());
     });
 
     it("leaves completedAt null when status is not COMPLETED", async () => {
@@ -220,7 +228,13 @@ describe("VcIssuanceRepository (integration)", () => {
       expect(fetched).not.toBeNull();
       expect(fetched!.issuerDid).toBeNull();
       expect(fetched!.subjectDid).toBeNull();
-      expect(warnSpy).toHaveBeenCalled();
+      // Verify the warn carried the diagnostic context we expect operators
+      // to grep on (`vcRequestId`) — a bare `toHaveBeenCalled()` would pass
+      // even if a future refactor stripped the structured payload.
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("vcJwt"),
+        expect.objectContaining({ vcRequestId: persisted.id }),
+      );
 
       warnSpy.mockRestore();
     });
@@ -240,35 +254,16 @@ describe("VcIssuanceRepository (integration)", () => {
         status: VcIssuanceStatus.COMPLETED,
       });
 
-      // Schema enforces `evaluationId` UNIQUE, so seed a second user/evaluation
-      // pair to back the second VC issuance row owned by the same user. We
-      // reassign `userId` on the participation so all rows belong to `userId`.
-      const otherUser = await TestDataSourceHelper.createUser({
-        name: "Other User",
-        slug: `other-${Date.now()}`,
-        currentPrefecture: CurrentPrefecture.KAGAWA,
-      });
-      const participation = await prismaClient.participation.create({
-        data: {
-          status: ParticipationStatus.PARTICIPATED,
-          reason: ParticipationStatusReason.PERSONAL_RECORD,
-          source: Source.INTERNAL,
-          user: { connect: { id: otherUser.id } },
-        },
-      });
-      const secondEvaluation = await prismaClient.evaluation.create({
-        data: {
-          status: EvaluationStatus.PASSED,
-          participation: { connect: { id: participation.id } },
-          evaluator: { connect: { id: otherUser.id } },
-        },
-      });
+      // Schema enforces `evaluationId` UNIQUE, so seed a second Evaluation
+      // for the same user via the existing helper — keeps both VC rows
+      // owned by `userId` without an unrelated otherUser hop.
+      const secondEvaluationId = await createEvaluationFor(userId);
 
       await new Promise((r) => setTimeout(r, 10));
 
       const second = await repo.create(ctx, {
         userId,
-        evaluationId: secondEvaluation.id,
+        evaluationId: secondEvaluationId,
         issuerDid: "did:web:api.civicship.app",
         subjectDid: `did:web:api.civicship.app:users:${userId}`,
         vcFormat: VcFormat.INTERNAL_JWT,


### PR DESCRIPTION
## Summary

Phase 1 (#1104) で `describe.skip(...)` で skeleton として残した `UserDidAnchorRepository` の integration test を有効化し、Phase 1 で実装した残り 3 つの Prisma-backed repository (`VcIssuanceRepository` / `AnchorBatchRepository` / `StatusListRepository`) の real DB round-trip を検証する integration test を追加する。

unit test は `useValue` mock で call shape を確認するだけなので、SQL 制約 (NOT NULL / UNIQUE / FK) や Postgres の atomic update セマンティクス (CAS / `increment: 1`) は real DB がないと検証できない。本 PR の test はそのギャップを埋める。

## 解禁・追加した test

### 1. 解禁: `UserDidAnchorRepository` (`src/__tests__/integration/application/domain/account/userDid/repository.test.ts`)

`describe.skip` の skeleton を外し real DB 経由で 6 件:

- `findLatestByUserId` が createdAt DESC 順で最新行を返す / 行が無いときは null
- `createCreate` / `createUpdate` / `createDeactivate` の operation marker と CBOR / Blake2b hash 永続化
- §E tombstone — DEACTIVATE 行は `documentCbor = null` で永続化される
- `network` (CARDANO_PREPROD vs CARDANO_MAINNET) が行ごとに保持される

### 2. 新規: `VcIssuanceRepository` (`src/__tests__/integration/application/domain/credential/vcIssuance/repository.test.ts`)

8 件:

- `create` の `evaluationId` 必須ガード (schema NOT NULL)
- INTERNAL_JWT は `claims = {}` で永続化される (canonical claims は JWT に存在)
- `completedAt` が COMPLETED 時にスタンプされる / それ以外では null
- `findById` が JWT payload から issuerDid / subjectDid を復元する
- JWT decode 失敗時は `{ issuerDid: null, subjectDid: null }` + warn log
- `findByUserId` が createdAt DESC 順 / 0 件のときは empty array

### 3. 新規: `AnchorBatchRepository` (`src/__tests__/integration/application/domain/anchor/anchorBatch/repository.test.ts`)

9 件:

- `findPendingAnchors` が transactionAnchor / vcAnchor / userDidAnchor 3 種を同時取得
- 既に claim 済 (`batchId IS NOT NULL`) は除外される
- `claimPendingAnchors` が CAS で `batchId` をスタンプ
- 並列 claim で 2 つ目は count = 0 (CAS guard が hit しない)
- `markSubmitted` / `markConfirmed` / `markFailed` が 3 テーブル全部の status を遷移させ side-channel column (chainTxHash / submittedAt / blockHeight / lastError) を埋める
- `getBatchTerminalStatus` の挙動 (null / CONFIRMED)

### 4. 新規: `StatusListRepository` (`src/__tests__/integration/application/domain/credential/statusList/repository.test.ts`)

9 件:

- `allocateSlot` の atomic `increment: 1` で serial allocations は 0, 1, 2... と sequential
- 並列 `Promise.all([allocate, allocate])` で distinct index (lost-update gap が無いことを検証)
- 最終 slot 割り当てで `frozen=true` に自動遷移
- frozen 後の allocation は `StatusListFrozenError` (Prisma P2025 → mapped error)
- `findMaxNumericListKey` が `MAX(list_key::int)` を 1 round-trip で返す
- `findActive` が frozen 行を skip して latest non-frozen を返す
- bootstrap → capacity 到達 → rollover (新 listKey 採番) の flow

合計 **32 件** の real DB integration test (6 + 8 + 9 + 9)。

## test data cleanup

`TestDataSourceHelper.deleteAll()` を更新して以下 5 テーブルの cleanup を追加。`UserDidAnchor.user` が `onDelete: Restrict` のため User 削除より前にこれらを消す必要がある:

- `userDidAnchor`
- `vcIssuanceRequest` (既存だったが順序を anchor 群と一緒にした)
- `vcAnchor`
- `transactionAnchor`
- `statusListCredential`

## CI 影響

無し。`.github/workflows/ci.yml` の `test` matrix `integration` job が既に postgres service container + `db:deploy` で `src/__tests__/integration` 配下を流すので、新規 test も既存 job にそのまま乗る。

## Test plan

- [x] `pnpm exec jest --runInBand src/__tests__/integration/application/` で新規 test 32 件 pass
- [x] `pnpm exec jest --runInBand src/__tests__/integration/` で既存含め 188 件 pass (36 suites)
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec eslint src/__tests__/integration/application src/__tests__/helper/test-data-source-helper.ts` clean
- [ ] CI で integration matrix job が green

https://claude.ai/code/session_019MKzV6DsfsHA6dLJ99chU8

---
_Generated by [Claude Code](https://claude.ai/code/session_019MKzV6DsfsHA6dLJ99chU8)_