### PR TITLE
feat(analytics): expose hubMemberCount / tenureDistribution on L2 payload

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -404,6 +404,25 @@ type AnalyticsCommunityPayload {
   """
   dormantCount: Int!
 
+  """
+  Number of members classified as a "hub" within a fixed 28-day
+  window ending at `asOf`. Same semantic as
+  `AnalyticsCommunityOverview.hubMemberCount` (L1) — a member
+  qualifies when they sent DONATION to `>= hubBreadthThreshold`
+  distinct counterparties during the window. Exposed at L2 so the
+  community-owner analytics surface can render the "ハブユーザー比率"
+  KPI (`hubMemberCount / totalMembers`) directly from the L2 payload
+  without falling back to the SYS_ADMIN-only L1 dashboard row.
+  
+  The window is fixed at 28 days regardless of the L2-specific
+  `windowMonths` input (which drives trend-array length, not the
+  hub classification window). This matches L1's default
+  `windowDays = 28` so the value is directly comparable to the
+  L1 dashboard row for the same community and `hubBreadthThreshold`.
+  The same JOINED-at-asOf membership filter as L1 applies.
+  """
+  hubMemberCount: Int!
+
   """Paginated member list — see type doc."""
   memberList: AnalyticsMemberList!
 
@@ -429,6 +448,16 @@ type AnalyticsCommunityPayload {
 
   """Summary card — see type doc."""
   summary: AnalyticsCommunitySummaryCard!
+
+  """
+  Tenure-bucket distribution of members at asOf. See
+  AnalyticsTenureDistribution. Sum of buckets equals totalMembers.
+  Exposed at L2 mirroring `AnalyticsCommunityOverview.tenureDistribution`
+  so the community-owner analytics surface can render the
+  "3ヶ月以上 在籍率" KPI and the in-tenure histogram directly
+  from the L2 payload — without the SYS_ADMIN-only L1 dashboard row.
+  """
+  tenureDistribution: AnalyticsTenureDistribution!
 
   """Trailing window length in JST months (echoed back)."""
   windowMonths: Int!

--- a/src/application/domain/analytics/community/presenter.ts
+++ b/src/application/domain/analytics/community/presenter.ts
@@ -264,6 +264,8 @@ export default class AnalyticsCommunityPresenter {
     dormantCount: number;
     chainDepthDistribution: AnalyticsChainDepthBucketRow[];
     cohortFunnel: AnalyticsCohortFunnelPoint[];
+    hubMemberCount: number;
+    tenureDistribution: TenureDistribution;
   }): GqlAnalyticsCommunityPayload {
     return {
       communityId: params.communityId,
@@ -286,6 +288,10 @@ export default class AnalyticsCommunityPresenter {
       // (cohortMonth + 4 stage counts) matches the GraphQL type
       // 1:1.
       cohortFunnel: params.cohortFunnel,
+      hubMemberCount: params.hubMemberCount,
+      tenureDistribution: AnalyticsCommunityPresenter.tenureDistribution(
+        params.tenureDistribution,
+      ),
     };
   }
 }

--- a/src/application/domain/analytics/community/schema/type.graphql
+++ b/src/application/domain/analytics/community/schema/type.graphql
@@ -1221,6 +1221,35 @@ type AnalyticsCommunityPayload {
   dormantCount: Int!
 
   """
+  Number of members classified as a "hub" within a fixed 28-day
+  window ending at `asOf`. Same semantic as
+  `AnalyticsCommunityOverview.hubMemberCount` (L1) — a member
+  qualifies when they sent DONATION to `>= hubBreadthThreshold`
+  distinct counterparties during the window. Exposed at L2 so the
+  community-owner analytics surface can render the "ハブユーザー比率"
+  KPI (`hubMemberCount / totalMembers`) directly from the L2 payload
+  without falling back to the SYS_ADMIN-only L1 dashboard row.
+
+  The window is fixed at 28 days regardless of the L2-specific
+  `windowMonths` input (which drives trend-array length, not the
+  hub classification window). This matches L1's default
+  `windowDays = 28` so the value is directly comparable to the
+  L1 dashboard row for the same community and `hubBreadthThreshold`.
+  The same JOINED-at-asOf membership filter as L1 applies.
+  """
+  hubMemberCount: Int!
+
+  """
+  Tenure-bucket distribution of members at asOf. See
+  AnalyticsTenureDistribution. Sum of buckets equals totalMembers.
+  Exposed at L2 mirroring `AnalyticsCommunityOverview.tenureDistribution`
+  so the community-owner analytics surface can render the
+  "3ヶ月以上 在籍率" KPI and the in-tenure histogram directly
+  from the L2 payload — without the SYS_ADMIN-only L1 dashboard row.
+  """
+  tenureDistribution: AnalyticsTenureDistribution!
+
+  """
   Distribution of DONATION `chain_depth` values across all-time
   DONATION transactions in this community. Each bucket counts
   distinct DONATION transactions whose `chain_depth` falls into

--- a/src/application/domain/analytics/community/service.ts
+++ b/src/application/domain/analytics/community/service.ts
@@ -510,6 +510,30 @@ export default class AnalyticsCommunityService {
    * against `t_transactions` (which the per-day MV cannot compose into
    * a window-wide DISTINCT).
    */
+  /**
+   * Single-community variant of `getWindowHubMemberCountBulk`. Thin
+   * wrapper over the bulk SQL — the L2 community-detail path is the
+   * only single-community caller, so we share the bulk primitive
+   * instead of duplicating its DISTINCT-recipient aggregation. Returns
+   * 0 for a community with no hub members in the window.
+   */
+  async getWindowHubMemberCount(
+    ctx: IContext,
+    communityId: string,
+    asOf: Date,
+    windowDays: number,
+    hubBreadthThreshold: number,
+  ): Promise<number> {
+    const map = await this.getWindowHubMemberCountBulk(
+      ctx,
+      [communityId],
+      asOf,
+      windowDays,
+      hubBreadthThreshold,
+    );
+    return map.get(communityId) ?? 0;
+  }
+
   async getWindowHubMemberCountBulk(
     ctx: IContext,
     communityIds: string[],

--- a/src/application/domain/analytics/community/usecase.ts
+++ b/src/application/domain/analytics/community/usecase.ts
@@ -6,6 +6,7 @@ import {
   GqlAnalyticsCommunityPayload,
 } from "@/types/graphql";
 import AnalyticsCommunityService, {
+  DEFAULT_WINDOW_DAYS,
   DEFAULT_WINDOW_MONTHS,
   MAX_WINDOW_MONTHS,
 } from "@/application/domain/analytics/community/service";
@@ -15,6 +16,7 @@ import {
   computeDormantCount,
   computeStageBreakdown,
   computeStageCounts,
+  computeTenureDistribution,
 } from "@/application/domain/analytics/community/aggregations";
 import { MAX_LIMIT, paginateMembers } from "@/application/domain/analytics/community/pagination";
 import AnalyticsCommunityPresenter from "@/application/domain/analytics/community/presenter";
@@ -80,6 +82,7 @@ export default class AnalyticsCommunityUseCase {
       cohortRetention,
       chainDepthDistribution,
       alerts,
+      hubMemberCount,
     ] = await Promise.all([
       this.service.getMemberStats(ctx, community.communityId, asOf),
       this.service.getMonthlyActivity(
@@ -95,12 +98,24 @@ export default class AnalyticsCommunityUseCase {
       this.service.getCohortRetention(ctx, community.communityId, asOf, windowMonths),
       this.service.getChainDepthDistribution(ctx, community.communityId, asOf),
       this.service.getAlerts(ctx, community.communityId, asOf),
+      // Fixed 28-day window matches L1's default `windowDays` so the
+      // L2 `hubMemberCount` reads directly comparable to L1 for the
+      // same community + `hubBreadthThreshold`. L2's `windowMonths`
+      // input drives trend-array length only, not hub classification.
+      this.service.getWindowHubMemberCount(
+        ctx,
+        community.communityId,
+        asOf,
+        DEFAULT_WINDOW_DAYS,
+        hubBreadthThreshold,
+      ),
     ]);
 
     const stageCounts = computeStageCounts(members, thresholds);
     const stageBreakdown = computeStageBreakdown(members, thresholds);
     const dormantCount = computeDormantCount(members, asOf, dormantThresholdDays);
     const cohortFunnel = computeCohortFunnel(members, asOf, windowMonths, thresholds);
+    const tenureDistribution = computeTenureDistribution(members);
 
     const memberList = paginateMembers(members, {
       minSendRate: input.userFilter?.minSendRate ?? 0.7,
@@ -141,6 +156,8 @@ export default class AnalyticsCommunityUseCase {
       dormantCount,
       chainDepthDistribution,
       cohortFunnel,
+      hubMemberCount,
+      tenureDistribution,
     });
   }
 }

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -397,6 +397,24 @@ export type GqlAnalyticsCommunityPayload = {
    * member list.
    */
   dormantCount: Scalars['Int']['output'];
+  /**
+   * Number of members classified as a "hub" within a fixed 28-day
+   * window ending at `asOf`. Same semantic as
+   * `AnalyticsCommunityOverview.hubMemberCount` (L1) — a member
+   * qualifies when they sent DONATION to `>= hubBreadthThreshold`
+   * distinct counterparties during the window. Exposed at L2 so the
+   * community-owner analytics surface can render the "ハブユーザー比率"
+   * KPI (`hubMemberCount / totalMembers`) directly from the L2 payload
+   * without falling back to the SYS_ADMIN-only L1 dashboard row.
+   *
+   * The window is fixed at 28 days regardless of the L2-specific
+   * `windowMonths` input (which drives trend-array length, not the
+   * hub classification window). This matches L1's default
+   * `windowDays = 28` so the value is directly comparable to the
+   * L1 dashboard row for the same community and `hubBreadthThreshold`.
+   * The same JOINED-at-asOf membership filter as L1 applies.
+   */
+  hubMemberCount: Scalars['Int']['output'];
   /** Paginated member list — see type doc. */
   memberList: GqlAnalyticsMemberList;
   /**
@@ -418,6 +436,15 @@ export type GqlAnalyticsCommunityPayload = {
   stages: GqlAnalyticsStageDistribution;
   /** Summary card — see type doc. */
   summary: GqlAnalyticsCommunitySummaryCard;
+  /**
+   * Tenure-bucket distribution of members at asOf. See
+   * AnalyticsTenureDistribution. Sum of buckets equals totalMembers.
+   * Exposed at L2 mirroring `AnalyticsCommunityOverview.tenureDistribution`
+   * so the community-owner analytics surface can render the
+   * "3ヶ月以上 在籍率" KPI and the in-tenure histogram directly
+   * from the L2 payload — without the SYS_ADMIN-only L1 dashboard row.
+   */
+  tenureDistribution: GqlAnalyticsTenureDistribution;
   /** Trailing window length in JST months (echoed back). */
   windowMonths: Scalars['Int']['output'];
 };
@@ -6352,11 +6379,13 @@ export type GqlAnalyticsCommunityPayloadResolvers<ContextType = any, ParentType 
   communityId?: Resolver<GqlResolversTypes['ID'], ParentType, ContextType>;
   communityName?: Resolver<GqlResolversTypes['String'], ParentType, ContextType>;
   dormantCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
+  hubMemberCount?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
   memberList?: Resolver<GqlResolversTypes['AnalyticsMemberList'], ParentType, ContextType>;
   monthlyActivityTrend?: Resolver<Array<GqlResolversTypes['AnalyticsMonthlyActivityPoint']>, ParentType, ContextType>;
   retentionTrend?: Resolver<Array<GqlResolversTypes['AnalyticsRetentionTrendPoint']>, ParentType, ContextType>;
   stages?: Resolver<GqlResolversTypes['AnalyticsStageDistribution'], ParentType, ContextType>;
   summary?: Resolver<GqlResolversTypes['AnalyticsCommunitySummaryCard'], ParentType, ContextType>;
+  tenureDistribution?: Resolver<GqlResolversTypes['AnalyticsTenureDistribution'], ParentType, ContextType>;
   windowMonths?: Resolver<GqlResolversTypes['Int'], ParentType, ContextType>;
 }>;
 


### PR DESCRIPTION
## Summary

- Add `hubMemberCount: Int!` and `tenureDistribution: AnalyticsTenureDistribution!` to `AnalyticsCommunityPayload` (L2), mirroring the L1 dashboard row.
- Compute `hubMemberCount` via the existing `getWindowHubMemberCountBulk` repository SQL, with a fixed 28-day window matching L1's default `windowDays` so values stay directly comparable across the two levels for the same community + `hubBreadthThreshold`.
- Derive `tenureDistribution` in-memory from the member rows already fetched for the L2 detail — no extra DB roundtrip.

## Why

FE PR Hopin-inc/civicship-portal#1220 opens the L2 community-owner analytics page (`/community/[communityId]/admin/analytics`) to community Owners (after BE PR #1154 added `IsCommunityOwner` to `analyticsCommunity`). The L1 dashboard remains sysAdmin-only, so Owners couldn't render two KPIs that previously only existed on the L1 row:

- **ハブユーザー比率** (= `hubMemberCount / totalMembers`)
- **3ヶ月以上 在籍率** + the in-tenure histogram (`tenureDistribution`)

Both fields fell back to the "未計測" placeholder on the Owner path. This PR exposes them on L2 so the FE can drop the props-passing path and read them directly from `analyticsCommunity`.

## Implementation notes

- `@authz` is inherited from the payload parent (`@authz(compositeRules: [{ or: [IsCommunityOwner, IsAdmin] }])` on the query), no new directive required.
- `hubMemberCount` is non-null (`Int!`) — same shape as L1's `AnalyticsCommunityOverview.hubMemberCount` and same JOINED-at-asOf membership scoping.
- `tenureDistribution` reuses `computeTenureDistribution` from the community/aggregations module — same function the L1 usecase calls, so the values are identical for a fixed member set.
- Single-community wrapper `AnalyticsCommunityService.getWindowHubMemberCount` added on top of the existing bulk SQL, mirroring the `getMemberStats` / `getMemberStatsBulk` pattern.

## Test plan

- [x] `pnpm gql:generate` (regenerates `src/types/graphql.ts` and `docs/schema.graphql`)
- [x] `npx jest src/__tests__/unit/analytics --runInBand` → 98 tests pass
- [x] `npx tsc --noEmit` against `src/application/domain/analytics` → no errors
- [ ] FE follow-up: switch `/community/[communityId]/admin/analytics/page.tsx` to read `hubMemberCount` / `tenureDistribution` from the `analyticsCommunity` payload and drop the prop drilling through `CommunityDashboardOverview`. Requires `gql:generate` on the portal side.

https://claude.ai/code/session_01Uq9YKHpo5NgftebnndBc71

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uq9YKHpo5NgftebnndBc71)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* **コミュニティ分析の拡張**: コミュニティ詳細情報に、ハブメンバーカウント（28日ウィンドウに基づく条件適合メンバー数）と任期分布情報が新たに追加されました。これらのメトリクスにより、コミュニティのメンバーシップ分析がより詳細に行えるようになります。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hopin-inc/civicship-api/pull/1156)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->