### PR TITLE
feat(gdpr): §9.7 削除フロー scaffold (Phase 4+ 実装の interface)

### DIFF
--- a/src/application/domain/gdpr/__tests__/service.test.ts
+++ b/src/application/domain/gdpr/__tests__/service.test.ts
@@ -1,0 +1,39 @@
+/**
+ * GdprDeletionService scaffold の interface 互換性検証。
+ *
+ * 本テストは Phase 4+ 実装まで「not implemented を投げる」ことを保証し、
+ * 誤って空実装が production に混入しないことを確認する。
+ *
+ * 設計参照: docs/report/did-vc-internalization.md §9.7
+ */
+
+import "reflect-metadata";
+import { container } from "tsyringe";
+import { GdprDeletionService } from "@/application/domain/gdpr/service";
+import type { IContext } from "@/types/server";
+
+describe("GdprDeletionService (§9.7 scaffold)", () => {
+  beforeEach(() => {
+    container.reset();
+    container.register("GdprDeletionService", { useClass: GdprDeletionService });
+  });
+
+  it("deleteUserData throws 'not implemented' until Phase 4+ implementation lands", async () => {
+    const service = container.resolve(GdprDeletionService);
+    const ctx = {} as IContext;
+
+    await expect(service.deleteUserData(ctx, "user_dummy")).rejects.toThrow(
+      /not implemented — §9.7 Phase 4\+ task/,
+    );
+  });
+
+  it("deleteUserData accepts optional reason parameter (interface contract)", async () => {
+    const service = container.resolve(GdprDeletionService);
+    const ctx = {} as IContext;
+
+    // reason を渡しても interface 上は受け付けることを確認 (throw は Phase 4+ で実装)
+    await expect(
+      service.deleteUserData(ctx, "user_dummy", { reason: "gdpr_art17" }),
+    ).rejects.toThrow(/not implemented/);
+  });
+});

--- a/src/application/domain/gdpr/data/interface.ts
+++ b/src/application/domain/gdpr/data/interface.ts
@@ -1,0 +1,35 @@
+/**
+ * GDPR (§9.7) 削除フローの service interface。
+ *
+ * 詳細な設計背景は `src/application/domain/gdpr/service.ts` 先頭の
+ * doc コメントと `docs/report/did-vc-internalization.md` §9.7 を参照。
+ *
+ * 本 interface は Phase 4+ 実装のための scaffold。
+ */
+
+import { IContext } from "@/types/server";
+import type {
+  GdprDeletionOptions,
+  GdprDeletionResult,
+} from "@/application/domain/gdpr/data/type";
+
+export interface IGdprDeletionService {
+  /**
+   * §9.7: 指定ユーザーの全個人データを DB から削除する。
+   *
+   * - chain 上の anchor (UserDidAnchor.chainTxHash / VcAnchor.rootHash)
+   *   は不可逆のため削除不能。orphan 化される。
+   * - DB 上の DID Document / VC payload が削除されることで、verifier
+   *   からの DID resolve は 404 となり、実質削除と同等となる。
+   * - 削除対象 entity 一覧と削除順序は service.ts 先頭コメント参照。
+   *
+   * Phase 4+ 実装。本 interface は scaffold。
+   *
+   * @throws Error 現状は `not implemented — §9.7 Phase 4+ task` を投げる。
+   */
+  deleteUserData(
+    ctx: IContext,
+    userId: string,
+    options?: GdprDeletionOptions,
+  ): Promise<GdprDeletionResult>;
+}

