### PR TITLE
phase2(router): /.well-known/did.json を §G multi-key Document に切替

### DIFF
--- a/src/__tests__/unit/presentation/router/did.test.ts
+++ b/src/__tests__/unit/presentation/router/did.test.ts
@@ -15,6 +15,7 @@
  *                                          → 500 (resolver throws)
  *   - GET /vc/:vcId/inclusion-proof      → 200 (CONFIRMED)
  *                                          → 404 (not_anchored)
+ *                                          → 400 (invalid_vc_id)
  *                                          → 500 (use case throws)
  *
  * The `DidDocumentResolver` and `IssuerDidUseCase` are both stubbed via
@@ -122,7 +123,10 @@ function registerPrismaIssuerStub(): void {
  * Build a §G overlap multi-key Document with one ENABLED key (key-7) and
  * one DISABLED key (key-6). Mirrors the spec §5.4.3 line 1131-1142
  * sample: every key in `verificationMethod`, ENABLED-only refs in
- * `assertionMethod` / `authentication`.
+ * `assertionMethod` / `authentication`, plus the
+ * `CivicshipIssuedCredentials` discovery `service` block (Gemini review
+ * on PR #1124 — must remain present in both single- and multi-key
+ * shapes so verifiers can resolve issued credential types uniformly).
  */
 function buildMultiKeyIssuerDoc(): IssuerMultiKeyDidDocument {
   const did = "did:web:api.civicship.app";
@@ -155,6 +159,15 @@ function buildMultiKeyIssuerDoc(): IssuerMultiKeyDidDocument {
     // advertised as signable per §9.1.2.
     assertionMethod: [`${did}#key-7`],
     authentication: [`${did}#key-7`],
+    service: [
+      {
+        id: `${did}#issued-credentials`,
+        type: "CivicshipIssuedCredentials",
+        serviceEndpoint: {
+          credentialTypes: ["civicship-attendance-credential-2026"],
+        },
+      },
+    ],
   };
 }
 
@@ -186,6 +199,18 @@ describe("router/did (§5.4)", () => {
       ]);
       expect(res.body.authentication).toEqual([
         "did:web:api.civicship.app#key-7",
+      ]);
+      // `service` parity with the single-key Document so verifiers can
+      // discover what credential types this issuer publishes regardless
+      // of which shape they hit (Gemini review on PR #1124).
+      expect(res.body.service).toEqual([
+        {
+          id: "did:web:api.civicship.app#issued-credentials",
+          type: "CivicshipIssuedCredentials",
+          serviceEndpoint: {
+            credentialTypes: ["civicship-attendance-credential-2026"],
+          },
+        },
       ]);
     });
 

--- a/src/__tests__/unit/presentation/router/did.test.ts
+++ b/src/__tests__/unit/presentation/router/did.test.ts
@@ -3,18 +3,19 @@
  *
  * Covers the three endpoints:
  *   - GET /.well-known/did.json
- *       → 200 + full Issuer DID Document when `IssuerDidUseCase` yields one
+ *       → 200 + §G overlap multi-key Document when
+ *         `IssuerDidUseCase.buildDidDocument()` yields one
  *       → 200 + minimal static fallback when the use case yields `null`
  *       → 500 when the use case throws
+ *       → response carries `Content-Type: application/did+json` and
+ *         `Cache-Control: public, max-age=300` per §5.4.1
  *   - GET /users/:userId/did.json        → 200 (CONFIRMED / DEACTIVATE)
  *                                          → 404 (no anchor)
  *                                          → 400 (malformed userId)
  *                                          → 500 (resolver throws)
- *   - GET /vc/:vcId/inclusion-proof      → 501 not_implemented
- *                                          → 400 (empty vcId — guarded by
- *                                            Express's own routing, but we
- *                                            still assert the shape on
- *                                            valid input)
+ *   - GET /vc/:vcId/inclusion-proof      → 200 (CONFIRMED)
+ *                                          → 404 (not_anchored)
+ *                                          → 500 (use case throws)
  *
  * The `DidDocumentResolver` and `IssuerDidUseCase` are both stubbed via
  * `container.register` so the tests never touch Prisma or KMS. Each route
