### PR TITLE
fix(provider): wire BlockfrostClient via factory (interface arg unresolvable)

### DIFF
--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -1,4 +1,4 @@
-import { container } from "tsyringe";
+import { container, instanceCachingFactory } from "tsyringe";
 import { prismaClient, PrismaClientIssuer } from "@/infrastructure/prisma/client";
 import TransactionUseCase from "@/application/domain/transaction/usecase";
 import TransactionRepository from "@/application/domain/transaction/data/repository";
@@ -591,7 +591,14 @@ export function registerProductionDependencies() {
   // KmsSigner は Phase 2 で KMS 経由署名を導入する PR で登録する
   //  （現時点では誰も `@inject("KmsSigner")` していないため、未使用 DI を
   //  残さない方針で削除した）。
-  container.registerSingleton("BlockfrostClient", BlockfrostClient);
+  // BlockfrostClient のコンストラクタは optional 引数 1 つ
+  // (`options: BlockfrostClientOptions = {}`) のみで、interface 型を
+  // tsyringe が auto-resolve できない (`TypeInfo not known for "Object"`)。
+  // 引数なしで構築すれば env (`BLOCKFROST_PROJECT_ID`) から値を引くため、
+  // factory + instanceCachingFactory で singleton 化する。
+  container.register("BlockfrostClient", {
+    useFactory: instanceCachingFactory(() => new BlockfrostClient()),
+  });
   container.register<BlockfrostLatestSlotProvider>("BlockfrostLatestSlotProvider", {
     useFactory: () => createBlockfrostLatestSlotProvider(),
   });

--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -596,9 +596,13 @@ export function registerProductionDependencies() {
   // tsyringe が auto-resolve できない (`TypeInfo not known for "Object"`)。
   // 引数なしで構築すれば env (`BLOCKFROST_PROJECT_ID`) から値を引くため、
   // factory + instanceCachingFactory で singleton 化する。
-  container.register("BlockfrostClient", {
-    useFactory: instanceCachingFactory(() => new BlockfrostClient()),
-  });
+  //
+  // dual-binding: クラス自体 (`@inject(BlockfrostClient)`) と string token
+  // (`@inject("BlockfrostClient")`) の両方で同じ singleton インスタンスに
+  // 解決させる。precedent は L304-306 の UserDidAnchorRepository。
+  const blockfrostFactory = instanceCachingFactory(() => new BlockfrostClient());
+  container.register(BlockfrostClient, { useFactory: blockfrostFactory });
+  container.register("BlockfrostClient", { useToken: BlockfrostClient });
   container.register<BlockfrostLatestSlotProvider>("BlockfrostLatestSlotProvider", {
     useFactory: () => createBlockfrostLatestSlotProvider(),
   });


### PR DESCRIPTION
## Summary

Cloud Run Job `sync-did-vc` の起動時に tsyringe が `AnchorBatchUseCase → AnchorBatchService → BlockfrostClient` の DI チェーンを構築できず exit(1) で死ぬ問題を修正。

## エラー詳細

```
Error: Cannot inject the dependency "service" at position #0 of
  "AnchorBatchUseCase" constructor. Reason:
    Cannot inject the dependency "blockfrost" at position #1 of
      "AnchorBatchService" constructor. Reason:
        Cannot inject the dependency at position #0 of
          "BlockfrostClient" constructor. Reason:
            TypeInfo not known for "Object"
    at file:///app/dist/presentation/batch/syncDIDVC/index.js:20:31
    at batchProcess (file:///app/dist/batch.js:14:19)
```

## 原因

- `BlockfrostClient` のコンストラクタは `options: BlockfrostClientOptions = {}` の optional 引数 1 つのみ
- tsyringe は interface 型を runtime に reflect できず (`Object` 扱い)、`registerSingleton(token, ClassRef)` ベースの auto-injection が破綻
- 引数なしで `new BlockfrostClient()` を呼べば env からの fallback で正常構築できる

## 修正

`register(token, { useFactory: instanceCachingFactory(...) })` で factory 経由 singleton に切替。factory 内では引数なしコンストラクタを呼ぶ。

## ⚠️ 関連する運用作業

`BLOCKFROST_PROJECT_ID` の env 設定が **dev Cloud Run + Cloud Run Job** で必要。本 PR とは別に以下のいずれかが必要:

```bash
# 例: Cloud Run service 側
gcloud run services update kyoso-dev-civicship-api \
  --region=us-central1 --project=kyoso-dev-453010 \
  --update-secrets=BLOCKFROST_PROJECT_ID=BLOCKFROST_PROJECT_ID_PREPROD:latest

# Cloud Run Job 側
gcloud run jobs update kyoso-dev-civicship-batch \
  --region=us-central1 --project=kyoso-dev-453010 \
  --update-secrets=BLOCKFROST_PROJECT_ID=BLOCKFROST_PROJECT_ID_PREPROD:latest
```

`BLOCKFROST_PROJECT_ID_PREPROD` を Secret Manager に登録する作業も必要（未済の場合）。

## Test plan

- [ ] PR CI green
- [ ] Merge 後、scheduler 強制 trigger で DI エラーが消えること
- [ ] BLOCKFROST_PROJECT_ID env 設定後、anchor batch が完走すること

https://claude.ai/code/session_01FmzzTMoHVwRrB7kAqc6m8G

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmzzTMoHVwRrB7kAqc6m8G)_