### PR TITLE
batch(anchor): repurpose `sync-did-vc` entry → new internalized anchor batch

### DIFF
--- a/src/presentation/batch/requestDIDVC/index.ts
+++ b/src/presentation/batch/requestDIDVC/index.ts
@@ -1,78 +1,22 @@
 import "reflect-metadata";
 import "@/application/provider";
 import logger from "@/infrastructure/logging";
-import { container } from "tsyringe";
-import { PrismaClientIssuer } from "@/infrastructure/prisma/client";
-import { DIDIssuanceService } from "@/application/domain/account/identity/didIssuanceRequest/service";
-import { VCIssuanceRequestService } from "@/application/domain/experience/evaluation/vcIssuanceRequest/service";
-import { createDIDRequests } from "./requestDID";
-import { IContext } from "@/types/server";
-import { createVCRequests } from "@/presentation/batch/requestDIDVC/requestVC";
-import VCIssuanceRequestConverter from "@/application/domain/experience/evaluation/vcIssuanceRequest/data/converter";
-import { checkBit } from "@/utils/misc";
 
 /**
- * EvaluationとIdentityに基づいて、
- * - 未リクエストのDIDを送信
- * - Evaluation(PASSED)だがVCリクエスト未発行のユーザーにVCを送信
+ * `BATCH_PROCESS_NAME=request-did-vc` で起動される Cloud Run Job のエントリ。
+ *
+ * 旧 IDENTUS 連携で「Evaluation を見て DID/VC 発行リクエストを Pending 行に
+ * 入れる」役割を担っていたが、内製化後は VC 発行は GraphQL mutation
+ * (`issueVc`) で同期発行され、anchor は週次 batch (`sync-did-vc`) で
+ * 一括処理されるため本エントリは不要。Cloud Scheduler job
+ * `kyoso-dev-civicship-batch-scheduler-request-did-vc` を PAUSED のまま
+ * 放置 / 削除する前提で no-op とする。
+ *
+ * 関連: docs/report/did-vc-internalization.md §5.3.1
  */
 export async function requestDIDVC() {
-  /**
-   * BATCH_DID_VC_REQUEST_MODE:
-   *   3: DID 実行 / VC 実行
-   *   2: DID 実行 / VC 無効
-   *   1: DID 無効 / VC 実行
-   *   0: DID 無効 / VC 無効
-   */
-  const requestMode = process.env.BATCH_DID_VC_REQUEST_MODE ? parseInt(process.env.BATCH_DID_VC_REQUEST_MODE) : 3; // デフォルトで全て実行
-  const executeDID = checkBit(requestMode, 2);
-  const executeVC = checkBit(requestMode, 1);
-
-  let limit = process.env.BATCH_LIMIT ? parseInt(process.env.BATCH_LIMIT) : undefined;
-  if (limit && limit > 0) {
-    logger.debug(`🚀 Starting DID & VC request batch (MODE: ${ requestMode }, LIMIT: ${ limit })`, {
-      executeDID,
-      executeVC,
-    });
-  } else {
-    limit = undefined;
-    logger.debug(`🚀 Starting DID & VC request batch (MODE: ${ requestMode })`, {
-      executeDID,
-      executeVC,
-    });
-  }
-
-  const issuer = container.resolve<PrismaClientIssuer>("PrismaClientIssuer");
-  const didService = container.resolve<DIDIssuanceService>("DIDIssuanceService");
-  const vcService = container.resolve<VCIssuanceRequestService>("VCIssuanceRequestService");
-  const vcConverter = container.resolve<VCIssuanceRequestConverter>("VCIssuanceRequestConverter");
-  const ctx = { issuer } as IContext;
-
-  try {
-    // --- DID ---
-    if (executeDID) {
-      const didResult = await createDIDRequests(issuer, didService, ctx, limit);
-      logger.debug(
-        `📦 DID Requests: ${ didResult.total } total, ` +
-        `${ didResult.successCount } succeeded, ` +
-        `${ didResult.failureCount } failed, ` +
-        `${ didResult.skippedCount } skipped.`,
-      );
-    }
-
-    // --- VC ---
-    if (executeVC) {
-      const vcResult = await createVCRequests(issuer, vcService, vcConverter, ctx, limit);
-      logger.debug(
-        `📦 VC Requests: ${ vcResult.total } total, ` +
-        `${ vcResult.successCount } succeeded, ` +
-        `${ vcResult.failureCount } failed, ` +
-        `${ vcResult.skippedCount } skipped.`,
-      );
-    }
-
-    logger.debug("✅ DID & VC request batch completed");
-  } catch (error) {
-    logger.error("💥 Error in DID/VC request batch", error);
-  }
+  logger.warn(
+    "[request-did-vc] deprecated entry — anchor batch は sync-did-vc に統合済み。" +
+      "Cloud Scheduler の `request-did-vc` job は PAUSED のまま放置してください。",
+  );
 }

