### PR TITLE
fix(blockfrost): map getUtxos 404 to empty array

### DIFF
--- a/src/__tests__/unit/infrastructure/libs/blockfrost/client.test.ts
+++ b/src/__tests__/unit/infrastructure/libs/blockfrost/client.test.ts
@@ -150,6 +150,17 @@ describe("BlockfrostClient", () => {
       expect(mockAddressesUtxosAll).toHaveBeenCalledWith("addr_test1xyz");
     });
 
+    it("getUtxos(address) maps Blockfrost 404 (no on-chain activity) to []", async () => {
+      mockAddressesUtxosAll.mockRejectedValueOnce(
+        Object.assign(new Error("The requested component has not been found."), {
+          status_code: 404,
+        }),
+      );
+
+      const client = new BlockfrostClient({ network: "CARDANO_PREPROD" });
+      await expect(client.getUtxos("addr_test1empty")).resolves.toEqual([]);
+    });
+
     it("submitTx(bytes) delegates to txSubmit(bytes) and returns the hash", async () => {
       mockTxSubmit.mockResolvedValueOnce("a".repeat(64));
 

--- a/src/infrastructure/libs/blockfrost/client.ts
+++ b/src/infrastructure/libs/blockfrost/client.ts
@@ -258,20 +258,19 @@ export class BlockfrostClient {
    * "freshly-funded / never-funded" boundary case.
    */
   async getUtxos(address: string): Promise<BlockfrostUtxoResponse[]> {
-    try {
-      return await this.withRetry(
-        "getUtxos",
-        () => this.api.addressesUtxosAll(address) as Promise<BlockfrostUtxoResponse[]>,
-      );
-    } catch (err) {
-      if (isLikelyNotFound(err)) {
-        logger.info("[BlockfrostClient] getUtxos: address has no UTXOs (404 → [])", {
-          address,
-        });
-        return [];
+    return this.withRetry("getUtxos", async () => {
+      try {
+        return (await this.api.addressesUtxosAll(address)) as BlockfrostUtxoResponse[];
+      } catch (err) {
+        if (isLikelyNotFound(err)) {
+          logger.info("[BlockfrostClient] getUtxos: address has no UTXOs (404 → [])", {
+            address,
+          });
+          return [];
+        }
+        throw err;
       }
-      throw err;
-    }
+    });
   }
 
   /**

--- a/src/infrastructure/libs/blockfrost/client.ts
+++ b/src/infrastructure/libs/blockfrost/client.ts
@@ -249,12 +249,29 @@ export class BlockfrostClient {
     );
   }
 
-  /** §5.1.5 `getUtxos(address)` → `addressesUtxosAll`. */
+  /**
+   * §5.1.5 `getUtxos(address)` → `addressesUtxosAll`.
+   *
+   * Blockfrost returns 404 for an address that has no on-chain history at
+   * all (rather than an empty array). Map that to `[]` so callers can
+   * uniformly check `utxos.length === 0` without special-casing the
+   * "freshly-funded / never-funded" boundary case.
+   */
   async getUtxos(address: string): Promise<BlockfrostUtxoResponse[]> {
-    return this.withRetry(
-      "getUtxos",
-      () => this.api.addressesUtxosAll(address) as Promise<BlockfrostUtxoResponse[]>,
-    );
+    try {
+      return await this.withRetry(
+        "getUtxos",
+        () => this.api.addressesUtxosAll(address) as Promise<BlockfrostUtxoResponse[]>,
+      );
+    } catch (err) {
+      if (isLikelyNotFound(err)) {
+        logger.info("[BlockfrostClient] getUtxos: address has no UTXOs (404 → [])", {
+          address,
+        });
+        return [];
+      }
+      throw err;
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Blockfrost の `addressesUtxosAll` は **on-chain history がまったく無い address** に対して空配列ではなく `404 ("The requested component has not been found.")` を返します。この挙動が `BlockfrostClient.getUtxos` をそのまま貫通すると、freshly-funded / never-funded のケースで例外送出になり、anchor batch も Step B PoC script も「faucet で入金してください」というメッセージに辿り着けません。

## 再現

PR #1138 で追加した preprod-e2e-submit を未入金 wallet に対して走らせた例:

```
-> blockfrost: fetch params + utxos + latest slot ...
   FAIL: The requested component has not been found.
```

`scripts/preprod-e2e-submit.ts` 側には `utxos.length === 0` を判定して faucet URL を案内する分岐があるのに到達しません。同じ条件で本番 anchor batch も「PENDING anchor が居る → submit 失敗」の経路で死にます。

## 修正

`BlockfrostClient.getUtxos` 内で 404 を捕捉して `[]` に置き換え、それ以外のエラーは従来通り `withRetry` で扱う。`isLikelyNotFound` は本ファイル既存のヘルパー（`awaitConfirmation` の polling miss 判定で使われているもの）を再利用。

## Test plan

- [x] Unit test 追加 (`getUtxos 404 → []` 双方をカバー)
- [ ] PR CI green
- [ ] Step B verify: 未入金 / 入金前 wallet に対して `tsx scripts/preprod-e2e-submit.ts` を走らせ、faucet 案内メッセージで終了することを確認

## 関連

- 親 PR: #1138 (preprod-e2e-submit script), #1140 (reflect-metadata fix)
- Step B verify 中に発見

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_01NR9mGWrwj2CVsXqT2fGuoN)_