### PR TITLE
phase2(issuer-did): §G overlap multi-key — verificationMethod に旧鍵並列配信

### DIFF
--- a/src/__tests__/unit/application/domain/credential/issuerDid/service.test.ts
+++ b/src/__tests__/unit/application/domain/credential/issuerDid/service.test.ts
@@ -3,12 +3,18 @@
  *
  * Covers:
  *   - `getActiveIssuerDid()`        → constant, sync, no I/O
- *   - `getActiveIssuerDidDocument()`
+ *   - `getActiveIssuerDidDocument()` (Phase 1, single-active-key)
  *       - active key present → builds full Document via IssuerDidBuilder
  *       - active key absent  → returns null (router-side fallback)
  *       - public-key cache TTL → second call within TTL skips KMS
  *       - public-key cache TTL → second call after TTL refetches KMS
  *       - distinct resource names cached independently
+ *   - `buildDidDocument()` (Phase 2 §G overlap multi-key, spec §5.4.3)
+ *       - 1 ENABLED + 1 DISABLED → 2 verificationMethod, 1 assertionMethod
+ *       - empty repository       → returns null (bootstrap)
+ *       - JWK shape (kty/crv/x)  → matches RFC 8037 OKP / Ed25519
+ *       - ordering preserved from listActiveKeys
+ *       - assertionMethod / authentication contain only ENABLED rows
  *   - `signWithActiveKey()`
  *       - active key present → delegates to KmsSigner.signEd25519
  *       - active key absent  → throws (no fallback for signing)
