### PR TITLE
scripts(credential): resign STUB_SIGNATURE VCs with KmsJwtSigner

### DIFF
--- a/scripts/resign-stub-vcs.ts
+++ b/scripts/resign-stub-vcs.ts
@@ -1,0 +1,164 @@
+#!/usr/bin/env -S node --experimental-strip-types
+/**
+ * Re-sign `STUB_SIGNATURE`-bearing VCs with the production `KmsJwtSigner`.
+ *
+ * Phase 1 期間中（KmsJwtSigner ランディング前）に発行された VC は
+ * signature segment が `STUB_SIGNATURE` (`stub-not-signed`) のままで
+ * DB に残っている。Phase 2 移行後はそれらを実 KMS 署名に置換する必要がある。
+ * 本スクリプトは:
+ *
+ *   1. `t_vc_issuance_requests.vc_jwt LIKE '%stub-not-signed%'` で対象を抽出
+ *   2. 各行について middle segment (payload) は保持、header は新 signer の
+ *      `alg` / `kid` で再構築 (`STUB_SIGNATURE` 時代の `#stub` kid を捨てる)
+ *   3. `${headerB64u}.${payloadB64u}` を `KmsJwtSigner.sign()` に渡して
+ *      実 Ed25519 base64url signature を取得
+ *   4. `vc_jwt` のみを update（vcId / payload / created_at は不変）
+ *
+ * `--confirm` 無しは dry-run（件数と sample header/kid だけ表示）。
+ *
+ * 設計参照:
+ *   docs/report/did-vc-internalization.md §16     (Phase 2 KMS swap)
+ *   docs/report/did-vc-internalization.md §5.2.2  (VC issuance / JWT shape)
+ *
+ * 実行例 (dev):
+ *   pnpm exec dotenvx run -f .env.dev -- pnpm exec tsx scripts/resign-stub-vcs.ts
+ *   pnpm exec dotenvx run -f .env.dev -- pnpm exec tsx scripts/resign-stub-vcs.ts --confirm
+ *
+ * Exit codes: 0 = OK (dry-run or all rows resigned), 1 = error.
+ */
+
+import "reflect-metadata";
+import "@/application/provider";
+
+import { container } from "tsyringe";
+
+import { prismaClient } from "@/infrastructure/prisma/client";
+import type { JwtSigner } from "@/application/domain/credential/shared/jwtSigner";
+import { STUB_SIGNATURE } from "@/application/domain/credential/shared/stubJwtSigner";
+
+interface Flags {
+  confirm: boolean;
+  limit?: number;
+}
+
+function parseFlags(argv: string[]): Flags {
+  const flags: Flags = { confirm: false };
+  for (const arg of argv) {
+    if (arg === "--confirm") {
+      flags.confirm = true;
+      continue;
+    }
+    const limitMatch = /^--limit=(\d+)$/.exec(arg);
+    if (limitMatch) {
+      flags.limit = Number.parseInt(limitMatch[1], 10);
+      continue;
+    }
+    throw new Error(`Unknown flag: ${arg}`);
+  }
+  return flags;
+}
+
+function base64urlEncodeJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
+}
+
+function payloadSegmentOf(vcJwt: string): string {
+  const segments = vcJwt.split(".");
+  if (segments.length !== 3) {
+    throw new Error(`vcJwt has ${segments.length} segments, expected 3`);
+  }
+  return segments[1];
+}
+
+function isStubSignature(vcJwt: string): boolean {
+  const segments = vcJwt.split(".");
+  return segments[2] === Buffer.from(STUB_SIGNATURE, "utf8").toString("base64url")
+    || segments[2] === STUB_SIGNATURE;
+}
+
+async function rebuildJwt(payloadB64u: string, signer: JwtSigner): Promise<string> {
+  await signer.prepare();
+  const headerB64u = base64urlEncodeJson({
+    alg: signer.alg,
+    typ: "JWT",
+    kid: signer.kid,
+  });
+  const signingInput = `${headerB64u}.${payloadB64u}`;
+  const signature = await signer.sign(signingInput);
+  return `${signingInput}.${signature}`;
+}
+
+async function main(): Promise<number> {
+  const flags = parseFlags(process.argv.slice(2));
+  process.stdout.write("Re-sign STUB_SIGNATURE VCs with KmsJwtSigner\n\n");
+  process.stdout.write(`mode: ${flags.confirm ? "EXECUTE" : "DRY-RUN"}\n`);
+  if (flags.limit !== undefined) process.stdout.write(`limit: ${flags.limit}\n`);
+  process.stdout.write("\n");
+
+  const candidates = await prismaClient.vcIssuanceRequest.findMany({
+    where: {
+      vcJwt: { contains: STUB_SIGNATURE },
+    },
+    select: { id: true, vcJwt: true },
+    orderBy: { createdAt: "asc" },
+    take: flags.limit,
+  });
+
+  process.stdout.write(`Found ${candidates.length} stub-signed VC row(s)\n\n`);
+  if (candidates.length === 0) {
+    return 0;
+  }
+
+  // Sanity-check signer once before iterating so we fail loudly if KMS /
+  // active-key DB row is misconfigured before touching any row.
+  const signer = container.resolve<JwtSigner>("VcJwtSigner");
+  await signer.prepare();
+  process.stdout.write(`signer: alg=${signer.alg}, kid=${signer.kid}\n\n`);
+
+  let updated = 0;
+  let failed = 0;
+  for (const row of candidates) {
+    try {
+      if (!isStubSignature(row.vcJwt)) {
+        process.stdout.write(`SKIP  ${row.id}: signature not exactly STUB (likely already real-signed)\n`);
+        continue;
+      }
+      const payloadB64u = payloadSegmentOf(row.vcJwt);
+      const newJwt = await rebuildJwt(payloadB64u, signer);
+
+      if (flags.confirm) {
+        await prismaClient.vcIssuanceRequest.update({
+          where: { id: row.id },
+          data: { vcJwt: newJwt },
+        });
+        updated += 1;
+        process.stdout.write(`OK    ${row.id}: resigned (new len=${newJwt.length})\n`);
+      } else {
+        updated += 1;
+        process.stdout.write(`DRY   ${row.id}: would resign (new len=${newJwt.length})\n`);
+      }
+    } catch (err) {
+      failed += 1;
+      process.stderr.write(
+        `FAIL  ${row.id}: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+
+  process.stdout.write(
+    `\n${flags.confirm ? "resigned" : "would-resign"}: ${updated}, failed: ${failed}\n`,
+  );
+  if (!flags.confirm) {
+    process.stdout.write("\nRe-run with `--confirm` to apply.\n");
+  }
+  return failed === 0 ? 0 : 1;
+}
+
+main()
+  .then((code) => {
+    prismaClient.$disconnect().finally(() => process.exit(code));
+  })
+  .catch((err: unknown) => {
+    process.stderr.write(`ERROR: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`);
+    prismaClient.$disconnect().finally(() => process.exit(1));
+  });


### PR DESCRIPTION
## Summary

Phase 3 cutover backfill 3 本セットのうち、**DB-only / 即時実行可能** な最初の 1 本。

Phase 1 期間中（KmsJwtSigner ランディング前）に発行された VC は signature segment が `STUB_SIGNATURE` (`stub-not-signed`) のままで DB に残っている。Phase 2 移行後はそれらを実 KMS 署名に置換する必要がある。

## 処理

1. `t_vc_issuance_requests.vc_jwt LIKE '%stub-not-signed%'` で対象抽出
2. 各行の middle segment (payload) は保持、header は新 signer の `alg` / `kid` で再構築（旧 `#stub` kid → 新 `#key-1`）
3. `${headerB64u}.${payloadB64u}` を `KmsJwtSigner.sign()` に渡して実 Ed25519 base64url signature を取得
4. `vc_jwt` のみを update（**`vcId` / payload / `createdAt` は不変**）

vcId 不変なので、StatusList の bit index や verifier が参照する `id` 等の外部参照は壊れない。

## Flags

- `--confirm` : 実 update。無しは dry-run（件数と sample header/kid だけ表示）
- `--limit=N` : 対象件数制限

## 実行例 (dev)

```bash
# 1. dry-run
pnpm exec dotenvx run -f .env.dev -- pnpm exec tsx scripts/resign-stub-vcs.ts

# 2. 1 件だけ試す
pnpm exec dotenvx run -f .env.dev -- pnpm exec tsx scripts/resign-stub-vcs.ts --confirm --limit=1

# 3. 全件 apply
pnpm exec dotenvx run -f .env.dev -- pnpm exec tsx scripts/resign-stub-vcs.ts --confirm
```

期待出力:
```
Re-sign STUB_SIGNATURE VCs with KmsJwtSigner

mode: EXECUTE
Found N stub-signed VC row(s)

signer: alg=EdDSA, kid=did:web:api.civicship.app#key-1

OK    <vcId1>: resigned (new len=...)
OK    <vcId2>: resigned (new len=...)
...
resigned: N, failed: 0
```

## 既存 VC 数 (dev 確認済)

40 件（うち何件が stub かは要 dry-run 実行で確認）

## Test plan

- [ ] PR CI green
- [ ] dev で dry-run → 件数表示
- [ ] dev で `--confirm --limit=1` → 1 行更新後、その vcId を `scripts/dev-issue-vc.ts` ベースの verify で署名検証（または `jwt.io` decode）
- [ ] dev で `--confirm` → 残り全件更新

## 関連

- 親 PR: #1142 (KmsJwtSigner 本実装)
- Phase 3 cutover backfill 3 本セットの 1/3

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_01NR9mGWrwj2CVsXqT2fGuoN)_