### PR TITLE
ci: tls-dns-posture + cardano-canary workflows 新設

### DIFF
--- a/.github/workflows/cardano-canary.yml
+++ b/.github/workflows/cardano-canary.yml
@@ -1,0 +1,101 @@
+name: Cardano Preprod Canary (anchor batch dry-run)
+
+# Weekly dry-run of the anchor batch external dependencies (Blockfrost preprod
+# reachability, protocol params fetch, metadata 1985 construction). Does NOT
+# submit a transaction — it only proves the *external* surface that the real
+# Sunday batch will hit. 設計書 §15.4 / §5.1.5 / §5.1.6 参照。
+#
+# 背景:
+#   weekly anchor batch は Blockfrost preprod / mainnet を叩く前提で組まれて
+#   いる (§5.1.5)。Blockfrost の API key 失効、preprod の wedge、metadata 1985
+#   serializer の regression (CSL アップグレードや 64B / 16KB 境界の崩れ) は、
+#   いずれも本番 Sunday batch まで気付けないと数日 anchor 遅延になる。
+#   weekly canary を batch 実行の **1 時間前** に走らせ、外部依存が壊れた
+#   状態で本番 batch に突っ込むのを防ぐ。
+#
+# 設計通り「実 submit はしない」:
+#   - platform wallet UTXO / signing key は CI に持ち込まない (mainnet 鍵漏洩
+#     リスク回避、preprod でもオペが faucet refill を要する)
+#   - Prisma を読まない (DB schema drift と canary を結合させない)
+#   - KMS は ci.yml integration test で別途検証
+#   よって canary が拾うのは「外部 SaaS / 公開ライブラリの状態」だけ。
+#
+# 関連: docs/report/did-vc-internalization.md §15.4 / §5.1.5 / §5.1.6
+
+on:
+  schedule:
+    # 毎週土曜 23:00 UTC = 日曜 08:00 JST. 設計 §5.3 の Sunday weekly anchor
+    # batch (JST 09:00 想定) のおよそ 1 時間前に走らせ、外部依存が落ちて
+    # いれば本番 batch トリガー前に Slack 通知で運用が手動 hold をかけられる
+    # 余裕を作る。
+    - cron: '0 23 * * 6'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+# schedule + workflow_dispatch が同時刻に走るのを抑止する。
+concurrency:
+  group: cardano-canary
+  cancel-in-progress: false
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          # Blockfrost preprod API + npm registry へ egress 必須なので audit
+          # に留める (block にすると依存 install で死ぬ)。trivy-daily / tls-dns
+          # と同じ運用。
+          egress-policy: audit
+          disable-sudo: true
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # composite action 経由で pnpm + Node + frozen-lockfile install を再利用
+      # (DB は不要なので database-url / migrations / gql-generate は全部 off)。
+      - name: Setup civicship environment
+        uses: ./.github/actions/setup-civicship
+
+      # script は scripts/cardano-canary.ts (本 PR で追加)。Blockfrost preprod
+      # health → block freshness → protocol params → metadata 1985 構築を
+      # 順に検証し、いずれかで failure すれば exit 1。実 tx submit は **しない**。
+      #
+      # secrets:
+      #   BLOCKFROST_PROJECT_ID  Blockfrost preprod API key (prefix `preprod`)。
+      #                          repo secret 名は `BLOCKFROST_PROJECT_ID`。
+      #                          mainnet 鍵を誤って入れた場合は script 側で
+      #                          prefix チェック (preprod 以外は即 exit 1)。
+      - name: Run Cardano preprod canary (no submit)
+        env:
+          BLOCKFROST_PROJECT_ID: ${{ secrets.BLOCKFROST_PROJECT_ID }}
+        run: pnpm tsx scripts/cardano-canary.ts
+
+      # 失敗時 Slack 通知。SLACK_WEBHOOK_ENG が未登録の repo (= secret 設定前)
+      # では step を skip して silent fail を防ぐ。env 経由で値を渡す
+      # (context 直接埋め込みは避ける)。tls-dns-posture と同じパターン。
+      - name: Slack notify on failure
+        if: failure()
+        env:
+          SLACK_WEBHOOK_ENG: ${{ secrets.SLACK_WEBHOOK_ENG }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SLACK_WEBHOOK_ENG:-}" ]; then
+            echo "::warning::SLACK_WEBHOOK_ENG not set; skipping Slack notify."
+            exit 0
+          fi
+          payload=$(cat <<EOF
+          {"text":":x: Cardano preprod canary failed — anchor batch externals unhealthy. See ${RUN_URL}"}
+          EOF
+          )
+          curl -sS -X POST "$SLACK_WEBHOOK_ENG" \
+            -H 'Content-Type: application/json' \
+            -d "$payload"

