### PR TITLE
fix(test): exclude __helpers__ from jest test discovery

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -39,6 +39,7 @@ module.exports = {
     "<rootDir>/src/__tests__/helper/*.*",
     "<rootDir>/src/__tests__/.*/helpers\\.ts",
     "<rootDir>/src/__tests__/.*/fixtures\\.ts",
+    "<rootDir>/src/__tests__/.*/__helpers__/.*",
     "<rootDir>/dist/",
   ],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],

--- a/src/__tests__/helper/test-data-source-helper.ts
+++ b/src/__tests__/helper/test-data-source-helper.ts
@@ -34,6 +34,12 @@ export default class TestDataSourceHelper {
     await this.db.transactionAnchor.deleteMany();
     await this.db.statusListCredential.deleteMany();
     await this.db.didIssuanceRequest.deleteMany();
+    // IssuerDidKey rows (KMS key registry) have a UNIQUE constraint on
+    // `kms_key_resource_name` and persisted across tests prior to this — the
+    // repository tests reuse the same KMS resource names, and the multi-key
+    // serving acceptance test routes through the production KmsSigner when
+    // stale rows remain, which fails without GCP credentials in CI.
+    await this.db.issuerDidKey.deleteMany();
     await this.db.evaluation.deleteMany();
     await this.db.participation.deleteMany();
 

--- a/src/__tests__/integration/acceptance/phase-1.5/phase14_idempotency.test.ts
+++ b/src/__tests__/integration/acceptance/phase-1.5/phase14_idempotency.test.ts
@@ -25,8 +25,6 @@ import {
   buildCtx,
   createMockBlockfrostClient,
   createMockSlotProvider,
-  cslKeygenMockFactory,
-  cslTxBuilderMockFactory,
   fakeVcJwt,
   registerBlockfrostMocks,
   restoreEnv,
@@ -39,13 +37,19 @@ import {
 } from "@/__tests__/integration/acceptance/phase-1.5/__helpers__/setup";
 
 // Mock CSL-heavy modules (same approach as the unit-test suite).
-// jest.mock is hoisted, so the call sites must stay in this file — but the
-// factory bodies live in the shared helper.
-jest.mock(
-  "@/infrastructure/libs/cardano/txBuilder",
-  cslTxBuilderMockFactory({ txHashHex: "12".repeat(32) }),
-);
-jest.mock("@/infrastructure/libs/cardano/keygen", cslKeygenMockFactory());
+// jest.mock is hoisted above the ES `import`s, so the factory cannot
+// reference an imported binding directly (TDZ → "Cannot access 'setup_1'
+// before initialization"). Use `require()` inside the lazily-evaluated
+// factory so the helper is loaded at mock-construction time, after imports
+// have been bound.
+jest.mock("@/infrastructure/libs/cardano/txBuilder", () => {
+  const setup = require("@/__tests__/integration/acceptance/phase-1.5/__helpers__/setup");
+  return setup.cslTxBuilderMockFactory({ txHashHex: "12".repeat(32) })();
+});
+jest.mock("@/infrastructure/libs/cardano/keygen", () => {
+  const setup = require("@/__tests__/integration/acceptance/phase-1.5/__helpers__/setup");
+  return setup.cslKeygenMockFactory()();
+});
 
 describe("[§14.2] AnchorBatch idempotency — re-running the same batchId is a no-op", () => {
   jest.setTimeout(30_000);

--- a/src/__tests__/integration/acceptance/phase-1.5/phase14_inclusion_proof.test.ts
+++ b/src/__tests__/integration/acceptance/phase-1.5/phase14_inclusion_proof.test.ts
@@ -25,6 +25,7 @@ import didRouter from "@/presentation/router/did";
 import { buildRoot, verifyProof } from "@/infrastructure/libs/merkle/merkleTreeBuilder";
 import {
   fakeVcJwt,
+  seedExtraEvaluationForUser,
   seedUserParticipationEvaluation,
   seedVcRequest,
   setupAcceptanceTest,
@@ -50,12 +51,20 @@ describe("[§14.2] VC inclusion proof — GET /vc/:vcId/inclusion-proof returns 
 
   /** Seed `count` VC issuance rows owned by a fresh user. Returns the rows. */
   async function seedVcRequests(count: number) {
-    const { userId, evaluationId } = await seedUserParticipationEvaluation({
+    // `VcIssuanceRequest.evaluationId` is `@unique` (schema.prisma) — each
+    // VC needs its own Evaluation row. The first one comes from
+    // `seedUserParticipationEvaluation` (which also creates the User);
+    // subsequent ones use `seedExtraEvaluationForUser`.
+    const { userId, evaluationId: firstEvaluationId } = await seedUserParticipationEvaluation({
       name: "Inclusion Proof User",
       slugPrefix: "incl",
     });
     const rows: { id: string; vcJwt: string }[] = [];
     for (let i = 0; i < count; i += 1) {
+      const evaluationId =
+        i === 0
+          ? firstEvaluationId
+          : (await seedExtraEvaluationForUser(userId)).evaluationId;
       // Deterministic salt (no Math.random — fixes Sonar S2245).
       // The index already guarantees uniqueness across rows in this seed call,
       // and `setupAcceptanceTest` wipes the DB before each test, so collision

--- a/src/__tests__/integration/acceptance/phase-1.5/phase14_vc_anchoring.test.ts
+++ b/src/__tests__/integration/acceptance/phase-1.5/phase14_vc_anchoring.test.ts
@@ -35,8 +35,6 @@ import {
   buildCtx,
   createMockBlockfrostClient,
   createMockSlotProvider,
-  cslKeygenMockFactory,
-  cslTxBuilderMockFactory,
   fakeVcJwt,
   registerBlockfrostMocks,
   restoreEnv,
@@ -49,13 +47,18 @@ import {
 } from "@/__tests__/integration/acceptance/phase-1.5/__helpers__/setup";
 
 // CSL は native 依存が重いので、テスト時のみ tx 構築を mock 化する。
-// jest.mock は hoist されるため、call site は各 test file に残す必要がある
-// が、factory 本体は共通 helper から import している。
-jest.mock(
-  "@/infrastructure/libs/cardano/txBuilder",
-  cslTxBuilderMockFactory({ txHashHex: "ab".repeat(32) }),
-);
-jest.mock("@/infrastructure/libs/cardano/keygen", cslKeygenMockFactory());
+// jest.mock は ES `import` より上に hoist されるため、factory から
+// import バインディングを直接参照できない (TDZ で "Cannot access 'setup_1'
+// before initialization" になる)。factory 内で `require()` することで、
+// import 解決後の helper module を遅延ロードする。
+jest.mock("@/infrastructure/libs/cardano/txBuilder", () => {
+  const setup = require("@/__tests__/integration/acceptance/phase-1.5/__helpers__/setup");
+  return setup.cslTxBuilderMockFactory({ txHashHex: "ab".repeat(32) })();
+});
+jest.mock("@/infrastructure/libs/cardano/keygen", () => {
+  const setup = require("@/__tests__/integration/acceptance/phase-1.5/__helpers__/setup");
+  return setup.cslKeygenMockFactory()();
+});
 
 describe("[§14.2] VC anchoring — pending VcAnchor → CONFIRMED via batch", () => {
   jest.setTimeout(30_000);


### PR DESCRIPTION
## Summary
- Jest のデフォルト `testRegex` は `__tests__/` 配下の全 `.ts` を拾うため、`phase-1.5/__helpers__/setup.ts` がテストスイートとして検出され `"Your test suite must contain at least one test"` で CI が落ちていた
- `testPathIgnorePatterns` に `__tests__/.*/__helpers__/.*` を追加し、ヘルパーディレクトリを一括除外

## Test plan
- [ ] CI が green になることを確認
- [ ] `npx jest --listTests` で `__helpers__/setup.ts` が含まれないことを確認

https://claude.ai/code/session_01TxYCJcCU1NUpQs3dQc3BQU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxYCJcCU1NUpQs3dQc3BQU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

**新機能**
- ユーザーDIDの作成・無効化機能を追加
- 検証可能資格情報(VC)の発行・失効機能を実装
- Cardanoブロックチェーンへの認証情報のアンカリング対応
- VC失効管理用のStatusList 2021サポートを追加
- アンカリング状態の検証とインクルージョンプルーフ取得機能を提供

**ドキュメント**
- DID鍵ローテーション手順書を追加
- アンカーバッチデプロイメントチェックリストを追加
- Merkleツリーベースのアンカリング仕様書を発行

**テスト**
- Phase 1.5受け入れテストスイートを拡充

<!-- end of auto-generated comment: release notes by coderabbit.ai -->