@@ -207,6 +213,181 @@ describe("IssuerDidService", () => {
       expect(signer.getPublicKey).toHaveBeenCalledTimes(2);
       expect(signer.getPublicKey).toHaveBeenNthCalledWith(1, KMS_KEY_RESOURCE);
       expect(signer.getPublicKey).toHaveBeenNthCalledWith(2, KMS_KEY_RESOURCE_V2);
+    });
+  });
+
+  describe("buildDidDocument — §G overlap multi-key (Phase 2)", () => {
+    it("emits one verificationMethod per row (ENABLED + DISABLED) and ENABLED-only assertionMethod", async () => {
+      // Scenario: a rotation in progress. v2 is the new ENABLED key
+      // (assertionMethod target), v1 is DISABLED but still published in
+      // verificationMethod so verifiers can validate VCs signed with v1
+      // (design §9.1.3 — DISABLED retained forever, never DESTROYED).
+      const rowV1Disabled = makeRow({
+        id: "key_v1",
+        kmsKeyResourceName: KMS_KEY_RESOURCE,
+        deactivatedAt: new Date("2026-06-01T00:00:00Z"),
+      });
+      const rowV2Enabled = makeRow({
+        id: "key_v2",
+        kmsKeyResourceName: KMS_KEY_RESOURCE_V2,
+        activatedAt: new Date("2026-06-01T00:00:00Z"),
+        deactivatedAt: null,
+      });
+      const repo: RepoStub = {
+        findActiveKey: jest.fn().mockResolvedValue(rowV2Enabled),
+        // Repository contract: ordered by activatedAt ASC. Older
+        // (DISABLED) row first, newer (ENABLED) row last.
+        listActiveKeys: jest.fn().mockResolvedValue([rowV1Disabled, rowV2Enabled]),
+      };
+      const signer: SignerStub = {
+        signEd25519: jest.fn(),
+        // v1 returns ZERO_PUBKEY, v2 returns ALT_PUBKEY — distinct bytes
+        // so the test can verify the JWK `x` differs per row.
+        getPublicKey: jest
+          .fn()
+          .mockImplementation((name: string) =>
+            name === KMS_KEY_RESOURCE
+              ? Promise.resolve(ZERO_PUBKEY)
+              : Promise.resolve(ALT_PUBKEY),
+          ),
+      };
+      const svc = buildService({ repo, signer });
+
+      const doc = await svc.buildDidDocument();
+
+      expect(doc).not.toBeNull();
+      expect(doc!.id).toBe("did:web:api.civicship.app");
+
+      // verificationMethod: both keys (DISABLED v1 first per listActiveKeys order)
+      expect(doc!.verificationMethod).toHaveLength(2);
+      expect(doc!.verificationMethod[0].id).toBe("did:web:api.civicship.app#key-1");
+      expect(doc!.verificationMethod[0].type).toBe("JsonWebKey2020");
+      expect(doc!.verificationMethod[0].controller).toBe("did:web:api.civicship.app");
+      expect(doc!.verificationMethod[0].publicKeyJwk.kty).toBe("OKP");
+      expect(doc!.verificationMethod[0].publicKeyJwk.crv).toBe("Ed25519");
+      expect(doc!.verificationMethod[1].id).toBe("did:web:api.civicship.app#key-2");
+
+      // assertionMethod / authentication: ENABLED only (§9.1.2)
+      expect(doc!.assertionMethod).toEqual(["did:web:api.civicship.app#key-2"]);
+      expect(doc!.authentication).toEqual(["did:web:api.civicship.app#key-2"]);
+
+      // DISABLED key MUST NOT appear in assertionMethod (signs == false)
+      expect(doc!.assertionMethod).not.toContain("did:web:api.civicship.app#key-1");
+    });
+
+    it("returns null when no keys are registered (bootstrap state)", async () => {
+      const repo: RepoStub = {
+        findActiveKey: jest.fn().mockResolvedValue(null),
+        listActiveKeys: jest.fn().mockResolvedValue([]),
+      };
+      const signer = makeSigner();
+      const svc = buildService({ repo, signer });
+
+      const doc = await svc.buildDidDocument();
+
+      expect(doc).toBeNull();
+      // No KMS roundtrip when the repo says "no keys".
+      expect(signer.getPublicKey).not.toHaveBeenCalled();
+    });
+
+    it("encodes the public-key JWK as RFC 8037 Ed25519 OKP (kty/crv/x)", async () => {
+      const row = makeRow({ kmsKeyResourceName: KMS_KEY_RESOURCE });
+      const repo: RepoStub = {
+        findActiveKey: jest.fn().mockResolvedValue(row),
+        listActiveKeys: jest.fn().mockResolvedValue([row]),
+      };
+      // Use ALT_PUBKEY (bytes 1..32) so the base64url result has
+      // non-trivial characters (catches a `+` / `-` swap regression).
+      const signer: SignerStub = {
+        signEd25519: jest.fn(),
+        getPublicKey: jest.fn().mockResolvedValue(ALT_PUBKEY),
+      };
+      const svc = buildService({ repo, signer });
+
+      const doc = await svc.buildDidDocument();
+
+      expect(doc).not.toBeNull();
+      const jwk = doc!.verificationMethod[0].publicKeyJwk;
+      expect(jwk.kty).toBe("OKP");
+      expect(jwk.crv).toBe("Ed25519");
+      // base64url: no padding (`=`), `-` / `_` instead of `+` / `/`.
+      expect(jwk.x).not.toMatch(/[+/=]/);
+      // Length: ceil(32 / 3) * 4 = 44, minus 1 byte padding tail → 43.
+      expect(jwk.x).toHaveLength(43);
+    });
+
+    it("uses the @context that includes the JWK security vocab", async () => {
+      const row = makeRow();
+      const repo: RepoStub = {
+        findActiveKey: jest.fn().mockResolvedValue(row),
+        listActiveKeys: jest.fn().mockResolvedValue([row]),
+      };
+      const signer = makeSigner();
+      const svc = buildService({ repo, signer });
+
+      const doc = await svc.buildDidDocument();
+
+      expect(doc!["@context"]).toEqual([
+        "https://www.w3.org/ns/did/v1",
+        "https://w3id.org/security/jwk/v1",
+      ]);
+    });
+
+    it("treats deactivatedAt === null as ENABLED and a Date as DISABLED", async () => {
+      // Two ENABLED rows — both must appear in assertionMethod.
+      const rowA = makeRow({
+        id: "a",
+        kmsKeyResourceName: KMS_KEY_RESOURCE,
+        deactivatedAt: null,
+      });
+      const rowB = makeRow({
+        id: "b",
+        kmsKeyResourceName: KMS_KEY_RESOURCE_V2,
+        deactivatedAt: null,
+      });
+      const repo: RepoStub = {
+        findActiveKey: jest.fn().mockResolvedValue(rowA),
+        listActiveKeys: jest.fn().mockResolvedValue([rowA, rowB]),
+      };
+      const signer: SignerStub = {
+        signEd25519: jest.fn(),
+        getPublicKey: jest
+          .fn()
+          .mockImplementation((name: string) =>
+            name === KMS_KEY_RESOURCE
+              ? Promise.resolve(ZERO_PUBKEY)
+              : Promise.resolve(ALT_PUBKEY),
+          ),
+      };
+      const svc = buildService({ repo, signer });
+
+      const doc = await svc.buildDidDocument();
+
+      expect(doc!.assertionMethod).toEqual([
+        "did:web:api.civicship.app#key-1",
+        "did:web:api.civicship.app#key-2",
+      ]);
+      expect(doc!.authentication).toEqual(doc!.assertionMethod);
+    });
+
+    it("reuses the public-key TTL cache across single-key and multi-key paths", async () => {
+      // Calling getActiveIssuerDidDocument first should populate the
+      // cache so buildDidDocument's later read does not re-hit KMS for
+      // the same resource name. Same-process consistency: the cache is
+      // intentionally per-resource-name (not per-method).
+      const row = makeRow({ kmsKeyResourceName: KMS_KEY_RESOURCE });
+      const repo: RepoStub = {
+        findActiveKey: jest.fn().mockResolvedValue(row),
+        listActiveKeys: jest.fn().mockResolvedValue([row]),
+      };
+      const signer = makeSigner();
+      const svc = buildService({ repo, signer, now: () => 1_000_000 });
+
+      await svc.getActiveIssuerDidDocument();
+      await svc.buildDidDocument();
+
+      // One KMS call total — the second read hits the TTL cache.
+      expect(signer.getPublicKey).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/__tests__/unit/infrastructure/libs/did/issuerDidBuilder.test.ts
+++ b/src/__tests__/unit/infrastructure/libs/did/issuerDidBuilder.test.ts
@@ -20,8 +20,12 @@ import {
   CIVICSHIP_ATTENDANCE_VC_TYPE,
   buildIssuerDid,
   buildIssuerDidDocument,
+  buildMultiKeyIssuerDidDocument,
+  encodeEd25519Jwk,
   encodeMultikeyEd25519,
   base58btcEncode,
+  kmsResourceNameToKid,
+  type IssuerActiveKey,
 } from "@/infrastructure/libs/did/issuerDidBuilder";
 
 const KEY_RESOURCE_V1 =
@@ -150,6 +154,102 @@ describe("encodeMultikeyEd25519 — multibase prefix and multicodec", () => {
     const raw = new Uint8Array(32);
     for (let i = 0; i < 32; i++) raw[i] = (i * 7) & 0xff;
     expect(encodeMultikeyEd25519(raw)).toBe("z6MkeTNHUstoHASz3Q54jYAWPGMwiNF97JgneipczvRF9vLx");
+  });
+});
+
+describe("buildMultiKeyIssuerDidDocument — §G overlap multi-key (Phase 2)", () => {
+  function jwk(byteFill: number): IssuerActiveKey["jwk"] {
+    return encodeEd25519Jwk(new Uint8Array(32).fill(byteFill));
+  }
+
+  it("emits @context with the JWK security vocab (spec §5.4.3 line 1131)", () => {
+    const doc = buildMultiKeyIssuerDidDocument([
+      { kid: "key-1", jwk: jwk(0x01), enabled: true },
+    ]);
+    expect(doc["@context"]).toEqual([
+      "https://www.w3.org/ns/did/v1",
+      "https://w3id.org/security/jwk/v1",
+    ]);
+  });
+
+  it("emits one JsonWebKey2020 verificationMethod per active key, preserving order", () => {
+    const doc = buildMultiKeyIssuerDidDocument([
+      { kid: "key-1", jwk: jwk(0x01), enabled: false },
+      { kid: "key-2", jwk: jwk(0x02), enabled: true },
+    ]);
+    expect(doc.verificationMethod).toHaveLength(2);
+    expect(doc.verificationMethod[0]).toEqual({
+      id: "did:web:api.civicship.app#key-1",
+      type: "JsonWebKey2020",
+      controller: "did:web:api.civicship.app",
+      publicKeyJwk: jwk(0x01),
+    });
+    expect(doc.verificationMethod[1].id).toBe("did:web:api.civicship.app#key-2");
+  });
+
+  it("references ENABLED keys (only) from assertionMethod and authentication", () => {
+    const doc = buildMultiKeyIssuerDidDocument([
+      { kid: "key-1", jwk: jwk(0x01), enabled: false }, // DISABLED rotation tail
+      { kid: "key-2", jwk: jwk(0x02), enabled: true },  // ENABLED — signs new VCs
+    ]);
+    expect(doc.assertionMethod).toEqual(["did:web:api.civicship.app#key-2"]);
+    expect(doc.authentication).toEqual(["did:web:api.civicship.app#key-2"]);
+  });
+
+  it("returns empty assertionMethod when all keys are DISABLED (edge case)", () => {
+    // Defensive: a fully-DISABLED state shouldn't happen in practice
+    // (rotation runbook activates the new key before deactivating the
+    // old), but the builder must still be lossless — it advertises zero
+    // signable keys rather than fabricating one.
+    const doc = buildMultiKeyIssuerDidDocument([
+      { kid: "key-1", jwk: jwk(0x01), enabled: false },
+    ]);
+    expect(doc.assertionMethod).toEqual([]);
+    expect(doc.authentication).toEqual([]);
+    expect(doc.verificationMethod).toHaveLength(1);
+  });
+
+  it("throws when activeKeys is empty (caller must fall back to static stub)", () => {
+    expect(() => buildMultiKeyIssuerDidDocument([])).toThrow(/at least one entry/);
+  });
+});
+
+describe("encodeEd25519Jwk — RFC 8037 OKP / Ed25519", () => {
+  it("encodes a 32-byte key as { kty: 'OKP', crv: 'Ed25519', x: base64url }", () => {
+    const raw = new Uint8Array(32);
+    for (let i = 0; i < 32; i++) raw[i] = i + 1;
+    const jwk = encodeEd25519Jwk(raw);
+    expect(jwk.kty).toBe("OKP");
+    expect(jwk.crv).toBe("Ed25519");
+    // base64url: no `+` / `/` / padding `=`.
+    expect(jwk.x).not.toMatch(/[+/=]/);
+    expect(jwk.x).toHaveLength(43); // ceil(32 * 4 / 3) - padding
+  });
+
+  it("produces a stable reference vector for an all-zero pubkey", () => {
+    // base64url("\0" × 32) → 43 `A`s (no padding).
+    expect(encodeEd25519Jwk(new Uint8Array(32)).x).toBe("A".repeat(43));
+  });
+
+  it("rejects a wrong-length raw key", () => {
+    expect(() => encodeEd25519Jwk(new Uint8Array(16))).toThrow(/32 bytes/);
+    expect(() => encodeEd25519Jwk(new Uint8Array(48))).toThrow(/32 bytes/);
+  });
+});
+
+describe("kmsResourceNameToKid", () => {
+  it("derives '#key-<n>' from a pinned cryptoKeyVersion", () => {
+    expect(
+      kmsResourceNameToKid(
+        "projects/p/locations/global/keyRings/r/cryptoKeys/civicship-issuer-vc/cryptoKeyVersions/7",
+      ),
+    ).toBe("key-7");
+  });
+
+  it("throws on a missing cryptoKeyVersions suffix", () => {
+    expect(() =>
+      kmsResourceNameToKid("projects/p/locations/global/keyRings/r/cryptoKeys/x"),
+    ).toThrow(/cryptoKeyVersions/);
   });
 });
 

--- a/src/__tests__/unit/infrastructure/libs/kms/kmsSigner.test.ts
+++ b/src/__tests__/unit/infrastructure/libs/kms/kmsSigner.test.ts
@@ -293,6 +293,103 @@ describe("KmsSigner.getPublicKey", () => {
   });
 });
 
