### PR TITLE
refactor(authz): open analyticsCommunity to Owner + scope cross-community read paths

### DIFF
--- a/src/__tests__/unit/analytics/community/usecase.test.ts
+++ b/src/__tests__/unit/analytics/community/usecase.test.ts
@@ -1,0 +1,37 @@
+import "reflect-metadata";
+import AnalyticsCommunityUseCase from "@/application/domain/analytics/community/usecase";
+import { IContext } from "@/types/server";
+import { AuthorizationError } from "@/errors/graphql";
+
+describe("AnalyticsCommunityUseCase authz scoping", () => {
+  // Service is never reached in these tests — the guard runs first and
+  // throws before any service / repository code executes, so a no-op
+  // double is sufficient.
+  const service = {} as never;
+
+  const baseInput = {
+    communityId: "kibotcha",
+    asOf: new Date("2026-04-01T00:00:00Z"),
+  };
+
+  it("rejects non-admin callers whose ctx.communityId differs from input.communityId", async () => {
+    const usecase = new AnalyticsCommunityUseCase(service);
+    const ctx = { communityId: "other-community" } as IContext;
+
+    await expect(usecase.getCommunity({ input: baseInput }, ctx)).rejects.toThrow(
+      AuthorizationError,
+    );
+    await expect(usecase.getCommunity({ input: baseInput }, ctx)).rejects.toThrow(
+      /Community does not match the current scope/,
+    );
+  });
+
+  it("rejects non-admin callers with a missing ctx.communityId (no header)", async () => {
+    const usecase = new AnalyticsCommunityUseCase(service);
+    const ctx = {} as IContext;
+
+    await expect(usecase.getCommunity({ input: baseInput }, ctx)).rejects.toThrow(
+      AuthorizationError,
+    );
+  });
+});

--- a/src/__tests__/unit/report/usecase.test.ts
+++ b/src/__tests__/unit/report/usecase.test.ts
@@ -1137,6 +1137,13 @@ describe("ReportUseCase admin queries (Phase 1 + Phase 2)", () => {
     ).rejects.toThrow(/communityId does not match the current scope/);
   });
 