--- a/src/presentation/batch/syncDIDVC/index.ts
+++ b/src/presentation/batch/syncDIDVC/index.ts
@@ -3,43 +3,35 @@ import "@/application/provider";
 import logger from "@/infrastructure/logging";
 import { container } from "tsyringe";
 import { PrismaClientIssuer } from "@/infrastructure/prisma/client";
-import { DIDVCServerClient } from "@/infrastructure/libs/did";
-import { processDIDRequests } from "@/presentation/batch/syncDIDVC/syncDID";
-import { processVCRequests } from "@/presentation/batch/syncDIDVC/syncVC";
-import { DIDIssuanceService } from "@/application/domain/account/identity/didIssuanceRequest/service";
-import { VCIssuanceRequestService } from "@/application/domain/experience/evaluation/vcIssuanceRequest/service";
-import NotificationService from "@/application/domain/notification/service";
+import AnchorBatchUseCase from "@/application/domain/anchor/anchorBatch/usecase";
+import { IContext } from "@/types/server";
 
+/**
+ * `BATCH_PROCESS_NAME=sync-did-vc` で起動される Cloud Run Job のエントリ。
+ *
+ * 旧 IDENTUS 連携の sync ロジックは内製化に伴い廃止。本関数は新しい
+ * `AnchorBatchUseCase.runBatch` を呼び出し、週次 Cardano anchor バッチを
+ * 実行する単一の epoch を構成する (§5.3.1)。
+ *
+ * 既存の Cloud Scheduler job `kyoso-dev-civicship-batch-scheduler-sync-did-vc`
+ * を再利用するため、エントリポイント名 (`syncDIDVC`) と batch case 名
+ * (`sync-did-vc`) は据え置く。
+ */
 export async function syncDIDVC() {
-  logger.debug("🚀 Starting DID/VC synchronization batch");
+  logger.info("[sync-did-vc] starting weekly anchor batch");
 
   const issuer = container.resolve<PrismaClientIssuer>("PrismaClientIssuer");
-  const client = container.resolve<DIDVCServerClient>("DIDVCServerClient");
-  const didService = container.resolve<DIDIssuanceService>("DIDIssuanceService");
-  const vcService = container.resolve<VCIssuanceRequestService>("VCIssuanceRequestService");
-  const notificationService = container.resolve<NotificationService>("NotificationService");
+  const usecase = container.resolve(AnchorBatchUseCase);
+  const ctx = { issuer } as IContext;
 
   try {
-    logger.debug("🔄 Processing DID issuance requests...");
-    const didResult = await processDIDRequests(issuer, client, didService);
-    logger.debug(
-      `📦 DID Results: ${didResult.total} total, ` +
-        `${didResult.successCount} succeeded, ` +
-        `${didResult.failureCount} failed, ` +
-        `${didResult.skippedCount} skipped.`,
-    );
-
-    logger.debug("🔄 Processing VC issuance requests...");
-    const vcResult = await processVCRequests(issuer, client, vcService, notificationService);
-    logger.debug(
-      `📦 VC Results: ${vcResult.total} total, ` +
-        `${vcResult.successCount} succeeded, ` +
-        `${vcResult.failureCount} failed, ` +
-        `${vcResult.skippedCount} skipped.`,
-    );
-
-    logger.debug("✅ DID/VC synchronization batch completed");
-  } catch (error) {
-    logger.error("💥 Batch process error:", error);
+    const result = await usecase.runBatch(ctx, {});
+    logger.info("[sync-did-vc] anchor batch completed", { result });
+  } catch (err) {
+    logger.error("[sync-did-vc] anchor batch failed", {
+      message: err instanceof Error ? err.message : String(err),
+      stack: err instanceof Error ? err.stack : undefined,
+    });
+    throw err;
   }
 }