@@ -31,7 +32,7 @@ import { container } from "tsyringe";
 import didRouter from "@/presentation/router/did";
 import type IssuerDidUseCase from "@/application/domain/credential/issuerDid/usecase";
 import type VcIssuanceUseCase from "@/application/domain/credential/vcIssuance/usecase";
-import type { IssuerDidDocument } from "@/infrastructure/libs/did/issuerDidBuilder";
+import type { IssuerMultiKeyDidDocument } from "@/infrastructure/libs/did/issuerDidBuilder";
 import type {
   DidDocumentResolver,
   DidDocumentWithProof,
@@ -92,8 +93,13 @@ function registerResolverMock(buildDidDocument: jest.Mock): void {
   container.register("DidDocumentResolver", { useValue: mock as DidDocumentResolver });
 }
 
-function registerIssuerDidUseCaseMock(getActiveIssuerDidDocument: jest.Mock): void {
-  const mock: Partial<IssuerDidUseCase> = { getActiveIssuerDidDocument };
+/**
+ * Phase 2: the router consumes `buildDidDocument()` (§G overlap multi-key
+ * shape). The legacy `getActiveIssuerDidDocument` is preserved on the use
+ * case for backward compat but the router no longer calls it.
+ */
+function registerIssuerDidUseCaseMock(buildDidDocument: jest.Mock): void {
+  const mock: Partial<IssuerDidUseCase> = { buildDidDocument };
   container.register("IssuerDidUseCase", { useValue: mock as IssuerDidUseCase });
 }
 
@@ -112,27 +118,43 @@ function registerPrismaIssuerStub(): void {
   container.register("PrismaClientIssuer", { useValue: stub });
 }
 
-function buildFullIssuerDoc(): IssuerDidDocument {
+/**
+ * Build a §G overlap multi-key Document with one ENABLED key (key-7) and
+ * one DISABLED key (key-6). Mirrors the spec §5.4.3 line 1131-1142
+ * sample: every key in `verificationMethod`, ENABLED-only refs in
+ * `assertionMethod` / `authentication`.
+ */
+function buildMultiKeyIssuerDoc(): IssuerMultiKeyDidDocument {
+  const did = "did:web:api.civicship.app";
   return {
-    "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/multikey/v1"],
-    id: "did:web:api.civicship.app",
+    "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/jwk/v1"],
+    id: did,
     verificationMethod: [
       {
-        id: "did:web:api.civicship.app#key-1",
-        type: "Multikey",
-        controller: "did:web:api.civicship.app",
-        publicKeyMultibase: "z6MkfullmockedmultibaseTESTONLY",
+        id: `${did}#key-7`,
+        type: "JsonWebKey2020",
+        controller: did,
+        publicKeyJwk: {
+          kty: "OKP",
+          crv: "Ed25519",
+          x: "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo",
+        },
       },
-    ],
-    assertionMethod: ["did:web:api.civicship.app#key-1"],
-    authentication: ["did:web:api.civicship.app#key-1"],
-    service: [
       {
-        id: "did:web:api.civicship.app#issued-credentials",
-        type: "CivicshipIssuedCredentials",
-        serviceEndpoint: { credentialTypes: ["civicship-attendance-credential-2026"] },
+        id: `${did}#key-6`,
+        type: "JsonWebKey2020",
+        controller: did,
+        publicKeyJwk: {
+          kty: "OKP",
+          crv: "Ed25519",
+          x: "VCpo2LydsNZm0e7uLCyfKmYO2GMyfV-Z0nL3-bKBR_w",
+        },
       },
     ],
+    // ENABLED-only — key-6 is the rotating-out tail and MUST NOT be
+    // advertised as signable per §9.1.2.
+    assertionMethod: [`${did}#key-7`],
+    authentication: [`${did}#key-7`],
   };
 }
 
@@ -142,21 +164,47 @@ describe("router/did (§5.4)", () => {
   });
 
   describe("GET /.well-known/did.json", () => {
-    it("returns 200 with the full Issuer DID Document when the use case yields one", async () => {
-      const fullDoc = buildFullIssuerDoc();
-      const getActiveIssuerDidDocument = jest.fn().mockResolvedValue(fullDoc);
-      registerIssuerDidUseCaseMock(getActiveIssuerDidDocument);
+    it("returns 200 with the §G overlap multi-key Document when the use case yields one", async () => {
+      const fullDoc = buildMultiKeyIssuerDoc();
+      const buildDidDocument = jest.fn().mockResolvedValue(fullDoc);
+      registerIssuerDidUseCaseMock(buildDidDocument);
 
       const res = await request(buildApp()).get("/.well-known/did.json");
 
       expect(res.status).toBe(200);
-      expect(getActiveIssuerDidDocument).toHaveBeenCalledTimes(1);
+      expect(buildDidDocument).toHaveBeenCalledTimes(1);
+      // Wire shape: every key in verificationMethod, ENABLED-only in
+      // assertionMethod / authentication (§5.4.3 line 1131-1142).
       expect(res.body).toEqual(fullDoc);
+      expect(res.body.verificationMethod).toHaveLength(2);
+      expect(res.body.verificationMethod[0]).toMatchObject({
+        type: "JsonWebKey2020",
+        publicKeyJwk: { kty: "OKP", crv: "Ed25519" },
+      });
+      expect(res.body.assertionMethod).toEqual([
+        "did:web:api.civicship.app#key-7",
+      ]);
+      expect(res.body.authentication).toEqual([
+        "did:web:api.civicship.app#key-7",
+      ]);
+    });
+
+    it("sets Content-Type application/did+json and Cache-Control max-age=300 per §5.4.1", async () => {
+      const buildDidDocument = jest.fn().mockResolvedValue(buildMultiKeyIssuerDoc());
+      registerIssuerDidUseCaseMock(buildDidDocument);
+
+      const res = await request(buildApp()).get("/.well-known/did.json");
+
+      expect(res.status).toBe(200);
+      // Express normalises charset onto the Content-Type — match by
+      // prefix so the assertion stays robust if Express ever appends one.
+      expect(res.headers["content-type"]).toMatch(/^application\/did\+json/);
+      expect(res.headers["cache-control"]).toBe("public, max-age=300");
     });
 
     it("falls back to the minimal static Document when the use case yields null", async () => {
-      const getActiveIssuerDidDocument = jest.fn().mockResolvedValue(null);
-      registerIssuerDidUseCaseMock(getActiveIssuerDidDocument);
+      const buildDidDocument = jest.fn().mockResolvedValue(null);
+      registerIssuerDidUseCaseMock(buildDidDocument);
 
       const res = await request(buildApp()).get("/.well-known/did.json");
 
@@ -165,13 +213,16 @@ describe("router/did (§5.4)", () => {
         "@context": ["https://www.w3.org/ns/did/v1"],
         id: "did:web:api.civicship.app",
       });
+      // Headers still applied on the bootstrap fallback.
+      expect(res.headers["content-type"]).toMatch(/^application\/did\+json/);
+      expect(res.headers["cache-control"]).toBe("public, max-age=300");
     });
 
     it("returns 500 when the use case throws (genuine misconfiguration, no silent fallback)", async () => {
-      const getActiveIssuerDidDocument = jest
+      const buildDidDocument = jest
         .fn()
         .mockRejectedValue(new Error("KMS PERMISSION_DENIED"));
-      registerIssuerDidUseCaseMock(getActiveIssuerDidDocument);
+      registerIssuerDidUseCaseMock(buildDidDocument);
 
       const res = await request(buildApp()).get("/.well-known/did.json");
 

--- a/src/application/domain/credential/issuerDid/presenter.ts
+++ b/src/application/domain/credential/issuerDid/presenter.ts
@@ -2,9 +2,10 @@
  * `IssuerDidPresenter` — pure transform from internal types to the wire
  * shape served at `/.well-known/did.json`.
  *
- * Today the wire shape *is* the internal type (`IssuerDidDocument` is
- * already the W3C JSON-LD form built by `IssuerDidBuilder`). The presenter
- * therefore looks like an identity function — but it exists so that:
+ * Today the wire shape *is* the internal type (`IssuerDidDocument` /
+ * `IssuerMultiKeyDidDocument` are already the W3C JSON-LD forms built by
+ * `IssuerDidBuilder`). The presenter therefore looks like an identity
+ * function — but it exists so that:
  *
  *   1. The architectural pattern (UseCase always invokes a presenter
  *      before returning) holds uniformly across domains.
@@ -14,12 +15,21 @@
  *   3. Tests can import the presenter alone to assert the wire contract
  *      without the service / KMS layers.
  *
+ * Phase 2 (PR #1124) adds `toMultiKeyDocumentResponse` for the §G
+ * overlap-window shape (spec §5.4.3 line 1131-1142). Same identity-pass
+ * rationale — the multi-key Document is already in wire form when the
+ * service hands it over.
+ *
  * Design references:
  *   docs/report/did-vc-internalization.md §5.1.2 (DID Document shape)
+ *   docs/report/did-vc-internalization.md §5.4.3 (multi-key shape)
  *   CLAUDE.md "Layer Responsibilities" (Presenter — pure functions only)
  */
 
-import type { IssuerDidDocument } from "@/infrastructure/libs/did/issuerDidBuilder";
+import type {
+  IssuerDidDocument,
+  IssuerMultiKeyDidDocument,
+} from "@/infrastructure/libs/did/issuerDidBuilder";
 
 const IssuerDidPresenter = {
   /**
@@ -46,6 +56,22 @@ const IssuerDidPresenter = {
    * object per request rather than retroactively freezing.
    */
   toDocumentResponse(document: IssuerDidDocument): IssuerDidDocument {
+    return document;
+  },
+
+  /**
+   * Identity transform for the §G overlap multi-key shape. Same
+   * read-only / no-clone discipline as `toDocumentResponse`.
+   *
+   * Distinct method (rather than overloading `toDocumentResponse`) so
+   * that future per-shape adjustments (e.g. omitting the rotating-out
+   * `verificationMethod` from a future admin-only audit endpoint) have
+   * a dedicated injection point and TypeScript can statically guarantee
+   * the wire shape at the call site.
+   */
+  toMultiKeyDocumentResponse(
+    document: IssuerMultiKeyDidDocument,
+  ): IssuerMultiKeyDidDocument {
     return document;
   },
 };

--- a/src/application/domain/credential/issuerDid/usecase.ts
+++ b/src/application/domain/credential/issuerDid/usecase.ts
@@ -1,22 +1,31 @@
 /**
  * `IssuerDidUseCase` — orchestration entry point for the Issuer DID flows.
  *
- * Phase 1 step 8 ships exactly one flow: serving the
- * `/.well-known/did.json` body. The route handler (`presentation/router/did.ts`)
- * historically reached straight into `IssuerDidService`, which works but
- * places presentation-layer code one architectural step too close to the
- * service. The use case wraps the service so that:
+ * Phase 1 step 8 shipped exactly one flow: serving the
+ * `/.well-known/did.json` body via `getActiveIssuerDidDocument()`
+ * (single-key Multikey shape). The route handler
+ * (`presentation/router/did.ts`) historically reached straight into
+ * `IssuerDidService`, which works but places presentation-layer code one
+ * architectural step too close to the service. The use case wraps the
+ * service so that:
  *
  *   - future GraphQL admin queries (e.g. `issuerDidDocument` in the admin
  *     panel) can reuse exactly the same orchestration layer;
  *   - the presenter (below) is invoked uniformly regardless of caller.
  *
- * The use case does NOT manage transactions — `findActiveKey()` is a
- * single read with no community scope, so opening a transaction would add
- * latency without correctness benefit.
+ * Phase 2 (PR #1124) adds `buildDidDocument()` — the §G overlap multi-key
+ * shape per spec §5.4.3 line 1131-1142. The router now consumes this
+ * method; the legacy `getActiveIssuerDidDocument()` is preserved for
+ * backward compatibility (admin GraphQL Phase 1 contract, ad-hoc tooling).
+ *
+ * The use case does NOT manage transactions — `findActiveKey()` /
+ * `listActiveKeys()` are single reads with no community scope, so opening
+ * a transaction would add latency without correctness benefit.
  *
  * Design references:
+ *   docs/report/did-vc-internalization.md §5.4.1 (router contract)
  *   docs/report/did-vc-internalization.md §5.4.3 (IssuerDidService)
+ *   docs/report/did-vc-internalization.md §9.1.2 (24h overlap rotation)
  *   CLAUDE.md "Layer Responsibilities" (UseCase ↔ Service ↔ Repository)
  */
 
@@ -24,7 +33,10 @@ import { inject, injectable } from "tsyringe";
 
 import IssuerDidService from "@/application/domain/credential/issuerDid/service";
 import IssuerDidPresenter from "@/application/domain/credential/issuerDid/presenter";
-import type { IssuerDidDocument } from "@/infrastructure/libs/did/issuerDidBuilder";
+import type {
+  IssuerDidDocument,
+  IssuerMultiKeyDidDocument,
+} from "@/infrastructure/libs/did/issuerDidBuilder";
 
 @injectable()
 export default class IssuerDidUseCase {
@@ -34,12 +46,18 @@ export default class IssuerDidUseCase {
   ) {}
 
   /**
-   * Resolve the JSON body for `/.well-known/did.json`.
+   * Resolve the **single-key** JSON body for `/.well-known/did.json`
+   * (Phase 1 Multikey shape).
    *
    * Returns `null` (not a payload) when no active key is registered, to
    * preserve the router's "fall back to minimal static stub" path. The
    * presenter is invoked only on the happy path so callers cannot
    * accidentally bypass it.
+   *
+   * **Backward compatibility**: kept after Phase 2's router migration to
+   * `buildDidDocument()` so admin GraphQL / ad-hoc tooling that depends
+   * on the single-key shape keeps compiling. Do NOT call this from new
+   * router code — use `buildDidDocument()` for the §G overlap shape.
    */
   async getActiveIssuerDidDocument(): Promise<IssuerDidDocument | null> {
     const document = await this.service.getActiveIssuerDidDocument();
@@ -47,5 +65,26 @@ export default class IssuerDidUseCase {
       return null;
     }
     return IssuerDidPresenter.toDocumentResponse(document);
+  }
+
+  /**
+   * Resolve the §G overlap **multi-key** JSON body for
+   * `/.well-known/did.json` (Phase 2 / spec §5.4.3 line 1131-1142).
+   *
+   * Returns `null` when no keys are registered; the router falls back to
+   * the same minimal static Document as the single-key path so dev /
+   * staging UX is preserved during bootstrap.
+   *
+   * Wire shape: `JsonWebKey2020` + `publicKeyJwk` for every key in the
+   * §G overlap window (ENABLED + DISABLED). `assertionMethod` /
+   * `authentication` reference ENABLED keys only — DISABLED rows are
+   * verification-only tails kept for past-VC verification (§9.1.3).
+   */
+  async buildDidDocument(): Promise<IssuerMultiKeyDidDocument | null> {
+    const document = await this.service.buildDidDocument();
+    if (document === null) {
+      return null;
+    }
+    return IssuerDidPresenter.toMultiKeyDocumentResponse(document);
   }
 }

--- a/src/infrastructure/libs/did/issuerDidBuilder.ts
+++ b/src/infrastructure/libs/did/issuerDidBuilder.ts
@@ -110,6 +110,13 @@ export interface IssuerJwkVerificationMethod {
  * key during the 24-hour overlap. `assertionMethod` / `authentication`
  * reference only currently-signable (ENABLED) keys.
  *
+ * `service` carries the same `CivicshipIssuedCredentials` block as the
+ * single-key shape (`IssuerDidDocument`) so verifiers using the
+ * multi-key Document can still discover what credential types this
+ * issuer publishes — dropping the field would force them to keep a
+ * fallback path against the legacy Multikey response. (Gemini review on
+ * PR #1124.)
+ *
  * Design references:
  *   docs/report/did-vc-internalization.md §5.4.3 (line 1131-1142)
  *   docs/report/did-vc-internalization.md §9.1.2 (rotation overlap)
@@ -122,6 +129,7 @@ export interface IssuerMultiKeyDidDocument {
   verificationMethod: readonly IssuerJwkVerificationMethod[];
   assertionMethod: readonly string[];
   authentication: readonly string[];
+  service: readonly IssuerService[];
 }
 
 /**
@@ -157,11 +165,17 @@ export interface IssuerActiveKey {
  *       { id: "...#key-6", type: "JsonWebKey2020", controller: "...", publicKeyJwk: { ... } }
  *     ],
  *     "assertionMethod": ["...#key-7"],   // ENABLED only
- *     "authentication":  ["...#key-7"]    // ENABLED only
+ *     "authentication":  ["...#key-7"],   // ENABLED only
+ *     "service": [{ id: "...#issued-credentials", type: "CivicshipIssuedCredentials", ... }]
  *   }
  *
  * Ordering is preserved from the input — callers (`IssuerDidService`) sort
  * by `activatedAt ASC` so the wire output is stable across re-renders.
+ *
+ * `service` mirrors `buildIssuerDidDocument` so verifiers see an
+ * identical `CivicshipIssuedCredentials` discovery block regardless of
+ * whether they hit the legacy single-key shape or the §G overlap
+ * multi-key shape.
  *
  * Throws when `activeKeys` is empty: every caller of this builder already
  * checks `listActiveKeys()` length and falls back to the minimal static
@@ -201,6 +215,18 @@ export function buildMultiKeyIssuerDidDocument(
     verificationMethod,
     assertionMethod: enabledRefs,
     authentication: enabledRefs,
+    // Keep parity with the single-key Document so verifiers always see
+    // the same `CivicshipIssuedCredentials` discovery block regardless
+    // of which shape they hit (§5.4.3, Gemini review on PR #1124).
+    service: [
+      {
+        id: `${did}#issued-credentials`,
+        type: "CivicshipIssuedCredentials",
+        serviceEndpoint: {
+          credentialTypes: [CIVICSHIP_ATTENDANCE_VC_TYPE],
+        },
+      },
+    ],
   };
 }
 

--- a/src/presentation/router/did.ts
+++ b/src/presentation/router/did.ts
@@ -4,12 +4,25 @@
  * Exposes three endpoints:
  *
  *   GET /.well-known/did.json
- *     Returns the civicship.app Issuer DID Document. Phase 1 step 8
- *     wires this through `IssuerDidUseCase` so the response carries the
- *     active KMS-backed `verificationMethod` whenever a key has been
- *     activated. Until then the use case returns `null` and we fall back
- *     to the minimal static `{ "@context", id }` body — preserving the
- *     dev/staging UX that existed before the use case landed.
+ *     Returns the civicship.app Issuer DID Document.
+ *
+ *     Phase 1 (PR #1100) wired this through
+ *     `IssuerDidUseCase.getActiveIssuerDidDocument()` — single-key
+ *     Multikey shape. Phase 2 (PR #1124) migrates to
+ *     `IssuerDidUseCase.buildDidDocument()` — the §G overlap multi-key
+ *     shape per spec §5.4.3 line 1131-1142, so verifiers can validate
+ *     VCs signed by either the new or the rotating-out key during the
+ *     24-hour overlap window (§9.1.2).
+ *
+ *     Bootstrap fallback: when the use case yields `null` (no keys
+ *     registered yet) we serve the minimal static `{ "@context", id }`
+ *     body with the same 200 status so dev/staging environments remain
+ *     operable before the first key is provisioned.
+ *
+ *     Wire headers per §5.4.1:
+ *       - `Content-Type: application/did+json`
+ *       - `Cache-Control: public, max-age=300` (5 min — bounded so a
+ *         §G rotation propagates within at most one TTL window)
  *
  *   GET /users/:userId/did.json
  *     Returns the User DID Document for `userId`. Delegates to
@@ -33,8 +46,10 @@
  *
  * Design references:
  *   docs/report/did-vc-internalization.md §5.4   (public routes)
+ *   docs/report/did-vc-internalization.md §5.4.1 (router contract / headers)
  *   docs/report/did-vc-internalization.md §5.4.3 (IssuerDidService)
  *   docs/report/did-vc-internalization.md §5.4.4 (UserDidDocumentService)
+ *   docs/report/did-vc-internalization.md §9.1.2 (24h overlap rotation)
  *   docs/report/did-vc-internalization.md §B / §E / §F
  */
 
@@ -64,11 +79,11 @@ const router = express.Router();
 /**
  * Minimal static fallback Document.
  *
- * Served when `IssuerDidUseCase.getActiveIssuerDidDocument()` returns
- * `null` — i.e. no active KMS key is registered yet (bootstrap state on
- * dev/staging). The shape is the smallest body every DID-aware verifier
- * accepts (`@context` + `id`); the absence of `verificationMethod` is
- * intentional and matches the spec's "no proofs yet" mode.
+ * Served when `IssuerDidUseCase.buildDidDocument()` returns `null` —
+ * i.e. no KMS keys are registered yet (bootstrap state on dev/staging).
+ * The shape is the smallest body every DID-aware verifier accepts
+ * (`@context` + `id`); the absence of `verificationMethod` is intentional
+ * and matches the spec's "no proofs yet" mode.
  *
  * Adding fields later is backward-compatible. Switching to the use case
  * happens automatically as soon as the first key is activated.
@@ -78,16 +93,39 @@ const STATIC_FALLBACK_DOCUMENT = Object.freeze({
   id: "did:web:api.civicship.app",
 });
 
+/**
+ * Wire-format constants for `/.well-known/did.json` per §5.4.1.
+ *
+ *   - `application/did+json` is the W3C-spec Content-Type for DID
+ *     Documents (DID Core §7.1.2). Verifier libraries branch on this to
+ *     pick the JSON parser path vs JSON-LD; pinning it here keeps us
+ *     conformant regardless of Express's content-negotiation defaults.
+ *   - `public, max-age=300` (5 min) is the bound called out in §5.4.1.
+ *     Rationale: a §G rotation propagates to verifiers within at most
+ *     one TTL window, while the cache is long enough that hot-path
+ *     `/.well-known/did.json` traffic rarely re-hits KMS via the
+ *     service-layer TTL cache (also 1h). 5 min is the shorter of the
+ *     two and therefore the binding constraint on rotation latency.
+ */
+const ISSUER_DID_CONTENT_TYPE = "application/did+json";
+const ISSUER_DID_CACHE_CONTROL = "public, max-age=300";
+
 router.get("/.well-known/did.json", async (_req: Request, res: Response) => {
   try {
     const useCase = container.resolve<IssuerDidUseCase>("IssuerDidUseCase");
-    const document = await useCase.getActiveIssuerDidDocument();
+    // Phase 2: §G overlap multi-key shape (spec §5.4.3 line 1131-1142).
+    // The legacy `getActiveIssuerDidDocument()` is preserved on the use
+    // case for backward compat but is NOT called from this router.
+    const document = await useCase.buildDidDocument();
+
+    res.set("Content-Type", ISSUER_DID_CONTENT_TYPE);
+    res.set("Cache-Control", ISSUER_DID_CACHE_CONTROL);
 
     if (document === null) {
       // Bootstrap fallback — see `STATIC_FALLBACK_DOCUMENT` rationale.
       // Logged at debug level only; this is the expected steady state on
       // a freshly-deployed environment until the first key is provisioned.
-      logger.debug("[router/did] no active issuer key — serving static fallback");
+      logger.debug("[router/did] no issuer keys — serving static fallback");
       return res.status(200).json(STATIC_FALLBACK_DOCUMENT);
     }
 


### PR DESCRIPTION
## Summary

PR #1120 で追加された `IssuerDidService.buildDidDocument()` (§G overlap multi-key, JsonWebKey2020 形式) を `/.well-known/did.json` ルーターに wiring。Phase 1 の単一鍵 Multikey shape から、§9.1.2 の 24h overlap rotation 戦略をサポートする multi-key shape へ切替。

### Changes

- **`src/presentation/router/did.ts`** — handler を `IssuerDidUseCase.buildDidDocument()` 経由に切替。spec §5.4.1 line 1054-1055 に従い `Content-Type: application/did+json` と `Cache-Control: public, max-age=300` を設定。bootstrap fallback (use case が `null`) 時は最小静的 Document を 200 で返す既存挙動を維持。
- **`src/application/domain/credential/issuerDid/usecase.ts`** — `buildDidDocument()` を追加し、presenter 経由で multi-key Document を返却。既存 `getActiveIssuerDidDocument()` は backward compat 用に残置（コメントで非推奨方針を明記）。
- **`src/application/domain/credential/issuerDid/presenter.ts`** — `toMultiKeyDocumentResponse()` を追加（identity transform、既存 `toDocumentResponse` と同じ immutability 契約）。
- **`src/__tests__/unit/presentation/router/did.test.ts`** — `/.well-known/did.json` の test を `buildDidDocument` mock + multi-key Document (1 ENABLED + 1 DISABLED) + header assertion で更新。

### Wire shape (§5.4.3 line 1131-1142 準拠)

```jsonc
{
  "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/jwk/v1"],
  "id": "did:web:api.civicship.app",
  "verificationMethod": [
    { "id": "...#key-7", "type": "JsonWebKey2020", "controller": "...", "publicKeyJwk": { "kty": "OKP", "crv": "Ed25519", "x": "..." } },
    { "id": "...#key-6", "type": "JsonWebKey2020", "controller": "...", "publicKeyJwk": { ... } }
  ],
  "assertionMethod": ["...#key-7"],   // ENABLED only
  "authentication":  ["...#key-7"]    // ENABLED only
}
```

### Design references

- `docs/report/did-vc-internalization.md` §5.4.1 (router contract / headers)
- `docs/report/did-vc-internalization.md` §5.4.3 line 1131-1142 (multi-key DID Document shape)
- `docs/report/did-vc-internalization.md` §9.1.2 (24h overlap key rotation strategy)
- `docs/report/did-vc-internalization.md` §9.1.3 (旧鍵永続保持)

### Non-scope

- `getActiveIssuerDidDocument()` の削除（backward compat 維持のため残置）
- KMS 実 wiring (Phase 2 の別 PR)
- User DID router (`/users/:userId/did.json`)、`/vc/:vcId/inclusion-proof` は触らない

## Test plan

- [ ] `pnpm test src/__tests__/unit/presentation/router/did.test.ts` がグリーンであることを確認
- [ ] 新規 `multi-key Document` test が ENABLED / DISABLED の両 verificationMethod を返し、`assertionMethod` / `authentication` が ENABLED のみを参照することを確認
- [ ] Header test が `Content-Type: application/did+json` + `Cache-Control: public, max-age=300` を assert することを確認
- [ ] bootstrap fallback test が `null` 時に最小静的 Document を 200 で返し、headers も付与されることを確認
- [ ] 500 path (use case throw) に変更がないことを確認
- [ ] 既存の User DID / inclusion-proof test に影響がないことを確認
- [ ] `pnpm lint` がグリーンであることを確認

https://claude.ai/code/session_01XzsQPXMVEMPycqQ3sX6pq7

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzsQPXMVEMPycqQ3sX6pq7)_