### PR TITLE
refactor(credential): JwtSigner interface 抽出 — Phase 2 KMS 切替の下準備

### DIFF
--- a/src/__tests__/unit/application/domain/credential/statusList/service.test.ts
+++ b/src/__tests__/unit/application/domain/credential/statusList/service.test.ts
@@ -15,6 +15,8 @@ import StatusListService, {
   buildStatusListUrl,
   buildStatusListVcPayload,
 } from "@/application/domain/credential/statusList/service";
+import { StubJwtSigner } from "@/application/domain/credential/shared/stubJwtSigner";
+import { CIVICSHIP_ISSUER_DID } from "@/application/domain/credential/shared/constants";
 import type {
   IStatusListRepository,
   VcRevocationRow,
@@ -203,6 +205,17 @@ describe("StatusListService", () => {
     container.reset();
     repo = new FakeRepository();
     container.register("StatusListRepository", { useValue: repo });
+    // Phase 2 prep: StatusListService now resolves `StatusListJwtSigner`
+    // from DI rather than reaching for the inline `STUB_SIGNATURE_STATUS`
+    // constant. We bind the production stub so JWT output stays
+    // byte-identical and existing assertions on the third segment
+    // (`expect(segments[2]).toBe(STUB_SIGNATURE_STATUS)`) keep passing.
+    container.register("StatusListJwtSigner", {
+      useValue: new StubJwtSigner({
+        kid: `${CIVICSHIP_ISSUER_DID}#stub`,
+        stubSignature: STUB_SIGNATURE_STATUS,
+      }),
+    });
     container.register("StatusListService", { useClass: StatusListService });
     service = container.resolve(StatusListService);
   });

--- a/src/__tests__/unit/application/domain/credential/vcIssuance/service.test.ts
+++ b/src/__tests__/unit/application/domain/credential/vcIssuance/service.test.ts
@@ -18,6 +18,10 @@ import VcIssuanceService, {
   CIVICSHIP_ISSUER_DID,
   buildVcPayload,
 } from "@/application/domain/credential/vcIssuance/service";
+import {
+  StubJwtSigner,
+  STUB_SIGNATURE,
+} from "@/application/domain/credential/shared/stubJwtSigner";
 import { buildRoot, verifyProof } from "@/infrastructure/libs/merkle/merkleTreeBuilder";
 import type {
   VcAnchorRow,
@@ -87,6 +91,17 @@ describe("VcIssuanceService", () => {
     mockStatusList = new MockStatusListService();
     container.register("VcIssuanceRepository", { useValue: mockRepository });
     container.register("StatusListService", { useValue: mockStatusList });
+    // Phase 2 prep: VcIssuanceService now resolves `VcJwtSigner` from DI
+    // rather than reaching for the inline `STUB_SIGNATURE` constant. We
+    // bind the same `StubJwtSigner` used in production so the JWT output
+    // stays byte-identical and the existing assertions
+    // (`expect(segments[2]).toBe("stub-not-signed")`) keep passing.
+    container.register("VcJwtSigner", {
+      useValue: new StubJwtSigner({
+        kid: `${CIVICSHIP_ISSUER_DID}#stub`,
+        stubSignature: STUB_SIGNATURE,
+      }),
+    });
     container.register("VcIssuanceService", { useClass: VcIssuanceService });
 
     service = container.resolve(VcIssuanceService);

--- a/src/application/domain/credential/shared/jwtSigner.ts
+++ b/src/application/domain/credential/shared/jwtSigner.ts
@@ -55,6 +55,17 @@
  */
 export interface JwtSigner {
   /**
+   * JWS algorithm identifier stamped on the JWT header's `alg` field.
+   *
+   * Civicship runs EdDSA / Ed25519 (§5.2.2, RFC 8037), but pinning it
+   * to the signer instance instead of the call site means the eventual
+   * KMS swap (or any future migration to ES256K / etc.) flips one
+   * implementation property rather than every caller. Service-layer
+   * code MUST read `signer.alg` rather than hard-coding the string.
+   */
+  readonly alg: string;
+
+  /**
    * Produce the signature segment (third JWT component) for the supplied
    * signing input. The signing input is the ASCII string
    * `${headerB64u}.${payloadB64u}` exactly — implementations MUST NOT

--- a/src/application/domain/credential/shared/jwtSigner.ts
+++ b/src/application/domain/credential/shared/jwtSigner.ts
@@ -1,0 +1,84 @@
+/**
+ * `JwtSigner` — abstraction over the signature production step for
+ * Verifiable Credentials and StatusList VCs (§5.2.2 / §5.2.4).
+ *
+ * Why this interface exists (Phase 2 prep)
+ * ----------------------------------------
+ * `VcIssuanceService` and `StatusListService` both build a JWT of the
+ * form `${headerB64u}.${payloadB64u}.${signature}`. In Phase 1 the
+ * `signature` segment is a deterministic stub constant
+ * (`STUB_SIGNATURE` / `STUB_SIGNATURE_STATUS`) because the KMS-backed
+ * Ed25519 signer is still in PoC (Phase 0-2). When the KMS PoC graduates
+ * (design doc §16, Phase 2 / PR #1101 + #1102) the signer becomes a
+ * round-trip to Cloud KMS that produces a base64url-encoded Ed25519
+ * signature — but the *call shape* from the application services is
+ * exactly the same: feed them the unsigned `header.payload` string and
+ * get back a string to splice in as the third JWT segment.
+ *
+ * Extracting that call shape behind an interface lets us:
+ *
+ *   1. Swap `StubJwtSigner` for `KmsJwtSigner` per DI token in Phase 2
+ *      without touching service code.
+ *   2. Run integration tests against `StubJwtSigner` even after KMS is
+ *      wired up in production (deterministic output → stable snapshots).
+ *   3. Bind *different* signers to the VC issuance path and the
+ *      StatusList path if operations decide to rotate them on different
+ *      cadences (two DI tokens — `VcJwtSigner` / `StatusListJwtSigner`).
+ *
+ * Boundary discipline
+ * -------------------
+ * The interface intentionally does NOT manage:
+ *
+ *   - JSON canonicalisation / base64url encoding — those live in the
+ *     services so the JWT shape is testable without a signer mock.
+ *   - The `kid` derivation from the active KMS key version — the
+ *     `kid` field is read-only on the signer instance so the service
+ *     can stamp the JWT header without learning the KMS resource name.
+ *   - Caching / TTL — signature production has no inherent caching
+ *     story (every payload is unique). Public-key caching for the
+ *     verifier path lives in `IssuerDidService`.
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.2.2 (VC issuance)
+ *   docs/report/did-vc-internalization.md §5.2.4 (StatusList service)
+ *   docs/report/did-vc-internalization.md §16    (Phase 2 carryover)
+ */
+
+/**
+ * Production contract for "produce the third JWT segment for this
+ * `header.payload` signing input".
+ *
+ * Implementations:
+ *   - `StubJwtSigner`     — Phase 1, returns the same constant every call.
+ *   - `KmsJwtSigner`      — Phase 2 placeholder; throws until the KMS
+ *                           Ed25519 PoC graduates.
+ */
+export interface JwtSigner {
+  /**
+   * Produce the signature segment (third JWT component) for the supplied
+   * signing input. The signing input is the ASCII string
+   * `${headerB64u}.${payloadB64u}` exactly — implementations MUST NOT
+   * re-canonicalise or re-encode it.
+   *
+   * Return value is the base64url-encoded signature (no padding, no `=`)
+   * ready to be appended after the second `.` separator.
+   *
+   * Stubs may ignore the input and return a constant marker; real
+   * implementations MUST sign over the raw bytes of `signingInput` using
+   * the JWS algorithm declared in the JWT header (currently EdDSA /
+   * Ed25519 per §5.2.2).
+   */
+  sign(signingInput: string): Promise<string>;
+
+  /**
+   * `kid` (key id) to stamp on the JWT header. Stable for the lifetime
+   * of a signer instance — Phase 2 rotation will hand the service a
+   * *new* signer instance rather than mutating this field, so callers
+   * may read it eagerly.
+   *
+   * Format: `${issuerDid}#${keyFragment}` — e.g.
+   * `did:web:api.civicship.app#stub` for the Phase 1 stub. The fragment
+   * portion becomes the `verificationMethod` id in the DID Document.
+   */
+  readonly kid: string;
+}

--- a/src/application/domain/credential/shared/kmsJwtSigner.ts
+++ b/src/application/domain/credential/shared/kmsJwtSigner.ts
@@ -46,6 +46,23 @@ import type { JwtSigner } from "@/application/domain/credential/shared/jwtSigner
  */
 export class KmsJwtSigner implements JwtSigner {
   /**
+   * JWS algorithm identifier. Symmetric with the other throwing
+   * getters on this placeholder — accessed at JWT-build time, so
+   * fails fast with the same diagnostic the moment something tries
+   * to use the unwired KMS signer in Phase 1.
+   *
+   * Implemented as a getter so the throw fires on *access*, not on
+   * instantiation, mirroring `kid` / `sign`. Phase 2 will replace this
+   * with a literal `"EdDSA"` (the KMS key is Ed25519 per §5.1.1).
+   */
+  get alg(): string {
+    throw new Error(
+      "KmsJwtSigner.alg: not implemented — Phase 0-2 PoC pending. " +
+        "See docs/report/did-vc-internalization.md §16.",
+    );
+  }
+
+  /**
    * Property is declared (and read by TypeScript at compile time) so
    * the class structurally satisfies `JwtSigner`. Accessing it throws
    * — symmetric with `sign()` — so a misconfigured DI binding fails

--- a/src/application/domain/credential/shared/kmsJwtSigner.ts
+++ b/src/application/domain/credential/shared/kmsJwtSigner.ts
@@ -1,0 +1,73 @@
+/**
+ * `KmsJwtSigner` — Phase 2 placeholder implementation of `JwtSigner`.
+ *
+ * Throws on every method until the Phase 0-2 KMS Ed25519 PoC graduates
+ * (design doc §16 — "VC JWT の本番署名" / "StatusList VC JWT の本番署名").
+ *
+ * Why this file exists *before* the PoC lands
+ * -------------------------------------------
+ * Phase 2 will require:
+ *
+ *   1. A `KmsJwtSigner` class that delegates `sign()` to
+ *      `IssuerDidService.signWithActiveKey` (or directly to `KmsSigner`)
+ *      and exposes the active key's `kid`.
+ *   2. A DI swap from `StubJwtSigner` → `KmsJwtSigner` on the
+ *      `VcJwtSigner` / `StatusListJwtSigner` tokens.
+ *
+ * Shipping the placeholder now means the Phase 2 PR is a small,
+ * surgical diff: rewrite this file's method bodies, flip the DI
+ * binding. Nothing in the consuming services has to move.
+ *
+ * Intentionally NOT implemented in this PR
+ * ----------------------------------------
+ *   - No call to `KmsSigner.signEd25519` — the PoC has not yet validated
+ *     the algorithm choice / IAM scope / latency budget.
+ *   - No `IssuerDidService` injection — pulling that in here before the
+ *     PoC would couple the placeholder to a class that may itself be
+ *     refactored as part of Phase 2.
+ *   - No `kid` resolution from `t_issuer_did_keys.kmsKeyResourceName` —
+ *     same reason; the wiring belongs in the same PR as the working
+ *     `sign()` body so the change can be reviewed as one coherent
+ *     diff.
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §16    (Phase 2 carryover)
+ *   docs/report/did-vc-internalization.md §5.1.1 (KMS resource naming)
+ *   docs/report/did-vc-internalization.md §5.4.3 (Issuer DID + KMS signing)
+ */
+
+import type { JwtSigner } from "@/application/domain/credential/shared/jwtSigner";
+
+/**
+ * Placeholder for the future KMS-backed `JwtSigner`. Every method
+ * throws — production code MUST NOT bind this class to a DI token in
+ * Phase 1. The DI provider currently registers `StubJwtSigner` against
+ * both `VcJwtSigner` and `StatusListJwtSigner` tokens for that reason.
+ */
+export class KmsJwtSigner implements JwtSigner {
+  /**
+   * Property is declared (and read by TypeScript at compile time) so
+   * the class structurally satisfies `JwtSigner`. Accessing it throws
+   * — symmetric with `sign()` — so a misconfigured DI binding fails
+   * fast with the same diagnostic.
+   *
+   * Implemented as a getter (not a plain field) so the throw fires on
+   * *access*, not on instantiation. Phase 2 will replace this with a
+   * real value derived from `t_issuer_did_keys`.
+   */
+  get kid(): string {
+    throw new Error(
+      "KmsJwtSigner.kid: not implemented — Phase 0-2 PoC pending. " +
+        "See docs/report/did-vc-internalization.md §16.",
+    );
+  }
+
+  async sign(_signingInput: string): Promise<string> {
+    throw new Error(
+      "KmsJwtSigner.sign: not implemented — Phase 0-2 PoC pending. " +
+        "See docs/report/did-vc-internalization.md §16. " +
+        "Wire `StubJwtSigner` against the `VcJwtSigner` / `StatusListJwtSigner` " +
+        "DI tokens until the PoC graduates.",
+    );
+  }
+}

--- a/src/application/domain/credential/shared/stubJwtSigner.ts
+++ b/src/application/domain/credential/shared/stubJwtSigner.ts
@@ -1,14 +1,16 @@
 /**
  * `StubJwtSigner` — Phase 1 placeholder implementation of `JwtSigner`.
  *
- * Emits a deterministic, non-base64url marker as the JWT signature
+ * Emits a deterministic, non-signature marker as the JWT signature
  * segment so:
  *
  *   1. Tests can assert "this is a stub VC" with a single string
  *      comparison and without false positives against real signatures.
- *   2. Verifiers MUST reject it — it is not a valid base64url string
- *      (contains `-`), which is exactly what we want until the KMS
- *      signer lands.
+ *   2. Verifiers MUST reject it — it is not a valid Ed25519 signature
+ *      (wrong length and format), which is exactly what we want until
+ *      the KMS signer lands. (The `-` chars in the marker are
+ *      base64url-legal, so the failure mode is "signature does not
+ *      verify", not "signature is not parseable".)
  *   3. The grep target is unique enough to find every stub site once
  *      KMS replaces the stub in Phase 2.
  *
@@ -50,10 +52,18 @@ export const STUB_SIGNATURE_STATUS = "stub-status-list-not-signed";
  * marker and a fixed `kid`. Stateless — safe to register as a singleton.
  *
  * `sign()` ignores the signing input deliberately; production verifiers
- * would reject the output anyway because it is not a valid base64url
- * Ed25519 signature.
+ * would reject the output anyway because it is not a valid Ed25519
+ * signature.
  */
 export class StubJwtSigner implements JwtSigner {
+  /**
+   * JWS algorithm advertised on the JWT header. Phase 1 runs EdDSA
+   * (Ed25519, RFC 8037) so the header reflects the algorithm the Phase
+   * 2 KMS signer will eventually produce — the *signature value* is the
+   * only piece that changes when the stub is replaced.
+   */
+  readonly alg: string = "EdDSA";
+
   /**
    * `kid` is read by the service when assembling the JWT header. Phase 1
    * stamps `${issuerDid}#stub` so the verifier path can route to the

--- a/src/application/domain/credential/shared/stubJwtSigner.ts
+++ b/src/application/domain/credential/shared/stubJwtSigner.ts
@@ -1,0 +1,85 @@
+/**
+ * `StubJwtSigner` — Phase 1 placeholder implementation of `JwtSigner`.
+ *
+ * Emits a deterministic, non-base64url marker as the JWT signature
+ * segment so:
+ *
+ *   1. Tests can assert "this is a stub VC" with a single string
+ *      comparison and without false positives against real signatures.
+ *   2. Verifiers MUST reject it — it is not a valid base64url string
+ *      (contains `-`), which is exactly what we want until the KMS
+ *      signer lands.
+ *   3. The grep target is unique enough to find every stub site once
+ *      KMS replaces the stub in Phase 2.
+ *
+ * Two instances are wired in `src/application/provider.ts`:
+ *
+ *   - `VcJwtSigner`         → emits `STUB_SIGNATURE` for VC issuance.
+ *   - `StatusListJwtSigner` → emits `STUB_SIGNATURE_STATUS` for the
+ *                              StatusList VC body.
+ *
+ * The two markers are kept distinct (rather than reusing one) so a
+ * post-hoc grep can disambiguate which stub a captured JWT came from
+ * while we are mid-migration.
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.2.2
+ *   docs/report/did-vc-internalization.md §5.2.4
+ *   docs/report/did-vc-internalization.md §16 (Phase 2 carryover)
+ */
+
+import type { JwtSigner } from "@/application/domain/credential/shared/jwtSigner";
+
+/**
+ * Stub signature for issued VCs. Distinct from the StatusList stub.
+ * Keep in sync with `src/application/domain/credential/vcIssuance/service.ts`
+ * pre-extraction — the constant value MUST NOT change because existing
+ * unit tests pin it.
+ */
+export const STUB_SIGNATURE = "stub-not-signed";
+
+/**
+ * Stub signature for the StatusList VC. Kept distinct from `STUB_SIGNATURE`
+ * so the JWT origin can be identified by grep alone during the Phase 2
+ * cutover.
+ */
+export const STUB_SIGNATURE_STATUS = "stub-status-list-not-signed";
+
+/**
+ * Construct-time configured `JwtSigner` returning a fixed signature
+ * marker and a fixed `kid`. Stateless — safe to register as a singleton.
+ *
+ * `sign()` ignores the signing input deliberately; production verifiers
+ * would reject the output anyway because it is not a valid base64url
+ * Ed25519 signature.
+ */
+export class StubJwtSigner implements JwtSigner {
+  /**
+   * `kid` is read by the service when assembling the JWT header. Phase 1
+   * stamps `${issuerDid}#stub` so the verifier path can route to the
+   * stub `verificationMethod` (which doesn't actually verify anything —
+   * the design accepts that during the stub window).
+   */
+  readonly kid: string;
+
+  /**
+   * The constant returned by `sign()`. Two production instances differ
+   * only by this value (`STUB_SIGNATURE` vs `STUB_SIGNATURE_STATUS`).
+   */
+  private readonly stubSignature: string;
+
+  constructor(params: { kid: string; stubSignature: string }) {
+    this.kid = params.kid;
+    this.stubSignature = params.stubSignature;
+  }
+
+  /**
+   * Returns the configured stub marker. The `signingInput` argument is
+   * preserved on the interface (rather than being optional) because the
+   * Phase 2 `KmsJwtSigner` MUST receive it — making it optional would
+   * leak the stub's "I don't care" semantics into the production type.
+   */
+  async sign(_signingInput: string): Promise<string> {
+    return this.stubSignature;
+  }
+}

--- a/src/application/domain/credential/statusList/service.ts
+++ b/src/application/domain/credential/statusList/service.ts
@@ -23,8 +23,10 @@
  * re-zip on every read; the base64url wrapper is only applied at JWT
  * build time.
  *
- * KMS signing: production signing lives in `IssuerDidService.signWithActiveKey`
- * (sibling PR). Until that lands the JWT signature segment is the constant
+ * KMS signing: production signing will live in `KmsJwtSigner`
+ * (`credential/shared/kmsJwtSigner.ts`, placeholder for Phase 2 — design
+ * §16). Until Phase 0-2 PoC graduates, the bound `StatusListJwtSigner`
+ * DI token resolves to a `StubJwtSigner` that returns the constant
  * `STUB_SIGNATURE_STATUS` so verifiers reject it (it is not a valid
  * base64url signature) and so we can grep every stub site post-hoc.
  *
@@ -51,6 +53,8 @@ import {
   StatusListFrozenError,
 } from "@/application/domain/credential/statusList/data/errors";
 import { CIVICSHIP_ISSUER_DID } from "@/application/domain/credential/shared/constants";
+import type { JwtSigner } from "@/application/domain/credential/shared/jwtSigner";
+import { STUB_SIGNATURE_STATUS } from "@/application/domain/credential/shared/stubJwtSigner";
 
 /**
  * Public API host. Hard-coded per §B / §5.4 — civicship is a single-issuer
@@ -83,12 +87,13 @@ export function buildStatusListUrl(listKey: string): string {
 export const DEFAULT_STATUS_LIST_CAPACITY = 131_072;
 
 /**
- * Stub signature for the StatusList VC. Distinct from the VC issuance
- * stub so post-hoc grep can pin which stub a JWT came from. Replaced with
- * a real KMS-backed signature once `IssuerDidService.signWithActiveKey`
- * lands (sibling PR).
+ * Re-export so the public symbol's path stays stable for existing unit
+ * tests. The canonical definition now lives in
+ * `credential/shared/stubJwtSigner.ts` next to the `StubJwtSigner`
+ * implementation that emits it; this module keeps the export name so
+ * `service.test.ts` continues to compile unchanged.
  */
-export const STUB_SIGNATURE_STATUS = "stub-status-list-not-signed";
+export { STUB_SIGNATURE_STATUS };
 
 /**
  * Build the standard W3C contexts + types for a `StatusList2021Credential`
@@ -181,22 +186,25 @@ export function buildStatusListVcPayload(input: {
 }
 
 /**
- * Render a JWT from header/payload/signature. Currently signature is a
- * stub; swap to KMS once available.
+ * Render a JWT from header/payload/signature.
+ *
+ * Phase 2 prep: the signing step is delegated to a `JwtSigner` instance
+ * supplied by the caller. In Phase 1 the bound `StatusListJwtSigner` is
+ * a `StubJwtSigner` whose `sign()` returns `STUB_SIGNATURE_STATUS`, so
+ * the produced JWT byte-matches the pre-extraction version. The
+ * signing input fed to `signer.sign()` is exactly `${header}.${body}`
+ * per the JWS spec — Phase 2 KMS swap requires no rendering change.
  */
-function renderJwt(payload: Record<string, unknown>, kid: string): string {
+async function renderJwt(payload: Record<string, unknown>, signer: JwtSigner): Promise<string> {
   const header = base64urlEncodeJson({
     alg: "EdDSA",
     typ: "JWT",
-    kid,
+    kid: signer.kid,
   });
   const body = base64urlEncodeJson(payload);
-  // TODO(phase1-final): replace `STUB_SIGNATURE_STATUS` with the output of
-  // `IssuerDidService.signWithActiveKey(`${header}.${body}`)`. The function
-  // signature lives in the sibling KMS PR; tests assert on the stub
-  // marker today and will move to a structural shape check once signing
-  // lands.
-  return `${header}.${body}.${STUB_SIGNATURE_STATUS}`;
+  const signingInput = `${header}.${body}`;
+  const signature = await signer.sign(signingInput);
+  return `${signingInput}.${signature}`;
 }
 
 @injectable()
@@ -204,6 +212,17 @@ export default class StatusListService {
   constructor(
     @inject("StatusListRepository")
     private readonly repository: IStatusListRepository,
+    /**
+     * Phase 2 prep: signing is delegated to a `JwtSigner` rather than
+     * the inline stub constant. In Phase 1 the injected instance is a
+     * `StubJwtSigner` that returns `STUB_SIGNATURE_STATUS`, so the
+     * produced StatusList VC JWT is byte-identical to the
+     * pre-extraction version. The DI token `StatusListJwtSigner` is
+     * intentionally distinct from `VcJwtSigner` so the two paths can
+     * rotate independently once KMS lands (design doc §16).
+     */
+    @inject("StatusListJwtSigner")
+    private readonly signer: JwtSigner,
   ) {}
 
   /**
@@ -323,7 +342,7 @@ export default class StatusListService {
 
     // Re-sign the list VC and persist the new bytes + JWT.
     const issuedAt = new Date();
-    const vcJwt = this.signListVc(list, recompressed, issuedAt);
+    const vcJwt = await this.signListVc(list, recompressed, issuedAt);
 
     await this.repository.updateBitstring(ctx, list.id, { encodedList: recompressed, vcJwt }, tx);
     await this.repository.markVcRevoked(ctx, input.vcRequestId, { reason: input.reason }, tx);
@@ -384,7 +403,7 @@ export default class StatusListService {
       // listKey so it must be re-rendered if the listKey shifts after a
       // P2002 retry.
       const issuedAt = new Date();
-      const vcJwt = this.signBootstrapVc(listKey, compressed, issuedAt);
+      const vcJwt = await this.signBootstrapVc(listKey, compressed, issuedAt);
 
       try {
         return await this.repository.create(
@@ -431,12 +450,15 @@ export default class StatusListService {
   /**
    * Sign a list VC. Same path used at bootstrap and at each revocation;
    * the only difference is which bytes go into `encodedList`.
+   *
+   * Async because `JwtSigner.sign` is async (Phase 2 KMS round-trip).
+   * In Phase 1 the stub resolves immediately so the await is free.
    */
-  private signListVc(
+  private async signListVc(
     list: StatusListCredentialRow,
     compressedBitstring: Uint8Array,
     issuedAt: Date,
-  ): string {
+  ): Promise<string> {
     const listUrl = buildStatusListUrl(list.listKey);
     const payload = buildStatusListVcPayload({
       listUrl,
@@ -444,7 +466,7 @@ export default class StatusListService {
       issuer: CIVICSHIP_ISSUER_DID,
       issuedAt,
     });
-    return renderJwt(payload, `${CIVICSHIP_ISSUER_DID}#stub`);
+    return renderJwt(payload, this.signer);
   }
 
   /**
@@ -453,11 +475,11 @@ export default class StatusListService {
    * time). Kept separate to avoid a "fake row" hack in the bootstrap
    * path.
    */
-  private signBootstrapVc(
+  private async signBootstrapVc(
     listKey: string,
     compressedBitstring: Uint8Array,
     issuedAt: Date,
-  ): string {
+  ): Promise<string> {
     const listUrl = buildStatusListUrl(listKey);
     const payload = buildStatusListVcPayload({
       listUrl,
@@ -465,7 +487,7 @@ export default class StatusListService {
       issuer: CIVICSHIP_ISSUER_DID,
       issuedAt,
     });
-    return renderJwt(payload, `${CIVICSHIP_ISSUER_DID}#stub`);
+    return renderJwt(payload, this.signer);
   }
 
   /**

--- a/src/application/domain/credential/statusList/service.ts
+++ b/src/application/domain/credential/statusList/service.ts
@@ -27,8 +27,9 @@
  * (`credential/shared/kmsJwtSigner.ts`, placeholder for Phase 2 — design
  * §16). Until Phase 0-2 PoC graduates, the bound `StatusListJwtSigner`
  * DI token resolves to a `StubJwtSigner` that returns the constant
- * `STUB_SIGNATURE_STATUS` so verifiers reject it (it is not a valid
- * base64url signature) and so we can grep every stub site post-hoc.
+ * `STUB_SIGNATURE_STATUS` so verifiers reject it (the bytes don't form
+ * a valid Ed25519 signature) and so we can grep every stub site
+ * post-hoc.
  *
  * Design references:
  *   docs/report/did-vc-internalization.md §4.1   (StatusListCredential schema)
@@ -194,10 +195,16 @@ export function buildStatusListVcPayload(input: {
  * the produced JWT byte-matches the pre-extraction version. The
  * signing input fed to `signer.sign()` is exactly `${header}.${body}`
  * per the JWS spec — Phase 2 KMS swap requires no rendering change.
+ *
+ * `alg` is read off the signer (Phase 1 stub returns "EdDSA"; the
+ * future KMS signer pins whatever JWS alg the Ed25519 key advertises).
+ * Keeping the algorithm pinned to the signer instance means a future
+ * migration (e.g. ES256K) flips a single property rather than this
+ * call site.
  */
 async function renderJwt(payload: Record<string, unknown>, signer: JwtSigner): Promise<string> {
   const header = base64urlEncodeJson({
-    alg: "EdDSA",
+    alg: signer.alg,
     typ: "JWT",
     kid: signer.kid,
   });

--- a/src/application/domain/credential/vcIssuance/service.ts
+++ b/src/application/domain/credential/vcIssuance/service.ts
@@ -244,7 +244,11 @@ export default class VcIssuanceService {
     //    exactly `${header}.${payload}` per the JWS spec so the Phase 2
     //    swap requires no service-side change.
     const header = base64urlEncodeJson({
-      alg: "EdDSA",
+      // `alg` is read off the signer (Phase 1 stub returns "EdDSA"; the
+      // future KMS signer returns the same string for the Ed25519 key,
+      // or whatever JWS alg KMS ends up advertising). Keeps service-side
+      // code agnostic to the JWS algorithm choice.
+      alg: this.signer.alg,
       typ: "JWT",
       // `kid` is read off the signer so the stub path and the future
       // KMS path stamp the same header field without service-side

--- a/src/application/domain/credential/vcIssuance/service.ts
+++ b/src/application/domain/credential/vcIssuance/service.ts
@@ -27,6 +27,16 @@
  * be wired in Phase 1 step 10; the unit tests already verify the JWT
  * shape so the swap is mechanical.
  *
+ * Phase 2 prep (signer interface extraction)
+ * ------------------------------------------
+ * The signature production step has been hoisted behind a `JwtSigner`
+ * interface (`credential/shared/jwtSigner.ts`). This service is now
+ * injected with a `VcJwtSigner` token rather than reaching for the
+ * inline `STUB_SIGNATURE` constant. Behaviour is unchanged in Phase 1
+ * because the bound implementation is `StubJwtSigner` and its output is
+ * exactly `STUB_SIGNATURE`; the indirection only matters once
+ * `KmsJwtSigner` replaces the stub in Phase 2 (design doc §16).
+ *
  * Design references:
  *   docs/report/did-vc-internalization.md §5.2.2 (this service)
  *   docs/report/did-vc-internalization.md §D     (BitstringStatusList)
@@ -44,6 +54,8 @@ import type {
 } from "@/application/domain/credential/vcIssuance/data/type";
 import StatusListService from "@/application/domain/credential/statusList/service";
 import { CIVICSHIP_ISSUER_DID } from "@/application/domain/credential/shared/constants";
+import type { JwtSigner } from "@/application/domain/credential/shared/jwtSigner";
+import { STUB_SIGNATURE } from "@/application/domain/credential/shared/stubJwtSigner";
 import { buildProof } from "@/infrastructure/libs/merkle/merkleTreeBuilder";
 
 /**
@@ -76,16 +88,14 @@ export interface InclusionProof {
 export { CIVICSHIP_ISSUER_DID };
 
 /**
- * Phase 1 step 7 placeholder for the JWT signature. Real signing lives in
- * a sibling PR (`claude/phase1-infra-kms-issuer-did`) — we emit a
- * deterministic non-base64url marker so:
- *
- *   1. Tests can assert "this is a stub VC" without false positives.
- *   2. Verifiers will reject it (it's not a valid base64url signature).
- *   3. The grep target is unique enough to find every stub site once
- *      KMS lands.
+ * Re-export so the public symbol's path stays stable for existing unit
+ * tests (`__tests__/unit/application/domain/credential/vcIssuance/service.test.ts`
+ * imports the marker indirectly via the JWT's signature segment). The
+ * canonical definition now lives in
+ * `credential/shared/stubJwtSigner.ts` alongside the `StubJwtSigner`
+ * implementation that emits it.
  */
-const STUB_SIGNATURE = "stub-not-signed";
+export { STUB_SIGNATURE };
 
 /**
  * Build the unsigned VC payload (§5.2.2 `buildVcPayload`).
@@ -144,6 +154,17 @@ export default class VcIssuanceService {
     private readonly repository: IVcIssuanceRepository,
     @inject("StatusListService")
     private readonly statusListService: StatusListService,
+    /**
+     * Phase 2 prep: signing is delegated to a `JwtSigner` rather than
+     * the inline stub. In Phase 1 the injected instance is a
+     * `StubJwtSigner` that returns `STUB_SIGNATURE`, so the produced
+     * JWT is byte-identical to the pre-extraction version. The DI
+     * token `VcJwtSigner` is intentionally distinct from
+     * `StatusListJwtSigner` so the two paths can rotate independently
+     * once KMS lands (design doc §16).
+     */
+    @inject("VcJwtSigner")
+    private readonly signer: JwtSigner,
   ) {}
 
   /**
@@ -217,16 +238,23 @@ export default class VcIssuanceService {
     });
 
     // 2) Build a JWT-shape envelope. KMS-backed signing lands in
-    //    `claude/phase1-infra-kms-issuer-did`; until then the signature
-    //    segment is a deterministic stub marker (see `STUB_SIGNATURE`).
+    //    Phase 2 (`KmsJwtSigner`); until then the signer is a
+    //    `StubJwtSigner` that returns the deterministic marker
+    //    `STUB_SIGNATURE`. The signing input fed to `signer.sign()` is
+    //    exactly `${header}.${payload}` per the JWS spec so the Phase 2
+    //    swap requires no service-side change.
     const header = base64urlEncodeJson({
       alg: "EdDSA",
       typ: "JWT",
-      // `kid` will reference the active KMS key id once it lands.
-      kid: `${issuerDid}#stub`,
+      // `kid` is read off the signer so the stub path and the future
+      // KMS path stamp the same header field without service-side
+      // branching. Phase 1 stub kid: `${issuerDid}#stub`.
+      kid: this.signer.kid,
     });
     const payload = base64urlEncodeJson(vcPayload);
-    const vcJwt = `${header}.${payload}.${STUB_SIGNATURE}`;
+    const signingInput = `${header}.${payload}`;
+    const signature = await this.signer.sign(signingInput);
+    const vcJwt = `${signingInput}.${signature}`;
 
     logger.debug("[VcIssuanceService] issueVc", {
       userId: input.userId,

--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -171,6 +171,16 @@ import StatusListService from "@/application/domain/credential/statusList/servic
 import StatusListUseCase from "@/application/domain/credential/statusList/usecase";
 import StatusListRepository from "@/application/domain/credential/statusList/data/repository";
 
+// 🪪 JWT signer abstraction (Phase 2 prep — design §16). Both tokens
+//    resolve to `StubJwtSigner` in Phase 1; Phase 2 swaps them to
+//    `KmsJwtSigner` without touching the consuming services.
+import {
+  StubJwtSigner,
+  STUB_SIGNATURE,
+  STUB_SIGNATURE_STATUS,
+} from "@/application/domain/credential/shared/stubJwtSigner";
+import { CIVICSHIP_ISSUER_DID } from "@/application/domain/credential/shared/constants";
+
 export function registerProductionDependencies() {
   // ------------------------------
   // 🏗️ Infrastructure
@@ -292,6 +302,35 @@ export function registerProductionDependencies() {
   container.register("UserDidService", { useClass: UserDidService });
   container.register("UserDidUseCase", { useClass: UserDidUseCase });
   container.register("UserDidResolver", { useClass: UserDidResolver });
+
+  // 🪪 JWT Signer abstraction (Phase 2 prep — design §16).
+  //
+  // `VcJwtSigner` and `StatusListJwtSigner` are two DI tokens that both
+  // resolve to a `StubJwtSigner` instance in Phase 1. Each instance is
+  // configured with a distinct `stubSignature` so the two paths emit
+  // grep-distinguishable stub markers (`stub-not-signed` vs
+  // `stub-status-list-not-signed`) — matching the inline constants in
+  // the pre-extraction services so behaviour and unit tests are
+  // unchanged.
+  //
+  // Phase 2 will rebind one or both tokens to `KmsJwtSigner` (placeholder
+  // in `credential/shared/kmsJwtSigner.ts`) without touching
+  // `VcIssuanceService` / `StatusListService`. Splitting the tokens here
+  // (rather than sharing a single signer) keeps that swap independent
+  // across the two issuance paths — operations may roll one over before
+  // the other.
+  container.register("VcJwtSigner", {
+    useValue: new StubJwtSigner({
+      kid: `${CIVICSHIP_ISSUER_DID}#stub`,
+      stubSignature: STUB_SIGNATURE,
+    }),
+  });
+  container.register("StatusListJwtSigner", {
+    useValue: new StubJwtSigner({
+      kid: `${CIVICSHIP_ISSUER_DID}#stub`,
+      stubSignature: STUB_SIGNATURE_STATUS,
+    }),
+  });
 
   // 🪪 VC Issuance (§5.2 internal DID/VC) — Prisma-backed repository.
   // Distinct from the legacy `VCIssuanceRequest*` registrations above:


### PR DESCRIPTION
## Summary

VC / StatusList JWT 署名を `JwtSigner` interface 越しに統一し、Phase 2 で KMS 署名へ差し替える際の変更面を service 層から DI 層に局所化する preparatory refactor。

設計書 `docs/report/did-vc-internalization.md` §16 に持ち越された以下二項目の **準備工事**:

- "VC JWT の本番署名（現状 stub `STUB_SIGNATURE`）— Phase 2 / PR #1101"
- "StatusList VC JWT の本番署名（現状 stub `STUB_SIGNATURE_STATUS`）— Phase 2 / PR #1102"

実際の KMS 呼び出し実装は **Phase 0-2 PoC 完了後に別 PR** で行う。本 PR では interface と stub 実装、placeholder のみを導入し、service 層から `STUB_SIGNATURE*` 直接参照を排除する。

## 振る舞いの不変性

**JWT 出力は完全に byte-identical**:

- `VcIssuanceService` が生成する VC JWT の第三 segment は引き続き `stub-not-signed`
- `StatusListService` が生成する StatusList VC JWT の第三 segment は引き続き `stub-status-list-not-signed`
- JWT header の `alg` / `typ` / `kid` も従来と同じ (`EdDSA` / `JWT` / `${CIVICSHIP_ISSUER_DID}#stub`)

DI token 経由で `StubJwtSigner` instance が inject される indirection 一段だけが追加されている。

## 変更前後のクラス図

**変更前**:

```
VcIssuanceService ─┐
                   ├─→ inline `const STUB_SIGNATURE = "stub-not-signed"`
                   └─→ inline header.payload.${STUB_SIGNATURE}

StatusListService ─┐
                   ├─→ inline `const STUB_SIGNATURE_STATUS = "..."`
                   └─→ inline header.payload.${STUB_SIGNATURE_STATUS}
```

**変更後**:

```
                      ┌──────────────────────────┐
                      │ <<interface>> JwtSigner  │
                      │   sign(input): string    │
                      │   readonly kid: string   │
                      └────────────▲─────────────┘
                                   │
                ┌──────────────────┼──────────────────┐
                │                                     │
        ┌───────┴────────┐                  ┌─────────┴─────────┐
        │ StubJwtSigner  │                  │  KmsJwtSigner     │
        │ (Phase 1 prod) │                  │  (Phase 2 stub —  │
        │                │                  │   throws today)   │
        └───────▲────────┘                  └───────────────────┘
                │
        ┌───────┴────────────────────────────┐
        │ DI tokens (provider.ts):           │
        │  • "VcJwtSigner"        → Stub     │
        │  • "StatusListJwtSigner" → Stub    │
        └───────────────────▲────────────────┘
                            │
        ┌───────────────────┼────────────────────┐
        │                                        │
┌───────┴─────────────┐               ┌──────────┴──────────────┐
│ VcIssuanceService   │               │ StatusListService       │
│  @inject VcJwtSigner│               │  @inject                │
│                     │               │    StatusListJwtSigner  │
└─────────────────────┘               └─────────────────────────┘
```

## Scope (this PR)

- ✅ `src/application/domain/credential/shared/jwtSigner.ts` — interface 定義
- ✅ `src/application/domain/credential/shared/stubJwtSigner.ts` — Phase 1 stub 実装 + 二つの `STUB_SIGNATURE*` 定数 (canonical location)
- ✅ `src/application/domain/credential/shared/kmsJwtSigner.ts` — Phase 2 placeholder（全 method `throw new Error("not implemented — Phase 0-2 PoC pending")`)
- ✅ `vcIssuance/service.ts` — `@inject("VcJwtSigner")` で signer を受け取り、stub 直書きを排除
- ✅ `statusList/service.ts` — `@inject("StatusListJwtSigner")` で signer を受け取り、`renderJwt` / `signListVc` / `signBootstrapVc` を async 化
- ✅ `application/provider.ts` — `VcJwtSigner` / `StatusListJwtSigner` 二つの DI token を登録
- ✅ Unit tests — `container.reset()` 後に対応する signer token を `useValue` で bind

## Non-scope

- ❌ 実 KMS 呼び出し実装（Phase 0-2 PoC 待ち）
- ❌ `kid` の動的解決（`t_issuer_did_keys` lookup） — Phase 2 で `KmsJwtSigner` body と同じ PR で行う
- ❌ 署名出力値の変更（stub のまま）

## DI Token Split の意図

`VcJwtSigner` と `StatusListJwtSigner` を **別 token** にしている理由:

1. **独立 rotation**: 運用上 VC issuance と StatusList を別 KMS key に紐づけたい / 片方先に rebind したいケースに対応。
2. **異なる `kid` を持てる**: 将来 verifier path の DID Document に複数 `verificationMethod` を載せる際に役立つ。
3. **Phase 2 swap 単位の粒度**: Phase 2 PR #1101 と #1102 が別 PR である以上、token も分けておくのが自然。

Phase 1 では両 token とも同じ `StubJwtSigner` クラスの異なる instance を返す（`stubSignature` のみ異なる）。

## Test plan

- [x] `pnpm test src/__tests__/unit/application/domain/credential/vcIssuance/service.test.ts` — JWT 第三 segment が `"stub-not-signed"` のまま
- [x] `pnpm test src/__tests__/unit/application/domain/credential/statusList/service.test.ts` — JWT 第三 segment が `STUB_SIGNATURE_STATUS` のまま、`revokeVc` で bit が立つ
- [x] `pnpm test src/__tests__/unit/application/domain/credential/vcIssuance/usecase.test.ts` — UseCase 層は service を mock しているので無影響
- [x] Integration test (`__tests__/integration/.../repository.test.ts`) は `registerProductionDependencies()` を呼ぶため、新規 DI token も自動登録される
- [x] `pnpm lint` で型エラーなし（`async renderJwt` / `signListVc` / `signBootstrapVc` の await 漏れチェック）

## Migration path for Phase 2

Phase 0-2 KMS PoC が graduate したら以下二ステップで本番署名に切り替わる:

1. `src/application/domain/credential/shared/kmsJwtSigner.ts` の `sign()` / `kid` body を実装（`IssuerDidService.signWithActiveKey` 経由）
2. `application/provider.ts` で `VcJwtSigner` / `StatusListJwtSigner` の `useValue` を `KmsJwtSigner` instance に差し替え

`VcIssuanceService` / `StatusListService` は **一切変更不要**。

https://claude.ai/code/session_01XzsQPXMVEMPycqQ3sX6pq7

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzsQPXMVEMPycqQ3sX6pq7)_