--- a/.github/workflows/tls-dns-posture.yml
+++ b/.github/workflows/tls-dns-posture.yml
@@ -1,7 +1,7 @@
-name: TLS / DNS Posture (civicship.app)
+name: TLS / DNS Posture (civicship.app + api.civicship.app)
 
-# civicship.app の DNSSEC / CAA / HSTS preload 設定が誰かの誤操作で外れた瞬間
-# に検知する daily monitoring。設計書 §15.3 / §9.6 参照。
+# civicship.app / api.civicship.app の DNSSEC / CAA / HSTS preload 設定が
+# 誰かの誤操作で外れた瞬間に検知する daily monitoring。設計書 §15.3 / §9.6 参照。
 #
 # 背景:
 #   did:web は HTTPS / DNS のセキュリティに依存する (DID Document の真正性が
@@ -11,12 +11,20 @@ name: TLS / DNS Posture (civicship.app)
 #   設定変更は通常 Phase 0 で一度行ったあとは誰も触らないので、daily check
 #   で「気付いたら外れていた」を防ぐ。
 #
+# 対象ホスト:
+#   - civicship.app           did Document の親ドメイン (well-known/did.json)
+#   - api.civicship.app       per-user DID (/users/:id/did.json) と VC
+#                             credentialStatus / inclusion-proof エンドポイント
+#   どちらが落ちても verifier 体験が壊れる (DID resolution が止まる) ため
+#   両方を独立して check する。Apex のみ check していると subdomain だけ CAA
+#   が消えた事故を拾えない。
+#
 # Issue 起票はしない:
 #   trivy-daily と違い、posture 監視は「直す対象が決まっている」(DNS / CDN
 #   設定をロールバックするだけ)。tracking issue を upsert する価値は薄く、
 #   その瞬間の Slack 通知で十分。
 #
-# 関連: docs/report/did-vc-internalization.md §15.3 / §9.6
+# 関連: docs/report/did-vc-internalization.md §15.3 / §9.6 / 18 章 運用要件
 
 on:
   schedule:
@@ -40,69 +48,167 @@ jobs:
     permissions:
       contents: read
 
+    # matrix で apex / api を独立 job 化。片側が落ちてももう片側まで走り、
+    # Slack 通知で「どちらが壊れているか」が一発で分かる。両方落ちている
+    # ケース (= apex zone 障害) でも notification は 2 本飛ぶ。
+    strategy:
+      fail-fast: false
+      matrix:
+        host:
+          - civicship.app
+          - api.civicship.app
+
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
+          # 公開 DNS resolver (1.1.1.1) と https://hstspreload.org / 対象 host
+          # への egress が必須なので audit に留める (block にすると dig も死ぬ)。
           egress-policy: audit
           disable-sudo: true
 
-      # 公開 DNS resolver 経由で civicship.app の DNSSEC DS レコードを引く。
-      # DS が空になっていると親ゾーン (.app) に署名チェーンが繋がらず DNSSEC
-      # が事実上 OFF。DS 公開を Phase 0 で行ったあとは常に存在するべき。
-      - name: DNSSEC DS record check
+      # delv は権威 resolver からの DNSSEC chain を再検証して "fully validated"
+      # を返す (`dig +dnssec` だけだと AD bit を信用するしかなく、再帰
+      # resolver 側の bug を拾い損なう)。delv は ubuntu-latest の bind9-dnsutils
+      # に同梱されているのでインストール 1 行で済む。
+      - name: Install delv (bind9-dnsutils)
         run: |
           set -euo pipefail
-          ds=$(dig +short DS civicship.app @1.1.1.1)
+          if ! command -v delv >/dev/null 2>&1; then
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq bind9-dnsutils
+          fi
+          delv -V | head -n1
+
+      # 公開 DNS resolver 経由で DNSSEC DS レコードを引く。DS が空になっていると
+      # 親ゾーン (.app) に署名チェーンが繋がらず DNSSEC が事実上 OFF。
+      # api.civicship.app は通常 CNAME → apex なので apex 側の DS が引ければ
+      # 両方 OK の扱い、ただし matrix で個別に引いて誤設定を可視化する。
+      - name: DNSSEC DS record check (${{ matrix.host }})
+        run: |
+          set -euo pipefail
+          ds=$(dig +short DS ${{ matrix.host }} @1.1.1.1)
           if [ -z "$ds" ]; then
