### PR TITLE
fix(scripts): load reflect-metadata before BlockfrostClient import

### DIFF
--- a/scripts/preprod-e2e-submit.ts
+++ b/scripts/preprod-e2e-submit.ts
@@ -39,6 +39,11 @@
  *   docs/operations/anchor-batch-deploy-checklist.md
  */
 
+// `BlockfrostClient` is `@injectable()`; importing it loads `tsyringe`, which
+// asserts that `reflect-metadata` has been loaded before any decorator
+// metadata is read. Must be the FIRST import in this entrypoint.
+import "reflect-metadata";
+
 import { BlockFrostAPI } from "@blockfrost/blockfrost-js";
 
 import {


### PR DESCRIPTION
## Summary

`scripts/preprod-e2e-submit.ts` をローカルで実行した際に tsyringe が import 時 throw する不具合の修正。

```
Error: tsyringe requires a reflect polyfill. Please add 'import "reflect-metadata"' to the top of your entry point.
    at Object.<anonymous> (.../tsyringe/dist/cjs/index.js:5:11)
```

## 原因

`BlockfrostClient` は `@injectable()` 付き。当該 class を import すると tsyringe 本体が読み込まれ、tsyringe の `index.js` が module load 時に `reflect-metadata` の存在を assert して throw する。

アプリ側 (`src/bootstrap/index.ts`) は `reflect-metadata` を loader 経由で先に load しているが、standalone script はその責任を自前で持つ必要がある。

## 修正

`preprod-e2e-submit.ts` の最先頭（既存 import の前）に `import "reflect-metadata"` を追加。derive-platform-address.ts は DI を一切経由せず（`deriveCardanoKeypair` は CSL のみで完結）influenceあるクラスを load しないため修正不要。

## 再現 / 動作確認

修正前:
```
dotenvx run -f .env.dev -- tsx scripts/preprod-e2e-submit.ts
# → throws "tsyringe requires a reflect polyfill"
```

修正後:
```
dotenvx run -f .env.dev -- tsx scripts/preprod-e2e-submit.ts
# → 通常の env / key / blockfrost ステップへ進む
```

## Test plan

- [ ] PR CI green
- [ ] preprod faucet 入金済の wallet で submit → `ALL STEPS PASSED.` を確認（ユーザー側 E2E）

## 関連

- 親 PR: #1138, #1139
- Step B verify

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_01NR9mGWrwj2CVsXqT2fGuoN)_