+describe("KmsSigner.listActiveIssuerKeys — §G overlap multi-key (Phase 2)", () => {
+  const PARENT = "projects/p/locations/global/keyRings/r/cryptoKeys/civicship-issuer-vc";
+
+  function spkiPemFor(rawKey: Uint8Array): string {
+    const spki = new Uint8Array(44);
+    spki.set([0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00], 0);
+    spki.set(rawKey, 12);
+    return `-----BEGIN PUBLIC KEY-----\n${Buffer.from(spki).toString(
+      "base64",
+    )}\n-----END PUBLIC KEY-----`;
+  }
+
+  it("returns ENABLED + DISABLED versions with their raw public keys", async () => {
+    const v1Pub = new Uint8Array(32).fill(0x01);
+    const v2Pub = new Uint8Array(32).fill(0x02);
+    const listFn = jest.fn().mockResolvedValue([
+      [
+        { name: `${PARENT}/cryptoKeyVersions/1`, state: "DISABLED" },
+        { name: `${PARENT}/cryptoKeyVersions/2`, state: "ENABLED" },
+      ],
+      {},
+    ]);
+    const getPubFn = jest.fn().mockImplementation(({ name }: { name: string }) => {
+      const raw = name.endsWith("/1") ? v1Pub : v2Pub;
+      return Promise.resolve([{ pem: spkiPemFor(raw) }, {}, {}]);
+    });
+    const signer = new KmsSigner({
+      asymmetricSign: () => Promise.reject(new Error("unused")),
+      getPublicKey: getPubFn,
+      listCryptoKeyVersions: listFn,
+    });
+
+    const out = await signer.listActiveIssuerKeys(PARENT);
+
+    expect(out).toHaveLength(2);
+    expect(out[0].state).toBe("DISABLED");
+    expect(out[1].state).toBe("ENABLED");
+    expect(Array.from(out[0].publicKey)).toEqual(Array.from(v1Pub));
+    expect(Array.from(out[1].publicKey)).toEqual(Array.from(v2Pub));
+    // KMS server-side filter narrows the listing to ENABLED + DISABLED only.
+    expect(listFn).toHaveBeenCalledWith({
+      parent: PARENT,
+      filter: "state = ENABLED OR state = DISABLED",
+    });
+  });
+
+  it("client-side filters DESTROY_SCHEDULED / DESTROYED defensively", async () => {
+    // Even if the server-side filter is ignored / buggy, the client
+    // must NOT surface a version whose public key may not be retrievable.
+    const goodPub = new Uint8Array(32).fill(0x33);
+    const listFn = jest.fn().mockResolvedValue([
+      [
+        { name: `${PARENT}/cryptoKeyVersions/1`, state: "DESTROY_SCHEDULED" },
+        { name: `${PARENT}/cryptoKeyVersions/2`, state: "ENABLED" },
+        { name: `${PARENT}/cryptoKeyVersions/3`, state: "DESTROYED" },
+      ],
+      {},
+    ]);
+    const getPubFn = jest
+      .fn()
+      .mockResolvedValue([{ pem: spkiPemFor(goodPub) }, {}, {}]);
+    const signer = new KmsSigner({
+      asymmetricSign: () => Promise.reject(new Error("unused")),
+      getPublicKey: getPubFn,
+      listCryptoKeyVersions: listFn,
+    });
+
+    const out = await signer.listActiveIssuerKeys(PARENT);
+
+    expect(out).toHaveLength(1);
+    expect(out[0].state).toBe("ENABLED");
+    // Critically: getPublicKey was NOT called for DESTROYED (would fail).
+    expect(getPubFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects when the parent path includes a cryptoKeyVersions suffix", async () => {
+    const signer = new KmsSigner({
+      asymmetricSign: () => Promise.reject(new Error("unused")),
+      getPublicKey: () => Promise.reject(new Error("unused")),
+      listCryptoKeyVersions: () => Promise.resolve([[], {}]),
+    });
+    await expect(
+      signer.listActiveIssuerKeys(`${PARENT}/cryptoKeyVersions/1`),
+    ).rejects.toThrow(/must NOT end with/);
+  });
+
+  it("throws when the underlying client does not implement listCryptoKeyVersions", async () => {
+    const signer = new KmsSigner({
+      asymmetricSign: () => Promise.reject(new Error("unused")),
+      getPublicKey: () => Promise.reject(new Error("unused")),
+    });
+    await expect(signer.listActiveIssuerKeys(PARENT)).rejects.toThrow(
+      /does not implement listCryptoKeyVersions/,
+    );
+  });
+});
+
 describe("KmsSigner construction (S1848 lint guard)", () => {
   it("can be constructed with no arguments without exploding at import time", () => {
     // We don't actually call .signEd25519 here — that would require ADC.

--- a/src/application/domain/credential/issuerDid/service.ts
+++ b/src/application/domain/credential/issuerDid/service.ts
@@ -220,6 +220,11 @@ export default class IssuerDidService {
    * repository contract pins to `activatedAt ASC`). Stable ordering means
    * `verificationMethod` indices stay constant across re-renders.
    *
+   * **Parallelism**: per-row `fetchPublicKeyHex` calls are issued via
+   * `Promise.all`. Cache hits resolve synchronously; cache misses each
+   * fire one KMS round-trip and parallelizing them keeps cold-start
+   * latency at `O(1 × RTT)` rather than `O(rows × RTT)`.
+   *
    * Design references:
    *   docs/report/did-vc-internalization.md §5.4.3 line 1126-1142
    *   docs/report/did-vc-internalization.md §9.1.2 (24h overlap)
@@ -235,22 +240,23 @@ export default class IssuerDidService {
       return null;
     }
 
-    const activeKeys: IssuerActiveKey[] = [];
-    for (const row of rows) {
-      const publicKeyHex = await this.fetchPublicKeyHex(row.kmsKeyResourceName);
-      // Reuse the same hex → bytes path as `bytesToHex`'s inverse — we
-      // already encoded bytes → hex in the cache; here we decode hex →
-      // bytes for JWK encoding. Keeping the cache value in hex (rather
-      // than as Uint8Array) lets the legacy `buildIssuerDidDocument`
-      // path remain unchanged; the round-trip cost is negligible
-      // (32 bytes) versus invalidating the existing cache shape.
-      const publicKeyBytes = hexToBytes(publicKeyHex);
-      activeKeys.push({
-        kid: kmsResourceNameToKid(row.kmsKeyResourceName),
-        jwk: encodeEd25519Jwk(publicKeyBytes),
-        enabled: row.deactivatedAt === null,
-      });
-    }
+    const activeKeys: IssuerActiveKey[] = await Promise.all(
+      rows.map(async (row) => {
+        const publicKeyHex = await this.fetchPublicKeyHex(row.kmsKeyResourceName);
+        // Reuse the same hex → bytes path as `bytesToHex`'s inverse — we
+        // already encoded bytes → hex in the cache; here we decode hex →
+        // bytes for JWK encoding. Keeping the cache value in hex (rather
+        // than as Uint8Array) lets the legacy `buildIssuerDidDocument`
+        // path remain unchanged; the round-trip cost is negligible
+        // (32 bytes) versus invalidating the existing cache shape.
+        const publicKeyBytes = hexToBytes(publicKeyHex);
+        return {
+          kid: kmsResourceNameToKid(row.kmsKeyResourceName),
+          jwk: encodeEd25519Jwk(publicKeyBytes),
+          enabled: row.deactivatedAt === null,
+        };
+      }),
+    );
 
     return buildMultiKeyIssuerDidDocument(activeKeys);
   }
@@ -332,6 +338,13 @@ function bytesToHex(bytes: Uint8Array): string {
  * cached hex back into raw bytes for JWK encoding. Tolerant of an
  * optional `0x` prefix on the off chance a caller hand-feeds one in
  * (the cache itself never stores a prefix).
+ *
+ * Validates each pair: `Number.parseInt(..., 16)` returns `NaN` for
+ * non-hex characters which would silently coerce to `0` in a
+ * `Uint8Array` and produce a wrong-key disaster downstream. Explicit
+ * `NaN` check surfaces the bad input immediately. (Gemini review on
+ * PR #1120: matches the inline regex check in `issuerDidBuilder.ts`'s
+ * private `hexToBytes`.)
  */
 function hexToBytes(hex: string): Uint8Array {
   const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
@@ -340,7 +353,11 @@ function hexToBytes(hex: string): Uint8Array {
   }
   const out = new Uint8Array(clean.length / 2);
   for (let i = 0; i < out.length; i++) {
-    out[i] = Number.parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+    const value = Number.parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+    if (Number.isNaN(value)) {
+      throw new Error(`hex string contains non-hex character at offset ${i * 2}`);
+    }
+    out[i] = value;
   }
   return out;
 }

--- a/src/application/domain/credential/issuerDid/service.ts
+++ b/src/application/domain/credential/issuerDid/service.ts
@@ -339,12 +339,13 @@ function bytesToHex(bytes: Uint8Array): string {
  * optional `0x` prefix on the off chance a caller hand-feeds one in
  * (the cache itself never stores a prefix).
  *
- * Validates each pair: `Number.parseInt(..., 16)` returns `NaN` for
- * non-hex characters which would silently coerce to `0` in a
- * `Uint8Array` and produce a wrong-key disaster downstream. Explicit
- * `NaN` check surfaces the bad input immediately. (Gemini review on
- * PR #1120: matches the inline regex check in `issuerDidBuilder.ts`'s
- * private `hexToBytes`.)
+ * Validates each pair with a strict regex (`/^[0-9a-fA-F]{2}$/`). The
+ * earlier NaN-only guard had a real defect noted by Gemini on PR #1123:
+ * `Number.parseInt("1z", 16)` returns `1` (parseInt stops at the first
+ * invalid char), so a non-hex character would slip through and produce a
+ * silently truncated value in the resulting `Uint8Array`. Matching the
+ * regex used by `issuerDidBuilder.ts`'s sibling `hexToBytes` makes the
+ * two sites byte-for-byte equivalent and rejects any non-hex input.
  */
 function hexToBytes(hex: string): Uint8Array {
   const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
@@ -353,11 +354,11 @@ function hexToBytes(hex: string): Uint8Array {
   }
   const out = new Uint8Array(clean.length / 2);
   for (let i = 0; i < out.length; i++) {
-    const value = Number.parseInt(clean.slice(i * 2, i * 2 + 2), 16);
-    if (Number.isNaN(value)) {
+    const pair = clean.slice(i * 2, i * 2 + 2);
+    if (!/^[0-9a-fA-F]{2}$/.test(pair)) {
       throw new Error(`hex string contains non-hex character at offset ${i * 2}`);
     }
-    out[i] = value;
+    out[i] = Number.parseInt(pair, 16);
   }
   return out;
 }

--- a/src/application/domain/credential/issuerDid/service.ts
+++ b/src/application/domain/credential/issuerDid/service.ts
@@ -335,32 +335,33 @@ function bytesToHex(bytes: Uint8Array): string {
 
 /**
  * Inverse of `bytesToHex`. Used by `buildDidDocument` to round-trip the
- * cached hex back into raw bytes for JWK encoding. Tolerant of an
- * optional `0x` prefix on the off chance a caller hand-feeds one in
- * (the cache itself never stores a prefix).
+ * cached hex back into raw bytes for JWK encoding.
  *
- * Validates each pair with a strict regex (`/^[0-9a-fA-F]{2}$/`). The
- * earlier NaN-only guard had a real defect noted by Gemini on PR #1123:
- * `Number.parseInt("1z", 16)` returns `1` (parseInt stops at the first
- * invalid char), so a non-hex character would slip through and produce a
- * silently truncated value in the resulting `Uint8Array`. Matching the
- * regex used by `issuerDidBuilder.ts`'s sibling `hexToBytes` makes the
- * two sites byte-for-byte equivalent and rejects any non-hex input.
+ * Implementation: `Buffer.from(hex, "hex")` is the canonical Node fast
+ * path, but it silently truncates at the first non-hex character (e.g.
+ * `Buffer.from("1z", "hex").length === 0`) so we cannot rely on it for
+ * input validation. A single whole-string regex test runs before the
+ * decode and rejects any non-hex char up front; the decode itself is
+ * then guaranteed to consume every byte.
+ *
+ * The earlier NaN-only guard (`Number.isNaN(parseInt(pair, 16))`) had
+ * a real defect noted by Gemini on PR #1123: `parseInt("1z", 16)`
+ * returns 1 (parseInt stops at the first invalid char), so a non-hex
+ * character would slip through and produce a silently truncated value.
+ * Switching to a whole-string regex + Buffer decode also avoids the
+ * per-pair loop pattern duplicated in `issuerDidBuilder.ts` (Sonar
+ * duplication detector flagged the byte-identical loop).
  */
 function hexToBytes(hex: string): Uint8Array {
   const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
   if (clean.length % 2 !== 0) {
     throw new Error(`hex string must have even length, got ${clean.length}`);
   }
-  const out = new Uint8Array(clean.length / 2);
-  for (let i = 0; i < out.length; i++) {
-    const pair = clean.slice(i * 2, i * 2 + 2);
-    if (!/^[0-9a-fA-F]{2}$/.test(pair)) {
-      throw new Error(`hex string contains non-hex character at offset ${i * 2}`);
-    }
-    out[i] = Number.parseInt(pair, 16);
+  // Anchored character class with `*` — linear time, no backtracking.
+  if (!/^[0-9a-fA-F]*$/.test(clean)) {
+    throw new Error("hex string contains non-hex characters");
   }
-  return out;
+  return new Uint8Array(Buffer.from(clean, "hex"));
 }
 
 // Exported for tests — see file-header re: TTL cache.

--- a/src/application/domain/credential/issuerDid/service.ts
+++ b/src/application/domain/credential/issuerDid/service.ts
@@ -34,17 +34,24 @@
  *
  * §G key-rotation scope (Phase 1 vs Phase 2):
  *
- *   Phase 1 (this PR) intentionally operates in **single-active-key** mode.
- *   `getActiveIssuerDidDocument()` calls `findActiveKey()` once and emits a
- *   DID Document carrying exactly one `verificationMethod`. The repository
- *   interface already declares `listActiveKeys()` (see `data/interface.ts`)
- *   — that method is reserved for Phase 2 §G overlap-window support, where
- *   the Document will publish *both* the outgoing and incoming keys for the
- *   duration of the rotation grace period so verifiers can validate proofs
- *   signed by either key. Phase 1 deliberately does not consume
- *   `listActiveKeys()`; rotation in Phase 1 is a hard cut-over (single
- *   activate-then-deactivate transaction) and the §G overlap window is
- *   tracked in the design doc as Phase 2 work.
+ *   Phase 1 shipped **single-active-key** mode via
+ *   `getActiveIssuerDidDocument()` — one row from `findActiveKey()`, one
+ *   `verificationMethod` entry, hard cut-over rotation.
+ *
+ *   Phase 2 (this layer, PR #1100) adds `buildDidDocument()` — the §G
+ *   overlap multi-key shape per spec §5.4.3 line 1131-1142. It calls
+ *   `repository.listActiveKeys()` and publishes **every** key in the
+ *   overlap window (ENABLED + DISABLED) so verifiers can validate VCs
+ *   signed by either the new or the rotating-out key during the 24-hour
+ *   grace period (§9.1.2). `assertionMethod` / `authentication`
+ *   reference only ENABLED rows — DISABLED rows are verification-only
+ *   tails kept forever (§9.1.3, no DESTROYED).
+ *
+ *   The single-key entry point `getActiveIssuerDidDocument()` is
+ *   preserved for backward compatibility (existing router wiring, admin
+ *   GraphQL Phase 1 contract). The router will migrate to
+ *   `buildDidDocument()` once §G is fully exercised in staging
+ *   (`docs/runbooks/issuer-did-key-rotation.md`).
  *
  * TTL cache rationale:
  *
@@ -71,7 +78,12 @@ import type { IIssuerDidKeyRepository } from "@/application/domain/credential/is
 import {
   CIVICSHIP_ISSUER_DID,
   buildIssuerDidDocument,
+  buildMultiKeyIssuerDidDocument,
+  encodeEd25519Jwk,
+  kmsResourceNameToKid,
+  type IssuerActiveKey,
   type IssuerDidDocument,
+  type IssuerMultiKeyDidDocument,
 } from "@/infrastructure/libs/did/issuerDidBuilder";
 import { KmsSigner } from "@/infrastructure/libs/kms/kmsSigner";
 
@@ -179,6 +191,71 @@ export default class IssuerDidService {
   }
 
   /**
+   * Build the §G overlap multi-key Issuer DID Document (spec §5.4.3
+   * line 1131-1142 / Phase 2 PR #1100).
+   *
+   * Combines every row in the §G overlap window (`listActiveKeys()` —
+   * ENABLED + DISABLED) with their KMS-fetched public-key bytes and
+   * emits the spec's `JsonWebKey2020` shape:
+   *
+   *   - `verificationMethod[]`: every key (ENABLED + DISABLED) so past
+   *     VCs signed by a rotating-out key remain verifiable (§9.1.3).
+   *   - `assertionMethod` / `authentication`: ENABLED only — DISABLED
+   *     keys MUST NOT be advertised as signable (§9.1.2).
+   *
+   * Returns `null` when no keys are registered. The router falls back to
+   * the same minimal static Document as `getActiveIssuerDidDocument()`,
+   * preserving dev/staging UX during bootstrap.
+   *
+   * ENABLED vs DISABLED mapping: the repository contract says a row's
+   * `deactivatedAt IS NULL` ↔ KMS state ENABLED, and `deactivatedAt IS NOT
+   * NULL` ↔ KMS state DISABLED (rotating-out, retained for verification).
+   * We trust the row state here rather than re-querying KMS lifecycle on
+   * every `/.well-known/did.json` hit — the rotation runbook is the
+   * single writer of both `deactivatedAt` and the KMS state transition,
+   * and the public-key bytes (which are the part KMS authoritatively
+   * owns) are still fetched per-key via the existing TTL cache.
+   *
+   * Ordering: rows are emitted in `listActiveKeys()` order (which the
+   * repository contract pins to `activatedAt ASC`). Stable ordering means
+   * `verificationMethod` indices stay constant across re-renders.
+   *
+   * Design references:
+   *   docs/report/did-vc-internalization.md §5.4.3 line 1126-1142
+   *   docs/report/did-vc-internalization.md §9.1.2 (24h overlap)
+   *   docs/report/did-vc-internalization.md §9.1.3 (旧鍵永続保持)
+   *   docs/report/did-vc-internalization.md §16    (Phase 2 持ち越し)
+   */
+  async buildDidDocument(): Promise<IssuerMultiKeyDidDocument | null> {
+    const rows = await this.repository.listActiveKeys();
+    if (rows.length === 0) {
+      // Same bootstrap signal as `findActiveKey() === null`. The router
+      // maps null to the minimal static Document.
+      logger.debug("[IssuerDidService.buildDidDocument] no keys in §G overlap window");
+      return null;
+    }
+
+    const activeKeys: IssuerActiveKey[] = [];
+    for (const row of rows) {
+      const publicKeyHex = await this.fetchPublicKeyHex(row.kmsKeyResourceName);
+      // Reuse the same hex → bytes path as `bytesToHex`'s inverse — we
+      // already encoded bytes → hex in the cache; here we decode hex →
+      // bytes for JWK encoding. Keeping the cache value in hex (rather
+      // than as Uint8Array) lets the legacy `buildIssuerDidDocument`
+      // path remain unchanged; the round-trip cost is negligible
+      // (32 bytes) versus invalidating the existing cache shape.
+      const publicKeyBytes = hexToBytes(publicKeyHex);
+      activeKeys.push({
+        kid: kmsResourceNameToKid(row.kmsKeyResourceName),
+        jwk: encodeEd25519Jwk(publicKeyBytes),
+        enabled: row.deactivatedAt === null,
+      });
+    }
+
+    return buildMultiKeyIssuerDidDocument(activeKeys);
+  }
+
+  /**
    * Sign `payload` with the currently-active KMS key.
    *
    * Used by `VcIssuanceService` (Phase 1 step 9) and the anchor batch
@@ -246,6 +323,24 @@ function bytesToHex(bytes: Uint8Array): string {
     const b = bytes[i];
     out += (b >>> 4).toString(16);
     out += (b & 0x0f).toString(16);
+  }
+  return out;
+}
+
+/**
+ * Inverse of `bytesToHex`. Used by `buildDidDocument` to round-trip the
+ * cached hex back into raw bytes for JWK encoding. Tolerant of an
+ * optional `0x` prefix on the off chance a caller hand-feeds one in
+ * (the cache itself never stores a prefix).
+ */
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  if (clean.length % 2 !== 0) {
+    throw new Error(`hex string must have even length, got ${clean.length}`);
+  }
+  const out = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = Number.parseInt(clean.slice(i * 2, i * 2 + 2), 16);
   }
   return out;
 }

--- a/src/infrastructure/libs/did/issuerDidBuilder.ts
+++ b/src/infrastructure/libs/did/issuerDidBuilder.ts
@@ -63,6 +63,195 @@ export interface IssuerDidDocument {
   service: readonly IssuerService[];
 }
 
+// ---------------------------------------------------------------------------
+// §G overlap multi-key shape (Phase 2 / spec §5.4.3 line 1131-1142)
+// ---------------------------------------------------------------------------
+
+/**
+ * Ed25519 JWK as published in a multi-key Issuer DID Document
+ * (`type: "JsonWebKey2020"`).
+ *
+ * The spec sample in `docs/report/did-vc-internalization.md` §5.4.3 (line
+ * 1131-1142) embeds public keys as RFC 7517 JWK rather than Multikey when
+ * the Document publishes more than one key for the §G overlap window. The
+ * civicship Issuer is exclusively Ed25519, so we narrow the JWK shape to
+ * `kty: "OKP"` / `crv: "Ed25519"` with the single 32-byte coordinate
+ * `x` base64url-encoded (no padding).
+ *
+ * See `encodeEd25519Jwk` below for the canonical builder.
+ */
+export interface Ed25519PublicJwk {
+  kty: "OKP";
+  crv: "Ed25519";
+  /** base64url-encoded (no padding) raw 32-byte Ed25519 public key. */
+  x: string;
+}
+
+/**
+ * One entry of `verificationMethod[]` in the multi-key Document shape.
+ *
+ * Distinct from `IssuerVerificationMethod` (which is single-key + Multikey)
+ * because the wire types are different on purpose: `JsonWebKey2020` +
+ * `publicKeyJwk` is the form §5.4.3 line 1133-1138 specifies for the §G
+ * overlap-window Document.
+ */
+export interface IssuerJwkVerificationMethod {
+  id: string;
+  type: "JsonWebKey2020";
+  controller: string;
+  publicKeyJwk: Ed25519PublicJwk;
+}
+
+/**
+ * Multi-key Issuer DID Document — the §G overlap-window shape.
+ *
+ * Carries every still-valid key (ENABLED + DISABLED rotation tail) so
+ * verifiers can validate VCs signed by either the new or the outgoing
+ * key during the 24-hour overlap. `assertionMethod` / `authentication`
+ * reference only currently-signable (ENABLED) keys.
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.4.3 (line 1131-1142)
+ *   docs/report/did-vc-internalization.md §9.1.2 (rotation overlap)
+ *   docs/report/did-vc-internalization.md §9.1.3 (旧鍵永続保持)
+ *   docs/report/did-vc-internalization.md §16    (Phase 2 持ち越し)
+ */
+export interface IssuerMultiKeyDidDocument {
+  "@context": readonly string[];
+  id: string;
+  verificationMethod: readonly IssuerJwkVerificationMethod[];
+  assertionMethod: readonly string[];
+  authentication: readonly string[];
+}
+
+/**
+ * One key in the §G overlap window. Produced by `IssuerDidService.buildDidDocument`
+ * by combining repository rows (`t_issuer_did_keys`) with KMS public-key bytes.
+ *
+ * `enabled === true`  → ENABLED in KMS → signs new VCs, lands in `assertionMethod`
+ * `enabled === false` → DISABLED in KMS → past-VC verification only, NOT in `assertionMethod`
+ *
+ * `kid` is the verificationMethod fragment (e.g. `"key-7"`) — derived once
+ * via `keyVersionToFragment` and passed in pre-formatted so the builder
+ * stays a pure transform with no string-parsing side effects.
+ */
+export interface IssuerActiveKey {
+  /** Stable per-version fragment, e.g. `"key-7"`. */
+  kid: string;
+  /** Public-key JWK (Ed25519 OKP). */
+  jwk: Ed25519PublicJwk;
+  /** Whether KMS reports the version as ENABLED (signs) vs DISABLED (verify-only). */
+  enabled: boolean;
+}
+
+/**
+ * Build the multi-key Issuer DID Document per spec §5.4.3 line 1131-1142.
+ *
+ * Output shape (input from one ENABLED + one DISABLED key):
+ *
+ *   {
+ *     "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/jwk/v1"],
+ *     "id": "did:web:api.civicship.app",
+ *     "verificationMethod": [
+ *       { id: "...#key-7", type: "JsonWebKey2020", controller: "...", publicKeyJwk: { kty, crv, x } },
+ *       { id: "...#key-6", type: "JsonWebKey2020", controller: "...", publicKeyJwk: { ... } }
+ *     ],
+ *     "assertionMethod": ["...#key-7"],   // ENABLED only
+ *     "authentication":  ["...#key-7"]    // ENABLED only
+ *   }
+ *
+ * Ordering is preserved from the input — callers (`IssuerDidService`) sort
+ * by `activatedAt ASC` so the wire output is stable across re-renders.
+ *
+ * Throws when `activeKeys` is empty: every caller of this builder already
+ * checks `listActiveKeys()` length and falls back to the minimal static
+ * Document in the bootstrap state, so reaching here with `[]` is a
+ * programming error worth surfacing.
+ */
+export function buildMultiKeyIssuerDidDocument(
+  activeKeys: readonly IssuerActiveKey[],
+): IssuerMultiKeyDidDocument {
+  if (activeKeys.length === 0) {
+    throw new Error(
+      "buildMultiKeyIssuerDidDocument: activeKeys must contain at least one entry. " +
+        "Callers MUST check listActiveKeys().length and fall back to the minimal " +
+        "static Document in the bootstrap state (design §5.4.3 / §G).",
+    );
+  }
+  const did = CIVICSHIP_ISSUER_DID;
+  const vmRefId = (kid: string) => `${did}#${kid}`;
+
+  const verificationMethod: IssuerJwkVerificationMethod[] = activeKeys.map((k) => ({
+    id: vmRefId(k.kid),
+    type: "JsonWebKey2020",
+    controller: did,
+    publicKeyJwk: k.jwk,
+  }));
+
+  // ENABLED-only: only signable keys belong in assertionMethod /
+  // authentication (§5.4.3 line 1139-1141). DISABLED keys stay in
+  // verificationMethod for past-VC verification (§9.1.3 / §G).
+  const enabledRefs: string[] = activeKeys
+    .filter((k) => k.enabled)
+    .map((k) => vmRefId(k.kid));
+
+  return {
+    "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/jwk/v1"],
+    id: did,
+    verificationMethod,
+    assertionMethod: enabledRefs,
+    authentication: enabledRefs,
+  };
+}
+
+/**
+ * Encode a raw 32-byte Ed25519 public key as an RFC 7517 / RFC 8037 JWK.
+ *
+ * Format:
+ *   {
+ *     kty: "OKP",       -- RFC 8037 §2 (Octet Key Pair)
+ *     crv: "Ed25519",   -- RFC 8037 §3.1
+ *     x:   <base64url>  -- raw 32 bytes, no padding (RFC 7515 §2)
+ *   }
+ *
+ * Throws on wrong-length input — symmetric with `encodeMultikeyEd25519`'s
+ * guard so callers that swap encodings get the same error shape.
+ */
+export function encodeEd25519Jwk(rawPubKey: Uint8Array): Ed25519PublicJwk {
+  if (rawPubKey.length !== 32) {
+    throw new Error(`Ed25519 public key must be 32 bytes, got ${rawPubKey.length}`);
+  }
+  return {
+    kty: "OKP",
+    crv: "Ed25519",
+    x: base64UrlEncode(rawPubKey),
+  };
+}
+
+/**
+ * Derive the `#fragment` for a KMS resource name (re-exported helper so
+ * `IssuerDidService` can build `IssuerActiveKey.kid` without duplicating
+ * the regex).
+ */
+export function kmsResourceNameToKid(kmsKeyResourceName: string): string {
+  return keyVersionToFragment(kmsKeyResourceName);
+}
+
+/**
+ * base64url encoder (RFC 7515 §2 / RFC 4648 §5) — no padding, `-` and `_`
+ * instead of `+` and `/`. Hand-rolled rather than reaching for `Buffer`
+ * because the encoder is the entire spec-defined contract and we want a
+ * single, audit-friendly definition.
+ */
+function base64UrlEncode(bytes: Uint8Array): string {
+  // Node 18+: `Buffer.from(bytes).toString("base64url")` would also work,
+  // but the manual transform keeps this module portable to Workers /
+  // Edge runtimes if we ever extract it (same rationale as `bytesToHex`
+  // in `service.ts`).
+  const std = Buffer.from(bytes).toString("base64");
+  return std.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
 /**
  * Return the canonical Issuer DID. Argument-less by design: civicship has
  * exactly one Issuer DID and it is bound to the API host.

--- a/src/infrastructure/libs/did/issuerDidBuilder.ts
+++ b/src/infrastructure/libs/did/issuerDidBuilder.ts
@@ -238,18 +238,15 @@ export function kmsResourceNameToKid(kmsKeyResourceName: string): string {
 }
 
 /**
- * base64url encoder (RFC 7515 §2 / RFC 4648 §5) — no padding, `-` and `_`
- * instead of `+` and `/`. Hand-rolled rather than reaching for `Buffer`
- * because the encoder is the entire spec-defined contract and we want a
- * single, audit-friendly definition.
+ * base64url encoder (RFC 7515 §2 / RFC 4648 §5) — no padding, `-` / `_`
+ * substitution. Uses Node 18+'s native `Buffer.toString("base64url")`
+ * rather than a manual replace chain: the previous regex chain tripped
+ * SonarCloud `typescript:S5852` on the trailing `/=+$/g` anchor (false
+ * positive — the pattern is linear — but the native API is clearer
+ * regardless).
  */
 function base64UrlEncode(bytes: Uint8Array): string {
-  // Node 18+: `Buffer.from(bytes).toString("base64url")` would also work,
-  // but the manual transform keeps this module portable to Workers /
-  // Edge runtimes if we ever extract it (same rationale as `bytesToHex`
-  // in `service.ts`).
-  const std = Buffer.from(bytes).toString("base64");
-  return std.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+  return Buffer.from(bytes).toString("base64url");
 }
 
 /**

--- a/src/infrastructure/libs/kms/kmsSigner.ts
+++ b/src/infrastructure/libs/kms/kmsSigner.ts
@@ -71,8 +71,10 @@ const RETRYABLE_HTTP_STATUSES = new Set<number>([429, 500, 502, 503, 504]);
  *
  * `listCryptoKeyVersions` is consumed by `KmsSigner.listActiveIssuerKeys`
  * (§G overlap multi-key, Phase 2 PR #1100) — it returns one entry per
- * version with its KMS lifecycle `state`, which the §5.4.3 multi-key
- * Document needs to distinguish ENABLED (signs) from DISABLED (verify-only).
+ * version with its KMS lifecycle `state`. Response shape follows the
+ * Google gax convention `[results, nextRequest|null, rawResponse]`:
+ * `nextRequest === null` (or missing `pageToken`) indicates the final
+ * page; otherwise the caller must re-issue with the carried `pageToken`.
  */
 export interface KmsClientLike {
   asymmetricSign(request: {
@@ -83,8 +85,14 @@ export interface KmsClientLike {
   listCryptoKeyVersions?(request: {
     parent: string;
     filter?: string;
+    pageToken?: string;
+    pageSize?: number;
   }): Promise<
-    [Array<{ name?: string | null; state?: string | null }>, ...unknown[]]
+    [
+      Array<{ name?: string | null; state?: string | null }>,
+      { pageToken?: string | null } | null | undefined,
+      ...unknown[],
+    ]
   >;
 }
 
@@ -195,6 +203,17 @@ export class KmsSigner {
    * suffix — e.g.
    *   `projects/p/locations/global/keyRings/r/cryptoKeys/civicship-issuer-vc`
    *
+   * **Pagination**: `listCryptoKeyVersions` returns at most 100 entries
+   * per page (KMS default). §9.1.3 mandates that DISABLED keys be kept
+   * forever, so a long-lived keyring will eventually exceed one page.
+   * We follow `nextRequest.pageToken` until exhausted before returning;
+   * skipping any page would silently truncate the DID Document.
+   *
+   * **Parallelism**: per-version `getPublicKey` calls are issued via
+   * `Promise.all` after the version list is fully drained. Each call is
+   * independent (one KMS round-trip, ~50-150ms p50) so serial awaiting
+   * would add `O(versions × RTT)` latency on cache-cold paths.
+   *
    * Phase 2 production wiring: real call to `listCryptoKeyVersions` +
    * per-version `getPublicKey`. Phase 1 callers do NOT invoke this
    * method (single-active-key mode); the §G overlap path is being
@@ -232,32 +251,47 @@ export class KmsSigner {
     }
     const listFn = this.client.listCryptoKeyVersions.bind(this.client);
 
-    const [versions] = await this.withRetry(() =>
-      listFn({
-        parent: cryptoKeyParent,
-        // KMS filter syntax: `state = ENABLED OR state = DISABLED`.
-        // Cheaper than fetching all versions and filtering client-side
-        // when the key ring has long rotation history.
-        filter: "state = ENABLED OR state = DISABLED",
-      }),
-    );
+    // -----------------------------------------------------------------
+    // Drain every page first. `nextRequest.pageToken` carries the cursor
+    // for the next call — KMS returns null/undefined for the final page.
+    // -----------------------------------------------------------------
+    const allVersions: Array<{ name?: string | null; state?: string | null }> = [];
+    let pageToken: string | undefined;
+    do {
+      const [page, nextRequest] = await this.withRetry(() =>
+        listFn({
+          parent: cryptoKeyParent,
+          // KMS filter syntax: `state = ENABLED OR state = DISABLED`.
+          // Cheaper than fetching all versions and filtering client-side
+          // when the key ring has long rotation history.
+          filter: "state = ENABLED OR state = DISABLED",
+          pageToken,
+        }),
+      );
+      allVersions.push(...page);
+      pageToken = nextRequest?.pageToken ?? undefined;
+    } while (pageToken);
 
-    const out: IssuerKeyMaterial[] = [];
-    for (const v of versions) {
+    // Defensive client-side filter — the server-side `filter` should
+    // already exclude DESTROY_SCHEDULED / DESTROYED, but a SDK that
+    // ignores the filter must not produce a wire Document containing
+    // an unverifiable key (§9.1.3).
+    const valid: Array<{ name: string; state: IssuerKeyState }> = [];
+    for (const v of allVersions) {
       if (!v.name || !v.state) continue;
-      // Defensive client-side filter — the server-side `filter` should
-      // already exclude DESTROY_SCHEDULED / DESTROYED, but a SDK that
-      // ignores the filter must not produce a wire Document containing
-      // an unverifiable key (§9.1.3).
       if (v.state !== "ENABLED" && v.state !== "DISABLED") continue;
-      const publicKey = await this.getPublicKey(v.name);
-      out.push({
-        kmsKeyResourceName: v.name,
-        publicKey,
-        state: v.state as IssuerKeyState,
-      });
+      valid.push({ name: v.name, state: v.state });
     }
-    return out;
+
+    // Fan-out `getPublicKey` in parallel: each call is independent and
+    // the latency floor is one KMS round-trip per key, not (key × RTT).
+    return Promise.all(
+      valid.map(async (v) => ({
+        kmsKeyResourceName: v.name,
+        publicKey: await this.getPublicKey(v.name),
+        state: v.state,
+      })),
+    );
   }
 
   /**

--- a/src/infrastructure/libs/kms/kmsSigner.ts
+++ b/src/infrastructure/libs/kms/kmsSigner.ts
@@ -68,6 +68,11 @@ const RETRYABLE_HTTP_STATUSES = new Set<number>([429, 500, 502, 503, 504]);
  * Minimal interface a `KeyManagementServiceClient` must satisfy for our
  * needs. We declare only what we use so unit tests can supply a hand-rolled
  * stub without instantiating the real (auth-requiring) gRPC client.
+ *
+ * `listCryptoKeyVersions` is consumed by `KmsSigner.listActiveIssuerKeys`
+ * (§G overlap multi-key, Phase 2 PR #1100) — it returns one entry per
+ * version with its KMS lifecycle `state`, which the §5.4.3 multi-key
+ * Document needs to distinguish ENABLED (signs) from DISABLED (verify-only).
  */
 export interface KmsClientLike {
   asymmetricSign(request: {
@@ -75,6 +80,43 @@ export interface KmsClientLike {
     data: Uint8Array;
   }): Promise<[{ signature?: Uint8Array | Buffer | string | null }, ...unknown[]]>;
   getPublicKey(request: { name: string }): Promise<[{ pem?: string | null }, ...unknown[]]>;
+  listCryptoKeyVersions?(request: {
+    parent: string;
+    filter?: string;
+  }): Promise<
+    [Array<{ name?: string | null; state?: string | null }>, ...unknown[]]
+  >;
+}
+
+/**
+ * GCP KMS lifecycle states we care about for the §G overlap window
+ * (`docs/report/did-vc-internalization.md` §9.1.3 table).
+ *
+ *  - `ENABLED`            : signs new VCs, appears in `assertionMethod`
+ *  - `DISABLED`           : rotating-out, verify-only, kept permanently
+ *  - `DESTROY_SCHEDULED`  : excluded — operator mistake, do NOT trust
+ *  - `DESTROYED`          : excluded — public key irretrievable anyway
+ *
+ * Strings match the KMS proto enum names verbatim
+ * (`google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState`).
+ */
+export type IssuerKeyState = "ENABLED" | "DISABLED";
+
+/**
+ * One row of `KmsSigner.listActiveIssuerKeys`. Combines the KMS resource
+ * name (used to derive `#key-N` fragments) with the raw 32-byte public key
+ * and the lifecycle state.
+ */
+export interface IssuerKeyMaterial {
+  /**
+   * Full resource name including `cryptoKeyVersions/N`. Used by the
+   * caller to derive the `#key-N` DID Document fragment.
+   */
+  kmsKeyResourceName: string;
+  /** Raw 32-byte Ed25519 public key. */
+  publicKey: Uint8Array;
+  /** ENABLED (signs) vs DISABLED (verify-only / rotation tail). */
+  state: IssuerKeyState;
 }
 
 @injectable()
@@ -137,6 +179,85 @@ export class KmsSigner {
       throw new Error(`KMS getPublicKey returned empty PEM for ${keyResourceName}`);
     }
     return extractEd25519RawFromSpkiPem(response.pem);
+  }
+
+  /**
+   * Enumerate Issuer key versions in the §G overlap window.
+   *
+   * Returns every `cryptoKeyVersion` under `cryptoKeyParent` whose state
+   * is `ENABLED` or `DISABLED` — i.e. the keys the §5.4.3 multi-key
+   * Document publishes. `DESTROY_SCHEDULED` / `DESTROYED` are excluded:
+   * an operator mistake (scheduling destroy) MUST NOT be silently
+   * propagated to the wire Document, and DESTROYED keys lack a public
+   * key entirely (§9.1.3 table).
+   *
+   * `cryptoKeyParent` is the parent without the `cryptoKeyVersions/N`
+   * suffix — e.g.
+   *   `projects/p/locations/global/keyRings/r/cryptoKeys/civicship-issuer-vc`
+   *
+   * Phase 2 production wiring: real call to `listCryptoKeyVersions` +
+   * per-version `getPublicKey`. Phase 1 callers do NOT invoke this
+   * method (single-active-key mode); the §G overlap path is being
+   * shipped piecewise so the production KMS wiring lands in a later PR
+   * once the rotation runbook has been exercised in staging
+   * (`docs/runbooks/issuer-did-key-rotation.md`).
+   *
+   * Design references:
+   *   docs/report/did-vc-internalization.md §5.4.3 line 1126-1142
+   *   docs/report/did-vc-internalization.md §9.1.2 (rotation overlap)
+   *   docs/report/did-vc-internalization.md §9.1.3 (永久保持 / DESTROYED 禁止)
+   */
+  async listActiveIssuerKeys(cryptoKeyParent: string): Promise<IssuerKeyMaterial[]> {
+    if (typeof cryptoKeyParent !== "string" || cryptoKeyParent.length === 0) {
+      throw new TypeError("KMS cryptoKeyParent must be a non-empty string");
+    }
+    if (/\/cryptoKeyVersions\/\d+$/.test(cryptoKeyParent)) {
+      throw new Error(
+        `KMS cryptoKeyParent must NOT end with /cryptoKeyVersions/<n>, got "${cryptoKeyParent}". ` +
+          "Pass the parent cryptoKey resource name; versions are enumerated by this call.",
+      );
+    }
+
+    if (!this.client.listCryptoKeyVersions) {
+      // Phase 1 KMS client wrapper did not surface listCryptoKeyVersions
+      // (it was not needed in single-active-key mode). Refuse rather than
+      // silently returning [] — a silent empty array would let
+      // `IssuerDidService.buildDidDocument` quietly serve a Document with
+      // zero `verificationMethod` entries, which verifiers reject.
+      throw new Error(
+        "KmsSigner.listActiveIssuerKeys: underlying KMS client does not implement " +
+          "listCryptoKeyVersions — Phase 2 KMS client wiring is required " +
+          "(design §5.4.3 / §G).",
+      );
+    }
+    const listFn = this.client.listCryptoKeyVersions.bind(this.client);
+
+    const [versions] = await this.withRetry(() =>
+      listFn({
+        parent: cryptoKeyParent,
+        // KMS filter syntax: `state = ENABLED OR state = DISABLED`.
+        // Cheaper than fetching all versions and filtering client-side
+        // when the key ring has long rotation history.
+        filter: "state = ENABLED OR state = DISABLED",
+      }),
+    );
+
+    const out: IssuerKeyMaterial[] = [];
+    for (const v of versions) {
+      if (!v.name || !v.state) continue;
+      // Defensive client-side filter — the server-side `filter` should
+      // already exclude DESTROY_SCHEDULED / DESTROYED, but a SDK that
+      // ignores the filter must not produce a wire Document containing
+      // an unverifiable key (§9.1.3).
+      if (v.state !== "ENABLED" && v.state !== "DISABLED") continue;
+      const publicKey = await this.getPublicKey(v.name);
+      out.push({
+        kmsKeyResourceName: v.name,
+        publicKey,
+        state: v.state as IssuerKeyState,
+      });
+    }
+    return out;
   }
 
   /**


### PR DESCRIPTION
## Summary

Phase 2 持ち越し項目（§16 line 2260）の **§G overlap multi-key 仕様** を実装。`IssuerDidService` に `buildDidDocument()` を追加し、§G overlap window 中の **ENABLED + DISABLED 全鍵を `verificationMethod` に並列配信** する。

設計参照: `docs/report/did-vc-internalization.md`
- **§5.4.3 line 1113-1145**: `IssuerDidService.buildDidDocument` 設計（JsonWebKey2020 / publicKeyJwk 形式）
- **§9.1.2 line 1539-**: Issuer 鍵 24h overlap rotation 戦略（`[#key-N+1, #key-N]` 並列配信）
- **§9.1.3 line 1562-**: 旧鍵で署名された VC を未来永劫検証可能にする戦略（DISABLED 鍵を `verificationMethod` に永久保持、DESTROY 禁止）
- **§16 line 2260**: Phase 2 / PR #1100

## 変更点

### `src/infrastructure/libs/did/issuerDidBuilder.ts`
- 新規型 `Ed25519PublicJwk` / `IssuerJwkVerificationMethod` / `IssuerMultiKeyDidDocument` / `IssuerActiveKey`
- `buildMultiKeyIssuerDidDocument(activeKeys)`: spec §5.4.3 line 1131-1142 の出力形（`@context` に `https://w3id.org/security/jwk/v1` を含む）
- `encodeEd25519Jwk(rawPubKey)`: RFC 8037 OKP / Ed25519 → base64url の純粋関数
- `kmsResourceNameToKid(name)`: `cryptoKeyVersions/N` → `key-N` (既存 `keyVersionToFragment` の export ラッパ)

### `src/infrastructure/libs/kms/kmsSigner.ts`
- `KmsClientLike` に optional `listCryptoKeyVersions` を追加
- 新規型 `IssuerKeyState` (`"ENABLED" | "DISABLED"`) / `IssuerKeyMaterial`
- `KmsSigner.listActiveIssuerKeys(cryptoKeyParent)`: KMS `listCryptoKeyVersions` を `state = ENABLED OR state = DISABLED` filter で叩き、各 version の SPKI から raw 32-byte pubkey を取得
  - **DESTROY_SCHEDULED / DESTROYED は server-side filter + client-side filter の二重防御で除外**（§9.1.3 要件: DESTROYED 状態を絶対に DID Document に乗せない）
  - 旧 KMS client (listCryptoKeyVersions 未実装) は silent empty array ではなく明示的 throw

### `src/application/domain/credential/issuerDid/service.ts`
- 新メソッド `buildDidDocument(): Promise<IssuerMultiKeyDidDocument | null>`
  - `repository.listActiveKeys()` で §G overlap window 中の全行を取得 (`activatedAt ASC`)
  - 各行の `deactivatedAt === null` を `enabled` にマップ（ENABLED ↔ deactivatedAt IS NULL, DISABLED ↔ deactivatedAt IS NOT NULL）
  - 既存 TTL cache を経由して per-key public-key bytes を取得
  - `buildMultiKeyIssuerDidDocument` に渡して JsonWebKey2020 形式の Document を組み立て
- 既存 `getActiveIssuerDidDocument()` (Phase 1 single-key / Multikey shape) は backward compatibility のため保持
- File-header の §G scope note を Phase 2 完了を反映する形に更新

### Tests
- **`src/__tests__/unit/application/domain/credential/issuerDid/service.test.ts`** に新規 describe `buildDidDocument — §G overlap multi-key (Phase 2)` を追加
  - **1 ENABLED + 1 DISABLED → `verificationMethod` 2 件 / `assertionMethod` 1 件**（spec 要件）
  - bootstrap state (`listActiveKeys() === []`) → null
  - JWK の `kty/crv/x` 形式が RFC 8037 (OKP / Ed25519) に準拠
  - `@context` が `https://w3id.org/security/jwk/v1` を含む
  - 全 ENABLED 2 件ケース → 両方とも assertionMethod に登場
  - TTL cache が `getActiveIssuerDidDocument` ↔ `buildDidDocument` 間で共有される
- **`src/__tests__/unit/infrastructure/libs/did/issuerDidBuilder.test.ts`** に `buildMultiKeyIssuerDidDocument` / `encodeEd25519Jwk` / `kmsResourceNameToKid` の純粋関数テストを追加（reference vector 含む）
- **`src/__tests__/unit/infrastructure/libs/kms/kmsSigner.test.ts`** に `listActiveIssuerKeys` のテストを追加（KMS は mock、実呼び出しなし）

## Non-scope

- `UserDidDocumentService` (§5.4.4) は触らず
- Cardano anchor 周り (§5.1.7 / §5.4.6) は触らず
- KMS 実呼び出し（production wiring）は別 PR — 本 PR では `listCryptoKeyVersions` の interface 追加のみで、production GCP KMS client wrapping は staging runbook 実走後に着手
- Router (`/.well-known/did.json`) の `buildDidDocument()` への切替も別 PR — 既存 `getActiveIssuerDidDocument()` を保持して Phase 1 contract を変えていない

## Test plan

- [ ] `pnpm test src/__tests__/unit/application/domain/credential/issuerDid/service.test.ts` — `buildDidDocument` 全シナリオ pass
- [ ] `pnpm test src/__tests__/unit/infrastructure/libs/did/issuerDidBuilder.test.ts` — `buildMultiKeyIssuerDidDocument` / `encodeEd25519Jwk` / `kmsResourceNameToKid` pass、既存 `Multikey` shape テストも regression なし
- [ ] `pnpm test src/__tests__/unit/infrastructure/libs/kms/kmsSigner.test.ts` — `listActiveIssuerKeys` の ENABLED+DISABLED / DESTROYED 除外 / parent validation / 旧 client 非対応 throw pass
- [ ] `pnpm lint` — TypeScript 型エラーなし
- [ ] (将来) router を `buildDidDocument()` に切替後、`/.well-known/did.json` integration test で multi-key Document が JSON serialize されて返ることを確認

## Phase 2 follow-up (この PR の scope 外)

- Router を `buildDidDocument()` に切替（既存 `getActiveIssuerDidDocument` から）
- `KmsSigner.listActiveIssuerKeys` の production KMS wiring（gRPC client が actual `listCryptoKeyVersions` を持つよう KmsClientLike 完全実装）
- `t_issuer_did_keys` schema PR (Phase 1 stub `IssuerDidKeyRepositoryStub` を Prisma-backed に置換)
- §G rotation runbook の staging 実走 (`docs/runbooks/issuer-did-key-rotation.md`)

https://claude.ai/code/session_01XzsQPXMVEMPycqQ3sX6pq7

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzsQPXMVEMPycqQ3sX6pq7)_