### PR DESCRIPTION
## Summary

既存の Cloud Run Job ベースの batch インフラ (`kyoso-dev-civicship-batch:run` + `BATCH_PROCESS_NAME` switch) を再利用して、内製化された週次 Cardano anchor batch を起動できるようにする。

## 背景

PR #1082 で導入した新しい `AnchorBatchUseCase.runBatch` は HTTP endpoint (`POST /admin/anchor-batch/run`) でしか起動できなかったが、dev 環境では既に Cloud Scheduler → Cloud Run Job の経路で他の batch (refresh views / sync-nft-metadata 等) が運用されている。新規 HTTP endpoint 用に Scheduler / IAM / Token を別系統で組むより、既存パターンに統合する方が運用一貫性が高い。

既存の Cloud Scheduler job:
- `kyoso-dev-civicship-batch-scheduler-sync-did-vc` (PAUSED, yearly cron)
- `kyoso-dev-civicship-batch-scheduler-request-did-vc` (PAUSED, yearly cron)

どちらも旧 IDENTUS 連携時代の placeholder で稼働していない。本 PR で `sync-did-vc` の中身を新 anchor batch 呼び出しに差し替え、ユーザーは cron を週次に修正して RESUME するだけで運用開始できる状態にする。

## 変更内容

### `src/presentation/batch/syncDIDVC/index.ts`
- 旧 IDENTUS sync ロジック (`processDIDRequests` / `processVCRequests`) の呼び出しを削除
- `AnchorBatchUseCase.runBatch(ctx, {})` を呼ぶシンプルな wrapper に置き換え
- エラーは throw して Cloud Run Job を失敗扱いにする（旧実装は swallow していたが、scheduler retry / on-call alert を有効化するため re-throw する）

### `src/presentation/batch/requestDIDVC/index.ts`
- 内製化後は VC 発行が同期 GraphQL mutation (`issueVc`) になり、anchor は週次 `sync-did-vc` で一括処理されるため本 entry は不要
- deprecation log を吐くだけの no-op に変更
- Cloud Scheduler job `request-did-vc` は PAUSED のまま放置 / 削除する前提

旧 IDENTUS helper file 群 (`syncDID.ts` / `syncVC.ts` / `requestDID.ts` / `requestVC.ts` / `utils.ts`) は import 元が無くなったが、依存削除を伴う cleanup PR は別途切り出す（本 PR は scheduler 配線だけに集中する）。

## 運用作業 (PR merge 後)

1. Cloud Scheduler `kyoso-dev-civicship-batch-scheduler-sync-did-vc` の cron を週次に修正（例: `0 0 * * 0` = 日曜 0:00 UTC）し、RESUME
2. `request-did-vc` job は PAUSED のまま (or 削除)
3. 動作確認: `gcloud scheduler jobs run ...` で強制 trigger → Cloud Run Job ログで anchor batch 完走を確認

## Test plan

- [ ] PR CI green (lint / typecheck / unit / integration)
- [ ] Merge 後、dev で scheduler 強制 trigger → batch 完走確認
- [ ] AnchorBatch DB 行 (`t_anchor_batches`) に week 行が立つこと
- [ ] Pending な VC anchor が Confirmed に遷移すること

https://claude.ai/code/session_01FmzzTMoHVwRrB7kAqc6m8G

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmzzTMoHVwRrB7kAqc6m8G)_