### PR TITLE
phase2(account): DID DEACTIVATE 時に subject の VC を cascade revoke

### DIFF
--- a/src/__tests__/integration/application/domain/credential/vcIssuance/repository.test.ts
+++ b/src/__tests__/integration/application/domain/credential/vcIssuance/repository.test.ts
@@ -281,4 +281,83 @@ describe("VcIssuanceRepository (integration)", () => {
       expect(rows).toEqual([]);
     });
   });
+
+  describe("findActiveByUserId (Phase 2 §14.2 cascade revoke)", () => {
+    it("returns only rows where revokedAt IS NULL, oldest first", async () => {
+      const ctx = buildCtx();
+
+      const evalA = await createEvaluationFor(userId);
+      const a = await repo.create(ctx, {
+        userId,
+        evaluationId: evalA,
+        issuerDid: "did:web:api.civicship.app",
+        subjectDid: `did:web:api.civicship.app:users:${userId}`,
+        vcFormat: VcFormat.INTERNAL_JWT,
+        vcJwt: "h.p.s",
+        status: VcIssuanceStatus.COMPLETED,
+      });
+
+      // Stamp `revokedAt` on `a` so the cascade should skip it.
+      await prismaClient.vcIssuanceRequest.update({
+        where: { id: a.id },
+        data: { revokedAt: new Date() },
+      });
+
+      // Wait so `createdAt` ordering is deterministic across PostgreSQL's
+      // sub-millisecond timestamp resolution.
+      await new Promise((r) => setTimeout(r, 10));
+      const evalB = await createEvaluationFor(userId);
+      const b = await repo.create(ctx, {
+        userId,
+        evaluationId: evalB,
+        issuerDid: "did:web:api.civicship.app",
+        subjectDid: `did:web:api.civicship.app:users:${userId}`,
+        vcFormat: VcFormat.INTERNAL_JWT,
+        vcJwt: "h.p.s",
+        status: VcIssuanceStatus.COMPLETED,
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+      const evalC = await createEvaluationFor(userId);
+      const c = await repo.create(ctx, {
+        userId,
+        evaluationId: evalC,
+        issuerDid: "did:web:api.civicship.app",
+        subjectDid: `did:web:api.civicship.app:users:${userId}`,
+        vcFormat: VcFormat.INTERNAL_JWT,
+        vcJwt: "h.p.s",
+        status: VcIssuanceStatus.COMPLETED,
+      });
+
+      const rows = await repo.findActiveByUserId(ctx, userId);
+      expect(rows.map((r) => r.id)).toEqual([b.id, c.id]);
+    });
+
+    it("returns empty array when every VC for the user is already revoked", async () => {
+      const ctx = buildCtx();
+      const evaluationId = await createEvaluationFor(userId);
+      const persisted = await repo.create(ctx, {
+        userId,
+        evaluationId,
+        issuerDid: "did:web:api.civicship.app",
+        subjectDid: `did:web:api.civicship.app:users:${userId}`,
+        vcFormat: VcFormat.INTERNAL_JWT,
+        vcJwt: "h.p.s",
+        status: VcIssuanceStatus.COMPLETED,
+      });
+      await prismaClient.vcIssuanceRequest.update({
+        where: { id: persisted.id },
+        data: { revokedAt: new Date() },
+      });
+
+      const rows = await repo.findActiveByUserId(ctx, userId);
+      expect(rows).toEqual([]);
+    });
+
+    it("returns empty array for a user with no VCs at all (no-op cascade)", async () => {
+      const ctx = buildCtx();
+      const rows = await repo.findActiveByUserId(ctx, userId);
+      expect(rows).toEqual([]);
+    });
+  });
 });

--- a/src/__tests__/unit/application/domain/account/userDid/usecase.test.ts
+++ b/src/__tests__/unit/application/domain/account/userDid/usecase.test.ts
@@ -15,6 +15,7 @@ import "reflect-metadata";
 import { container } from "tsyringe";
 import UserDidUseCase from "@/application/domain/account/userDid/usecase";
 import UserDidService from "@/application/domain/account/userDid/service";
+import VcIssuanceService from "@/application/domain/credential/vcIssuance/service";
 import { AuthorizationError } from "@/errors/graphql";
 import type { IContext } from "@/types/server";
 
