### PR TITLE
fix(scripts/backfill-user-did): drop interactive tx (5s timeout)

### DIFF
--- a/scripts/backfill-user-did.ts
+++ b/scripts/backfill-user-did.ts
@@ -273,48 +273,50 @@ async function main(): Promise<number> {
         const did = buildUserDid(user.id);
         const { cbor, hashHex } = encodeAndHashUserDoc(user.id);
 
-        await prismaClient.$transaction(async (tx) => {
-          // INTERNAL did issuance row (idempotent — should be missing
-          // by virtue of the WHERE in findUsersWithoutInternal, but
-          // race-safe via the `didMethod` filter below)
-          const existing = await tx.didIssuanceRequest.findFirst({
-            where: { userId: user.id, didMethod: DidMethod.INTERNAL },
-            select: { id: true },
-          });
-          if (!existing) {
-            await tx.didIssuanceRequest.create({
-              data: {
-                userId: user.id,
-                didMethod: DidMethod.INTERNAL,
-                status: DidIssuanceStatus.COMPLETED,
-                didValue: did,
-                completedAt: new Date(),
-                processedAt: new Date(),
-              },
-            });
-            insertedDids += 1;
-          }
-          // Skip anchor INSERT if a CREATE anchor already exists for this user
-          // (e.g. backfill was partially run).
-          const existingAnchor = await tx.userDidAnchor.findFirst({
-            where: { userId: user.id, operation: DidOperation.CREATE },
-            select: { id: true },
-          });
-          if (!existingAnchor) {
-            await tx.userDidAnchor.create({
-              data: {
-                userId: user.id,
-                did,
-                operation: DidOperation.CREATE,
-                documentHash: hashHex,
-                documentCbor: Buffer.from(cbor),
-                network: platform.chainNetwork,
-                status: AnchorStatus.PENDING,
-              },
-            });
-            insertedAnchors += 1;
-          }
+        // Idempotent INSERTs without an outer interactive transaction.
+        // Prisma's default `$transaction` timeout is 5 s and we burn it
+        // easily on the first cold-start cycle (4 queries × ~hundreds of
+        // ms each, × dozens of users). Per-user atomicity is not
+        // strictly needed here: there are no unique constraints on
+        // `(userId, didMethod)` or `(userId, operation)`, both create
+        // paths gate on a `findFirst` existence check, and a partial-
+        // state crash is recoverable simply by re-running the script
+        // (the next pass skips the existing row).
+        const existing = await prismaClient.didIssuanceRequest.findFirst({
+          where: { userId: user.id, didMethod: DidMethod.INTERNAL },
+          select: { id: true },
         });
+        if (!existing) {
+          await prismaClient.didIssuanceRequest.create({
+            data: {
+              userId: user.id,
+              didMethod: DidMethod.INTERNAL,
+              status: DidIssuanceStatus.COMPLETED,
+              didValue: did,
+              completedAt: new Date(),
+              processedAt: new Date(),
+            },
+          });
+          insertedDids += 1;
+        }
+        const existingAnchor = await prismaClient.userDidAnchor.findFirst({
+          where: { userId: user.id, operation: DidOperation.CREATE },
+          select: { id: true },
+        });
+        if (!existingAnchor) {
+          await prismaClient.userDidAnchor.create({
+            data: {
+              userId: user.id,
+              did,
+              operation: DidOperation.CREATE,
+              documentHash: hashHex,
+              documentCbor: Buffer.from(cbor),
+              network: platform.chainNetwork,
+              status: AnchorStatus.PENDING,
+            },
+          });
+          insertedAnchors += 1;
+        }
       }
       return {
         value: { inserted: insertedAnchors },


### PR DESCRIPTION
## Summary

dev で `backfill-user-did --confirm` 実行時に Prisma interactive transaction の 5s timeout で fail:

```
Transaction API error: Transaction already closed: A query cannot be executed
on an expired transaction. The timeout for this transaction was 5000 ms,
however 15781 ms passed since the start of the transaction.
```

per-user の `prismaClient.$transaction(async (tx) => { 4 query })` が cold start + connection pool 初期化と重なって 5s 超え。

## 修正

per-user atomicity は要件上不要:
- `(userId, didMethod)` / `(userId, operation)` に unique 制約なし
- 両 create path は `findFirst` の existence check で gating
- 部分 commit でクラッシュしても再実行で skip ＋ 続きから（idempotent）

→ 外側 `$transaction` を撤去、`find→create` を素のクライアントで実行。timeout なし、resumable 動作は保持。

## Test plan

- [ ] PR CI green
- [ ] dev で `backfill-user-did --confirm` (27 user) → INSERT step が 5s で死なない
- [ ] そのまま chain submission step に進み、1 tx で 27 user 全部 CONFIRMED に

## 関連

- 親 PR: #1150
- 直近 dev 実行ログ参照

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_01NR9mGWrwj2CVsXqT2fGuoN)_