--- a/src/application/domain/gdpr/data/type.ts
+++ b/src/application/domain/gdpr/data/type.ts
@@ -1,0 +1,66 @@
+/**
+ * GDPR (§9.7) 削除フロー関連の型定義。
+ *
+ * Phase 4+ 実装のための scaffold。詳細は
+ * `src/application/domain/gdpr/service.ts` 先頭コメント、および
+ * `docs/report/did-vc-internalization.md` §9.7 を参照。
+ */
+
+/**
+ * §9.7: ユーザー個人データ削除のリクエストオプション。
+ */
+export type GdprDeletionOptions = {
+  /**
+   * 削除理由（監査ログ用）。例: "user_request", "gdpr_art17",
+   * "admin_initiated"。
+   *
+   * Phase 4+ で監査ログテーブル (t_gdpr_deletion_audit) に記録する。
+   */
+  reason?: string;
+};
+
+/**
+ * §9.7: 削除実行結果。
+ *
+ * 「DB 上で削除した行数」と「chain 上に orphan として残る anchor 数」を
+ * 分けて返すことで、verifier 側ドキュメント / 監査担当に
+ * 「DB 削除は完了したが chain anchor は残存している（hash のみ）」
+ * という事実を明示する。
+ */
+export type GdprDeletionResult = {
+  /** 削除対象となった userId。 */
+  userId: string;
+  /**
+   * DB 上で削除（または匿名化）された entity 数。
+   *
+   * Phase 4+ の実装対象テーブル（暫定リスト）:
+   *   - User (PII カラムを匿名化、行自体は保持 → deletedAt セット)
+   *   - Identity / Membership / Wallet (PII 関連)
+   *   - DidIssuanceRequest (subjectDid を含む)
+   *   - VcIssuanceRequest (subject DID / payload)
+   *   - UserDidAnchor (DB 行を物理削除、chain hash は orphan 化)
+   *   - その他 PII を含む派生 entity
+   *
+   * 詳細は §9.7 の「削除対象 entity リスト」を参照。
+   */
+  deletedEntityCount: number;
+  /**
+   * chain 上に orphan として残存する anchor 数。
+   *
+   * Cardano on-chain anchor は不可逆のため削除不能。
+   * 該当する DB 側の DID Document / VC payload が削除されることで、
+   * verifier 視点では DID resolve が `404 Not Found` となり、
+   * 実質削除と同等の効果を得る。
+   *
+   * 内訳:
+   *   - UserDidAnchor.chainTxHash
+   *   - VcAnchor.rootHash
+   */
+  orphanedChainAnchorCount: number;
+  /** 削除実行時刻 (ISO8601)。 */
+  executedAt: Date;
+  /**
+   * リクエストに付与された削除理由（監査用）。
+   */
+  reason?: string;
+};

