### PR TITLE
docs(runbook): add issuer-did-key-bootstrap.sql for WebStorm-driven seed

### DIFF
--- a/docs/runbooks/issuer-did-key-bootstrap.sql
+++ b/docs/runbooks/issuer-did-key-bootstrap.sql
@@ -1,0 +1,98 @@
+-- =============================================================================
+-- Issuer DID Key bootstrap (§5.4.3 / §G)
+-- =============================================================================
+--
+-- 用途: 新規環境 (dev / staging / prd) で `t_issuer_did_keys` テーブルに
+-- 最初の KMS key version を 1 件 INSERT し、`/.well-known/did.json` が
+-- static fallback (verificationMethod 無し) → 実 KMS 鍵を含む Document を
+-- 返すように切り替える操作。
+--
+-- 前提:
+--   1. Cloud KMS 側で Ed25519 cryptoKey + version 1 を作成済み
+--      (docs/runbooks/issuer-did-key-rotation.md 参照、もしくは PoC 履歴)
+--   2. API を動かす service account に以下が付与済み:
+--        - roles/cloudkms.signer
+--        - roles/cloudkms.publicKeyViewer
+--   3. 下記の `kms_key_resource_name` 値を **使用する環境に合わせて差し替える**:
+--        - kyoso-dev-453010 / asia-northeast1 / ... / cryptoKeyVersions/1 (dev 用テンプレ)
+--        - prod project / location / cryptoKeyVersions/N (本番用)
+--
+-- 実行方法 (WebStorm DB tool 経由):
+--   1. WebStorm の Database tool で対象環境の DB に接続
+--   2. このファイルを開いて、目的の environment の VALUES 句を選択
+--   3. "Execute" でクエリ実行
+--   4. SELECT 文 (下部) で row が入ったことを確認
+--
+-- 実行方法 (CLI 経由、参考):
+--   psql "$DATABASE_URL" -f docs/runbooks/issuer-did-key-bootstrap.sql
+--
+-- 冪等性:
+--   `kms_key_resource_name` が @unique なので、2 回流しても 1 件目以降は
+--   ON CONFLICT DO NOTHING で no-op になる。安心して何度でも実行可。
+--
+-- 設計参照:
+--   docs/report/did-vc-internalization.md §5.4.3
+--   docs/report/did-vc-internalization.md §G    (key rotation overlap)
+-- =============================================================================
+
+
+-- ---------------------------------------------------------------------------
+-- [dev] kyoso-dev-453010 / asia-northeast1
+-- ---------------------------------------------------------------------------
+-- KMS PoC で動作確認済みの key version。WebStorm でこのブロックだけ選択して
+-- 実行してください。
+INSERT INTO t_issuer_did_keys (
+  id,
+  kms_key_resource_name,
+  activated_at,
+  created_at
+)
+VALUES (
+  gen_random_uuid()::text,
+  'projects/kyoso-dev-453010/locations/asia-northeast1/keyRings/civicship/cryptoKeys/civicship-issuer-vc/cryptoKeyVersions/1',
+  now(),
+  now()
+)
+ON CONFLICT (kms_key_resource_name) DO NOTHING;
+
+
+-- ---------------------------------------------------------------------------
+-- [prd] 本番用テンプレート (production 用に資源名を差し替えて使う)
+-- ---------------------------------------------------------------------------
+-- 本番では KeyRing / cryptoKey の resource 名を差し替えてから実行する。
+-- 上記の dev ブロックと同時に流さないこと (本番 INSERT を間違って dev DB に
+-- 流す事故を防ぐため、コメントアウトで配信する)。
+--
+-- INSERT INTO t_issuer_did_keys (
+--   id,
+--   kms_key_resource_name,
+--   activated_at,
+--   created_at
+-- )
+-- VALUES (
+--   gen_random_uuid()::text,
+--   'projects/<PRD_PROJECT_ID>/locations/asia-northeast1/keyRings/civicship/cryptoKeys/civicship-issuer-vc/cryptoKeyVersions/1',
+--   now(),
+--   now()
+-- )
+-- ON CONFLICT (kms_key_resource_name) DO NOTHING;
+
+
+-- ---------------------------------------------------------------------------
+-- 確認: INSERT 後の状態をチェック
+-- ---------------------------------------------------------------------------
+SELECT
+  id,
+  kms_key_resource_name,
+  activated_at,
+  deactivated_at,
+  created_at
+FROM t_issuer_did_keys
+ORDER BY activated_at DESC;
+-- 期待:
+--   - 1 行 (deactivated_at IS NULL)
+--   - kms_key_resource_name が PoC / 本番で確認した値と一致
+--
+-- 続いて `GET /.well-known/did.json` を叩いて
+-- verificationMethod[0].publicKeyJwk.x が 32-byte base64url で出れば
+-- KMS → API → DID Document の経路が通っている証拠です。


### PR DESCRIPTION
## Summary

`#1130` で `t_issuer_did_keys` テーブルが lands したけど、**最初の row は手動 INSERT** が必要。その INSERT 文を WebStorm の DB tool で開いて選択 → Execute するだけで済むよう、SQL ファイルを repo に置きます。

## 中身

`docs/runbooks/issuer-did-key-bootstrap.sql`:

- **dev ブロック** — `kyoso-dev-453010 / asia-northeast1 / civicship-issuer-vc / cryptoKeyVersions/1` (KMS PoC で動作確認済みの resource name) を入れる ready-to-run INSERT
- **prd ブロック** — コメントアウト状態のテンプレ。本番 INSERT を誤って dev DB に流す事故防止
- **確認用 SELECT** — INSERT 後の row 状態を見るための SELECT 文
- **冪等性**: `ON CONFLICT (kms_key_resource_name) DO NOTHING` で何度流しても安全

## 配置の意図

`docs/runbooks/issuer-did-key-rotation.md` の隣に置く。WebStorm の project tree でも実運用フロー上もこの 2 つは並ぶのが自然 (rotation runbook の「最初に key を 1 件 activate」の step がこの SQL に対応)。

## 使い方 (WebStorm)

1. Database tool で対象環境の DB に接続
2. `docs/runbooks/issuer-did-key-bootstrap.sql` を開く
3. 該当環境の `INSERT ... VALUES (...);` ブロックを選択
4. Execute (⌘⏎)
5. ファイル末尾の `SELECT ... FROM t_issuer_did_keys` で row が入ったか確認
6. `curl https://<env>/.well-known/did.json | jq .verificationMethod[0].publicKeyJwk.x` で実 KMS 公開鍵が含まれてれば完了

## After this merges

dev 環境では `pnpm db:deploy` で migration を流した後、このファイルの dev ブロックを実行 → DID Document が KMS から実公開鍵を fetch して publish する状態になります。

## Test plan

- [ ] WebStorm から `docs/runbooks/issuer-did-key-bootstrap.sql` を開ける
- [ ] dev ブロックの INSERT を選択して Execute → 1 row 追加される
- [ ] 同 INSERT を 2 回実行 → ON CONFLICT で no-op (エラー出ない)
- [ ] 末尾の SELECT で `kms_key_resource_name` / `activated_at` / `deactivated_at IS NULL` が見える
- [ ] `GET /.well-known/did.json` (dev) で `verificationMethod[0].publicKeyJwk.x` に PoC で確認した KMS 公開鍵 bytes (base64url) が出る

https://claude.ai/code/session_01VdvJYHmgGsH43iHMqsvv1i

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdvJYHmgGsH43iHMqsvv1i)_