### PR TITLE
scripts(cardano): platform address derive + preprod e2e submit

### DIFF
--- a/scripts/derive-platform-address.ts
+++ b/scripts/derive-platform-address.ts
@@ -1,0 +1,168 @@
+#!/usr/bin/env -S node --experimental-strip-types
+/**
+ * Derive the Cardano enterprise address for the platform anchoring key.
+ *
+ * Used by Phase 0/1 operations to:
+ *   - Confirm the bech32 address corresponding to a seed already stored in
+ *     Secret Manager (so the operator can feed it to the preprod faucet).
+ *   - Generate a fresh 32-byte Ed25519 seed when bootstrapping a new env.
+ *
+ * Standalone (no DI / Prisma) so it can run from a local machine with only
+ * the env vars below set.
+ *
+ * Required env (one of):
+ *   CARDANO_PLATFORM_PRIVATE_KEY_HEX   32-byte Ed25519 seed (64 hex chars).
+ *                                      In production sourced from Secret
+ *                                      Manager. NEVER commit / log.
+ *
+ * Optional env:
+ *   CARDANO_NETWORK                    "preprod" (default) | "mainnet"
+ *   CARDANO_PLATFORM_ADDRESS           If set, compared to the derived
+ *                                      address and a mismatch fails the run.
+ *
+ * Flags:
+ *   --generate                         Generate a fresh seed instead of
+ *                                      reading from env. Prints the seed
+ *                                      hex to stdout — write it straight to
+ *                                      Secret Manager, do NOT paste it
+ *                                      anywhere else.
+ *   --network=preprod|mainnet          Overrides CARDANO_NETWORK.
+ *
+ * Exit codes: 0 = OK, 1 = error (missing env / mismatch / invalid seed).
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §I/Phase-0 0-2 (platform key bootstrap)
+ *   src/infrastructure/libs/cardano/keygen.ts          (derivation primitives)
+ */
+
+import {
+  type CardanoNetwork,
+  deriveCardanoKeypair,
+  generateCardanoKeypair,
+} from "../src/infrastructure/libs/cardano/keygen.ts";
+
+function parseFlags(argv: string[]): {
+  generate: boolean;
+  network?: CardanoNetwork;
+} {
+  const flags = { generate: false, network: undefined as CardanoNetwork | undefined };
+  for (const arg of argv) {
+    if (arg === "--generate") {
+      flags.generate = true;
+      continue;
+    }
+    const match = /^--network=(.+)$/.exec(arg);
+    if (match) {
+      const value = match[1];
+      if (value !== "preprod" && value !== "mainnet") {
+        throw new Error(`--network must be "preprod" or "mainnet", got "${value}"`);
+      }
+      flags.network = value;
+    }
+  }
+  return flags;
+}
+
+function resolveNetwork(flagNetwork?: CardanoNetwork): CardanoNetwork {
+  if (flagNetwork) return flagNetwork;
+  const raw = process.env.CARDANO_NETWORK;
+  if (!raw || raw === "preprod") return "preprod";
+  if (raw === "mainnet") return "mainnet";
+  throw new Error(`CARDANO_NETWORK must be "preprod" or "mainnet", got "${raw}"`);
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  if (clean.length !== 64) {
+    throw new Error(
+      `CARDANO_PLATFORM_PRIVATE_KEY_HEX must be 64 hex chars (32 bytes), got ${clean.length}`,
+    );
+  }
+  if (!/^[0-9a-fA-F]+$/.test(clean)) {
+    throw new Error("CARDANO_PLATFORM_PRIVATE_KEY_HEX contains non-hex characters");
+  }
+  const out = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) {
+    out[i] = Number.parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+function printKeypair(opts: {
+  network: CardanoNetwork;
+  addressBech32: string;
+  publicKeyHex: string;
+  paymentKeyHashHex: string;
+}): void {
+  process.stdout.write(`network              ${opts.network}\n`);
+  process.stdout.write(`address (bech32)     ${opts.addressBech32}\n`);
+  process.stdout.write(`public key hex       ${opts.publicKeyHex}\n`);
+  process.stdout.write(`payment key hash hex ${opts.paymentKeyHashHex}\n`);
+}
+
+function bytesToHex(b: Uint8Array): string {
+  let s = "";
+  for (const byte of b) s += byte.toString(16).padStart(2, "0");
+  return s;
+}
+
+async function main(): Promise<number> {
+  const flags = parseFlags(process.argv.slice(2));
+  const network = resolveNetwork(flags.network);
+
+  if (flags.generate) {
+    process.stderr.write(
+      "WARNING: generating a fresh seed. Write the printed `seed hex` line " +
+        "directly to Secret Manager and discard the terminal scrollback. " +
+        "Do NOT commit or share.\n\n",
+    );
+    const kp = await generateCardanoKeypair(network);
+    process.stdout.write(`seed hex             ${bytesToHex(kp.privateKeySeed)}\n`);
+    printKeypair({
+      network: kp.network,
+      addressBech32: kp.addressBech32,
+      publicKeyHex: bytesToHex(kp.publicKey),
+      paymentKeyHashHex: kp.paymentKeyHashHex,
+    });
+    return 0;
+  }
+
+  const seedHex = process.env.CARDANO_PLATFORM_PRIVATE_KEY_HEX;
+  if (!seedHex) {
+    process.stderr.write(
+      "CARDANO_PLATFORM_PRIVATE_KEY_HEX is not set. Either pass --generate to " +
+        "create a fresh seed, or export the seed from Secret Manager before " +
+        "running this script.\n",
+    );
+    return 1;
+  }
+
+  const seed = hexToBytes(seedHex);
+  const kp = deriveCardanoKeypair(seed, network);
+
+  printKeypair({
+    network: kp.network,
+    addressBech32: kp.addressBech32,
+    publicKeyHex: bytesToHex(kp.publicKey),
+    paymentKeyHashHex: kp.paymentKeyHashHex,
+  });
+
+  const expected = process.env.CARDANO_PLATFORM_ADDRESS;
+  if (expected && expected !== kp.addressBech32) {
+    process.stderr.write(
+      `\nMISMATCH: derived address does not match CARDANO_PLATFORM_ADDRESS env.\n` +
+        `  derived  ${kp.addressBech32}\n` +
+        `  env      ${expected}\n` +
+        "Either the seed or the address env is wrong for this network.\n",
+    );
+    return 1;
+  }
+  return 0;
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((err: unknown) => {
+    process.stderr.write(`ERROR: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  });

--- a/scripts/derive-platform-address.ts
+++ b/scripts/derive-platform-address.ts
@@ -40,6 +40,10 @@ import {
   deriveCardanoKeypair,
   generateCardanoKeypair,
 } from "../src/infrastructure/libs/cardano/keygen.ts";
+import {
+  bytesToHex,
+  parseFixedLengthHex,
+} from "./lib/cardanoScriptHelpers.ts";
 
 function parseFlags(argv: string[]): {
   generate: boolean;
@@ -71,23 +75,6 @@ function resolveNetwork(flagNetwork?: CardanoNetwork): CardanoNetwork {
   throw new Error(`CARDANO_NETWORK must be "preprod" or "mainnet", got "${raw}"`);
 }
 
-function hexToBytes(hex: string): Uint8Array {
-  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
-  if (clean.length !== 64) {
-    throw new Error(
-      `CARDANO_PLATFORM_PRIVATE_KEY_HEX must be 64 hex chars (32 bytes), got ${clean.length}`,
-    );
-  }
-  if (!/^[0-9a-fA-F]+$/.test(clean)) {
-    throw new Error("CARDANO_PLATFORM_PRIVATE_KEY_HEX contains non-hex characters");
-  }
-  const out = new Uint8Array(32);
-  for (let i = 0; i < 32; i++) {
-    out[i] = Number.parseInt(clean.slice(i * 2, i * 2 + 2), 16);
-  }
-  return out;
-}
-
 function printKeypair(opts: {
   network: CardanoNetwork;
   addressBech32: string;
@@ -98,12 +85,6 @@ function printKeypair(opts: {
   process.stdout.write(`address (bech32)     ${opts.addressBech32}\n`);
   process.stdout.write(`public key hex       ${opts.publicKeyHex}\n`);
   process.stdout.write(`payment key hash hex ${opts.paymentKeyHashHex}\n`);
-}
-
-function bytesToHex(b: Uint8Array): string {
-  let s = "";
-  for (const byte of b) s += byte.toString(16).padStart(2, "0");
-  return s;
 }
 
 async function main(): Promise<number> {
@@ -137,7 +118,7 @@ async function main(): Promise<number> {
     return 1;
   }
 
-  const seed = hexToBytes(seedHex);
+  const seed = parseFixedLengthHex(seedHex, 32, "CARDANO_PLATFORM_PRIVATE_KEY_HEX");
   const kp = deriveCardanoKeypair(seed, network);
 
   printKeypair({

--- a/scripts/lib/cardanoScriptHelpers.ts
+++ b/scripts/lib/cardanoScriptHelpers.ts
@@ -1,0 +1,73 @@
+/**
+ * Shared helpers for one-shot Cardano operator scripts.
+ *
+ * Used by `scripts/derive-platform-address.ts` and
+ * `scripts/preprod-e2e-submit.ts` (and any future sibling script that needs
+ * to validate hex env input or stream step-by-step output).
+ *
+ * Kept under `scripts/lib/` so it's clearly script-local and not part of
+ * the application graph — these helpers intentionally do NOT depend on the
+ * DI container, Prisma, or `@/infrastructure/*` modules.
+ */
+
+export type StepResult<T = void> =
+  | { name: string; ok: true; value: T; detail: string }
+  | { name: string; ok: false; detail: string };
+
+/**
+ * Run a labelled step, printing `-> name ...` / `   PASS|FAIL: detail` so
+ * the GitHub Actions / terminal log surfaces precisely which dependency
+ * broke (mirrors the format used by `scripts/cardano-canary.ts`).
+ *
+ * `fn` returns `{ value, detail }` so callers can thread a result through
+ * to the next step without needing non-null assertions on outer
+ * variables. For void steps, return `{ value: undefined, detail }`.
+ */
+export async function runStep<T>(
+  name: string,
+  fn: () => Promise<{ value: T; detail: string }>,
+): Promise<StepResult<T>> {
+  process.stdout.write(`-> ${name} ...\n`);
+  try {
+    const { value, detail } = await fn();
+    process.stdout.write(`   PASS: ${detail}\n`);
+    return { name, ok: true, value, detail };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    process.stdout.write(`   FAIL: ${msg}\n`);
+    return { name, ok: false, detail: msg };
+  }
+}
+
+/**
+ * Parse a fixed-length hex string into raw bytes. The `label` is woven into
+ * error messages so the operator sees which env var was malformed.
+ */
+export function parseFixedLengthHex(
+  hex: string,
+  expectedBytes: number,
+  label: string,
+): Uint8Array {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  const expectedHexLen = expectedBytes * 2;
+  if (clean.length !== expectedHexLen) {
+    throw new Error(
+      `${label} must be ${expectedHexLen} hex chars (${expectedBytes} bytes), got ${clean.length}`,
+    );
+  }
+  if (!/^[0-9a-fA-F]+$/.test(clean)) {
+    throw new Error(`${label} contains non-hex characters`);
+  }
+  const out = new Uint8Array(expectedBytes);
+  for (let i = 0; i < expectedBytes; i++) {
+    out[i] = Number.parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+/** Lowercase hex encoding (no `0x` prefix). */
+export function bytesToHex(b: Uint8Array): string {
+  let s = "";
+  for (const byte of b) s += byte.toString(16).padStart(2, "0");
+  return s;
+}

--- a/scripts/preprod-e2e-submit.ts
+++ b/scripts/preprod-e2e-submit.ts
@@ -39,10 +39,12 @@
  *   docs/operations/anchor-batch-deploy-checklist.md
  */
 
+import { BlockFrostAPI } from "@blockfrost/blockfrost-js";
 import { blake2b } from "@noble/hashes/blake2b";
 
 import {
   BlockfrostClient,
+  type BlockfrostProtocolParamsResponse,
   type BlockfrostUtxoResponse,
 } from "../src/infrastructure/libs/blockfrost/client.ts";
 import { deriveCardanoKeypair } from "../src/infrastructure/libs/cardano/keygen.ts";
@@ -52,33 +54,29 @@ import {
   buildAuxiliaryData,
   type DidOp,
 } from "../src/infrastructure/libs/cardano/txBuilder.ts";
+import {
+  bytesToHex,
+  parseFixedLengthHex,
+  runStep,
+  type StepResult,
+} from "./lib/cardanoScriptHelpers.ts";
 
 const DEFAULT_AWAIT_TIMEOUT_MS = 6 * 60 * 1000;
 const PREPROD_EXPLORER_TX = "https://preprod.cardanoscan.io/transaction";
 
-type StepResult = { name: string; ok: boolean; detail: string };
-
-async function runStep(
-  name: string,
-  fn: () => Promise<string>,
-): Promise<StepResult> {
-  process.stdout.write(`-> ${name} ...\n`);
-  try {
-    const detail = await fn();
-    process.stdout.write(`   PASS: ${detail}\n`);
-    return { name, ok: true, detail };
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    process.stdout.write(`   FAIL: ${msg}\n`);
-    return { name, ok: false, detail: msg };
-  }
-}
-
-function requirePreprodEnv(): {
+interface PreprodEnv {
   projectId: string;
   seedHex: string;
   address: string;
-} {
+}
+
+interface ChainSnapshot {
+  params: BlockfrostProtocolParamsResponse;
+  utxos: BlockfrostUtxoResponse[];
+  currentSlot: number;
+}
+
+function requirePreprodEnv(): PreprodEnv {
   const projectId = process.env.BLOCKFROST_PROJECT_ID;
   if (!projectId) {
     throw new Error("BLOCKFROST_PROJECT_ID is unset.");
@@ -104,29 +102,6 @@ function requirePreprodEnv(): {
     throw new Error("CARDANO_PLATFORM_ADDRESS is unset.");
   }
   return { projectId, seedHex, address };
-}
-
-function hexToBytes(hex: string): Uint8Array {
-  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
-  if (clean.length !== 64) {
-    throw new Error(
-      `CARDANO_PLATFORM_PRIVATE_KEY_HEX must be 64 hex chars (32 bytes), got ${clean.length}`,
-    );
-  }
-  if (!/^[0-9a-fA-F]+$/.test(clean)) {
-    throw new Error("CARDANO_PLATFORM_PRIVATE_KEY_HEX contains non-hex characters");
-  }
-  const out = new Uint8Array(32);
-  for (let i = 0; i < 32; i++) {
-    out[i] = Number.parseInt(clean.slice(i * 2, i * 2 + 2), 16);
-  }
-  return out;
-}
-
-function bytesToHex(b: Uint8Array): string {
-  let s = "";
-  for (const byte of b) s += byte.toString(16).padStart(2, "0");
-  return s;
 }
 
 function sumLovelace(utxos: BlockfrostUtxoResponse[]): bigint {
@@ -178,60 +153,66 @@ function resolveAwaitTimeoutMs(): number {
 async function main(): Promise<number> {
   process.stdout.write("Cardano preprod e2e submit (anchor-batch shape)\n\n");
 
-  const results: StepResult[] = [];
+  const results: StepResult<unknown>[] = [];
 
-  // Step 1 — env
-  const envStep = await runStep("env: preprod creds present", async () => {
-    const { projectId, address } = requirePreprodEnv();
-    return `BLOCKFROST_PROJECT_ID=preprod*** (${projectId.length} chars), CARDANO_PLATFORM_ADDRESS=${address}`;
+  // Step 1 — env (parsed once, threaded through subsequent steps via the step value)
+  const envStep = await runStep<PreprodEnv>("env: preprod creds present", async () => {
+    const env = requirePreprodEnv();
+    return {
+      value: env,
+      detail: `BLOCKFROST_PROJECT_ID=preprod*** (${env.projectId.length} chars), CARDANO_PLATFORM_ADDRESS=${env.address}`,
+    };
   });
   results.push(envStep);
   if (!envStep.ok) return 1;
-
-  const { projectId, seedHex, address } = requirePreprodEnv();
+  const { projectId, seedHex, address } = envStep.value;
 
   // Step 2 — derive + verify keypair
-  const seed = hexToBytes(seedHex);
-  const kp = deriveCardanoKeypair(seed, "preprod");
   const keyStep = await runStep("key: derived address matches env", async () => {
-    if (kp.addressBech32 !== address) {
+    const seed = parseFixedLengthHex(seedHex, 32, "CARDANO_PLATFORM_PRIVATE_KEY_HEX");
+    const derived = deriveCardanoKeypair(seed, "preprod");
+    if (derived.addressBech32 !== address) {
       throw new Error(
-        `derived "${kp.addressBech32}" != CARDANO_PLATFORM_ADDRESS "${address}". ` +
+        `derived "${derived.addressBech32}" != CARDANO_PLATFORM_ADDRESS "${address}". ` +
           "Seed and address env don't pair — refusing to submit.",
       );
     }
-    return `payment key hash ${kp.paymentKeyHashHex}`;
+    return {
+      value: derived,
+      detail: `payment key hash ${derived.paymentKeyHashHex}`,
+    };
   });
   results.push(keyStep);
   if (!keyStep.ok) return 1;
+  const kp = keyStep.value;
 
   // Step 3 — BlockfrostClient
   const client = new BlockfrostClient({ network: "CARDANO_PREPROD" });
 
   // Step 4 — protocol params + utxos + slot in parallel
-  let params: Awaited<ReturnType<BlockfrostClient["getProtocolParams"]>>;
-  let utxos: BlockfrostUtxoResponse[];
-  let currentSlot: number;
-  const fetchStep = await runStep("blockfrost: fetch params + utxos + latest slot", async () => {
-    const { BlockFrostAPI } = await import("@blockfrost/blockfrost-js");
-    const api = new BlockFrostAPI({ projectId, network: "preprod" });
-    const [p, u, latest] = await Promise.all([
-      client.getProtocolParams(),
-      client.getUtxos(address),
-      api.blocksLatest() as Promise<{ slot?: number | null }>,
-    ]);
-    params = p;
-    utxos = u;
-    const slot = latest?.slot;
-    if (typeof slot !== "number") {
-      throw new Error("blocksLatest returned no slot");
-    }
-    currentSlot = slot;
-    return `slot=${currentSlot}, utxos=${utxos.length}, lovelace=${sumLovelace(utxos).toString()}`;
-  });
+  const fetchStep = await runStep<ChainSnapshot>(
+    "blockfrost: fetch params + utxos + latest slot",
+    async () => {
+      const api = new BlockFrostAPI({ projectId, network: "preprod" });
+      const [params, utxos, latest] = await Promise.all([
+        client.getProtocolParams(),
+        client.getUtxos(address),
+        api.blocksLatest() as Promise<{ slot?: number | null }>,
+      ]);
+      const slot = latest?.slot;
+      if (typeof slot !== "number") {
+        throw new Error("blocksLatest returned no slot");
+      }
+      return {
+        value: { params, utxos, currentSlot: slot },
+        detail: `slot=${slot}, utxos=${utxos.length}, lovelace=${sumLovelace(utxos).toString()}`,
+      };
+    },
+  );
   results.push(fetchStep);
   if (!fetchStep.ok) return 1;
-  if (utxos!.length === 0) {
+  const { params, utxos, currentSlot } = fetchStep.value;
+  if (utxos.length === 0) {
     process.stdout.write(
       `\nWallet ${address} has no UTXOs on preprod. Fund it via\n` +
         "  https://docs.cardano.org/cardano-testnets/tools/faucet/\n" +
@@ -242,37 +223,43 @@ async function main(): Promise<number> {
 
   // Step 5 — build + sign tx (single build; reuse the CBOR for submit)
   const aux = buildSampleAuxiliaryData();
-  let tx: BuildAnchorTxOutput | undefined;
-  const built = await runStep("txBuilder: build + sign anchor tx", async () => {
-    tx = buildAnchorTx({
-      utxos: utxos!,
-      params: {
-        min_fee_a: params!.min_fee_a,
-        min_fee_b: params!.min_fee_b,
-        pool_deposit: params!.pool_deposit,
-        key_deposit: params!.key_deposit,
-        max_val_size: params!.max_val_size,
-        max_tx_size: params!.max_tx_size,
-        coins_per_utxo_size: params!.coins_per_utxo_size,
-      },
-      signKey: kp.cslPrivateKey,
-      auxiliaryData: aux,
-      changeAddressBech32: address,
-      currentSlot: currentSlot!,
-    });
-    return `txHash=${tx.txHashHex}, size=${tx.txCborBytes.length}B`;
-  });
-  results.push(built);
-  if (!built.ok || !tx) return 1;
+  const builtStep = await runStep<BuildAnchorTxOutput>(
+    "txBuilder: build + sign anchor tx",
+    async () => {
+      const tx = buildAnchorTx({
+        utxos,
+        params: {
+          min_fee_a: params.min_fee_a,
+          min_fee_b: params.min_fee_b,
+          pool_deposit: params.pool_deposit,
+          key_deposit: params.key_deposit,
+          max_val_size: params.max_val_size,
+          max_tx_size: params.max_tx_size,
+          coins_per_utxo_size: params.coins_per_utxo_size,
+        },
+        signKey: kp.cslPrivateKey,
+        auxiliaryData: aux,
+        changeAddressBech32: address,
+        currentSlot,
+      });
+      return {
+        value: tx,
+        detail: `txHash=${tx.txHashHex}, size=${tx.txCborBytes.length}B`,
+      };
+    },
+  );
+  results.push(builtStep);
+  if (!builtStep.ok) return 1;
+  const tx = builtStep.value;
 
   // Step 6 — submit (uses the CBOR bytes signed above)
-  let submittedHash = "";
-  const submitStep = await runStep("blockfrost: submitTx", async () => {
-    submittedHash = await client.submitTx(tx!.txCborBytes);
-    return `submitted hash=${submittedHash}`;
+  const submitStep = await runStep<string>("blockfrost: submitTx", async () => {
+    const hash = await client.submitTx(tx.txCborBytes);
+    return { value: hash, detail: `submitted hash=${hash}` };
   });
   results.push(submitStep);
   if (!submitStep.ok) return 1;
+  const submittedHash = submitStep.value;
 
   // Step 7 — await confirmation
   const awaitMs = resolveAwaitTimeoutMs();
@@ -280,7 +267,10 @@ async function main(): Promise<number> {
     `blockfrost: awaitConfirmation (timeout=${awaitMs}ms)`,
     async () => {
       const confirmed = await client.awaitConfirmation(submittedHash, awaitMs);
-      return `block_height=${confirmed.block_height ?? "null"}, block_time=${confirmed.block_time ?? "null"}`;
+      return {
+        value: undefined,
+        detail: `block_height=${confirmed.block_height ?? "null"}, block_time=${confirmed.block_time ?? "null"}`,
+      };
     },
   );
   results.push(confirmStep);

--- a/scripts/preprod-e2e-submit.ts
+++ b/scripts/preprod-e2e-submit.ts
@@ -1,0 +1,303 @@
+#!/usr/bin/env -S node --experimental-strip-types
+/**
+ * End-to-end PoC: submit a real anchor-batch-shaped tx to Cardano preprod.
+ *
+ * Unlike `cardano-canary.ts` (which only dry-runs metadata construction),
+ * this script actually:
+ *   1. Builds a fully-signed Transaction via the production txBuilder
+ *   2. Submits it through BlockfrostClient.submitTx
+ *   3. Awaits confirmation
+ *
+ * Intended for one-shot Phase 1 validation that
+ *   BLOCKFROST_PROJECT_ID + CARDANO_PLATFORM_PRIVATE_KEY_HEX + funded
+ *   CARDANO_PLATFORM_ADDRESS
+ * combine into a working anchoring pipeline. Once green, the weekly
+ * Cloud Run Job is expected to behave identically.
+ *
+ * Required env:
+ *   BLOCKFROST_PROJECT_ID              `preprod...` Blockfrost key.
+ *   CARDANO_PLATFORM_PRIVATE_KEY_HEX   32-byte Ed25519 seed (64 hex chars).
+ *   CARDANO_PLATFORM_ADDRESS           bech32 address that owns the UTXOs.
+ *
+ * Optional env:
+ *   CARDANO_NETWORK                    "preprod" (default) | "mainnet"
+ *                                      — mainnet is hard-refused by this
+ *                                      script even if set.
+ *   PREPROD_E2E_AWAIT_TIMEOUT_MS       awaitConfirmation timeout
+ *                                      (default 360_000 = 6 min).
+ *
+ * Exit codes: 0 = PASS, 1 = FAIL.
+ *
+ * SAFETY:
+ *   - Refuses to run against mainnet under any configuration.
+ *   - Verifies the derived address matches CARDANO_PLATFORM_ADDRESS before
+ *     spending anything (catches a wrong-seed pairing before the faucet
+ *     funds are consumed for nothing).
+ *
+ * Design references:
+ *   docs/report/did-vc-internalization.md §5.1.5 / §5.1.6 / §5.3.1
+ *   docs/operations/anchor-batch-deploy-checklist.md
+ */
+
+import { blake2b } from "@noble/hashes/blake2b";
+
+import {
+  BlockfrostClient,
+  type BlockfrostUtxoResponse,
+} from "../src/infrastructure/libs/blockfrost/client.ts";
+import { deriveCardanoKeypair } from "../src/infrastructure/libs/cardano/keygen.ts";
+import {
+  buildAnchorTx,
+  type BuildAnchorTxOutput,
+  buildAuxiliaryData,
+  type DidOp,
+} from "../src/infrastructure/libs/cardano/txBuilder.ts";
+
+const DEFAULT_AWAIT_TIMEOUT_MS = 6 * 60 * 1000;
+const PREPROD_EXPLORER_TX = "https://preprod.cardanoscan.io/transaction";
+
+type StepResult = { name: string; ok: boolean; detail: string };
+
+async function runStep(
+  name: string,
+  fn: () => Promise<string>,
+): Promise<StepResult> {
+  process.stdout.write(`-> ${name} ...\n`);
+  try {
+    const detail = await fn();
+    process.stdout.write(`   PASS: ${detail}\n`);
+    return { name, ok: true, detail };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    process.stdout.write(`   FAIL: ${msg}\n`);
+    return { name, ok: false, detail: msg };
+  }
+}
+
+function requirePreprodEnv(): {
+  projectId: string;
+  seedHex: string;
+  address: string;
+} {
+  const projectId = process.env.BLOCKFROST_PROJECT_ID;
+  if (!projectId) {
+    throw new Error("BLOCKFROST_PROJECT_ID is unset.");
+  }
+  if (!projectId.startsWith("preprod")) {
+    throw new Error(
+      `BLOCKFROST_PROJECT_ID must be a preprod key (prefix "preprod"). ` +
+        "Refusing to submit against the wrong network.",
+    );
+  }
+  const network = process.env.CARDANO_NETWORK ?? "preprod";
+  if (network !== "preprod") {
+    throw new Error(
+      `CARDANO_NETWORK="${network}" — this PoC only runs against preprod.`,
+    );
+  }
+  const seedHex = process.env.CARDANO_PLATFORM_PRIVATE_KEY_HEX;
+  if (!seedHex) {
+    throw new Error("CARDANO_PLATFORM_PRIVATE_KEY_HEX is unset.");
+  }
+  const address = process.env.CARDANO_PLATFORM_ADDRESS;
+  if (!address) {
+    throw new Error("CARDANO_PLATFORM_ADDRESS is unset.");
+  }
+  return { projectId, seedHex, address };
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  if (clean.length !== 64) {
+    throw new Error(
+      `CARDANO_PLATFORM_PRIVATE_KEY_HEX must be 64 hex chars (32 bytes), got ${clean.length}`,
+    );
+  }
+  if (!/^[0-9a-fA-F]+$/.test(clean)) {
+    throw new Error("CARDANO_PLATFORM_PRIVATE_KEY_HEX contains non-hex characters");
+  }
+  const out = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) {
+    out[i] = Number.parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+function bytesToHex(b: Uint8Array): string {
+  let s = "";
+  for (const byte of b) s += byte.toString(16).padStart(2, "0");
+  return s;
+}
+
+function sumLovelace(utxos: BlockfrostUtxoResponse[]): bigint {
+  let total = 0n;
+  for (const u of utxos) {
+    for (const a of u.amount) {
+      if (a.unit === "lovelace") total += BigInt(a.quantity);
+    }
+  }
+  return total;
+}
+
+function buildSampleAuxiliaryData() {
+  const sampleRoot = blake2b(new TextEncoder().encode("preprod-e2e-tx"), { dkLen: 32 });
+  const sampleVcRoot = blake2b(new TextEncoder().encode("preprod-e2e-vc"), { dkLen: 32 });
+  const sampleDocHash = blake2b(new TextEncoder().encode("preprod-e2e-doc"), { dkLen: 32 });
+
+  const ops: DidOp[] = [
+    {
+      k: "c",
+      did: "did:web:api.civicship.app:users:preprod-e2e",
+      h: bytesToHex(sampleDocHash),
+      doc: {
+        "@context": ["https://www.w3.org/ns/did/v1"],
+        id: "did:web:api.civicship.app:users:preprod-e2e",
+      },
+      prev: null,
+    },
+  ];
+
+  return buildAuxiliaryData({
+    v: 1,
+    bid: `e2e_${Date.now().toString(36)}`,
+    ts: Math.floor(Date.now() / 1000),
+    tx: { root: sampleRoot, count: 1 },
+    vc: { root: sampleVcRoot, count: 1 },
+    ops,
+  });
+}
+
+function resolveAwaitTimeoutMs(): number {
+  const raw = process.env.PREPROD_E2E_AWAIT_TIMEOUT_MS;
+  if (!raw) return DEFAULT_AWAIT_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_AWAIT_TIMEOUT_MS;
+  return parsed;
+}
+
+async function main(): Promise<number> {
+  process.stdout.write("Cardano preprod e2e submit (anchor-batch shape)\n\n");
+
+  const results: StepResult[] = [];
+
+  // Step 1 — env
+  const envStep = await runStep("env: preprod creds present", async () => {
+    const { projectId, address } = requirePreprodEnv();
+    return `BLOCKFROST_PROJECT_ID=preprod*** (${projectId.length} chars), CARDANO_PLATFORM_ADDRESS=${address}`;
+  });
+  results.push(envStep);
+  if (!envStep.ok) return 1;
+
+  const { projectId, seedHex, address } = requirePreprodEnv();
+
+  // Step 2 — derive + verify keypair
+  const seed = hexToBytes(seedHex);
+  const kp = deriveCardanoKeypair(seed, "preprod");
+  const keyStep = await runStep("key: derived address matches env", async () => {
+    if (kp.addressBech32 !== address) {
+      throw new Error(
+        `derived "${kp.addressBech32}" != CARDANO_PLATFORM_ADDRESS "${address}". ` +
+          "Seed and address env don't pair — refusing to submit.",
+      );
+    }
+    return `payment key hash ${kp.paymentKeyHashHex}`;
+  });
+  results.push(keyStep);
+  if (!keyStep.ok) return 1;
+
+  // Step 3 — BlockfrostClient
+  const client = new BlockfrostClient({ network: "CARDANO_PREPROD" });
+
+  // Step 4 — protocol params + utxos + slot in parallel
+  let params: Awaited<ReturnType<BlockfrostClient["getProtocolParams"]>>;
+  let utxos: BlockfrostUtxoResponse[];
+  let currentSlot: number;
+  const fetchStep = await runStep("blockfrost: fetch params + utxos + latest slot", async () => {
+    const { BlockFrostAPI } = await import("@blockfrost/blockfrost-js");
+    const api = new BlockFrostAPI({ projectId, network: "preprod" });
+    const [p, u, latest] = await Promise.all([
+      client.getProtocolParams(),
+      client.getUtxos(address),
+      api.blocksLatest() as Promise<{ slot?: number | null }>,
+    ]);
+    params = p;
+    utxos = u;
+    const slot = latest?.slot;
+    if (typeof slot !== "number") {
+      throw new Error("blocksLatest returned no slot");
+    }
+    currentSlot = slot;
+    return `slot=${currentSlot}, utxos=${utxos.length}, lovelace=${sumLovelace(utxos).toString()}`;
+  });
+  results.push(fetchStep);
+  if (!fetchStep.ok) return 1;
+  if (utxos!.length === 0) {
+    process.stdout.write(
+      `\nWallet ${address} has no UTXOs on preprod. Fund it via\n` +
+        "  https://docs.cardano.org/cardano-testnets/tools/faucet/\n" +
+        "and re-run.\n",
+    );
+    return 1;
+  }
+
+  // Step 5 — build + sign tx (single build; reuse the CBOR for submit)
+  const aux = buildSampleAuxiliaryData();
+  let tx: BuildAnchorTxOutput | undefined;
+  const built = await runStep("txBuilder: build + sign anchor tx", async () => {
+    tx = buildAnchorTx({
+      utxos: utxos!,
+      params: {
+        min_fee_a: params!.min_fee_a,
+        min_fee_b: params!.min_fee_b,
+        pool_deposit: params!.pool_deposit,
+        key_deposit: params!.key_deposit,
+        max_val_size: params!.max_val_size,
+        max_tx_size: params!.max_tx_size,
+        coins_per_utxo_size: params!.coins_per_utxo_size,
+      },
+      signKey: kp.cslPrivateKey,
+      auxiliaryData: aux,
+      changeAddressBech32: address,
+      currentSlot: currentSlot!,
+    });
+    return `txHash=${tx.txHashHex}, size=${tx.txCborBytes.length}B`;
+  });
+  results.push(built);
+  if (!built.ok || !tx) return 1;
+
+  // Step 6 — submit (uses the CBOR bytes signed above)
+  let submittedHash = "";
+  const submitStep = await runStep("blockfrost: submitTx", async () => {
+    submittedHash = await client.submitTx(tx!.txCborBytes);
+    return `submitted hash=${submittedHash}`;
+  });
+  results.push(submitStep);
+  if (!submitStep.ok) return 1;
+
+  // Step 7 — await confirmation
+  const awaitMs = resolveAwaitTimeoutMs();
+  const confirmStep = await runStep(
+    `blockfrost: awaitConfirmation (timeout=${awaitMs}ms)`,
+    async () => {
+      const confirmed = await client.awaitConfirmation(submittedHash, awaitMs);
+      return `block_height=${confirmed.block_height ?? "null"}, block_time=${confirmed.block_time ?? "null"}`;
+    },
+  );
+  results.push(confirmStep);
+
+  process.stdout.write(`\n${PREPROD_EXPLORER_TX}/${submittedHash}\n`);
+  const failed = results.filter((r) => !r.ok);
+  if (failed.length > 0) {
+    process.stdout.write(`\nFAIL: ${failed.length} step(s) failed.\n`);
+    return 1;
+  }
+  process.stdout.write("\nALL STEPS PASSED.\n");
+  return 0;
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((err: unknown) => {
+    process.stderr.write(`ERROR: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

引き継ぎロードマップ Step B として、anchor batch を **Cloud Run Job 起動を待たずローカルから** 検証できる一回実行型スクリプトを 2 つ追加します。Phase 0 0-2（platform wallet bootstrap）と preprod 実 submit PoC をカバーします。

## 追加スクリプト

### `scripts/derive-platform-address.ts`
- `CARDANO_PLATFORM_PRIVATE_KEY_HEX`（64 hex chars）から bech32 enterprise address を再現
- `--generate` で新規 Ed25519 seed を発行（Secret Manager 投入用、stdout 単発出力）
- `CARDANO_PLATFORM_ADDRESS` が既に env に入っている場合は派生結果と突き合わせて mismatch を exit 1 で弾く
- `--network=preprod|mainnet` または `CARDANO_NETWORK` で切替

実行例：
```bash
# 既存 seed の address 確認
dotenvx run -f .env.dev -- tsx scripts/derive-platform-address.ts

# 新規 seed 発行（出力は Secret Manager に貼り付け、ターミナル履歴は破棄）
tsx scripts/derive-platform-address.ts --generate --network=preprod
```

### `scripts/preprod-e2e-submit.ts`
- `BlockfrostClient` + `buildAnchorTx` を通して **実 anchor tx を preprod に submit** する PoC
- 直列で env → key derive → blockfrost fetch → build/sign → submit → awaitConfirmation を実行、各ステップ PASS/FAIL を表示
- mainnet は `BLOCKFROST_PROJECT_ID` prefix / `CARDANO_NETWORK` どちらでも hard-refuse
- 派生 address が `CARDANO_PLATFORM_ADDRESS` と一致しない場合は submit 前に失敗（faucet UTxO 消費を防止）
- UTxO が無いときは Cardano testnets faucet URL を案内
- 確認後に `https://preprod.cardanoscan.io/transaction/<hash>` を出力

実行例：
```bash
dotenvx run -f .env.dev -- tsx scripts/preprod-e2e-submit.ts
```

## 設計上の判断

- `scripts/cardano-canary.ts`（既存）は dry-run なのに対し、本 PoC は **実際に submit する** 唯一の手段（Cloud Run Job 経由を待たない）
- DI / Prisma 非依存。標準的な `import "reflect-metadata"` も不要（DI container 一切使わない）
- CI には組み込まない（手動 1 回実行を想定）
- canary と同じ「ステップ runner」パターンを採用してログを揃える

## Test plan

- [ ] PR CI green（lint + type-check）
- [ ] `tsx scripts/derive-platform-address.ts --generate` でローカル動作確認
- [ ] dev env で `dotenvx run -f .env.dev -- tsx scripts/derive-platform-address.ts` を実行し、`CARDANO_PLATFORM_ADDRESS` と一致することを確認
- [ ] faucet 入金後、`scripts/preprod-e2e-submit.ts` を実行し preprod に tx が乗ることを CardanoScan で確認

## 関連

- 引き継ぎサマリ Step B
- `docs/report/did-vc-internalization.md` §I/Phase-0 0-2（platform key bootstrap）
- `scripts/cardano-canary.ts`（同パターンの dry-run 版）

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_01NR9mGWrwj2CVsXqT2fGuoN)_