--- a/src/application/domain/gdpr/service.ts
+++ b/src/application/domain/gdpr/service.ts
@@ -1,0 +1,132 @@
+/**
+ * =============================================================================
+ * GdprDeletionService — §9.7 GDPR / 個人情報削除と chain 整合性
+ * =============================================================================
+ *
+ * 本ファイルは Phase 4+ 実装のための **scaffold** である。実 deletion ロジック
+ * は本 PR には含まれない。すべての public method は
+ *   `throw new Error("not implemented — §9.7 Phase 4+ task")`
+ * のみを行う。実装は別 PR (Phase 4+) で行う。
+ *
+ * -----------------------------------------------------------------------------
+ * 設計参照
+ * -----------------------------------------------------------------------------
+ *   docs/report/did-vc-internalization.md §9.7 (line 1788-1876)
+ *     "GDPR / 個人情報削除と chain 整合性 (§N 対応)"
+ *
+ * -----------------------------------------------------------------------------
+ * 設計要点
+ * -----------------------------------------------------------------------------
+ *
+ *   1. **chain 上の anchor は削除不能**
+ *      Cardano on-chain anchor (UserDidAnchor.chainTxHash /
+ *      VcAnchor.rootHash) は不可逆性こそが anchor の価値。GDPR Art. 17
+ *      「忘れられる権利」のために on-chain データを書き換えることはできない。
+ *      → **そもそも chain 上には PII を直接書き込まない設計** とすることで、
+ *        この問題を回避する。chain に乗るのは hash と cuid 形式の DID 文字列
+ *        のみで、復元不能・PII 該当回避。
+ *
+ *   2. **削除は DB の personal data に対してのみ実施**
+ *      DB 上の以下を削除（または匿名化）する:
+ *        - User: PII カラム (email, name, phone) を匿名化、deletedAt をセット
+ *        - Identity / Membership / Wallet: PII 含む列を NULL/匿名化
+ *        - DidIssuanceRequest: subject DID 紐付けを削除
+ *        - VcIssuanceRequest: VC JWT payload (subject claim を含む) を削除
+ *        - UserDidAnchor: DB 行は物理削除（chain hash は orphan 化）
+ *      ただし監査ログ保管期間 (§9.7 では 90 日例) は論理削除のみ。
+ *
+ *   3. **verifier 視点で実質削除と同等**
+ *      DB 側の DID Document が消える → did:web:api.civicship.app:users:u_xyz
+ *      の resolve が `404 Not Found` を返す → verifier は VC を検証不能
+ *      → 実質、DID/VC ともに削除されたのと同じ効果。
+ *      chain anchor は orphan として残るが、対応する DID Document が存在
+ *      しない限り意味を持たない。
+ *
+ *   4. **削除フローは 2 段階 (cf. §9.7 ユーザー削除時のフロー)**
+ *      a. 論理削除フェーズ: VC 一括 revoke → DID DEACTIVATE op 発行
+ *         → User.deletedAt セット → PII カラム匿名化
+ *      b. 物理削除フェーズ (X 日経過後): VcIssuanceRequest →
+ *         UserDidAnchor → User の順に物理削除
+ *      この 2 段階を本 service の `deleteUserData` で吸収するか、
+ *      `deactivateUser(=論理)` と `purgeUserData(=物理)` に分けるかは
+ *      Phase 4+ の実装時に決定する。
+ *
+ *   5. **DID DEACTIVATE と VC revocation は不可分**
+ *      §4 cascade ロジックに従い、DID 失効 ＋ VC 取り消しは 1 つの
+ *      transaction として扱う。実装漏れ防止のため usecase.ts に集約する
+ *      (本 PR では usecase 層もまだ存在しない)。
+ *
+ * -----------------------------------------------------------------------------
+ * 削除対象 entity リスト (Phase 4+ 実装時に確定)
+ * -----------------------------------------------------------------------------
+ *
+ *   PII を含む / DID-VC chain と連動する主な entity:
+ *     - User (匿名化)
+ *     - Identity
+ *     - Membership
+ *     - Wallet
+ *     - DidIssuanceRequest
+ *     - VcIssuanceRequest
+ *     - UserDidAnchor       ← DB 削除、chainTxHash は orphan 化
+ *     - VcAnchor / VcIssuance ← rootHash は orphan 化
+ *     - その他 PII を含む派生 entity (notification 履歴等)
+ *
+ *   詳細削除順序は FK 制約に従い Phase 4+ の DB migration PR で決定。
+ *
+ * -----------------------------------------------------------------------------
+ * 検証者 (verifier) 向け補足ドキュメント
+ * -----------------------------------------------------------------------------
+ *
+ *   Phase 4+ で `docs/handbook/VERIFIER.md` (仮) に以下を記載する:
+ *     - 削除済みユーザーの DID は 404 を返す
+ *     - chain 上の anchor は残存するが対応 Document 不在で resolve 不能
+ *     - VC は revoke 済み (StatusList のビット立て) でも検証可能だが、
+ *       subject DID resolve 不能のため実質的に検証失敗扱い
+ *
+ * -----------------------------------------------------------------------------
+ * Open question (Q12)
+ * -----------------------------------------------------------------------------
+ *
+ *   §9.7 末尾 / 設計レビュー Q12: "EU ユーザー対応時の GDPR 削除フロー実装"
+ *   は本 scaffold の範囲外。Phase 4+ で本 service の実装と並行して
+ *   admin UI / GraphQL mutation / 監査ログテーブルを追加する。
+ *
+ * =============================================================================
+ */
+
+import { injectable } from "tsyringe";
+import { IContext } from "@/types/server";
+import type { IGdprDeletionService } from "@/application/domain/gdpr/data/interface";
+import type {
+  GdprDeletionOptions,
+  GdprDeletionResult,
+} from "@/application/domain/gdpr/data/type";
+
+@injectable()
+export class GdprDeletionService implements IGdprDeletionService {
+  /**
+   * §9.7: ユーザー個人データ削除のエントリポイント。
+   *
+   * 本実装は Phase 4+ で行う。本 scaffold は interface 互換性の確保と
+   * DI 配線テストのために存在する。
+   */
+  async deleteUserData(
+    _ctx: IContext,
+    _userId: string,
+    _options?: GdprDeletionOptions,
+  ): Promise<GdprDeletionResult> {
+    // TODO(§9.7 Phase 4+):
+    //   1. VC 一括 revoke (StatusList ビット立て)
+    //   2. DID DEACTIVATE op 発行 (UserDidAnchor)
+    //   3. User.deletedAt セット + PII カラム匿名化 (論理削除フェーズ)
+    //   4. 監査ログ記録 (t_gdpr_deletion_audit)
+    //   5. X 日後 (例: 90 日) のバッチで物理削除
+    //      (VcIssuanceRequest → UserDidAnchor → User の順)
+    //   6. orphan 化された chain anchor の集計を返す
+    //
+    // 実装漏れ防止のため throw する。
+    throw new Error("not implemented — §9.7 Phase 4+ task");
+  }
+}
+
+export default GdprDeletionService;