@@ -45,6 +46,11 @@ function makeCtx(overrides: Partial<IContext> = {}): IContext {
 
 describe("UserDidUseCase (authz hardening for PR #1101)", () => {
   let mockService: jest.Mocked<Pick<UserDidService, "findLatestForUser" | "createDidForUser" | "deactivateDid">>;
+  // Phase 2: the usecase now also depends on VcIssuanceService for the
+  // DID DEACTIVATE → cascade-revoke flow (§14.2). Authz tests below
+  // don't drive the deactivate path far enough to exercise it, but the
+  // container still needs a registration to construct the usecase.
+  let mockVcIssuanceService: { cascadeRevokeForUser: jest.Mock };
   let usecase: UserDidUseCase;
 
   beforeEach(() => {
@@ -56,8 +62,12 @@ describe("UserDidUseCase (authz hardening for PR #1101)", () => {
       createDidForUser: jest.fn(),
       deactivateDid: jest.fn(),
     };
+    mockVcIssuanceService = {
+      cascadeRevokeForUser: jest.fn().mockResolvedValue(0),
+    };
 
     container.register("UserDidService", { useValue: mockService });
+    container.register("VcIssuanceService", { useValue: mockVcIssuanceService });
     container.register("UserDidUseCase", { useClass: UserDidUseCase });
 
     usecase = container.resolve(UserDidUseCase);
@@ -133,6 +143,79 @@ describe("UserDidUseCase (authz hardening for PR #1101)", () => {
         AuthorizationError,
       );
       expect(mockService.deactivateDid).not.toHaveBeenCalled();
+      // Authz failure must short-circuit before the cascade — otherwise a
+      // forbidden caller could still revoke another user's VCs.
+      expect(mockVcIssuanceService.cascadeRevokeForUser).not.toHaveBeenCalled();
+    });
+
+    it("invokes cascade-revoke after the DID anchor is enqueued (§14.2)", async () => {
+      const anchor = {
+        id: "anchor-1",
+        userId: SELF_USER_ID,
+        did: `did:web:api.civicship.app:users:${SELF_USER_ID}`,
+        operation: "DEACTIVATE",
+        documentHash: "0".repeat(64),
+        documentCbor: null,
+        network: "CARDANO_MAINNET",
+        chainTxHash: null,
+        chainOpIndex: null,
+        status: "PENDING",
+        confirmedAt: null,
+        createdAt: new Date(),
+      } as never;
+      mockService.deactivateDid.mockResolvedValueOnce(anchor);
+      mockVcIssuanceService.cascadeRevokeForUser.mockResolvedValueOnce(2);
+      const ctx = makeCtx();
+
+      await usecase.deactivateUserDidForUser(ctx, SELF_USER_ID);
+
+      // Both writes commit inside the same `ctx.issuer.public` block — the
+      // sentinel tx is forwarded to the cascade so it shares the snapshot.
+      expect(mockService.deactivateDid).toHaveBeenCalledWith(
+        ctx,
+        SELF_USER_ID,
+        expect.objectContaining({ sentinel: "tx" }),
+      );
+      expect(mockVcIssuanceService.cascadeRevokeForUser).toHaveBeenCalledWith(
+        ctx,
+        SELF_USER_ID,
+        expect.objectContaining({ sentinel: "tx" }),
+        "did-deactivated",
+      );
+
+      // Ordering matters: revoking VCs *before* the DEACTIVATE anchor is
+      // enqueued would leave a window where the DID still verifies live
+      // but the VCs are already dead. Assert the DEACTIVATE call lands
+      // before the cascade.
+      const deactivateOrder = mockService.deactivateDid.mock.invocationCallOrder[0];
+      const cascadeOrder = mockVcIssuanceService.cascadeRevokeForUser.mock.invocationCallOrder[0];
+      expect(deactivateOrder).toBeLessThan(cascadeOrder);
+    });
+
+    it("admin path also runs the cascade", async () => {
+      mockService.deactivateDid.mockResolvedValueOnce({} as never);
+      const ctx = makeCtx({ isAdmin: true, currentUser: { id: "admin-1" } as never });
+
+      await usecase.deactivateUserDidForUser(ctx, OTHER_USER_ID);
+
+      expect(mockVcIssuanceService.cascadeRevokeForUser).toHaveBeenCalledWith(
+        ctx,
+        OTHER_USER_ID,
+        expect.anything(),
+        "did-deactivated",
+      );
+    });
+  });
+
+  describe("deactivateDid service-level wrapper", () => {
+    it("also runs the cascade so non-GraphQL callers cannot bypass it", async () => {
+      mockService.deactivateDid.mockResolvedValueOnce({} as never);
+      mockVcIssuanceService.cascadeRevokeForUser.mockResolvedValueOnce(0);
+      const ctx = makeCtx();
+
+      await usecase.deactivateDid(ctx, SELF_USER_ID);
+
+      expect(mockVcIssuanceService.cascadeRevokeForUser).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/__tests__/unit/application/domain/credential/vcIssuance/service.test.ts
+++ b/src/__tests__/unit/application/domain/credential/vcIssuance/service.test.ts
@@ -18,10 +18,6 @@ import VcIssuanceService, {
   CIVICSHIP_ISSUER_DID,
   buildVcPayload,
 } from "@/application/domain/credential/vcIssuance/service";
-import {
-  StubJwtSigner,
-  STUB_SIGNATURE,
-} from "@/application/domain/credential/shared/stubJwtSigner";
 import { buildRoot, verifyProof } from "@/infrastructure/libs/merkle/merkleTreeBuilder";
 import type {
   VcAnchorRow,
@@ -37,6 +33,10 @@ const FAKE_STATUS_URL = "https://api.civicship.app/credentials/status/1.jwt";
 class MockVcIssuanceRepository {
   findById = jest.fn().mockResolvedValue(null);
   findByUserId = jest.fn().mockResolvedValue([]);
+  // Phase 2: cascadeRevokeForUser drives the DID DEACTIVATE → VC revoke
+  // flow (§14.2). Default to "no active VCs" so unrelated tests don't
+  // accidentally enter the revoke loop.
+  findActiveByUserId = jest.fn().mockResolvedValue([]);
   create = jest.fn();
   findVcAnchorById = jest.fn().mockResolvedValue(null);
   findVcJwtsByIds = jest.fn().mockResolvedValue([]);
@@ -71,6 +71,9 @@ class MockStatusListService {
     statusListIndex: 42,
     statusListCredentialUrl: FAKE_STATUS_URL,
   });
+  // Phase 2: cascadeRevokeForUser delegates to revokeVc per VC. Default
+  // to a no-op so the call counter is meaningful in tests that opt in.
+  revokeVc = jest.fn().mockResolvedValue(undefined);
 }
 
 function decodeJwtSegment(segment: string): unknown {
@@ -91,17 +94,6 @@ describe("VcIssuanceService", () => {
     mockStatusList = new MockStatusListService();
     container.register("VcIssuanceRepository", { useValue: mockRepository });
     container.register("StatusListService", { useValue: mockStatusList });
-    // Phase 2 prep: VcIssuanceService now resolves `VcJwtSigner` from DI
-    // rather than reaching for the inline `STUB_SIGNATURE` constant. We
-    // bind the same `StubJwtSigner` used in production so the JWT output
-    // stays byte-identical and the existing assertions
-    // (`expect(segments[2]).toBe("stub-not-signed")`) keep passing.
-    container.register("VcJwtSigner", {
-      useValue: new StubJwtSigner({
-        kid: `${CIVICSHIP_ISSUER_DID}#stub`,
-        stubSignature: STUB_SIGNATURE,
-      }),
-    });
     container.register("VcIssuanceService", { useClass: VcIssuanceService });
 
     service = container.resolve(VcIssuanceService);
@@ -401,6 +393,103 @@ describe("VcIssuanceService", () => {
       await expect(
         service.generateInclusionProof(mockCtx, leafRows[0].vcIssuanceRequestId),
       ).rejects.toThrow(/not present in anchor/);
+    });
+  });
+
+  describe("cascadeRevokeForUser (Phase 2 §14.2 / §E)", () => {
+    // Sentinel `tx` so we can assert the same client is forwarded to both
+    // the repository read and every StatusList write.
+    const tx = { sentinel: "tx" } as never;
+
+    it("revokes every active VC for the user via StatusListService.revokeVc", async () => {
+      const rows = [
+        makeVcRow({ id: "vc-a", statusListIndex: 1 }),
+        makeVcRow({ id: "vc-b", statusListIndex: 2 }),
+      ];
+      mockRepository.findActiveByUserId.mockResolvedValueOnce(rows);
+
+      const count = await service.cascadeRevokeForUser(mockCtx, "u_1", tx);
+
+      expect(count).toBe(2);
+      expect(mockRepository.findActiveByUserId).toHaveBeenCalledWith(mockCtx, "u_1", tx);
+      expect(mockStatusList.revokeVc).toHaveBeenCalledTimes(2);
+      expect(mockStatusList.revokeVc).toHaveBeenNthCalledWith(
+        1,
+        mockCtx,
+        { vcRequestId: "vc-a", reason: "did-deactivated" },
+        tx,
+      );
+      expect(mockStatusList.revokeVc).toHaveBeenNthCalledWith(
+        2,
+        mockCtx,
+        { vcRequestId: "vc-b", reason: "did-deactivated" },
+        tx,
+      );
+    });
+
+    it("returns 0 and does not call the StatusList when the user has no active VCs", async () => {
+      mockRepository.findActiveByUserId.mockResolvedValueOnce([]);
+
+      const count = await service.cascadeRevokeForUser(mockCtx, "u_lonely", tx);
+
+      expect(count).toBe(0);
+      expect(mockStatusList.revokeVc).not.toHaveBeenCalled();
+    });
+
+    it("is idempotent because findActiveByUserId filters revokedAt IS NULL at the repo layer", async () => {
+      // Simulate the second cascade call: every prior revocation already
+      // stamped revokedAt, so the repo returns nothing.
+      mockRepository.findActiveByUserId.mockResolvedValueOnce([]);
+
+      const count = await service.cascadeRevokeForUser(mockCtx, "u_already_revoked", tx);
+
+      expect(count).toBe(0);
+      expect(mockStatusList.revokeVc).not.toHaveBeenCalled();
+    });
+
+    it("skips rows that have no §D StatusList wiring without blocking the cascade", async () => {
+      const rows = [
+        // Pre-§D row — no statusListIndex / statusListCredential. Must be
+        // skipped (we have no bit to flip) but must not stop later rows.
+        makeVcRow({ id: "vc-legacy", statusListIndex: null, statusListCredential: null }),
+        makeVcRow({ id: "vc-modern", statusListIndex: 7 }),
+      ];
+      mockRepository.findActiveByUserId.mockResolvedValueOnce(rows);
+
+      const count = await service.cascadeRevokeForUser(mockCtx, "u_mixed", tx);
+
+      expect(count).toBe(1);
+      expect(mockStatusList.revokeVc).toHaveBeenCalledTimes(1);
+      expect(mockStatusList.revokeVc).toHaveBeenCalledWith(
+        mockCtx,
+        { vcRequestId: "vc-modern", reason: "did-deactivated" },
+        tx,
+      );
+    });
+
+    it("respects a custom reason when supplied", async () => {
+      mockRepository.findActiveByUserId.mockResolvedValueOnce([makeVcRow({ id: "vc-a" })]);
+
+      await service.cascadeRevokeForUser(mockCtx, "u_1", tx, "operator-purge");
+
+      expect(mockStatusList.revokeVc).toHaveBeenCalledWith(
+        mockCtx,
+        { vcRequestId: "vc-a", reason: "operator-purge" },
+        tx,
+      );
+    });
+
+    it("propagates errors from StatusListService.revokeVc so the surrounding tx rolls back", async () => {
+      mockRepository.findActiveByUserId.mockResolvedValueOnce([
+        makeVcRow({ id: "vc-a" }),
+        makeVcRow({ id: "vc-b" }),
+      ]);
+      mockStatusList.revokeVc.mockRejectedValueOnce(new Error("KMS down"));
+
+      await expect(service.cascadeRevokeForUser(mockCtx, "u_1", tx)).rejects.toThrow(/KMS down/);
+      // The second VC must NOT be revoked — leaving the tx half-applied
+      // is exactly what the surrounding usecase transaction prevents.
+      expect(mockStatusList.revokeVc).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/__tests__/unit/application/domain/credential/vcIssuance/service.test.ts
+++ b/src/__tests__/unit/application/domain/credential/vcIssuance/service.test.ts
@@ -9,6 +9,11 @@
  * Step 8 update: `StatusListService` is now a constructor dependency. We
  * inject a fake that returns a deterministic slot so the assertions can
  * pin the embedded `credentialStatus` block.
+ *
+ * Phase 2 prep update: `VcIssuanceService` now also resolves a
+ * `VcJwtSigner` via DI (PR #1121). We register the production
+ * `StubJwtSigner` instance so the produced JWT byte-matches the
+ * pre-extraction version (`segments[2] === "stub-not-signed"`).
  */
 
 import "reflect-metadata";
@@ -18,6 +23,10 @@ import VcIssuanceService, {
   CIVICSHIP_ISSUER_DID,
   buildVcPayload,
 } from "@/application/domain/credential/vcIssuance/service";
+import {
+  StubJwtSigner,
+  STUB_SIGNATURE,
+} from "@/application/domain/credential/shared/stubJwtSigner";
 import { buildRoot, verifyProof } from "@/infrastructure/libs/merkle/merkleTreeBuilder";
 import type {
   VcAnchorRow,
@@ -94,6 +103,17 @@ describe("VcIssuanceService", () => {
     mockStatusList = new MockStatusListService();
     container.register("VcIssuanceRepository", { useValue: mockRepository });
     container.register("StatusListService", { useValue: mockStatusList });
+    // Phase 2 prep: VcIssuanceService now resolves `VcJwtSigner` from DI
+    // rather than reaching for the inline `STUB_SIGNATURE` constant. We
+    // bind the same `StubJwtSigner` used in production so the JWT output
+    // stays byte-identical and the existing assertions
+    // (`expect(segments[2]).toBe("stub-not-signed")`) keep passing.
+    container.register("VcJwtSigner", {
+      useValue: new StubJwtSigner({
+        kid: `${CIVICSHIP_ISSUER_DID}#stub`,
+        stubSignature: STUB_SIGNATURE,
+      }),
+    });
     container.register("VcIssuanceService", { useClass: VcIssuanceService });
 
     service = container.resolve(VcIssuanceService);

--- a/src/application/domain/account/userDid/usecase.ts
+++ b/src/application/domain/account/userDid/usecase.ts
@@ -43,6 +43,9 @@ import { IContext } from "@/types/server";
 import { AuthorizationError } from "@/errors/graphql";
 import UserDidService from "@/application/domain/account/userDid/service";
 import UserDidPresenter from "@/application/domain/account/userDid/presenter";
+import VcIssuanceService from "@/application/domain/credential/vcIssuance/service";
+import logger from "@/infrastructure/logging";
+import type { Prisma } from "@prisma/client";
 import type {
   AnchorNetworkValue,
   UserDidAnchorRow,
@@ -60,9 +63,48 @@ function isSelfOrAdmin(ctx: IContext, userId: string): boolean {
   return ctx.currentUser?.id === userId;
 }
 
+/**
+ * Reason string passed to `StatusListService.revokeVc` (via
+ * `VcIssuanceService.cascadeRevokeForUser`) for every VC revoked as a
+ * side-effect of a DID DEACTIVATE. Persisted to `revocation_reason` so
+ * audit log queries can distinguish operator-initiated revocations from
+ * the lifecycle cascade (§14.2 / §E).
+ */
+const DID_DEACTIVATE_REASON = "did-deactivated";
+
 @injectable()
 export default class UserDidUseCase {
-  constructor(@inject("UserDidService") private readonly service: UserDidService) {}
+  constructor(
+    @inject("UserDidService") private readonly service: UserDidService,
+    @inject("VcIssuanceService") private readonly vcIssuanceService: VcIssuanceService,
+  ) {}
+
+  /**
+   * §14.2 / §E — cascade-revoke every still-live VC for `userId` inside
+   * the supplied transaction. Pulled out so both the GraphQL-facing
+   * (`deactivateUserDidForUser`) and service-level (`deactivateDid`)
+   * entry points share a single cascade implementation; behavioural
+   * drift between the two would let one path leave dangling VCs.
+   *
+   * Logs a single line with the revoked count so the cascade is visible
+   * in audit traces without re-querying the StatusList.
+   */
+  private async cascadeRevokeUserVcs(
+    ctx: IContext,
+    userId: string,
+    tx: Prisma.TransactionClient,
+  ): Promise<void> {
+    const revoked = await this.vcIssuanceService.cascadeRevokeForUser(
+      ctx,
+      userId,
+      tx,
+      DID_DEACTIVATE_REASON,
+    );
+    logger.info("[UserDidUseCase] DID DEACTIVATE → cascade-revoked VCs", {
+      userId,
+      revokedCount: revoked,
+    });
+  }
 
   /**
    * GraphQL `userDid(userId)` resolver entry. Reads outside a write
@@ -121,8 +163,14 @@ export default class UserDidUseCase {
     if (!isSelfOrAdmin(ctx, userId)) {
       throw new AuthorizationError("userId must match the authenticated user");
     }
+    // §14.2 — DID DEACTIVATE + VC cascade revoke commit in the SAME
+    // transaction. Splitting them would create a "DID is tombstoned but
+    // a freshly-fetched VC still verifies as live" window that the
+    // design's acceptance check (line 2123) explicitly forbids.
     const row = await ctx.issuer.public(ctx, async (tx) => {
-      return this.service.deactivateDid(ctx, userId, tx);
+      const anchor = await this.service.deactivateDid(ctx, userId, tx);
+      await this.cascadeRevokeUserVcs(ctx, userId, tx);
+      return anchor;
     });
     return UserDidPresenter.view(row);
   }
@@ -144,8 +192,13 @@ export default class UserDidUseCase {
   }
 
   async deactivateDid(ctx: IContext, userId: string): Promise<UserDidAnchorRow> {
+    // §14.2 — same cascade as `deactivateUserDidForUser` so non-GraphQL
+    // callers (admin tooling, batch hooks) cannot bypass the VC revoke
+    // step by reaching for the service-level wrapper.
     return ctx.issuer.public(ctx, async (tx) => {
-      return this.service.deactivateDid(ctx, userId, tx);
+      const anchor = await this.service.deactivateDid(ctx, userId, tx);
+      await this.cascadeRevokeUserVcs(ctx, userId, tx);
+      return anchor;
     });
   }
 }

--- a/src/application/domain/credential/vcIssuance/data/interface.ts
+++ b/src/application/domain/credential/vcIssuance/data/interface.ts
@@ -39,6 +39,24 @@ export interface IVcIssuanceRepository {
    */
   findByUserId(ctx: IContext, userId: string): Promise<VcIssuanceRow[]>;
 
+  /**
+   * Return every *unrevoked* VC issuance row owned by `userId`. Used by
+   * the DID DEACTIVATE → cascade-revoke flow (§14.2 / §E): when a user's
+   * DID is tombstoned every still-live VC issued for that subject must
+   * be revoked atomically. The filter is `revokedAt IS NULL` so already-
+   * revoked rows are skipped and the cascade stays idempotent.
+   *
+   * `tx` is forwarded so the caller (UserDidUseCase) reads inside the
+   * same transaction that flips the StatusList bits — without that, a
+   * race between two concurrent DEACTIVATE calls could double-revoke a
+   * row (harmless, but noisy).
+   */
+  findActiveByUserId(
+    ctx: IContext,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<VcIssuanceRow[]>;
+
   create(
     ctx: IContext,
     input: CreateVcIssuanceInput,

--- a/src/application/domain/credential/vcIssuance/data/repository.ts
+++ b/src/application/domain/credential/vcIssuance/data/repository.ts
@@ -143,6 +143,38 @@ export default class VcIssuanceRepository implements IVcIssuanceRepository {
     });
   }
 
+  /**
+   * §14.2 / §E — DID DEACTIVATE cascade. Returns every VC issuance row
+   * for `userId` whose `revokedAt` is still null, oldest first so the
+   * caller can revoke deterministically (matters for log ordering when a
+   * user has many VCs).
+   *
+   * Uses the caller-supplied `tx` when present so the read shares the
+   * snapshot used by the surrounding StatusList writes; otherwise opens
+   * an issuer-scoped public transaction so RLS still applies.
+   */
+  async findActiveByUserId(
+    ctx: IContext,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<VcIssuanceRow[]> {
+    const persisted = tx
+      ? await tx.vcIssuanceRequest.findMany({
+          where: { userId, revokedAt: null },
+          orderBy: { createdAt: "asc" },
+        })
+      : await this.issuer.public(ctx, (innerTx) =>
+          innerTx.vcIssuanceRequest.findMany({
+            where: { userId, revokedAt: null },
+            orderBy: { createdAt: "asc" },
+          }),
+        );
+    return persisted.map((row) => {
+      const { issuerDid, subjectDid } = decodeIssuerSubjectFromJwt(row.vcJwt, row.id);
+      return toRow(row, issuerDid, subjectDid);
+    });
+  }
+
   async create(
     ctx: IContext,
     input: CreateVcIssuanceInput,

--- a/src/application/domain/credential/vcIssuance/service.ts
+++ b/src/application/domain/credential/vcIssuance/service.ts
@@ -27,16 +27,6 @@
  * be wired in Phase 1 step 10; the unit tests already verify the JWT
  * shape so the swap is mechanical.
  *
- * Phase 2 prep (signer interface extraction)
- * ------------------------------------------
- * The signature production step has been hoisted behind a `JwtSigner`
- * interface (`credential/shared/jwtSigner.ts`). This service is now
- * injected with a `VcJwtSigner` token rather than reaching for the
- * inline `STUB_SIGNATURE` constant. Behaviour is unchanged in Phase 1
- * because the bound implementation is `StubJwtSigner` and its output is
- * exactly `STUB_SIGNATURE`; the indirection only matters once
- * `KmsJwtSigner` replaces the stub in Phase 2 (design doc §16).
- *
  * Design references:
  *   docs/report/did-vc-internalization.md §5.2.2 (this service)
  *   docs/report/did-vc-internalization.md §D     (BitstringStatusList)
@@ -54,8 +44,6 @@ import type {
 } from "@/application/domain/credential/vcIssuance/data/type";
 import StatusListService from "@/application/domain/credential/statusList/service";
 import { CIVICSHIP_ISSUER_DID } from "@/application/domain/credential/shared/constants";
-import type { JwtSigner } from "@/application/domain/credential/shared/jwtSigner";
-import { STUB_SIGNATURE } from "@/application/domain/credential/shared/stubJwtSigner";
 import { buildProof } from "@/infrastructure/libs/merkle/merkleTreeBuilder";
 
 /**
@@ -88,14 +76,16 @@ export interface InclusionProof {
 export { CIVICSHIP_ISSUER_DID };
 
 /**
- * Re-export so the public symbol's path stays stable for existing unit
- * tests (`__tests__/unit/application/domain/credential/vcIssuance/service.test.ts`
- * imports the marker indirectly via the JWT's signature segment). The
- * canonical definition now lives in
- * `credential/shared/stubJwtSigner.ts` alongside the `StubJwtSigner`
- * implementation that emits it.
+ * Phase 1 step 7 placeholder for the JWT signature. Real signing lives in
+ * a sibling PR (`claude/phase1-infra-kms-issuer-did`) — we emit a
+ * deterministic non-base64url marker so:
+ *
+ *   1. Tests can assert "this is a stub VC" without false positives.
+ *   2. Verifiers will reject it (it's not a valid base64url signature).
+ *   3. The grep target is unique enough to find every stub site once
+ *      KMS lands.
  */
-export { STUB_SIGNATURE };
+const STUB_SIGNATURE = "stub-not-signed";
 
 /**
  * Build the unsigned VC payload (§5.2.2 `buildVcPayload`).
@@ -154,17 +144,6 @@ export default class VcIssuanceService {
     private readonly repository: IVcIssuanceRepository,
     @inject("StatusListService")
     private readonly statusListService: StatusListService,
-    /**
-     * Phase 2 prep: signing is delegated to a `JwtSigner` rather than
-     * the inline stub. In Phase 1 the injected instance is a
-     * `StubJwtSigner` that returns `STUB_SIGNATURE`, so the produced
-     * JWT is byte-identical to the pre-extraction version. The DI
-     * token `VcJwtSigner` is intentionally distinct from
-     * `StatusListJwtSigner` so the two paths can rotate independently
-     * once KMS lands (design doc §16).
-     */
-    @inject("VcJwtSigner")
-    private readonly signer: JwtSigner,
   ) {}
 
   /**
@@ -185,6 +164,73 @@ export default class VcIssuanceService {
   /** Pass-through for the GraphQL `vcIssuancesByUser` query. */
   async findVcsByUserId(ctx: IContext, userId: string): Promise<VcIssuanceRow[]> {
     return this.repository.findByUserId(ctx, userId);
+  }
+
+  /**
+   * §14.2 / §E — DID DEACTIVATE cascade revoke.
+   *
+   * Used by `UserDidUseCase.deactivateDid*` to revoke every still-live VC
+   * issued for the deactivated user's subject DID. Looks up unrevoked
+   * rows via the repository's `revokedAt IS NULL` filter, then delegates
+   * each bit-flip + `revokedAt` stamp to `StatusListService.revokeVc` so
+   * the StatusList side stays the single owner of the revocation
+   * mechanics.
+   *
+   * Behaviour notes:
+   *   - Idempotent: rows with a non-null `revokedAt` are filtered at the
+   *     repository layer, so a second cascade for the same user is a
+   *     no-op (no StatusList re-sign churn).
+   *   - Skips rows that were issued before §D StatusList wiring
+   *     (statusListIndex / statusListCredential null). These rows have
+   *     no bit to flip; logging avoids silent data loss while keeping
+   *     the cascade unblockable.
+   *   - Returns the count of rows whose StatusList bit was actually
+   *     flipped — useful for the caller to log "revoked N VCs for user
+   *     X" without re-querying.
+   *   - `tx` is REQUIRED rather than optional because the cascade is
+   *     only ever invoked from inside the DEACTIVATE transaction; a
+   *     standalone caller would risk leaving a half-revoked StatusList
+   *     and a still-active DID.
+   */
+  async cascadeRevokeForUser(
+    ctx: IContext,
+    userId: string,
+    tx: Prisma.TransactionClient,
+    reason: string = "did-deactivated",
+  ): Promise<number> {
+    const active = await this.repository.findActiveByUserId(ctx, userId, tx);
+    if (active.length === 0) {
+      logger.debug("[VcIssuanceService] cascadeRevokeForUser: no active VCs", { userId });
+      return 0;
+    }
+
+    let revoked = 0;
+    for (const vc of active) {
+      if (vc.statusListIndex === null || vc.statusListCredential === null) {
+        // Pre-§D legacy / replay rows have no StatusList wiring — nothing
+        // to flip. Log so operators can backfill if needed; do NOT throw
+        // because that would block the DEACTIVATE for unrelated rows.
+        logger.warn(
+          "[VcIssuanceService] cascadeRevokeForUser: skipping VC without StatusList wiring",
+          { userId, vcRequestId: vc.id },
+        );
+        continue;
+      }
+      await this.statusListService.revokeVc(
+        ctx,
+        { vcRequestId: vc.id, reason },
+        tx,
+      );
+      revoked += 1;
+    }
+
+    logger.debug("[VcIssuanceService] cascadeRevokeForUser", {
+      userId,
+      candidateCount: active.length,
+      revokedCount: revoked,
+      reason,
+    });
+    return revoked;
   }
 
   /**
@@ -238,27 +284,16 @@ export default class VcIssuanceService {
     });
 
     // 2) Build a JWT-shape envelope. KMS-backed signing lands in
-    //    Phase 2 (`KmsJwtSigner`); until then the signer is a
-    //    `StubJwtSigner` that returns the deterministic marker
-    //    `STUB_SIGNATURE`. The signing input fed to `signer.sign()` is
-    //    exactly `${header}.${payload}` per the JWS spec so the Phase 2
-    //    swap requires no service-side change.
+    //    `claude/phase1-infra-kms-issuer-did`; until then the signature
+    //    segment is a deterministic stub marker (see `STUB_SIGNATURE`).
     const header = base64urlEncodeJson({
-      // `alg` is read off the signer (Phase 1 stub returns "EdDSA"; the
-      // future KMS signer returns the same string for the Ed25519 key,
-      // or whatever JWS alg KMS ends up advertising). Keeps service-side
-      // code agnostic to the JWS algorithm choice.
-      alg: this.signer.alg,
+      alg: "EdDSA",
       typ: "JWT",
-      // `kid` is read off the signer so the stub path and the future
-      // KMS path stamp the same header field without service-side
-      // branching. Phase 1 stub kid: `${issuerDid}#stub`.
-      kid: this.signer.kid,
+      // `kid` will reference the active KMS key id once it lands.
+      kid: `${issuerDid}#stub`,
     });
     const payload = base64urlEncodeJson(vcPayload);
-    const signingInput = `${header}.${payload}`;
-    const signature = await this.signer.sign(signingInput);
-    const vcJwt = `${signingInput}.${signature}`;
+    const vcJwt = `${header}.${payload}.${STUB_SIGNATURE}`;
 
     logger.debug("[VcIssuanceService] issueVc", {
       userId: input.userId,

--- a/src/application/domain/credential/vcIssuance/service.ts
+++ b/src/application/domain/credential/vcIssuance/service.ts
@@ -27,6 +27,16 @@
  * be wired in Phase 1 step 10; the unit tests already verify the JWT
  * shape so the swap is mechanical.
  *
+ * Phase 2 prep (signer interface extraction)
+ * ------------------------------------------
+ * The signature production step has been hoisted behind a `JwtSigner`
+ * interface (`credential/shared/jwtSigner.ts`). This service is now
+ * injected with a `VcJwtSigner` token rather than reaching for the
+ * inline `STUB_SIGNATURE` constant. Behaviour is unchanged in Phase 1
+ * because the bound implementation is `StubJwtSigner` and its output is
+ * exactly `STUB_SIGNATURE`; the indirection only matters once
+ * `KmsJwtSigner` replaces the stub in Phase 2 (design doc §16).
+ *
  * Design references:
  *   docs/report/did-vc-internalization.md §5.2.2 (this service)
  *   docs/report/did-vc-internalization.md §D     (BitstringStatusList)
@@ -44,6 +54,8 @@ import type {
 } from "@/application/domain/credential/vcIssuance/data/type";
 import StatusListService from "@/application/domain/credential/statusList/service";
 import { CIVICSHIP_ISSUER_DID } from "@/application/domain/credential/shared/constants";
+import type { JwtSigner } from "@/application/domain/credential/shared/jwtSigner";
+import { STUB_SIGNATURE } from "@/application/domain/credential/shared/stubJwtSigner";
 import { buildProof } from "@/infrastructure/libs/merkle/merkleTreeBuilder";
 
 /**
@@ -76,16 +88,14 @@ export interface InclusionProof {
 export { CIVICSHIP_ISSUER_DID };
 
 /**
- * Phase 1 step 7 placeholder for the JWT signature. Real signing lives in
- * a sibling PR (`claude/phase1-infra-kms-issuer-did`) — we emit a
- * deterministic non-base64url marker so:
- *
- *   1. Tests can assert "this is a stub VC" without false positives.
- *   2. Verifiers will reject it (it's not a valid base64url signature).
- *   3. The grep target is unique enough to find every stub site once
- *      KMS lands.
+ * Re-export so the public symbol's path stays stable for existing unit
+ * tests (`__tests__/unit/application/domain/credential/vcIssuance/service.test.ts`
+ * imports the marker indirectly via the JWT's signature segment). The
+ * canonical definition now lives in
+ * `credential/shared/stubJwtSigner.ts` alongside the `StubJwtSigner`
+ * implementation that emits it.
  */
-const STUB_SIGNATURE = "stub-not-signed";
+export { STUB_SIGNATURE };
 
 /**
  * Build the unsigned VC payload (§5.2.2 `buildVcPayload`).
@@ -144,6 +154,17 @@ export default class VcIssuanceService {
     private readonly repository: IVcIssuanceRepository,
     @inject("StatusListService")
     private readonly statusListService: StatusListService,
+    /**
+     * Phase 2 prep: signing is delegated to a `JwtSigner` rather than
+     * the inline stub. In Phase 1 the injected instance is a
+     * `StubJwtSigner` that returns `STUB_SIGNATURE`, so the produced
+     * JWT is byte-identical to the pre-extraction version. The DI
+     * token `VcJwtSigner` is intentionally distinct from
+     * `StatusListJwtSigner` so the two paths can rotate independently
+     * once KMS lands (design doc §16).
+     */
+    @inject("VcJwtSigner")
+    private readonly signer: JwtSigner,
   ) {}
 
   /**
@@ -191,6 +212,18 @@ export default class VcIssuanceService {
    *     only ever invoked from inside the DEACTIVATE transaction; a
    *     standalone caller would risk leaving a half-revoked StatusList
    *     and a still-active DID.
+   *
+   * Performance / scaling (Gemini review on PR #1128, Phase 2 deferred):
+   * the per-VC `revokeVc` call re-decodes, flips, re-compresses, and
+   * **re-signs** the StatusList VC every iteration. When a single user
+   * holds many VCs that all sit on the same StatusList (steady-state
+   * for civicship: one list per ~13 years, §7.3) this re-signs the same
+   * list N times. Acceptable now because cascades fire on user-delete
+   * (low frequency) and N is single-digit per user; revisit with a
+   * `revokeVcsBulk(listKey, indexes[])` repository write + single re-sign
+   * in Phase 2 once admin bulk-purge tooling is in scope. TODO marker
+   * lives next to `statusListService.revokeVc` below for grep
+   * traceability.
    */
   async cascadeRevokeForUser(
     ctx: IContext,
@@ -216,6 +249,12 @@ export default class VcIssuanceService {
         );
         continue;
       }
+      // TODO(Phase 2 — Gemini PR #1128): batch by listKey and call a
+      // single `StatusListService.revokeVcsBulk` so the StatusList VC
+      // is decoded / re-signed once per list rather than once per VC.
+      // Out of scope for the cascade-revoke PR (deferred until admin
+      // bulk-purge tooling lands; cascade frequency is low enough that
+      // the loop is fine for the user-delete trigger).
       await this.statusListService.revokeVc(
         ctx,
         { vcRequestId: vc.id, reason },
@@ -284,16 +323,27 @@ export default class VcIssuanceService {
     });
 
     // 2) Build a JWT-shape envelope. KMS-backed signing lands in
-    //    `claude/phase1-infra-kms-issuer-did`; until then the signature
-    //    segment is a deterministic stub marker (see `STUB_SIGNATURE`).
+    //    Phase 2 (`KmsJwtSigner`); until then the signer is a
+    //    `StubJwtSigner` that returns the deterministic marker
+    //    `STUB_SIGNATURE`. The signing input fed to `signer.sign()` is
+    //    exactly `${header}.${payload}` per the JWS spec so the Phase 2
+    //    swap requires no service-side change.
     const header = base64urlEncodeJson({
-      alg: "EdDSA",
+      // `alg` is read off the signer (Phase 1 stub returns "EdDSA"; the
+      // future KMS signer returns the same string for the Ed25519 key,
+      // or whatever JWS alg KMS ends up advertising). Keeps service-side
+      // code agnostic to the JWS algorithm choice.
+      alg: this.signer.alg,
       typ: "JWT",
-      // `kid` will reference the active KMS key id once it lands.
-      kid: `${issuerDid}#stub`,
+      // `kid` is read off the signer so the stub path and the future
+      // KMS path stamp the same header field without service-side
+      // branching. Phase 1 stub kid: `${issuerDid}#stub`.
+      kid: this.signer.kid,
     });
     const payload = base64urlEncodeJson(vcPayload);
-    const vcJwt = `${header}.${payload}.${STUB_SIGNATURE}`;
+    const signingInput = `${header}.${payload}`;
+    const signature = await this.signer.sign(signingInput);
+    const vcJwt = `${signingInput}.${signature}`;
 
     logger.debug("[VcIssuanceService] issueVc", {
       userId: input.userId,


### PR DESCRIPTION
## Summary

設計書 §14.2 acceptance check (line 2123): "DID DEACTIVATE → VC cascade revocation: ユーザー削除時に該当 VC が自動的に revoke される" を実装。

ユーザーが DID DEACTIVATE すると、当該 user の subject DID で発行された未 revoke の VC を **すべて自動的に revoke** する (StatusList の bit を立てる)。同一 transaction 内で実行することで、「DID は tombstone なのに VC は live」という window を防ぐ。

参照:
- `docs/report/did-vc-internalization.md` §14.2 line 2123 (acceptance check)
- `docs/report/did-vc-internalization.md` §E (Tombstone)
- `docs/report/did-vc-internalization.md` §7.x (StatusList revoke)

## Design

### Layer 配置

DDD/Clean Architecture に沿って役割を分離:

- `VcIssuanceRepository.findActiveByUserId(ctx, userId, tx?)` — `revokedAt IS NULL` filter で active row のみ抽出 (`createdAt ASC` 順)。`tx` を forward して同一 snapshot で読む。
- `VcIssuanceService.cascadeRevokeForUser(ctx, userId, tx, reason?)` — active rows をループして `StatusListService.revokeVc` に委譲。`tx` は **required** (DEACTIVATE 内でのみ呼ばれる前提)。
- `UserDidUseCase.deactivateUserDidForUser` / `deactivateDid` — `ctx.issuer.public(ctx, async (tx) => {…})` で DEACTIVATE anchor enqueue → cascade revoke を **同一 transaction** で実行。

### 順序と原子性

```
ctx.issuer.public(ctx, async (tx) => {
  const anchor = await this.service.deactivateDid(ctx, userId, tx);  // ① DEACTIVATE
  await this.cascadeRevokeUserVcs(ctx, userId, tx);                  // ② cascade revoke
  return anchor;
});
```

- ①失敗 → ②も実行されず DEACTIVATE 取り消し (整合性保持)
- ②失敗 → tx rollback で ①も取り消し (StatusList 半適用なし)
- DEACTIVATE 後に cascade することで、「VC だけ revoke されたが DID は live」という逆 window も発生しない

### 冪等性

- `findActiveByUserId` が `revokedAt IS NULL` でフィルタするため、2 回目以降の DEACTIVATE 呼び出しは StatusList を一切叩かず no-op
- `StatusListService.revokeVc` 自体も冪等 (既存 PR #1102 で担保済)

### Edge case 処理

- VC が 0 件の user → `findActiveByUserId` が `[]` を返し no-op
- §D StatusList wiring が無い legacy/replay 行 → skip + warn log (cascade 全体は止めない)
- 操作起源の区別: cascade は `reason: "did-deactivated"` を `revocation_reason` に記録 (operator-initiated `revokeUserVc` と audit 上区別可能)

### Layer 違反していないこと

- service ↔ service の cross-domain call (`UserDidUseCase` → `VcIssuanceService`) は usecase 経由なので CLAUDE.md 準拠
- transaction は usecase でのみ open
- presenter / converter は無変更

## Non-scope

- VC の論理削除 (`revokedAt` のみ立てる、行は残す)
- chain anchor の rebuild (StatusList 側で再署名するだけで OK)
- 他 issuer 発行 VC の扱い (subjectDid が civicship issuer の VC のみ対象)
- ユーザー削除 (`Mutation.userDeleteMe`) からの DID DEACTIVATE 自動発火 (現状ユーザー削除は DID DEACTIVATE を呼んでいない。本 PR は **DID DEACTIVATE が trigger された時** の cascade のみを担保する。user delete → DID DEACTIVATE 連動は別 issue)

## Test plan

- [x] **Unit (VcIssuanceService.cascadeRevokeForUser)**
  - [x] 2 件の active VC → 両方 `StatusListService.revokeVc` 呼び出し、`reason: "did-deactivated"` を渡す、count=2
  - [x] 0 件 → StatusList を一切呼ばない、count=0
  - [x] 既に全 revoke 済 (repo が `[]` 返す) → idempotent no-op
  - [x] StatusList wiring 無い legacy 行 → skip + warn、後続 modern 行は revoke される
  - [x] custom reason 受理
  - [x] StatusList エラーは throw 伝播 (tx rollback 担保)
- [x] **Unit (UserDidUseCase)**
  - [x] authz 失敗時に cascade を呼ばない (defence-in-depth)
  - [x] DEACTIVATE → cascade の **呼び出し順序** assertion (`invocationCallOrder`)
  - [x] tx forwarding (sentinel tx が両方に渡る)
  - [x] admin path も cascade 実行
  - [x] service-level wrapper `deactivateDid` も cascade 実行 (bypass 防止)
- [x] **Integration (VcIssuanceRepository.findActiveByUserId)**
  - [x] 3 件 (1 件 revoked, 2 件 active) → active 2 件のみを `createdAt ASC` で返却
  - [x] 全 revoke 済 → `[]`
  - [x] VC 0 件 → `[]`
- [ ] (manual) `pnpm test --runInBand src/__tests__/unit/application/domain/account/userDid/usecase.test.ts`
- [ ] (manual) `pnpm test --runInBand src/__tests__/unit/application/domain/credential/vcIssuance/service.test.ts`
- [ ] (manual) `pnpm test --runInBand src/__tests__/integration/application/domain/credential/vcIssuance/repository.test.ts` (要 PostgreSQL)

## Files changed

- `src/application/domain/credential/vcIssuance/data/interface.ts`
- `src/application/domain/credential/vcIssuance/data/repository.ts`
- `src/application/domain/credential/vcIssuance/service.ts`
- `src/application/domain/account/userDid/usecase.ts`
- `src/__tests__/unit/application/domain/account/userDid/usecase.test.ts`
- `src/__tests__/unit/application/domain/credential/vcIssuance/service.test.ts`
- `src/__tests__/integration/application/domain/credential/vcIssuance/repository.test.ts`


---
_Generated by [Claude Code](https://claude.ai/code/session_01XzsQPXMVEMPycqQ3sX6pq7)_