-            echo "::error::DNSSEC DS record missing for civicship.app"
+            # subdomain は親 (apex) の DS でカバーされるケースがある。subdomain
+            # 側が空なら apex に fallback して chain の存在を確認する。
+            apex=$(echo "${{ matrix.host }}" | awk -F. '{print $(NF-1)"."$NF}')
+            if [ "${{ matrix.host }}" = "$apex" ]; then
+              echo "::error::DNSSEC DS record missing for ${{ matrix.host }}"
+              exit 1
+            fi
+            ds_apex=$(dig +short DS "$apex" @1.1.1.1)
+            if [ -z "$ds_apex" ]; then
+              echo "::error::DNSSEC DS record missing for ${{ matrix.host }} and parent zone $apex"
+              exit 1
+            fi
+            echo "DS via parent zone $apex: $ds_apex"
+          else
+            echo "DS record: $ds"
+          fi
+
+      # delv で DNSSEC chain 全体を検証。"fully validated" を含まなければ
+      # chain 切断 (= DS / RRSIG mismatch、KSK ローテ失敗等)。
+      - name: DNSSEC chain validation via delv (${{ matrix.host }})
+        run: |
+          set -euo pipefail
+          # delv は失敗時 stderr に "validation failure" を出す。+rtrace は
+          # path を残してデバッグしやすくする。
+          out=$(delv +rtrace @1.1.1.1 ${{ matrix.host }} A 2>&1 || true)
+          echo "$out"
+          if ! echo "$out" | grep -q 'fully validated'; then
+            echo "::error::delv could not fully validate DNSSEC chain for ${{ matrix.host }}"
             exit 1
           fi
-          echo "DS record: $ds"
 
       # CAA レコードで「pki.goog (Google Trust Services) 以外で証明書を発行
-      # してはいけない」を宣言しているか確認。CAA が消えると任意の CA で
-      # 証明書発行できてしまう (= TLS MITM の入口になる)。
-      - name: CAA record check
+      # してはいけない」を宣言しているか確認。CAA が消える / issuer が
+      # 想定外に増えると、任意の CA で証明書発行できてしまう (= TLS MITM の
+      # 入口になる)。subdomain の CAA は親ドメインから継承されうるので
+      # 親側も併せて確認。
+      - name: CAA record check (${{ matrix.host }})
         run: |
           set -euo pipefail
-          caa=$(dig CAA civicship.app +short @1.1.1.1)
+          caa=$(dig CAA ${{ matrix.host }} +short @1.1.1.1)
+          if [ -z "$caa" ]; then
+            apex=$(echo "${{ matrix.host }}" | awk -F. '{print $(NF-1)"."$NF}')
+            if [ "${{ matrix.host }}" != "$apex" ]; then
+              caa=$(dig CAA "$apex" +short @1.1.1.1)
+              echo "Falling back to parent zone $apex CAA"
+            fi
+          fi
+          echo "CAA records:"
+          echo "$caa"
           if ! echo "$caa" | grep -q 'pki.goog'; then
-            echo "::error::CAA record does not include pki.goog for civicship.app"
-            echo "Got: $caa"
+            echo "::error::CAA record does not include expected issuer pki.goog for ${{ matrix.host }}"
             exit 1
           fi
-          echo "CAA record: $caa"
 
       # HSTS preload directive が response header に乗っているか確認。
       # preload リスト登録自体は手動申請が必要だが、`preload` directive を
       # 削ってしまうと Chrome 等の HSTS preload リストへの登録維持条件
       # (https://hstspreload.org/) を満たさず将来的に外される。
-      - name: HSTS preload header check
+      - name: HSTS response header check (${{ matrix.host }})
         run: |
           set -euo pipefail