--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -181,6 +181,11 @@ import {
 } from "@/application/domain/credential/shared/stubJwtSigner";
 import { CIVICSHIP_ISSUER_DID } from "@/application/domain/credential/shared/constants";
 
+// 🗑️ GDPR (§9.7 — 個人情報削除と chain 整合性) — Phase 4+ 実装の scaffold。
+//    interface のみ提供し、実 deletion ロジックは Phase 4+ の別 PR で実装。
+//    詳細は src/application/domain/gdpr/service.ts 先頭コメントを参照。
+import { GdprDeletionService } from "@/application/domain/gdpr/service";
+
 export function registerProductionDependencies() {
   // ------------------------------
   // 🏗️ Infrastructure
@@ -364,6 +369,22 @@ export function registerProductionDependencies() {
   container.register("StatusListRepository", { useClass: StatusListRepository });
   container.register("StatusListService", { useClass: StatusListService });
   container.register("StatusListUseCase", { useClass: StatusListUseCase });
+
+  // ------------------------------
+  // 🗑️ GDPR (§9.7 — 個人情報削除と chain 整合性)
+  // ------------------------------
+  //
+  // Phase 4+ 実装の scaffold。`GdprDeletionService.deleteUserData` は
+  // 現状 `not implemented — §9.7 Phase 4+ task` を throw する。Phase 4+
+  // で本実装を別 PR として追加する際、本 DI 登録はそのまま再利用される。
+  //
+  // singleton 登録の理由: Phase 4+ 実装で監査ログテーブル
+  // (t_gdpr_deletion_audit) を保持する場合、prepared statement の再利用や
+  // 内部 cache を検討するため、一貫したインスタンスで扱う。
+  //
+  // Open question (Q12 / §9.7 末尾): EU ユーザー対応時の admin endpoint /
+  // GraphQL mutation 配線は本 scaffold の範囲外。Phase 4+ で追加する。
+  container.registerSingleton("GdprDeletionService", GdprDeletionService);
 
   // ------------------------------
   // 📰 Content

--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -384,7 +384,17 @@ export function registerProductionDependencies() {
   //
   // Open question (Q12 / §9.7 末尾): EU ユーザー対応時の admin endpoint /
   // GraphQL mutation 配線は本 scaffold の範囲外。Phase 4+ で追加する。
-  container.registerSingleton("GdprDeletionService", GdprDeletionService);
+  //
+  // Singleton via class + string-token alias: `registerSingleton(token, class)`
+  // would scope the singleton only to lookups by `"GdprDeletionService"`.
+  // A `container.resolve(GdprDeletionService)` (used in service.test.ts
+  // and any future class-direct injector) would construct a *new*
+  // instance because tsyringe treats `@injectable()` classes as transient
+  // by default. Same dual-binding pattern as `UserDidAnchorRepository`
+  // above — register the class as singleton, then alias the string token
+  // via `useToken` so both resolution paths return the same instance.
+  container.registerSingleton(GdprDeletionService);
+  container.register("GdprDeletionService", { useToken: GdprDeletionService });
 
   // ------------------------------
   // 📰 Content


### PR DESCRIPTION
## Summary

`docs/report/did-vc-internalization.md` §9.7 「GDPR / 個人情報削除と chain 整合性」の **scaffold のみ** を追加する。実 deletion ロジックは Phase 4+ の別 PR で実装する。

EU ユーザー対応時の GDPR Art. 17「忘れられる権利」と Cardano on-chain anchor の不可逆性を両立するための削除フローを、interface + 空 method + TODO marker のレベルで先に切り出すことで、Phase 4+ で本実装する際に DI 配線・型契約から組み直す必要を無くす。

## Scope

### 含むもの

- 新規 domain `src/application/domain/gdpr/`
  - `data/type.ts` — `GdprDeletionOptions` / `GdprDeletionResult`
  - `data/interface.ts` — `IGdprDeletionService` interface
  - `service.ts` — `GdprDeletionService` 実装 (現状 `throw new Error("not implemented — §9.7 Phase 4+ task")`)
  - `__tests__/service.test.ts` — interface 形式の検証
- `src/application/provider.ts` に DI 登録 (singleton)

### 含まないもの (Phase 4+ で別 PR)

- 実 deletion ロジック (VC 一括 revoke / DID DEACTIVATE op 発行 / User 論理&物理削除)
- GraphQL mutation 配線
- admin endpoint / admin UI 連携
- 監査ログテーブル `t_gdpr_deletion_audit`

## §9.7 設計の要点 (service.ts 先頭コメントに記載)

1. **chain 上の anchor は削除不可** (Cardano の不可逆性が anchor の価値) → そもそも chain には PII を直接書込まない設計とする
2. **削除は DB の personal data に対してのみ実施** (UserDidAnchor の DB 行は物理削除、`chainTxHash` は orphan 化される)
3. **verifier 視点で実質削除と同等** — DB の DID Document が消えれば DID resolve が `404 Not Found` を返し、chain anchor が残っても意味を持たない
4. **削除フローは 2 段階** (論理削除フェーズ → X 日後の物理削除フェーズ)
5. **DID DEACTIVATE と VC revocation は不可分なトランザクション** (§4 cascade)

## Open question (Q12) との関係

設計レビュー Q12「EU ユーザー対応時の GDPR 削除フロー実装」は本 scaffold の範囲外。Phase 4+ で:

- 本 service の実 deletion ロジック
- admin GraphQL mutation 配線
- 監査ログテーブル migration
- verifier 向けドキュメント (`docs/handbook/VERIFIER.md` 仮)

を伴う follow-up PR で対応する。

## Test plan

- [ ] `pnpm test src/application/domain/gdpr/__tests__/service.test.ts` — `not implemented` throw を確認
- [ ] `pnpm tsc --noEmit` — interface / 型契約のコンパイル確認
- [ ] DI 解決確認 — `container.resolve("GdprDeletionService")` が singleton として解決されること

## References

- `docs/report/did-vc-internalization.md` §9.7 (line 1788-1876)
- 設計レビュー Q12 (open question)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XzsQPXMVEMPycqQ3sX6pq7)_