+  it("browseAllReports rejects non-admin callers with no x-community-id header (defence-in-depth)", async () => {
+    const ownerCtx = {} as IContext;
+    await expect(usecase.browseAllReports({}, ownerCtx)).rejects.toThrow(
+      /communityId is required/,
+    );
+  });
+
   it("viewReportSummaries clamps `first` and forwards cursor", async () => {
     await usecase.viewReportSummaries(
       { cursor: "comm-cursor", first: 50 },

--- a/src/__tests__/unit/report/usecase.test.ts
+++ b/src/__tests__/unit/report/usecase.test.ts
@@ -1020,7 +1020,10 @@ describe("ReportUseCase A-3 community last-publish pointer maintenance", () => {
  */
 describe("ReportUseCase admin queries (Phase 1 + Phase 2)", () => {
   const communityId = "kibotcha";
-  const fakeCtx = {} as IContext;
+  // SYS_ADMIN context for the cross-community admin paths. browseAllReports
+  // pins non-admin callers to ctx.communityId, so the admin variant must
+  // opt out of that scoping explicitly.
+  const fakeCtx = { isAdmin: true } as IContext;
 
   let service: jest.Mocked<Pick<
     ReportService,
@@ -1116,6 +1119,22 @@ describe("ReportUseCase admin queries (Phase 1 + Phase 2)", () => {
     await expect(
       usecase.browseAllReports({ first: 500 }, fakeCtx),
     ).rejects.toThrow(/first must be an integer between 1 and 100/);
+  });
+
+  it("browseAllReports pins owner callers to ctx.communityId when args.communityId is omitted", async () => {
+    const ownerCtx = { communityId } as IContext;
+    await usecase.browseAllReports({}, ownerCtx);
+    expect(service.getAllReports).toHaveBeenLastCalledWith(
+      ownerCtx,
+      expect.objectContaining({ communityId }),
+    );
+  });
+
+  it("browseAllReports rejects owner calls when args.communityId points at a foreign community", async () => {
+    const ownerCtx = { communityId } as IContext;
+    await expect(
+      usecase.browseAllReports({ communityId: "other-community" }, ownerCtx),
+    ).rejects.toThrow(/communityId does not match the current scope/);
   });
 
   it("viewReportSummaries clamps `first` and forwards cursor", async () => {

--- a/src/application/domain/analytics/community/schema/query.graphql
+++ b/src/application/domain/analytics/community/schema/query.graphql
@@ -2,10 +2,12 @@
 # Analytics Community Query Definitions
 #
 # Per-community analytics view (member stats, stage distribution,
-# trailing-window trends, cohort retention, alerts) for admin
-# operators. Bypasses per-community RLS under the hood
-# (ctx.issuer.public) because admins legitimately need to see across
-# every community at once.
+# trailing-window trends, cohort retention, alerts) for community
+# owners (scoped to their own community) and SYS_ADMIN (any community).
+# The usecase pins owners to `ctx.communityId` so cross-community reads
+# stay limited to admins. Internals use `ctx.issuer.public` to bypass
+# per-community RLS — authorization is enforced at the GraphQL layer
+# (`@authz`) plus the usecase's explicit `input.communityId` check.
 # ------------------------------
 extend type Query {
   """

--- a/src/application/domain/analytics/community/schema/query.graphql
+++ b/src/application/domain/analytics/community/schema/query.graphql
@@ -15,5 +15,5 @@ extend type Query {
   report conversation.
   """
   analyticsCommunity(input: AnalyticsCommunityInput!): AnalyticsCommunityPayload!
-    @authz(rules: [IsAdmin])
+    @authz(compositeRules: [{ or: [IsCommunityOwner, IsAdmin] }])
 }

--- a/src/application/domain/analytics/community/usecase.ts
+++ b/src/application/domain/analytics/community/usecase.ts
@@ -1,6 +1,6 @@
 import { inject, injectable } from "tsyringe";
 import { IContext } from "@/types/server";
-import { NotFoundError } from "@/errors/graphql";
+import { AuthorizationError, NotFoundError } from "@/errors/graphql";
 import {
   GqlQueryAnalyticsCommunityArgs,
   GqlAnalyticsCommunityPayload,
@@ -37,6 +37,15 @@ export default class AnalyticsCommunityUseCase {
     { input }: GqlQueryAnalyticsCommunityArgs,
     ctx: IContext,
   ): Promise<GqlAnalyticsCommunityPayload> {
+    // IsCommunityOwner verifies the caller owns `ctx.communityId` but
+    // does not bind `input.communityId` to it — without this check an
+    // owner of community A could read community B's analytics by
+    // passing the foreign id. SYS_ADMIN bypasses scoping because the
+    // role is cross-community by design.
+    if (!ctx.isAdmin && input.communityId !== ctx.communityId) {
+      throw new AuthorizationError("Community does not match the current scope");
+    }
+
     const asOf = input.asOf ?? new Date();
     const thresholds = AnalyticsConverter.resolveThresholds(input.segmentThresholds);
     const dormantThresholdDays = AnalyticsConverter.clampDormantThresholdDays(

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -978,12 +978,17 @@ export default class ReportUseCase {
     // community. If they pass `communityId`, it has to match the
     // header-bound scope; if they omit it, we inject ctx.communityId so
     // the underlying repo doesn't fan out across the platform.
+    // `getCommunityIdFromCtx` throws when the header is missing — the
+    // IsCommunityOwner rule already rejects that state, but rechecking
+    // here keeps the cross-community guarantee local to this method
+    // rather than implicit in the authz layer.
     let scopedCommunityId = args.communityId ?? undefined;
     if (!ctx.isAdmin) {
-      if (args.communityId && args.communityId !== ctx.communityId) {
+      const ctxCommunityId = getCommunityIdFromCtx(ctx);
+      if (args.communityId && args.communityId !== ctxCommunityId) {
         throw new AuthorizationError("communityId does not match the current scope");
       }
-      scopedCommunityId = ctx.communityId ?? undefined;
+      scopedCommunityId = ctxCommunityId;
     }
 
     const result = await this.service.getAllReports(ctx, {

--- a/src/application/domain/report/usecase.ts
+++ b/src/application/domain/report/usecase.ts
@@ -960,10 +960,11 @@ export default class ReportUseCase {
   }
 
   /**
-   * Phase 2 sysAdmin: cross-community report search. The IsAdmin
-   * directive on the GraphQL query is the only authz gate (no
-   * community scoping hand-off) — the usecase trusts the
-   * directive and does not re-check sysRole.
+   * Phase 2: cross-community report search. SYS_ADMIN sees every
+   * community (or filters by `args.communityId`); IsCommunityOwner
+   * callers are pinned to their own community — the optional
+   * `communityId` arg, when supplied, must match `ctx.communityId`
+   * to keep the result set from leaking other communities' reports.
    */
   async browseAllReports(
     args: GqlQueryReportsAllArgs,
@@ -972,8 +973,21 @@ export default class ReportUseCase {
     const first = args.first
       ? validateIntInRange(args.first, 1, MAX_REPORTS_PER_PAGE, "first")
       : DEFAULT_REPORTS_PER_PAGE;
+
+    // Non-admin callers (community owners) must stay inside their own
+    // community. If they pass `communityId`, it has to match the
+    // header-bound scope; if they omit it, we inject ctx.communityId so
+    // the underlying repo doesn't fan out across the platform.
+    let scopedCommunityId = args.communityId ?? undefined;
+    if (!ctx.isAdmin) {
+      if (args.communityId && args.communityId !== ctx.communityId) {
+        throw new AuthorizationError("communityId does not match the current scope");
+      }
+      scopedCommunityId = ctx.communityId ?? undefined;
+    }
+
     const result = await this.service.getAllReports(ctx, {
-      communityId: args.communityId ?? undefined,
+      communityId: scopedCommunityId,
       status: args.status ?? undefined,
       variant: args.variant ?? undefined,
       publishedAfter: args.publishedAfter ? new Date(args.publishedAfter) : undefined,


### PR DESCRIPTION
## Summary

FE 側で sysAdmin 限定だった L2 analytics 画面をコミュニティ Owner にも開放する PR (FE は draft 中) のための BE 側認可調整。

### 変更点

1. **`analyticsCommunity` の `@authz`**
   `rules: [IsAdmin]` → `compositeRules: [{ or: [IsCommunityOwner, IsAdmin] }]`

2. **`analyticsCommunity` usecase に `input.communityId` ガード追加**
   `IsCommunityOwner` ルールは `ctx.communityId` 基準で Owner 判定するが、`input.communityId` を別の community に向けたリクエストは弾けない。`submitReportFeedback` / `viewReport` と同じ defence-in-depth パターンで usecase 側でも一致を強制。

3. **`browseAllReports` (= `reportsAll`) を non-admin caller に対して `ctx.communityId` に scope**
   - 既に `@authz` は `IsCommunityOwner` 許可済みだが、`args.communityId` を省略すると repo は platform 全体に fan out していた → Owner が他 community の report を読めてしまう
   - `args.communityId` が指定されかつ `ctx.communityId` と不一致 → `AuthorizationError`
   - `args.communityId` が省略 → `ctx.communityId` を注入
   - SYS_ADMIN は従来通り cross-community

4. **`analyticsDashboard` (L1) は IsAdmin のまま**
   cross-community overview は Owner には開放しない仕様。FE 側でも Owner ルートから L1 fetcher を除外する。

### 設計判断

「Owner は自 community のみ閲覧可、cross-community は SYS_ADMIN のみ」が境界線。Owner 同士が互いの community 運営数値を覗ける状態は意図しない。

### Test plan

- [x] `src/__tests__/unit/report/usecase.test.ts` — admin path / owner-scope (default to ctx.communityId) / foreign communityId rejection の 3 ケース追加。25 件 pass
- [x] `src/__tests__/unit/analytics/community/usecase.test.ts` (new) — non-admin guard / missing ctx.communityId の 2 ケース追加。pass
- [x] `pnpm test src/__tests__/unit --runInBand` — 727 件全 pass (55 suite)
- [x] `pnpm tsc --noEmit` — 変更モジュールに型エラー無し (既存の `@prisma/client/sql` 関連エラーは live DB 必須で本 PR と無関係)

### Notes

`reportSummaries` (Phase 2 / L1 dashboard 用 per-community summary list) も現状 `IsCommunityOwner` 許可済みだが cross-community データを返す構造。本 PR の scope 外だが follow-up 対応推奨 — FE 側で当該クエリを使う計画が無ければ実害なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wr5oELzQVAP2RgGAcjTbH8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 非管理者ユーザーがコミュニティ外のデータにアクセスできないよう権限制御を強化
* **新機能**
  * コミュニティオーナーが自身のコミュニティの分析データへアクセス可能に（管理者と同等の閲覧権限を一部付与）
* **テスト**
  * 権限スコープとエラーハンドリングを検証する単体テストを追加・更新

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hopin-inc/civicship-api/pull/1154)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->