-          headers=$(curl -sI --max-time 10 https://civicship.app/)
+          headers=$(curl -sI --max-time 10 https://${{ matrix.host }}/)
           hsts=$(echo "$headers" | grep -i 'strict-transport-security' || true)
           if [ -z "$hsts" ]; then
-            echo "::error::strict-transport-security header missing on https://civicship.app/"
+            echo "::error::strict-transport-security header missing on https://${{ matrix.host }}/"
             exit 1
           fi
           if ! echo "$hsts" | grep -qi 'preload'; then
-            echo "::error::HSTS header missing 'preload' directive"
+            echo "::error::HSTS header missing 'preload' directive for ${{ matrix.host }}"
             echo "Got: $hsts"
             exit 1
           fi
           echo "HSTS header: $hsts"
 
+      # https://hstspreload.org/api/v2/status?domain=... で preload list 上の
+      # 公式 status を確認。response の `status` が "preloaded" 以外だと
+      # Chrome に登録されていない (= preload 効果なし)。header check と独立
+      # して走らせるのは、header だけ正しくて公式 list から外れた状態を
+      # 拾えるようにするため。
+      - name: HSTS preload list status (${{ matrix.host }})
+        run: |
+          set -euo pipefail
+          json=$(curl -sS --max-time 15 \
+            "https://hstspreload.org/api/v2/status?domain=${{ matrix.host }}")
+          echo "Response: $json"
+          status=$(echo "$json" | jq -r '.status // empty')
+          if [ -z "$status" ]; then
+            echo "::error::hstspreload.org returned no status field for ${{ matrix.host }}"
+            exit 1
+          fi
+          # preloaded = Chrome に焼き込み済 / 完全 OK
+          # pending   = 申請中だが Chrome rollout 待ち (warning のみ、fail させない)
+          # その他 (unknown / removed / rejected) は posture broken。
+          case "$status" in
+            preloaded)
+              echo "preload status OK: $status"
+              ;;
+            pending)
+              echo "::warning::HSTS preload status is 'pending' for ${{ matrix.host }} — Chrome rollout 待ち"
+              ;;
+            *)
+              echo "::error::HSTS preload status is '$status' for ${{ matrix.host }} (expected 'preloaded')"
+              exit 1
+              ;;
+          esac
+
       # いずれかの check が失敗した時だけ Slack に投げる。SLACK_WEBHOOK_INFRA
       # secret が未登録の repo (= Phase 0 で webhook を設定する前) でも step
       # が無声に skip するように `if` で webhook の有無を確認する。secret は
       # context にそのまま埋め込めないので env 経由で渡す。
