### PR TITLE
fix(scripts/dev-issue-vc): pass x-community-id header

### DIFF
--- a/scripts/dev-issue-vc.ts
+++ b/scripts/dev-issue-vc.ts
@@ -71,6 +71,7 @@ interface Flags {
   subjectDid: string;
   claims: Record<string, unknown>;
   api: string;
+  communityId: string;
 }
 
 function parseFlags(argv: string[]): Flags {
@@ -82,8 +83,16 @@ function parseFlags(argv: string[]): Flags {
   }
   const uid = map.get("uid");
   const userId = map.get("user-id");
+  const communityId = map.get("community-id");
   if (!uid) throw new Error("--uid=<firebase-uid> is required");
   if (!userId) throw new Error("--user-id=<civicship user.id> is required");
+  if (!communityId) {
+    throw new Error(
+      "--community-id=<civicship Community.id> is required " +
+        "(the API enforces `x-community-id` on authenticated requests, " +
+        "since callers may belong to multiple communities).",
+    );
+  }
 
   const claimsRaw = map.get("claims") ?? "{}";
   let claims: Record<string, unknown>;
@@ -100,6 +109,7 @@ function parseFlags(argv: string[]): Flags {
     subjectDid: map.get("subject-did") ?? `${SUBJECT_DID_PREFIX}${userId}`,
     claims,
     api: map.get("api") ?? DEFAULT_API,
+    communityId,
   };
 }
 
@@ -222,6 +232,10 @@ async function callIssueVc(
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${idToken}`,
+      // The auth middleware rejects authenticated calls without an explicit
+      // community context — callers may sit in multiple communities so the
+      // server cannot infer one. Mirror the same header the frontend sends.
+      "x-community-id": flags.communityId,
     },
     body: JSON.stringify({ query, variables }),
   });


### PR DESCRIPTION
## Summary

dev で `scripts/dev-issue-vc.ts` を実行すると `UNAUTHENTICATED — Missing x-community-id header` で 500。auth middleware が「caller は複数 community に居うる、server 側で一意に決められない」として明示的な community context を要求する仕様。

## 修正

- `--community-id=<Community.id>` を required flag に追加
- GraphQL POST の headers に `x-community-id: <community-id>` を付与（frontend と同じ動作）

## 使い方

```bash
pnpm exec dotenvx run -f .env.dev -- pnpm exec tsx scripts/dev-issue-vc.ts \
  --uid=<firebase-uid> \
  --user-id=<civicship-user-id> \
  --community-id=<civicship-community-id>
```

## 関連

- 親 PR: #1146

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_01NR9mGWrwj2CVsXqT2fGuoN)_