### PR TITLE
docs(analytics): reattach hub-count JSDoc to its target method

### DIFF
--- a/src/application/domain/analytics/community/service.ts
+++ b/src/application/domain/analytics/community/service.ts
@@ -510,30 +510,6 @@ export default class AnalyticsCommunityService {
    * against `t_transactions` (which the per-day MV cannot compose into
    * a window-wide DISTINCT).
    */
-  /**
-   * Single-community variant of `getWindowHubMemberCountBulk`. Thin
-   * wrapper over the bulk SQL — the L2 community-detail path is the
-   * only single-community caller, so we share the bulk primitive
-   * instead of duplicating its DISTINCT-recipient aggregation. Returns
-   * 0 for a community with no hub members in the window.
-   */
-  async getWindowHubMemberCount(
-    ctx: IContext,
-    communityId: string,
-    asOf: Date,
-    windowDays: number,
-    hubBreadthThreshold: number,
-  ): Promise<number> {
-    const map = await this.getWindowHubMemberCountBulk(
-      ctx,
-      [communityId],
-      asOf,
-      windowDays,
-      hubBreadthThreshold,
-    );
-    return map.get(communityId) ?? 0;
-  }
-
   async getWindowHubMemberCountBulk(
     ctx: IContext,
     communityIds: string[],
@@ -556,6 +532,30 @@ export default class AnalyticsCommunityService {
       out.set(id, rowsByCommunity.get(id)?.count ?? 0);
     }
     return out;
+  }
+
+  /**
+   * Single-community variant of `getWindowHubMemberCountBulk`. Thin
+   * wrapper over the bulk SQL — the L2 community-detail path is the
+   * only single-community caller, so we share the bulk primitive
+   * instead of duplicating its DISTINCT-recipient aggregation. Returns
+   * 0 for a community with no hub members in the window.
+   */
+  async getWindowHubMemberCount(
+    ctx: IContext,
+    communityId: string,
+    asOf: Date,
+    windowDays: number,
+    hubBreadthThreshold: number,
+  ): Promise<number> {
+    const map = await this.getWindowHubMemberCountBulk(
+      ctx,
+      [communityId],
+      asOf,
+      windowDays,
+      hubBreadthThreshold,
+    );
+    return map.get(communityId) ?? 0;
   }
 
   /**


### PR DESCRIPTION
## Summary

Follow-up to #1156. Gemini Code Assist correctly pointed out that the long JSDoc explaining `getWindowHubMemberCountBulk` (t_transactions vs MV rationale, DISTINCT-recipient aggregation, breadth-only classification) was orphaned from its target method when the new single-community wrapper `getWindowHubMemberCount` was inserted between them.

This PR swaps the definition order so the original JSDoc sits directly above `getWindowHubMemberCountBulk` again. The wrapper retains its own short JSDoc immediately above itself.

No behavior change — pure documentation / source-order cleanup.

## Test plan

- [x] `npx jest src/__tests__/unit/analytics --runInBand` → 98 tests pass

https://claude.ai/code/session_01Uq9YKHpo5NgftebnndBc71

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uq9YKHpo5NgftebnndBc71)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **Refactor**
  * 内部コードの構成を最適化しました。ユーザーへの影響はありません。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hopin-inc/civicship-api/pull/1158)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->