+      #
+      # secrets:
+      #   SLACK_WEBHOOK_INFRA  infra channel 宛 Slack incoming webhook URL。
+      #                        repo secret 名は `SLACK_WEBHOOK_INFRA`。
       - name: Slack notify on failure
         if: failure()
         env:
           SLACK_WEBHOOK_INFRA: ${{ secrets.SLACK_WEBHOOK_INFRA }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          HOST: ${{ matrix.host }}
         run: |
           set -euo pipefail
           if [ -z "${SLACK_WEBHOOK_INFRA:-}" ]; then
@@ -110,7 +216,7 @@ jobs:
             exit 0
           fi
           payload=$(cat <<EOF
-          {"text":":rotating_light: civicship.app TLS/DNS posture broken — see ${RUN_URL}"}
+          {"text":":rotating_light: ${HOST} TLS/DNS posture broken — see ${RUN_URL}"}
           EOF
           )
           curl -sS -X POST "$SLACK_WEBHOOK_INFRA" \

--- a/scripts/cardano-canary.ts
+++ b/scripts/cardano-canary.ts
@@ -53,6 +53,14 @@ import {
   type DidOp,
 } from "../src/infrastructure/libs/cardano/txBuilder.ts";
 
+/**
+ * Length of the public `preprod` prefix on Blockfrost project IDs. Used to
+ * cap any logged slice — slicing one byte further would expose the first
+ * char of the secret payload, which Gemini security review flagged on PR
+ * #1126.
+ */
+const BLOCKFROST_PROJECT_ID_PUBLIC_PREFIX_LENGTH = "preprod".length;
+
 // ---------------------------------------------------------------------------
 // Tiny step runner — no external deps, just a "PASS / FAIL" log line per step
 // so the GitHub Actions log surfaces precisely which dependency broke.
@@ -91,7 +99,7 @@ function requirePreprodProjectId(): string {
   if (!projectId.startsWith("preprod")) {
     throw new Error(
       "BLOCKFROST_PROJECT_ID does not look like a preprod key " +
-        `(expected prefix "preprod", got "${projectId.slice(0, 8)}..."). ` +
+        `(expected prefix "preprod", got "${projectId.slice(0, BLOCKFROST_PROJECT_ID_PUBLIC_PREFIX_LENGTH)}..."). ` +
         "The canary must run against preprod, never mainnet.",
     );
   }
@@ -239,7 +247,9 @@ async function main(): Promise<number> {
 
   const envStep = await runStep("env: BLOCKFROST_PROJECT_ID is preprod*", async () => {
     const id = requirePreprodProjectId();
-    return `project_id prefix OK (${id.slice(0, 8)}...)`;
+    // Log only the public `preprod` prefix — never expose the secret payload
+    // (Gemini security review on PR #1126).
+    return `project_id prefix OK (${id.slice(0, BLOCKFROST_PROJECT_ID_PUBLIC_PREFIX_LENGTH)}...)`;
   });
   results.push(envStep);
   if (!envStep.ok) return summarize(results);

--- a/scripts/cardano-canary.ts
+++ b/scripts/cardano-canary.ts
@@ -1,0 +1,304 @@
+#!/usr/bin/env -S node --experimental-strip-types
+/**
+ * Weekly Cardano preprod canary for the anchor batch pipeline.
+ *
+ * This script proves that all *external* dependencies the weekly anchor batch
+ * relies on are healthy, **without** actually submitting a transaction to
+ * the chain. It is intentionally standalone (no DI container, no Prisma,
+ * no app config) so it can run in a minimal CI job and fail loudly on any
+ * single broken external before the real Sunday batch tries to submit.
+ *
+ * What it checks (in order, fail-fast):
+ *   1. Blockfrost preprod reachability + API key validity
+ *      → `health()` returns `is_healthy === true`
+ *      → `BLOCKFROST_PROJECT_ID` exists and is a `preprod*` key
+ *   2. Latest preprod block freshness
+ *      → block within last 30 minutes (preprod block time ~20s, so >30 min
+ *        means either the network is wedged or our key lost access)
+ *   3. Blockfrost protocol params fetch (`epochsLatestParameters`)
+ *      → required input for `txBuilder.buildAnchorTx` (§5.1.5)
+ *   4. Metadata 1985 construction with sample roots + DID ops (§5.1.6)
+ *      → builds an `AuxiliaryData` exactly like the real batch does
+ *      → confirms the CSL serializer accepts our 64-byte chunking + UTF-8
+ *        boundary handling (§5.1.6 / §5.1.7)
+ *      → confirms metadata stays well under the 16 KB ceiling
+ *
+ * What this script intentionally does NOT do:
+ *   - Submit a tx (no platform wallet UTXOs, no signing key in CI)
+ *   - Touch our DB (Prisma not loaded → no schema drift coupling)
+ *   - Talk to KMS (KMS health is covered by ci.yml integration tests)
+ *
+ * Required env:
+ *   BLOCKFROST_PROJECT_ID   Blockfrost preprod API key (Secret Manager
+ *                           `BLOCKFROST_PROJECT_ID_PREPROD` in production;
+ *                           in CI passed via secrets.BLOCKFROST_PROJECT_ID)
+ *
+ * Optional env:
+ *   CANARY_BLOCK_FRESHNESS_SECONDS   Override block freshness threshold
+ *                                    (default 1800 = 30 min)
+ *
+ * Exit codes: 0 = PASS, 1 = FAIL.
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §15.4  (this canary)
+ *   docs/report/did-vc-internalization.md §5.1.5 (Blockfrost client)
+ *   docs/report/did-vc-internalization.md §5.1.6 (metadata 1985 schema)
+ */
+
+import { BlockFrostAPI } from "@blockfrost/blockfrost-js";
+import { blake2b } from "@noble/hashes/blake2b";
+import {
+  buildAuxiliaryData,
+  MAX_METADATA_TX_BYTES,
+  type DidOp,
+} from "../src/infrastructure/libs/cardano/txBuilder.ts";
+
+// ---------------------------------------------------------------------------
+// Tiny step runner — no external deps, just a "PASS / FAIL" log line per step
+// so the GitHub Actions log surfaces precisely which dependency broke.
+// ---------------------------------------------------------------------------
+
+type StepResult = { name: string; ok: boolean; detail: string };
+
+async function runStep(
+  name: string,
+  fn: () => Promise<string>,
+): Promise<StepResult> {
+  process.stdout.write(`-> ${name} ...\n`);
+  try {
+    const detail = await fn();
+    process.stdout.write(`   PASS: ${detail}\n`);
+    return { name, ok: true, detail };
+  } catch (e) {
+    const msg = (e as Error).message ?? String(e);
+    process.stdout.write(`   FAIL: ${msg}\n`);
+    return { name, ok: false, detail: msg };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Step 1 — env validation
+// ---------------------------------------------------------------------------
+
+function requirePreprodProjectId(): string {
+  const projectId = process.env.BLOCKFROST_PROJECT_ID;
+  if (!projectId) {
+    throw new Error(
+      "BLOCKFROST_PROJECT_ID is unset. Configure GitHub Actions secret " +
+        "`BLOCKFROST_PROJECT_ID` (preprod key, prefix `preprod...`).",
+    );
+  }
+  if (!projectId.startsWith("preprod")) {
+    throw new Error(
+      "BLOCKFROST_PROJECT_ID does not look like a preprod key " +
+        `(expected prefix "preprod", got "${projectId.slice(0, 8)}..."). ` +
+        "The canary must run against preprod, never mainnet.",
+    );
+  }
+  return projectId;
+}
+
+// ---------------------------------------------------------------------------
+// Step 2 — Blockfrost health + freshness
+// ---------------------------------------------------------------------------
+
+async function checkBlockfrostHealth(api: BlockFrostAPI): Promise<string> {
+  const health = await api.health();
+  if (!health.is_healthy) {
+    throw new Error(
+      `Blockfrost preprod reports is_healthy=false: ${JSON.stringify(health)}`,
+    );
+  }
+  return "Blockfrost preprod is_healthy=true";
+}
+
+async function checkPreprodBlockFreshness(
+  api: BlockFrostAPI,
+  thresholdSeconds: number,
+): Promise<string> {
+  const latest = await api.blocksLatest();
+  const time = latest.time; // unix seconds
+  if (typeof time !== "number") {
+    throw new Error(
+      `blocksLatest returned no usable time field: ${JSON.stringify(latest)}`,
+    );
+  }
+  const ageSeconds = Math.floor(Date.now() / 1000) - time;
+  if (ageSeconds > thresholdSeconds) {
+    throw new Error(
+      `latest preprod block is ${ageSeconds}s old (> ${thresholdSeconds}s threshold). ` +
+        "Either the preprod network is wedged or our Blockfrost key is rate-limited / wrong.",
+    );
+  }
+  return `latest preprod block #${latest.height} is ${ageSeconds}s old (slot=${latest.slot})`;
+}
+
+// ---------------------------------------------------------------------------
+// Step 3 — protocol params
+// ---------------------------------------------------------------------------
+
+async function checkProtocolParams(api: BlockFrostAPI): Promise<string> {
+  const params = await api.epochsLatestParameters();
+  // Spot-check the fields the real batch uses (txBuilder reads these).
+  if (typeof params.min_fee_a !== "number" || typeof params.min_fee_b !== "number") {
+    throw new Error(
+      `epochsLatestParameters missing min_fee_a / min_fee_b: ${JSON.stringify(params)}`,
+    );
+  }
+  if (typeof params.max_tx_size !== "number") {
+    throw new Error(
+      `epochsLatestParameters missing max_tx_size: ${JSON.stringify(params)}`,
+    );
+  }
+  return `epoch=${params.epoch} min_fee_a=${params.min_fee_a} min_fee_b=${params.min_fee_b} max_tx_size=${params.max_tx_size}`;
+}
+
+// ---------------------------------------------------------------------------
+// Step 4 — metadata 1985 construction (dry-run, no submit)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a representative AuxiliaryData mirroring a real anchor batch:
+ *   - 1 tx Merkle root (32 bytes)
+ *   - 1 vc Merkle root (32 bytes)
+ *   - 2 DID ops (CREATE + UPDATE) with realistic chunk lengths
+ *
+ * If anything in the metadata serialization is broken (CSL update, encoding
+ * regression, 16 KB ceiling overshoot) this throws and the canary fails.
+ */
+function buildSampleMetadata(): string {
+  const sampleRoot = blake2b(new TextEncoder().encode("canary-tx"), { dkLen: 32 });
+  const sampleVcRoot = blake2b(new TextEncoder().encode("canary-vc"), { dkLen: 32 });
+  const sampleDocHash = blake2b(new TextEncoder().encode("canary-doc"), { dkLen: 32 });
+
+  const ops: DidOp[] = [
+    {
+      k: "c",
+      did: "did:web:api.civicship.app:users:canary-create",
+      h: bytesToHex(sampleDocHash),
+      doc: {
+        "@context": ["https://www.w3.org/ns/did/v1"],
+        id: "did:web:api.civicship.app:users:canary-create",
+        verificationMethod: [
+          {
+            id: "did:web:api.civicship.app:users:canary-create#key-1",
+            type: "Ed25519VerificationKey2020",
+            controller: "did:web:api.civicship.app:users:canary-create",
+            publicKeyMultibase: "z6Mk" + "x".repeat(44),
+          },
+        ],
+      },
+      prev: null,
+    },
+    {
+      k: "u",
+      did: "did:web:api.civicship.app:users:canary-update",
+      h: bytesToHex(sampleDocHash),
+      doc: {
+        "@context": ["https://www.w3.org/ns/did/v1"],
+        id: "did:web:api.civicship.app:users:canary-update",
+      },
+      prev: bytesToHex(sampleRoot),
+    },
+  ];
+
+  const aux = buildAuxiliaryData({
+    bid: `canary_${Date.now().toString(36)}`,
+    ts: Math.floor(Date.now() / 1000),
+    tx: { root: sampleRoot, count: 1 },
+    vc: { root: sampleVcRoot, count: 1 },
+    ops,
+  });
+
+  // Serialize to CBOR bytes — this is the same path the chain will see.
+  const cborBytes = aux.to_bytes();
+  const sizeBytes = cborBytes.length;
+  if (sizeBytes >= MAX_METADATA_TX_BYTES) {
+    throw new Error(
+      `sample metadata is ${sizeBytes}B (>= ceiling ${MAX_METADATA_TX_BYTES}B). ` +
+        "txBuilder size estimation has regressed.",
+    );
+  }
+  return `AuxiliaryData CBOR size=${sizeBytes}B (ceiling ${MAX_METADATA_TX_BYTES}B), 2 ops, 1 tx root, 1 vc root`;
+}
+
+function bytesToHex(b: Uint8Array): string {
+  let s = "";
+  for (let i = 0; i < b.length; i++) s += b[i].toString(16).padStart(2, "0");
+  return s;
+}
+
+// ---------------------------------------------------------------------------
+// Entrypoint
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<number> {
+  process.stdout.write("Cardano preprod canary (anchor batch dry-run)\n\n");
+
+  const results: StepResult[] = [];
+
+  const envStep = await runStep("env: BLOCKFROST_PROJECT_ID is preprod*", async () => {
+    const id = requirePreprodProjectId();
+    return `project_id prefix OK (${id.slice(0, 8)}...)`;
+  });
+  results.push(envStep);
+  if (!envStep.ok) return summarize(results);
+
+  const projectId = process.env.BLOCKFROST_PROJECT_ID as string;
+  const api = new BlockFrostAPI({ projectId, network: "preprod" });
+
+  results.push(
+    await runStep("blockfrost: health()", () => checkBlockfrostHealth(api)),
+  );
+  if (!results[results.length - 1].ok) return summarize(results);
+
+  const thresholdSeconds = Number(
+    process.env.CANARY_BLOCK_FRESHNESS_SECONDS ?? "1800",
+  );
+  results.push(
+    await runStep(
+      `blockfrost: blocksLatest() freshness < ${thresholdSeconds}s`,
+      () => checkPreprodBlockFreshness(api, thresholdSeconds),
+    ),
+  );
+  if (!results[results.length - 1].ok) return summarize(results);
+
+  results.push(
+    await runStep("blockfrost: epochsLatestParameters()", () =>
+      checkProtocolParams(api),
+    ),
+  );
+  if (!results[results.length - 1].ok) return summarize(results);
+
+  results.push(
+    await runStep("txBuilder: build sample metadata 1985 (no submit)", async () =>
+      buildSampleMetadata(),
+    ),
+  );
+
+  return summarize(results);
+}
+
+function summarize(results: StepResult[]): number {
+  const failed = results.filter((r) => !r.ok);
+  process.stdout.write("\n--- Canary summary ---\n");
+  for (const r of results) {
+    process.stdout.write(`  [${r.ok ? "PASS" : "FAIL"}] ${r.name}\n`);
+  }
+  if (failed.length === 0) {
+    process.stdout.write("\nAll canary checks passed.\n");
+    return 0;
+  }
+  process.stdout.write(
+    `\n${failed.length} of ${results.length} canary checks FAILED.\n`,
+  );
+  return 1;
+}
+
+main().then(
+  (code) => process.exit(code),
+  (err) => {
+    process.stderr.write(`Unhandled canary error: ${(err as Error).stack ?? err}\n`);
+    process.exit(1);
+  },
+);


### PR DESCRIPTION
## Summary

設計書 `docs/report/did-vc-internalization.md` §15.3 / §15.4 で定義された Phase 2 follow-up CI/CD 統合の 2 本を実装する。

### Workflow 1: `.github/workflows/tls-dns-posture.yml` (§15.3)

did:web の根本である DNS / TLS posture が誤操作で外れた瞬間に検知する daily monitoring。既存 file をベースに、設計書要件を満たすよう拡張:

- **対象を `civicship.app` + `api.civicship.app` の両方に拡張** (matrix job, `fail-fast: false`)
  - `api.civicship.app` は per-user DID + VC `credentialStatus` / inclusion-proof エンドポイントを配信するため独立 check が必要
- **DNSSEC 検証を強化**: 既存の `dig DS` に加え、`delv +rtrace` で chain 全体を再検証 (`fully validated` 文字列確認)
- **CAA**: `pki.goog` (Google Trust Services) を期待 issuer として確認、subdomain で空なら apex に fallback
- **HSTS**: response header の `preload` directive 確認 + `https://hstspreload.org/api/v2/status?domain=...` で公式 preload list 上の status を確認 (`preloaded` = OK / `pending` = warning / その他 = fail)
- 失敗時 Slack notify (`SLACK_WEBHOOK_INFRA`、未設定なら silent skip)

**Trigger**: `cron: '0 0 * * *'` (毎日 09:00 JST) + `workflow_dispatch`
**Required secrets**: `SLACK_WEBHOOK_INFRA` (任意、未設定なら通知 skip)

### Workflow 2: `.github/workflows/cardano-canary.yml` + `scripts/cardano-canary.ts` (§15.4)

Weekly anchor batch の外部依存 (Blockfrost preprod / metadata 1985 serializer) が壊れたまま本番 batch に突っ込むのを防ぐ dry-run canary。**実 tx submit はしない**。

`scripts/cardano-canary.ts` が以下を順に check (fail-fast):

1. `BLOCKFROST_PROJECT_ID` の存在 + `preprod` prefix (mainnet 鍵誤投入を即弾く)
2. Blockfrost preprod `health()` (`is_healthy === true`)
3. `blocksLatest()` で latest block が 30 min 以内 (preprod wedge / key 失効を検知)
4. `epochsLatestParameters()` (txBuilder が読む min_fee_a/b, max_tx_size を spot-check)
5. `buildAuxiliaryData` で実 batch と同形の metadata 1985 を構築 → CSL 経由で CBOR シリアライズ → 16KB 以内を検証

意図的にやらないこと:
- 実 tx submit (platform wallet UTXO / signing key を CI に持ち込まない)
- Prisma 起動 (DB schema drift と canary を結合させない)
- KMS 接続 (ci.yml integration test で別途検証)

**Trigger**: `cron: '0 23 * * 6'` (毎週土曜 23:00 UTC = 日曜 08:00 JST、Sunday weekly anchor batch §5.3 の約 1h 前) + `workflow_dispatch`
**Required secrets**: `BLOCKFROST_PROJECT_ID` (preprod 鍵)、`SLACK_WEBHOOK_ENG` (任意)

### 設計方針 (両 workflow 共通)

- 既存 `trivy-daily.yml` / `tls-dns-posture.yml` に揃えて `step-security/harden-runner` (egress audit, sudo 無効) + pinned action SHA + `concurrency` group + 最小権限 `permissions: contents: read`
- secret は `env:` 経由で渡し context 直接埋め込みは回避
- workflow comment 冒頭に「対象 / 背景 / 設計参照」を JP で明記、各 secret の repo 命名規約をコメントに残す

### Non-scope
- DNSSEC / CAA / HSTS の実 DNS 設定そのもの (インフラ作業、§9.6 / 18 章)
- アプリ内 alert (§15.6) — logger / Slack 通知基盤への乗せ込み
- 既存 workflow 改変 (trivy-daily.yml / ci.yml 等)

## Test plan

- [ ] PR push で GitHub Actions が両 workflow を syntax-check (workflow_dispatch がリストに出る)
- [ ] `tls-dns-posture.yml` を `workflow_dispatch` で手動 run → 両 host の matrix job が並列起動 / 各 step が PASS or 期待される FAIL を出す
- [ ] `cardano-canary.yml` を `workflow_dispatch` で手動 run (`BLOCKFROST_PROJECT_ID` secret 設定後) → 4 step すべて PASS で exit 0
- [ ] 意図的に bad secret (mainnet key) を入れて canary が prefix check で fail することを確認
- [ ] Slack webhook 未設定の状態で failure path を踏み、`::warning::` に落ちて exit 0 することを確認

https://claude.ai/code/session_01XzsQPXMVEMPycqQ3sX6pq7

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzsQPXMVEMPycqQ3sX6pq7)_