### PR TITLE
fix(test): unblock §14.2 bootstrap fallback + VcAnchor-only idempotency

### DIFF
--- a/src/__tests__/unit/application/domain/anchor/anchorBatch/service.test.ts
+++ b/src/__tests__/unit/application/domain/anchor/anchorBatch/service.test.ts
@@ -81,6 +81,7 @@ function restoreEnv(): void {
 describe("AnchorBatchService", () => {
   let mockRepository: {
     findExistingBatchTransactionAnchors: jest.Mock;
+    findFirstChainTxHashByBatchId: jest.Mock;
     findPendingAnchors: jest.Mock;
     findVcJwtsByVcIssuanceRequestIds: jest.Mock;
     findPreviousAnchorChainTxHashes: jest.Mock;
@@ -111,6 +112,7 @@ describe("AnchorBatchService", () => {
 
     mockRepository = {
       findExistingBatchTransactionAnchors: jest.fn().mockResolvedValue([]),
+      findFirstChainTxHashByBatchId: jest.fn().mockResolvedValue(null),
       findPendingAnchors: jest.fn().mockResolvedValue({
         transactionAnchors: [],
         vcAnchors: [],
@@ -332,6 +334,7 @@ describe("AnchorBatchService", () => {
           periodEnd: new Date(),
         },
       ]);
+      mockRepository.findFirstChainTxHashByBatchId.mockResolvedValue("ff".repeat(32));
 
       const service = container.resolve(AnchorBatchService);
       const result = await service.runWeeklyBatch(ctx, { weeklyKey: "2026-W19" });

--- a/src/application/domain/anchor/anchorBatch/data/interface.ts
+++ b/src/application/domain/anchor/anchorBatch/data/interface.ts
@@ -110,6 +110,14 @@ export interface IAnchorBatchRepository {
   /** 既存 batch の終端ステータス（idempotency 早期 return 判定用）。 */
   getBatchTerminalStatus(ctx: IContext, batchId: string): Promise<AnchorStatus | null>;
 
+  /**
+   * idempotency 早期 return 時に txHash を回復するため、3 つの anchor テーブル
+   * 全体から最初に見つかった chainTxHash を返す。一部 batch (VcAnchor のみ等)
+   * は TransactionAnchor 行を持たないため、`findExistingBatchTransactionAnchors`
+   * 単独では txHash が null になり、test の txHashFirst 一致期待が崩れる。
+   */
+  findFirstChainTxHashByBatchId(ctx: IContext, batchId: string): Promise<string | null>;
+
   /** 任意：batchId に紐づく PENDING な VcAnchor を返す（resume パス用、未使用でも interface に含める）。 */
   findPendingVcAnchorsByBatchId?(ctx: IContext, batchId: string): Promise<PendingVcAnchor[]>;
 

--- a/src/application/domain/anchor/anchorBatch/data/repository.ts
+++ b/src/application/domain/anchor/anchorBatch/data/repository.ts
@@ -41,12 +41,18 @@ export default class AnchorBatchRepository implements IAnchorBatchRepository {
 
   async getBatchTerminalStatus(ctx: IContext, batchId: string): Promise<AnchorStatus | null> {
     const issuer = ctx.issuer ?? this.getIssuer();
-    const rows = await issuer.internal((tx) =>
-      tx.transactionAnchor.findMany({
-        where: { batchId },
-        select: { status: true },
-      }),
-    );
+    // 終端ステータス判定は 3 つの anchor テーブル全てを横断的に見る。
+    // 一部の batch (e.g. VcAnchor のみ) は TransactionAnchor 行を持たないため、
+    // transactionAnchor 単独で見ると「rows 0 → null」となり idempotency の
+    // 早期 return が抜ける（同 weeklyKey の再実行が二重 submit になる）。
+    const rows = await issuer.internal(async (tx) => {
+      const [txRows, vcRows, didRows] = await Promise.all([
+        tx.transactionAnchor.findMany({ where: { batchId }, select: { status: true } }),
+        tx.vcAnchor.findMany({ where: { batchId }, select: { status: true } }),
+        tx.userDidAnchor.findMany({ where: { batchId }, select: { status: true } }),
+      ]);
+      return [...txRows, ...vcRows, ...didRows];
+    });
     if (rows.length === 0) return null;
     // 1 batch 内に異なる status が混在することは通常ないが、
     // 「終端ステータス」の判定として SUBMITTED / CONFIRMED / FAILED が
@@ -56,6 +62,27 @@ export default class AnchorBatchRepository implements IAnchorBatchRepository {
     if (statuses.has(AnchorStatus.SUBMITTED)) return AnchorStatus.SUBMITTED;
     if (statuses.has(AnchorStatus.FAILED)) return AnchorStatus.FAILED;
     return AnchorStatus.PENDING;
+  }
+
+  async findFirstChainTxHashByBatchId(ctx: IContext, batchId: string): Promise<string | null> {
+    const issuer = ctx.issuer ?? this.getIssuer();
+    return issuer.internal(async (tx) => {
+      const [txRow, vcRow, didRow] = await Promise.all([
+        tx.transactionAnchor.findFirst({
+          where: { batchId, chainTxHash: { not: null } },
+          select: { chainTxHash: true },
+        }),
+        tx.vcAnchor.findFirst({
+          where: { batchId, chainTxHash: { not: null } },
+          select: { chainTxHash: true },
+        }),
+        tx.userDidAnchor.findFirst({
+          where: { batchId, chainTxHash: { not: null } },
+          select: { chainTxHash: true },
+        }),
+      ]);
+      return txRow?.chainTxHash ?? vcRow?.chainTxHash ?? didRow?.chainTxHash ?? null;
+    });
   }
 
   async findPendingAnchors(ctx: IContext): Promise<AnchorBatchPendingSet> {

--- a/src/application/domain/anchor/anchorBatch/service.ts
+++ b/src/application/domain/anchor/anchorBatch/service.ts
@@ -374,15 +374,16 @@ export class AnchorBatchService {
     return sorted.map((a) => buildOp(a, prevByAnchorId));
   }
 
-  /** SUBMITTED/CONFIRMED 済 batch から chainTxHash を 1 件取得（idempotency 早期 return 用）。 */
+  /**
+   * SUBMITTED/CONFIRMED 済 batch から chainTxHash を 1 件取得
+   * （idempotency 早期 return 用）。
+   *
+   * 3 つの anchor テーブル全てを横断的に見る。一部の batch
+   * (VcAnchor のみ等) は TransactionAnchor 行を持たず、その場合は
+   * vcAnchor/userDidAnchor 側の chainTxHash を返す必要がある。
+   */
   private async firstChainTxHashOf(ctx: IContext, weeklyKey: string): Promise<string | null> {
-    const rows = await this.repository.findExistingBatchTransactionAnchors(ctx, weeklyKey);
-    for (const r of rows) {
-      if (typeof r.chainTxHash === "string" && r.chainTxHash.length > 0) {
-        return r.chainTxHash;
-      }
-    }
-    return null;
+    return this.repository.findFirstChainTxHashByBatchId(ctx, weeklyKey);
   }
 }
 

--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -359,6 +359,15 @@ export function registerProductionDependencies() {
   // it sits adjacent to its single application-layer consumer for the
   // lifetime of Phase 1; future consumers (anchor batch worker) can lift
   // it into a shared "Cryptography" group once they land.
+  // Default KMS client value for `KmsSigner`. `KmsSigner`'s constructor
+  // parameter is `@inject("KmsClient")`-decorated because tsyringe cannot
+  // reflect an interface-typed optional parameter (`emitDecoratorMetadata`
+  // emits `Object` → "TypeInfo not known for 'Object'" on resolve).
+  // `useFactory: () => undefined` makes the param resolve to undefined and
+  // the constructor body falls back to `new KeyManagementServiceClient()`.
+  // (Plain `useValue: undefined` is rejected by tsyringe — "TypeInfo not
+  // known for 'undefined'" — so the factory form is required.)
+  container.register("KmsClient", { useFactory: () => undefined });
   container.registerSingleton("KmsSigner", KmsSigner);
   // Default clock for `IssuerDidService.now` (public-key TTL cache). Tests
   // can override via `container.register("IssuerDidClock", { useValue: ... })`.

--- a/src/infrastructure/libs/kms/kmsSigner.ts
+++ b/src/infrastructure/libs/kms/kmsSigner.ts
@@ -45,7 +45,7 @@
  */
 
 import { KeyManagementServiceClient } from "@google-cloud/kms";
-import { injectable } from "tsyringe";
+import { inject, injectable } from "tsyringe";
 
 /** Maximum number of attempts (1 initial + 2 retries = 3 attempts total). */
 const MAX_ATTEMPTS = 3;
@@ -139,8 +139,18 @@ export class KmsSigner {
    * The constructor does NOT validate credentials proactively — the gRPC
    * client lazily initializes the auth client on first call, so credential
    * problems surface as a 4xx on the first sign and propagate immediately.
+   *
+   * The `@inject("KmsClient")` token is required because tsyringe cannot
+   * reflect an interface-typed optional parameter — TS's
+   * `emitDecoratorMetadata` emits `Object` for `KmsClientLike` and tsyringe
+   * throws `TypeInfo not known for "Object"` when no token is supplied.
+   * Production registers `useValue: undefined` so the body's
+   * `?? new KeyManagementServiceClient()` fallback kicks in; tests can
+   * inject a stub by either overriding `KmsSigner` itself (preferred) or
+   * registering a `KmsClient` value before resolving. Direct
+   * `new KmsSigner(client)` calls bypass DI entirely.
    */
-  constructor(client?: KmsClientLike) {
+  constructor(@inject("KmsClient") client?: KmsClientLike) {
     // Cast: `KeyManagementServiceClient.listCryptoKeyVersions` returns
     // `ICryptoKeyVersion[]` whose `state` field is the proto enum union
     // (`CryptoKeyVersionState | "ENABLED" | "DISABLED" | ...`), while


### PR DESCRIPTION
## Summary

Two unrelated phase-1.5 integration failures that survived #1132 / c4496ea:

1. **`/.well-known/did.json` bootstrap fallback returned 500 instead of 200.**
   With the `t_issuer_did_keys` table empty, the route still has to construct `IssuerDidService` through DI, which `@inject`s `KmsSigner`. The `KmsSigner` ctor parameter `client?: KmsClientLike` had no `@inject` token, so tsyringe reflected it as `Object` and threw `TypeInfo not known for "Object"` — the same shape of bug `c4496ea` fixed for `IssuerDidClock`, just on a different optional parameter. Annotate with `@inject("KmsClient")` and register `useFactory: () => undefined` so the constructor body's `?? new KeyManagementServiceClient()` fallback kicks in. (Plain `useValue: undefined` is rejected by tsyringe with `TypeInfo not known for "undefined"`.)

2. **`phase14_idempotency` re-run was not a no-op.**
   `getBatchTerminalStatus` only queried `transactionAnchor`, so a batch composed solely of `VcAnchor` rows never observed its own terminal status on the second run (`rows.length === 0` → `null`), fell through to `findPendingAnchors`, and returned `submitted: false`. Widen the status lookup to all three anchor tables (TransactionAnchor / VcAnchor / UserDidAnchor) and add `findFirstChainTxHashByBatchId` so `firstChainTxHashOf` can recover the original `chainTxHash` even when no TransactionAnchor exists for the batch. The unit-test repository mock is updated to expose the new method.

## Test plan

- [x] `phase14_issuer_multikey_serving.test.ts` — all 4 cases pass (including the bootstrap fallback)
- [x] `phase14_idempotency.test.ts` — all 3 cases pass
- [x] `phase-1.5` acceptance suite — 18/18 passing locally against postgres
- [x] `anchorBatch` unit + integration tests — 29/29 passing
- [x] `issuerDid` unit + integration tests — passing
- [x] `kmsSigner` unit tests — passing

https://claude.ai/code/session_016pE4kcaUzfSsBSfeHE7Sq3

---
_Generated by [Claude Code](https://claude.ai/code/session_016pE4kcaUzfSsBSfeHE7Sq3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ユーザーDIDの作成・更新・無効化機能を追加
  * VCの発行と失効管理（Bitstring Status List対応）を実装
  * Cardanoブロックチェーンへの週次アンカリングバッチ処理を追加
  * 発行者DIDのマルチキー対応と鍵ローテーション機能を実装
  * アンカー済みVC検証用の包含証明エンドポイントを追加

* **監視 / インフラ**
  * Cardano preprod依存関係の定期ヘルスチェック（カナリア）を追加
  * TLS/DNSセキュリティポスチャ検証ワークフローを追加

* **ドキュメント**
  * 鍵ローテーション運用手順書を追加
  * アンカーバッチデプロイメントチェックリストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->