### PR TITLE
feat(issuer-did): add t_issuer_did_keys schema + replace Strategy A stub with Prisma repo

### DIFF
--- a/src/__tests__/integration/acceptance/phase-1.5/phase14_issuer_multikey_serving.test.ts
+++ b/src/__tests__/integration/acceptance/phase-1.5/phase14_issuer_multikey_serving.test.ts
@@ -116,9 +116,10 @@ describe("[§14.2] Issuer DID /.well-known/did.json — §G overlap multi-key se
   // `container.register(...)` override done inside one test (e.g.
   // `wireOverlapKeys()` below) is wiped before the next one runs.
   // The bootstrap-fallback test relies on this — it MUST see the
-  // production `IssuerDidKeyRepositoryStub` (which returns `[]`), not
-  // a stub left behind by a prior test. Do not move this reset into a
-  // less aggressive lifecycle hook (e.g. `beforeAll`).
+  // production `IssuerDidKeyRepository` against an empty
+  // `t_issuer_did_keys` table (which yields `[]`), not a stub left
+  // behind by a prior test. Do not move this reset into a less
+  // aggressive lifecycle hook (e.g. `beforeAll`).
   beforeEach(async () => {
     await setupAcceptanceTest();
   });
@@ -224,9 +225,11 @@ describe("[§14.2] Issuer DID /.well-known/did.json — §G overlap multi-key se
   });
 
   it("falls back to the minimal static Document when no keys are registered (bootstrap)", async () => {
-    // Default production wiring uses `IssuerDidKeyRepositoryStub`, which
-    // returns [] from listActiveKeys(). No override needed — this exercises
-    // the bootstrap state straight from registerProductionDependencies().
+    // Default production wiring is `IssuerDidKeyRepository` against an
+    // empty `t_issuer_did_keys` table — `listActiveKeys()` returns []
+    // and the router falls through to the static fallback. No DI
+    // override needed; this exercises the bootstrap state straight from
+    // registerProductionDependencies() + the migration's empty table.
     const res = await request(makeApp()).get("/.well-known/did.json");
 
     expect(res.status).toBe(200);

--- a/src/__tests__/integration/application/domain/credential/issuerDid/repository.test.ts
+++ b/src/__tests__/integration/application/domain/credential/issuerDid/repository.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Integration tests for `IssuerDidKeyRepository` (§5.4.3 / §G).
+ *
+ * Covers the persistence-layer behaviours that the previous Phase 1.5
+ * Strategy A stub could not exercise:
+ *
+ *   - empty table → `findActiveKey() === null`, `listActiveKeys() === []`
+ *     (bootstrap state for a freshly-deployed environment)
+ *   - one ENABLED row → `findActiveKey()` returns it, `listActiveKeys()`
+ *     returns the same row
+ *   - one DISABLED row (rotating-out tail, `deactivatedAt !== null`) →
+ *     `findActiveKey()` returns null even though the row exists;
+ *     `listActiveKeys()` still returns it (§9.1.3 — DISABLED kept forever
+ *     for past-VC verification)
+ *   - mid-rotation overlap (1 ENABLED + 1 DISABLED) → `findActiveKey()`
+ *     returns the ENABLED row, `listActiveKeys()` returns both in
+ *     activatedAt ASC order
+ *   - multiple ENABLED rows (transient overlap during admin activation
+ *     before the old key is disabled) → `findActiveKey()` returns the
+ *     most-recently-activated row
+ *
+ * Schema references:
+ *   src/infrastructure/prisma/schema.prisma — `model IssuerDidKey`
+ *   migrations/20260512060000_add_issuer_did_keys/migration.sql
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.4.3 (IssuerDidService)
+ *   docs/report/did-vc-internalization.md §G    (key rotation overlap)
+ *   docs/report/did-vc-internalization.md §9.1.2 (24h overlap)
+ *   docs/report/did-vc-internalization.md §9.1.3 (DISABLED 永続保持)
+ */
+
+import "reflect-metadata";
+import { container } from "tsyringe";
+import { registerProductionDependencies } from "@/application/provider";
+import TestDataSourceHelper from "@/__tests__/helper/test-data-source-helper";
+import { prismaClient } from "@/infrastructure/prisma/client";
+import IssuerDidKeyRepository from "@/application/domain/credential/issuerDid/data/repository";
+
+const KMS_KEY_V1 =
+  "projects/kyoso-dev/locations/asia-northeast1/keyRings/civicship/cryptoKeys/civicship-issuer-vc/cryptoKeyVersions/1";
+const KMS_KEY_V2 =
+  "projects/kyoso-dev/locations/asia-northeast1/keyRings/civicship/cryptoKeys/civicship-issuer-vc/cryptoKeyVersions/2";
+const KMS_KEY_V3 =
+  "projects/kyoso-dev/locations/asia-northeast1/keyRings/civicship/cryptoKeys/civicship-issuer-vc/cryptoKeyVersions/3";
+
+describe("IssuerDidKeyRepository (integration)", () => {
+  jest.setTimeout(30_000);
+  let repo: IssuerDidKeyRepository;
+
+  beforeEach(async () => {
+    await TestDataSourceHelper.deleteAll();
+    container.reset();
+    registerProductionDependencies();
+    repo = container.resolve<IssuerDidKeyRepository>("IssuerDidKeyRepository");
+  });
+
+  afterAll(async () => {
+    await TestDataSourceHelper.disconnect();
+  });
+
+  describe("empty table (bootstrap state)", () => {
+    it("findActiveKey() returns null when no rows exist", async () => {
+      await expect(repo.findActiveKey()).resolves.toBeNull();
+    });
+
+    it("listActiveKeys() returns [] when no rows exist", async () => {
+      await expect(repo.listActiveKeys()).resolves.toEqual([]);
+    });
+  });
+
+  describe("single ENABLED row", () => {
+    it("findActiveKey() returns the row; listActiveKeys() returns [row]", async () => {
+      const row = await prismaClient.issuerDidKey.create({
+        data: {
+          kmsKeyResourceName: KMS_KEY_V1,
+          activatedAt: new Date("2026-01-01T00:00:00Z"),
+        },
+      });
+
+      const active = await repo.findActiveKey();
+      expect(active).toMatchObject({
+        id: row.id,
+        kmsKeyResourceName: KMS_KEY_V1,
+        deactivatedAt: null,
+      });
+
+      const all = await repo.listActiveKeys();
+      expect(all).toHaveLength(1);
+      expect(all[0].id).toBe(row.id);
+    });
+  });
+
+  describe("single DISABLED row (orphan tail)", () => {
+    it("findActiveKey() returns null but listActiveKeys() still returns it (§9.1.3)", async () => {
+      const row = await prismaClient.issuerDidKey.create({
+        data: {
+          kmsKeyResourceName: KMS_KEY_V1,
+          activatedAt: new Date("2026-01-01T00:00:00Z"),
+          deactivatedAt: new Date("2026-03-01T00:00:00Z"),
+        },
+      });
+
+      // No ENABLED key → no row eligible to sign with.
+      await expect(repo.findActiveKey()).resolves.toBeNull();
+
+      // But the DISABLED row stays in listActiveKeys so past-VC
+      // verifiers can still resolve its public key via the DID
+      // Document's verificationMethod array.
+      const all = await repo.listActiveKeys();
+      expect(all).toHaveLength(1);
+      expect(all[0]).toMatchObject({ id: row.id, deactivatedAt: row.deactivatedAt });
+    });
+  });
+
+  describe("§G overlap window (ENABLED + DISABLED)", () => {
+    it("findActiveKey() returns the ENABLED row; listActiveKeys() returns both ordered by activatedAt ASC", async () => {
+      const disabled = await prismaClient.issuerDidKey.create({
+        data: {
+          kmsKeyResourceName: KMS_KEY_V1,
+          activatedAt: new Date("2026-01-01T00:00:00Z"),
+          deactivatedAt: new Date("2026-05-01T00:00:00Z"),
+        },
+      });
+      const enabled = await prismaClient.issuerDidKey.create({
+        data: {
+          kmsKeyResourceName: KMS_KEY_V2,
+          activatedAt: new Date("2026-05-01T00:00:00Z"),
+        },
+      });
+
+      // findActiveKey targets the still-signable row.
+      const active = await repo.findActiveKey();
+      expect(active?.id).toBe(enabled.id);
+      expect(active?.deactivatedAt).toBeNull();
+
+      // listActiveKeys publishes BOTH (DISABLED v1 first, ENABLED v2
+      // second) so the DID Document's verificationMethod array is
+      // stable across re-renders and verifiers can resolve VCs signed
+      // with either key.
+      const all = await repo.listActiveKeys();
+      expect(all).toHaveLength(2);
+      expect(all.map((r) => r.id)).toEqual([disabled.id, enabled.id]);
+    });
+  });
+
+  describe("multiple ENABLED rows (transient activation overlap)", () => {
+    it("findActiveKey() returns the most-recently-activated row", async () => {
+      // Operational sequence the admin runbook performs:
+      //   1. Activate v2 (INSERT with deactivatedAt = NULL)
+      //   2. Eventually deactivate v1 (UPDATE deactivatedAt = now)
+      // Between (1) and (2) the table briefly holds two ENABLED rows.
+      // findActiveKey must still return a single, deterministic row —
+      // the newer one — so a sign() call during the overlap doesn't
+      // pick the rotating-out key.
+      const older = await prismaClient.issuerDidKey.create({
+        data: {
+          kmsKeyResourceName: KMS_KEY_V1,
+          activatedAt: new Date("2026-01-01T00:00:00Z"),
+        },
+      });
+      const newer = await prismaClient.issuerDidKey.create({
+        data: {
+          kmsKeyResourceName: KMS_KEY_V2,
+          activatedAt: new Date("2026-05-01T00:00:00Z"),
+        },
+      });
+
+      const active = await repo.findActiveKey();
+      expect(active?.id).toBe(newer.id);
+
+      // listActiveKeys still publishes both — ordered by activatedAt ASC.
+      const all = await repo.listActiveKeys();
+      expect(all.map((r) => r.id)).toEqual([older.id, newer.id]);
+    });
+  });
+
+  describe("kmsKeyResourceName uniqueness", () => {
+    it("rejects a duplicate kmsKeyResourceName (schema @unique)", async () => {
+      await prismaClient.issuerDidKey.create({
+        data: { kmsKeyResourceName: KMS_KEY_V1 },
+      });
+      await expect(
+        prismaClient.issuerDidKey.create({
+          data: { kmsKeyResourceName: KMS_KEY_V1 },
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("listActiveKeys ordering with 3+ rows", () => {
+    it("preserves activatedAt ASC even when inserted out of order", async () => {
+      // Insert v3 first, then v1, then v2 — exercise that ORDER BY is
+      // on activated_at not the insertion / id order.
+      await prismaClient.issuerDidKey.create({
+        data: {
+          kmsKeyResourceName: KMS_KEY_V3,
+          activatedAt: new Date("2026-09-01T00:00:00Z"),
+        },
+      });
+      await prismaClient.issuerDidKey.create({
+        data: {
+          kmsKeyResourceName: KMS_KEY_V1,
+          activatedAt: new Date("2026-01-01T00:00:00Z"),
+          deactivatedAt: new Date("2026-05-01T00:00:00Z"),
+        },
+      });
+      await prismaClient.issuerDidKey.create({
+        data: {
+          kmsKeyResourceName: KMS_KEY_V2,
+          activatedAt: new Date("2026-05-01T00:00:00Z"),
+          deactivatedAt: new Date("2026-09-01T00:00:00Z"),
+        },
+      });
+
+      const all = await repo.listActiveKeys();
+      expect(all.map((r) => r.kmsKeyResourceName)).toEqual([
+        KMS_KEY_V1,
+        KMS_KEY_V2,
+        KMS_KEY_V3,
+      ]);
+    });
+  });
+});

--- a/src/application/domain/credential/issuerDid/data/interface.ts
+++ b/src/application/domain/credential/issuerDid/data/interface.ts
@@ -7,15 +7,15 @@
  * audit trail, historical lookups by activation date) live behind a
  * separate interface and will be added when key rotation tooling lands.
  *
- * Strategy A note (Phase 1 step 8) ----------------------------------------
+ * Schema status -----------------------------------------------------------
  *
- * The Prisma model `IssuerDidKey` is not yet in the schema (§4 redesign in
- * progress). The repository implementation in this PR is a Strategy A stub
- * — `findActiveKey()` returns `null` so the router falls through to the
- * minimal static Document. `listActiveKeys()` returns `[]` for the same
- * reason. Both methods become real Prisma queries once the schema PR adds
- * `t_issuer_did_keys`; the interface itself is forward-compatible with
- * that swap.
+ * Phase 1.5 shipped a Strategy A stub (both methods short-circuited to
+ * `null` / `[]`) because `t_issuer_did_keys` did not exist yet. The
+ * migration `20260512060000_add_issuer_did_keys` adds the table and the
+ * default repository binding is now the Prisma-backed implementation
+ * (`./repository.ts`). The empty-table behaviour is preserved — when no
+ * key row has been registered yet, `findActiveKey()` still returns
+ * `null` and the router falls through to the minimal static Document.
  *
  * Design references:
  *   docs/report/did-vc-internalization.md §5.4.3 (IssuerDidService)

--- a/src/application/domain/credential/issuerDid/data/repository.ts
+++ b/src/application/domain/credential/issuerDid/data/repository.ts
@@ -1,79 +1,106 @@
 /**
- * Stub repository for `IssuerDidKey` (Strategy A, Phase 1 step 8).
+ * Prisma-backed repository for `IssuerDidKey` (§5.4.3 / §G).
  *
- * The Prisma model `IssuerDidKey` (`t_issuer_did_keys`) has NOT yet been
- * added to `schema.prisma` — the schema migration scope (#1094) shipped
- * `UserDidAnchor`, `VcAnchor`, `TransactionAnchor`, and
- * `StatusListCredential`, but the Issuer DID key registry was deferred
- * pending §G (key rotation) tooling design.
+ * Replaces the Phase 1.5 Strategy A stub: the schema migration
+ * `20260512060000_add_issuer_did_keys` shipped the `t_issuer_did_keys`
+ * table, so `findActiveKey()` / `listActiveKeys()` can now resolve real
+ * rows. Empty-table behaviour is unchanged from the stub — both methods
+ * still degrade gracefully (null / []) so the router's "minimal static
+ * Document" bootstrap fallback continues to work on a freshly-deployed
+ * environment where no key has been registered yet.
  *
- * Until the schema PR adds the table, the repository implementation
- * returns:
+ * RLS / transaction discipline:
  *
- *   - `findActiveKey()` → `null` (no row at all)
- *   - `listActiveKeys()` → `[]`  (no rows at all)
+ *   The `IssuerDidKey` table is **platform-global** — there is exactly one
+ *   Issuer DID for civicship and the keys belong to the API host, not to
+ *   any community or user. There is no per-row scope to enforce via
+ *   `ctx.issuer.public(...)`. Reads therefore go through `prismaClient`
+ *   directly. This mirrors how `IIssuerDidKeyRepository` declares its
+ *   methods without `ctx` / `tx` parameters — the surface area
+ *   intentionally hides RLS plumbing the table doesn't need.
  *
- * This is intentionally identical to "freshly-deployed bootstrap state":
- * `IssuerDidService` and the `/.well-known/did.json` route both treat a
- * `null` active key as the trigger to fall back to a minimal static
- * Document, which preserves dev/staging UX (clients still get a 200 with
- * a syntactically-valid `did:web` Document body).
- *
- * Once the schema PR merges, the swap is mechanical:
- *
- *   1. Replace the bodies with `tx.issuerDidKey.findFirst({ where: { deactivatedAt: null } })`
- *      and `tx.issuerDidKey.findMany({ where: { ... }, orderBy: { activatedAt: "asc" } })`.
- *   2. Use `ctx.issuer.public(ctx, tx => ...)` for RLS — the Issuer DID
- *      table is platform-global so `public` is appropriate (no community
- *      scope).
- *   3. Delete `IssuerDidKeyRepositoryNotImplementedError` (kept for
- *      consistency with the other Phase 1 stub repositories).
+ *   Write methods (`activateKeyVersion`, `deactivateKeyVersion`) are NOT
+ *   shipped in this PR; they belong to the §G rotation runbook tooling
+ *   and will be added when the admin-side rotation flow lands. Operators
+ *   bootstrap the first row directly via SQL / Prisma Studio for now —
+ *   the same as how `StatusListCredential` was bootstrapped pre-runbook.
  *
  * Design references:
  *   docs/report/did-vc-internalization.md §5.4.3 (IssuerDidService)
  *   docs/report/did-vc-internalization.md §G    (key rotation overlap)
- *   src/application/domain/account/userDid/data/repository.ts (sibling stub)
+ *   docs/report/did-vc-internalization.md §9.1.2 (24h overlap)
+ *   docs/report/did-vc-internalization.md §9.1.3 (DISABLED 永続保持)
  */
 
 import { injectable } from "tsyringe";
 
 import type { IIssuerDidKeyRepository } from "@/application/domain/credential/issuerDid/data/interface";
 import type { IssuerDidKeyRow } from "@/application/domain/credential/issuerDid/data/type";
+import { prismaClient } from "@/infrastructure/prisma/client";
+import type { IssuerDidKey as PrismaIssuerDidKey } from "@prisma/client";
 
 /**
- * Marker error for future write methods (`activateKeyVersion`,
- * `deactivateKeyVersion`) that intentionally do not exist yet. Mirrors
- * `UserDidAnchorRepositoryNotImplementedError` so a single grep finds
- * every Phase 1 stub site.
- *
- * Kept exported so an admin runbook script that probes for write support
- * can `instanceof`-check the error and produce a clear "feature not yet
- * shipped" message rather than a generic 500.
+ * Map the Prisma row shape to the domain `IssuerDidKeyRow`. The fields
+ * are 1:1 today — kept as a centralised converter so future schema
+ * additions (e.g. `purpose`, `algorithm`) can be filtered out here
+ * without leaking into the application layer.
  */
-export class IssuerDidKeyRepositoryNotImplementedError extends Error {
-  constructor(method: string) {
-    super(
-      `IssuerDidKeyRepositoryStub.${method}: not implemented yet — depends on ` +
-        "schema PR adding t_issuer_did_keys. Replace stub with the production " +
-        "Prisma-backed repository when that table lands (Phase 1 step 8+).",
-    );
-    this.name = "IssuerDidKeyRepositoryNotImplementedError";
-  }
+function toRow(record: PrismaIssuerDidKey): IssuerDidKeyRow {
+  return {
+    id: record.id,
+    kmsKeyResourceName: record.kmsKeyResourceName,
+    activatedAt: record.activatedAt,
+    deactivatedAt: record.deactivatedAt,
+  };
 }
 
 @injectable()
-export default class IssuerDidKeyRepositoryStub implements IIssuerDidKeyRepository {
-  // Returning `null` is the *correct* bootstrap signal — see file-header
-  // comment. `IssuerDidService.getActiveIssuerDidDocument()` propagates
-  // null upward and the router maps it to the minimal static Document.
+export default class IssuerDidKeyRepository implements IIssuerDidKeyRepository {
+  /**
+   * Return the row representing the **single currently-active** key.
+   *
+   *   WHERE deactivated_at IS NULL
+   *   ORDER BY activated_at DESC
+   *   LIMIT 1
+   *
+   * If the table is empty OR every row is DISABLED (no ENABLED key at
+   * the moment, e.g. mid-rotation gap), returns `null`. The service
+   * layer propagates null upward and `signWithActiveKey` throws —
+   * which is the right behaviour: signing without an active key would
+   * silently emit unverifiable VCs.
+   *
+   * Ordering by `activated_at DESC` (not `created_at`) so a backfilled
+   * row whose activation time predates an existing key still gets the
+   * "most recently activated" semantics right.
+   */
   async findActiveKey(): Promise<IssuerDidKeyRow | null> {
-    return null;
+    const record = await prismaClient.issuerDidKey.findFirst({
+      where: { deactivatedAt: null },
+      orderBy: { activatedAt: "desc" },
+    });
+    return record ? toRow(record) : null;
   }
 
-  // Returning `[]` matches the empty-table state. Callers building a
-  // DID Document `verificationMethod[]` array will see no keys and fall
-  // back to the minimal static Document via the same null-check path.
+  /**
+   * Return every row, ordered by `activated_at ASC`.
+   *
+   * §G overlap window = ENABLED rows + every DISABLED row (§9.1.3 —
+   * DISABLED is retained forever for past-VC verification). Pruning a
+   * DISABLED row would invalidate VCs signed against it, so the
+   * "overlap window" is effectively "all history". This keeps the
+   * verificationMethod array stable: row ordering is pinned to
+   * activation time, which matches the spec's §5.4.3 line 1131-1142
+   * sample (older key first, newest last).
+   *
+   * Returns `[]` (not null) on empty table so callers building a DID
+   * Document `verificationMethod[]` array see the same bootstrap signal
+   * as `findActiveKey() === null` and fall back to the minimal static
+   * Document via the router.
+   */
   async listActiveKeys(): Promise<IssuerDidKeyRow[]> {
-    return [];
+    const records = await prismaClient.issuerDidKey.findMany({
+      orderBy: { activatedAt: "asc" },
+    });
+    return records.map(toRow);
   }
 }

--- a/src/application/domain/credential/issuerDid/data/type.ts
+++ b/src/application/domain/credential/issuerDid/data/type.ts
@@ -8,13 +8,14 @@
  * deactivated. The `did:web` Document served at `/.well-known/did.json`
  * exposes every still-active key as a separate `verificationMethod`.
  *
- * Strategy A note (Phase 1 step 8) ----------------------------------------
+ * Schema status -----------------------------------------------------------
  *
- * The Prisma model `IssuerDidKey` is NOT in the schema yet. Until the
- * schema PR adds the table, the repository implementation returns `null`
- * from `findActiveKey()` so the router falls back to the minimal static
- * Document (which preserves dev/staging UX). The shape of `IssuerDidKeyRow`
- * below mirrors the planned columns one-for-one so the swap is mechanical.
+ * The Prisma model `IssuerDidKey` is now in the schema (migration
+ * `20260512060000_add_issuer_did_keys`). `IssuerDidKeyRow` is the
+ * application-layer view of one row from that table — kept as a
+ * dedicated type so the persistence shape (`Prisma.IssuerDidKey`) and
+ * the domain shape can evolve independently if the schema later grows
+ * fields the service doesn't need (e.g. ops-only annotations).
  *
  * Design references:
  *   docs/report/did-vc-internalization.md §5.1.1 (KMS resource naming)

--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -163,7 +163,7 @@ import VcIssuanceResolver from "@/application/domain/credential/vcIssuance/contr
 // 🪪 Issuer DID (§5.4.3 internal DID Document service, Phase 1 step 8)
 import IssuerDidService from "@/application/domain/credential/issuerDid/service";
 import IssuerDidUseCase from "@/application/domain/credential/issuerDid/usecase";
-import IssuerDidKeyRepositoryStub from "@/application/domain/credential/issuerDid/data/repository";
+import IssuerDidKeyRepository from "@/application/domain/credential/issuerDid/data/repository";
 import { KmsSigner } from "@/infrastructure/libs/kms/kmsSigner";
 
 // 🪪 Status List (§5.2.4 — VC revocation per W3C Bitstring Status List 2021)
@@ -347,18 +347,20 @@ export function registerProductionDependencies() {
   container.register("VcIssuanceUseCase", { useClass: VcIssuanceUseCase });
   container.register("VcIssuanceResolver", { useClass: VcIssuanceResolver });
 
-  // 🪪 Issuer DID (§5.4.3 internal DID Document service) — Strategy A stub
-  // repository. Drives `/.well-known/did.json` via `IssuerDidUseCase`. The
-  // stub returns `null` for `findActiveKey` until the schema PR adds the
-  // `t_issuer_did_keys` table; the router then falls back to a minimal
-  // static Document, preserving dev/staging UX.
+  // 🪪 Issuer DID (§5.4.3 internal DID Document service).
+  // Prisma-backed repository against `t_issuer_did_keys` (migration
+  // `20260512060000_add_issuer_did_keys`). Drives `/.well-known/did.json`
+  // via `IssuerDidUseCase`. When the table is empty (freshly-deployed
+  // environment with no key registered yet), `findActiveKey()` returns
+  // `null` and the router falls back to the minimal static Document —
+  // same UX as the prior Phase 1.5 stub.
   //
   // `KmsSigner` is registered here (not in a dedicated infra section) so
   // it sits adjacent to its single application-layer consumer for the
   // lifetime of Phase 1; future consumers (anchor batch worker) can lift
   // it into a shared "Cryptography" group once they land.
   container.registerSingleton("KmsSigner", KmsSigner);
-  container.register("IssuerDidKeyRepository", { useClass: IssuerDidKeyRepositoryStub });
+  container.register("IssuerDidKeyRepository", { useClass: IssuerDidKeyRepository });
   container.register("IssuerDidService", { useClass: IssuerDidService });
   container.register("IssuerDidUseCase", { useClass: IssuerDidUseCase });
 

--- a/src/infrastructure/prisma/migrations/20260512060000_add_issuer_did_keys/migration.sql
+++ b/src/infrastructure/prisma/migrations/20260512060000_add_issuer_did_keys/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "t_issuer_did_keys" (
+    "id" TEXT NOT NULL,
+    "kms_key_resource_name" TEXT NOT NULL,
+    "activated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "deactivated_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3),
+
+    CONSTRAINT "t_issuer_did_keys_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "t_issuer_did_keys_kms_key_resource_name_key" ON "t_issuer_did_keys"("kms_key_resource_name");
+
+-- CreateIndex
+CREATE INDEX "t_issuer_did_keys_activated_at_idx" ON "t_issuer_did_keys"("activated_at");
+
+-- CreateIndex
+CREATE INDEX "t_issuer_did_keys_deactivated_at_activated_at_idx" ON "t_issuer_did_keys"("deactivated_at", "activated_at");

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -2231,6 +2231,59 @@ enum DidOperation {
   DEACTIVATE
 }
 
+// (D) Issuer DID 鍵レジストリ（§5.4.3 / §G 鍵 rotation overlap）
+// civicship platform は単一の Issuer DID (`did:web:api.civicship.app`) を持ち、
+// 内部 VC 発行と StatusList VC の署名にこの DID の private key を使う。
+// 鍵自体は GCP Cloud KMS が保管し、本テーブルはどの KMS key version が
+// 「いつ activated / deactivated されたか」の運用 metadata を持つだけ。
+//
+// §G 鍵 rotation の流れ（PR #1100 / docs/runbooks/issuer-did-key-rotation.md）:
+//   1. 新 key version (v2) を KMS で作成
+//   2. 本テーブルに row を 1 件 INSERT（activatedAt = now, deactivatedAt = NULL）
+//   3. /.well-known/did.json は ENABLED + DISABLED 両方を verificationMethod に publish
+//      （`IssuerDidUseCase.buildDidDocument` が listActiveKeys を読む）
+//   4. signWithActiveKey は findActiveKey が返す 1 件（最新 ENABLED）で署名する
+//   5. 24h overlap (§9.1.2) 経過後、旧 key (v1) の row を UPDATE で
+//      deactivatedAt = now にする（KMS 側も DISABLED 状態に遷移）
+//   6. 旧 row は永続保持（§9.1.3：DISABLED は DESTROYED にしない）し、
+//      過去 VC の verifier 検証に対応する verificationMethod として残す
+//
+// なぜ row を残す:
+//   過去 VC を verify するには「その VC を発行したときに使われた public key」
+//   を解決できる必要がある。DID Document はその時点の verificationMethod を
+//   全部 publish するため、DISABLED な行も含めて永続保持する。
+//   行数の規模: 鍵 rotation は ≤ 1 回 / 四半期（§G）→ 10 年で 40 行程度。
+//   無視できる data 量。
+model IssuerDidKey {
+  id String @id @default(cuid())
+
+  // KMS の cryptoKeyVersions リソースの完全名。例:
+  //   "projects/kyoso-dev-453010/locations/asia-northeast1/keyRings/civicship/cryptoKeys/civicship-issuer-vc/cryptoKeyVersions/1"
+  // 末尾の `cryptoKeyVersions/<n>` から DID Document の `#key-<n>` fragment を
+  // 派生する（`issuerDidBuilder.kmsResourceNameToKid`）。重複登録防止のため @unique。
+  kmsKeyResourceName String @unique @map("kms_key_resource_name")
+
+  // この鍵が ENABLED 状態に遷移した時刻。findActiveKey の最新性判定で使う
+  // （複数行が deactivatedAt IS NULL の overlap 状態でも一意に "最新 ENABLED" を選べる）。
+  activatedAt DateTime @default(now()) @map("activated_at")
+
+  // ENABLED 中は NULL、DISABLED 後に値が入る。§9.1.3: 永続保持し DESTROYED にしない。
+  deactivatedAt DateTime? @map("deactivated_at")
+
+  createdAt DateTime  @default(now()) @map("created_at")
+  updatedAt DateTime? @updatedAt @map("updated_at")
+
+  // findActiveKey は WHERE deactivated_at IS NULL ORDER BY activated_at DESC LIMIT 1。
+  // listActiveKeys は ORDER BY activated_at ASC (DID Document の verificationMethod
+  // 並び順を安定させる)。どちらも activated_at を sort key として使う。
+  @@index([activatedAt])
+  // partial index 相当の最適化：deactivated_at IS NULL の絞り込みは findActiveKey の
+  // hot path なので、複合 index で seq scan を回避。
+  @@index([deactivatedAt, activatedAt])
+
+  @@map("t_issuer_did_keys")
+}
+
 // (C) Status List 2021 / Bitstring Status List 配信用（§D 対応：VC revocation）
 // 1 つの StatusListCredential は最大 131,072 ビット（16 KB）の bitstring を保持し、
 // それぞれのビットが 1 つの VC の revoked 状態を表す。


### PR DESCRIPTION
## Summary

Lands the schema migration that Phase 1.5's Strategy A stub (`IssuerDidKeyRepositoryStub`) was waiting on. After this PR `/.well-known/did.json` can resolve real KMS key versions from `t_issuer_did_keys`, instead of forever short-circuiting to the static fallback Document.

The KMS PoC (Q13 in the handoff) was completed against `kyoso-dev-453010` / `asia-northeast1` / `civicship/civicship-issuer-vc/cryptoKeyVersions/1` — that resource name will populate the first row of this table.

## What's in the PR

### 1. Prisma model + migration

`schema.prisma`:
```prisma
model IssuerDidKey {
  id                 String    @id @default(cuid())
  kmsKeyResourceName String    @unique @map("kms_key_resource_name")
  activatedAt        DateTime  @default(now()) @map("activated_at")
  deactivatedAt      DateTime? @map("deactivated_at")
  createdAt          DateTime  @default(now()) @map("created_at")
  updatedAt          DateTime? @updatedAt @map("updated_at")

  @@index([activatedAt])
  @@index([deactivatedAt, activatedAt])
  @@map("t_issuer_did_keys")
}
```

Migration: `20260512060000_add_issuer_did_keys/migration.sql`.

Indexes are sized for the two hot paths the service consumes:
- `(activated_at)` — `ORDER BY activated_at ASC/DESC` in both `findActiveKey` (DESC LIMIT 1) and `listActiveKeys` (ASC)
- `(deactivated_at, activated_at)` — partial-style for the `WHERE deactivated_at IS NULL` filter in `findActiveKey`

### 2. `IssuerDidKeyRepository` (replaces `IssuerDidKeyRepositoryStub`)

- `findActiveKey()` — `WHERE deactivatedAt IS NULL ORDER BY activatedAt DESC LIMIT 1`. Picks the newest ENABLED row so transient "multiple ENABLED rows during admin activation" doesn't accidentally select the rotating-out key.
- `listActiveKeys()` — `ORDER BY activatedAt ASC`, no filter. Pulls every row (ENABLED + DISABLED), driving the multi-key DID Document's `verificationMethod[]`. §9.1.3 — DISABLED rows are retained **forever**.
- Uses `prismaClient` directly. `t_issuer_did_keys` is a platform-global lookup table with no community / user scope, so `ctx.issuer.public(...)` plumbing is intentionally absent — same shape as the interface (no `ctx` / `tx` params).
- `IssuerDidKeyRepositoryNotImplementedError` is dropped (was a stub-only marker, no production caller).

### 3. DI re-binding

`provider.ts` registers `IssuerDidKeyRepository` (new class) under the same DI token name `"IssuerDidKeyRepository"`. Consumers (`IssuerDidService`) and existing tests (multi-key integration test from #1129, service unit tests) require no changes.

### 4. Doc / comment updates

- `interface.ts`, `type.ts`: replaced the "Strategy A stub placeholder" notes with the current "schema landed" status.
- `phase14_issuer_multikey_serving.test.ts`: two stale "IssuerDidKeyRepositoryStub returns []" comments updated to point at the new Prisma-backed repo against an empty table (same behaviour).

### 5. Integration test (`repository.test.ts`, new)

Covers what the prior stub couldn't:
- empty table → `null` / `[]`
- single ENABLED → returned
- single DISABLED (orphan tail) → `findActiveKey()` is null, `listActiveKeys()` still returns it (§9.1.3)
- 1 ENABLED + 1 DISABLED (§G overlap) → ENABLED active, both listed in `activatedAt ASC`
- 2 ENABLED rows (transient activation overlap) → newer wins `findActiveKey`
- `kmsKeyResourceName` `@unique` rejects duplicates
- `listActiveKeys` ordering with 3 rows inserted out of order

## Bootstrap behaviour preserved

On a freshly-deployed environment the table is empty → both methods return their bootstrap signal (`null` / `[]`) and the router serves the minimal static Document. Identical UX to Phase 1.5 from the wire side; nothing in dev / staging breaks.

## What's NOT in this PR

The actual KMS signing wiring. `IssuerDidService.signWithActiveKey()` still calls `KmsSigner.signEd25519` against whatever resource name `findActiveKey()` returns, and the StatusList / VC issuance flows still use `StubJwtSigner`. **Next PR** (`KmsJwtSigner` implementation + DI rebind) replaces those Phase 1.5 stubs with real KMS-backed signers, now that this table exists for them to consult.

## Test plan

- [ ] `pnpm db:deploy` applies the migration cleanly (idempotent re-run works)
- [ ] `pnpm test src/__tests__/integration/application/domain/credential/issuerDid/repository.test.ts --runInBand` — 7 cases pass
- [ ] `pnpm test src/__tests__/integration/acceptance/phase-1.5/phase14_issuer_multikey_serving.test.ts --runInBand` — 4 cases still pass (no behavioural regression)
- [ ] `pnpm test src/__tests__/unit/application/domain/credential/issuerDid/service.test.ts` — service unit tests still pass (they mock the repo interface, not the impl)
- [ ] `pnpm dev:https:dev` boots cleanly; `GET /.well-known/did.json` returns the static fallback Document until the first key row is `INSERT`-ed

## After this merges

Bootstrap the first row on the dev DB:

```sql
INSERT INTO t_issuer_did_keys (id, kms_key_resource_name, activated_at)
VALUES (
  gen_random_uuid()::text,
  'projects/kyoso-dev-453010/locations/asia-northeast1/keyRings/civicship/cryptoKeys/civicship-issuer-vc/cryptoKeyVersions/1',
  now()
);
```

Then `GET /.well-known/did.json` should return a Document with `verificationMethod[0]` carrying the real Ed25519 public key bytes from KMS — verifiable round-trip end-to-end.

https://claude.ai/code/session_01VdvJYHmgGsH43iHMqsvv1i

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdvJYHmgGsH43iHMqsvv1i)_