### PR TITLE
ci(canary): wire `BLOCKFROST_PROJECT_ID` to `dev` environment

### DIFF
--- a/.github/workflows/cardano-canary.yml
+++ b/.github/workflows/cardano-canary.yml
@@ -43,6 +43,11 @@ jobs:
   canary:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # `BLOCKFROST_PROJECT_ID` を repo secret ではなく `dev` environment から引く。
+    # mainnet 切替は別 environment (co-creation-dao-prod) を別 workflow が指す形
+    # で行い、本 canary は preprod 専用のまま固定する。env 経由にすることで
+    # 同名 secret を環境ごとに別値で持てるようになる。
+    environment: dev
     permissions:
       contents: read
 


### PR DESCRIPTION
## Summary

`cardano-canary.yml` を repo secret ベースから GitHub Environments ベースに切り替え、`dev` environment に登録した preprod 鍵を引くようにする。

## 背景

- mainnet 移行時に同名 secret `BLOCKFROST_PROJECT_ID` の値だけ差し替えたい
  - canary は preprod 専用のまま
  - Cloud Run deploy は `co-creation-dao-prod` environment で mainnet 値を引く、という分離
- repo 直下に `BLOCKFROST_PROJECT_ID` を置くと canary も deploy も同じ値を共有してしまい、preprod prefix チェック (script 側) と mainnet 必須要件 (Cloud Run prd) が衝突する
- environment 分離なら、同名で別値を保持できる

## 変更内容

`cardano-canary.yml` の `canary:` job に `environment: dev` を 1 行追加。

## 実運用

- canary は `environment: dev` を指定 → dev env の `BLOCKFROST_PROJECT_ID` (preprod 鍵) を読む
- mainnet 切替時は別 workflow が `environment: co-creation-dao-prod` を指定し、そこに登録された mainnet 鍵を読む形にする（本 PR では未着手）

## Test plan

- [ ] PR merge 後、`gh workflow run cardano-canary.yml` で手動 dispatch
- [ ] dev environment の `BLOCKFROST_PROJECT_ID` (preprod 鍵) が正しく注入されることを run log で確認
- [ ] canary script が exit 0 で完走（Blockfrost preprod reachability / protocol params / metadata 1985 構築の各 stage が green）

https://claude.ai/code/session_01FmzzTMoHVwRrB7kAqc6m8G

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmzzTMoHVwRrB7kAqc6m8G)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ユーザーDID（分散識別子）の作成・無効化機能を追加
  * Verifiable Credential（検証可能資格情報）の発行・失効機能を実装
  * Cardanoブロックチェーンへの資格情報アンカリング機能を実装
  * 資格情報失効リストによる失効状態管理機能を追加

* **インフラストラクチャ改善**
  * 週次自動アンカリングバッチプロセスを実装
  * Cardanoプリプロド環境のヘルスチェック（Canary）を追加
  * TLS/DNS設定検証ワークフローを追加
  * 複数暗号鍵の段階的な切り替え機能に対応

* **ドキュメント**
  * マークルアンカリング仕様書を追加
  * オペレーション手順書・ランブックを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->