### PR TITLE
ci: skip trivy and docker build steps on code-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,64 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # PR で expensive job (trivy / build の docker step) を条件付き skip するため
+  # の changed-files detection。workflow コメント (上部) で「軽量化は job 側の
+  # changed-files filter で行い、aggregator は必ず走らせる」と決めた軌道に沿う。
+  #
+  # `docker` フィルタ: 以下のいずれかが変わった PR でのみ docker image build /
+  # trivy scan を走らせる (code-only PR では skip して ~5-7 分削減)。
+  #   - Dockerfile / Dockerfile.external / .dockerignore  ← image 自体
+  #   - pnpm-lock.yaml / package.json                     ← image layer の npm
+  #   - src/infrastructure/prisma/{schema.prisma,migrations,sql}/**
+  #                                                       ← db:generate 経由で
+  #                                                          image build に影響
+  #   - .github/workflows/ci.yml / .github/actions/setup-civicship/**
+  #                                                       ← CI 自身を触る PR は
+  #                                                          safety net で full
+  #
+  # push (master) では filter step ごと skip されるため、output の `||
+  # 'true'` fallback で `docker=true` を返し、後続 job は無条件 full 実行する。
+  # これにより deploy 前の master push は常にフル CI を担保したまま、PR では
+  # 関係ない job を skip できる。aggregator の case 句が `skipped` を success
+  # 等価扱いするので required check は壊れない。
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      docker: ${{ steps.filter.outputs.docker || 'true' }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+          disable-sudo: true
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # PR 以外 (push to master) では skip し、上の `|| 'true'` fallback で
+      # 全フィルタを true 扱いにする (= full CI 実行)。
+      - name: Detect changed paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            docker:
+              - 'Dockerfile'
+              - 'Dockerfile.external'
+              - '.dockerignore'
+              - 'pnpm-lock.yaml'
+              - 'package.json'
+              - 'src/infrastructure/prisma/schema.prisma'
+              - 'src/infrastructure/prisma/migrations/**'
+              - 'src/infrastructure/prisma/sql/**'
+              - '.github/workflows/ci.yml'
+              - '.github/actions/setup-civicship/**'
+
   # `dependency-review-action` は PR diff (base..head) で **新規追加された**
   # npm 依存に既知 CVE / 不適合 license が含まれていないかを GitHub の
   # advisory DB に問い合わせて gate する。`pnpm audit` (build job 内、
@@ -111,6 +169,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # `changes` を needs に取り、docker step を step-level if で gating する。
+    # tsc / typecheck / generated files check は code 変更で常に走らせたいので
+    # job 全体は skip しない。
+    needs: [changes]
     permissions:
       contents: read
 
@@ -259,10 +321,17 @@ jobs:
       # install / apt-get from scratch. mode=max caches all stages, not just
       # the final runtime stage, since trivy needs runtime + builder layers
       # for full coverage.
+      # docker step 群は changes job が docker-relevant な変更を検出した時
+      # (= push to master では常時 true / PR では Dockerfile・deps・Prisma
+      # 関連変更時のみ true) だけ走る。code-only PR では skip して docker
+      # buildx ×2 + smoke-test 分 (~2 分) を削減。tsc / dist の sanity check
+      # は上で済んでいるので runtime image validation を毎回回す必要はない。
       - name: Set up Docker Buildx
+        if: needs.changes.outputs.docker == 'true'
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
 
       - name: Validate Dockerfile build (internal API)
+        if: needs.changes.outputs.docker == 'true'
         run: |
           docker buildx build \
             --file Dockerfile \
@@ -273,6 +342,7 @@ jobs:
             .
 
       - name: Validate Dockerfile build (external API)
+        if: needs.changes.outputs.docker == 'true'
         run: |
           docker buildx build \
             --file Dockerfile.external \
@@ -289,6 +359,7 @@ jobs:
       # under the image's default USER (`node`) and don't connect to a DB,
       # so this is a pure load-time check, not a query check.
       - name: Smoke-test runtime image (Prisma engine load)
+        if: needs.changes.outputs.docker == 'true'
         run: |
           docker run --rm civicship-api:ci-validate \
             node -e "const { PrismaClient } = require('@prisma/client'); new PrismaClient(); console.log('prisma engine loaded');"
@@ -322,6 +393,13 @@ jobs:
   trivy:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # docker image を build しない PR では scan する image が存在しないので
+    # job ごと skip して ~5 分削減。push (master) では `changes` の fallback で
+    # docker=true になるため必ず走る (deploy 前の image CVE gate を維持)。
+    # aggregator (`ci` job) は `skipped` を success 等価扱いするので required
+    # check は壊れない。
+    needs: [changes]
+    if: needs.changes.outputs.docker == 'true'
     permissions:
       contents: read
     steps:
@@ -647,7 +725,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [dependency-review, lint, build, trivy, test]
+    needs: [changes, dependency-review, lint, build, trivy, test]
     # `if: !cancelled()` で以下を両立:
     #   - 通常 fail / skipped (= push 時の dependency-review) でも
     #     アグリゲータを走らせ status を必ず報告する (`success()` 単独だと
@@ -679,12 +757,13 @@ jobs:
 
       - name: Verify all required jobs passed
         run: |
+          changes='${{ needs.changes.result }}'
           dep_review='${{ needs.dependency-review.result }}'
           lint='${{ needs.lint.result }}'
           build='${{ needs.build.result }}'
           trivy='${{ needs.trivy.result }}'
           test='${{ needs.test.result }}'
-          echo "dep_review=$dep_review lint=$lint build=$build trivy=$trivy test=$test"
+          echo "changes=$changes dep_review=$dep_review lint=$lint build=$build trivy=$trivy test=$test"
           # CRITICAL を blocking 化したので trivy も required ジョブに昇格。
           # trivy job 内部で「scan = exit 0、最後に Surface step が件数 > 0 で
           # exit 1」という構造を取っているので、`failure` は CRITICAL 検出
@@ -694,7 +773,9 @@ jobs:
           # という挙動で十分)。
           # dependency-review は push (master) 時に if-skip するので
           # `skipped` を success と等価扱いする (case 句で吸収)。
-          for j in "$dep_review" "$lint" "$build" "$trivy" "$test"; do
+          # trivy も docker-relevant change がない PR で skip されるため
+          # 同じく `skipped` を success 等価扱いする。
+          for j in "$changes" "$dep_review" "$lint" "$build" "$trivy" "$test"; do
             case "$j" in
               success|skipped) ;;
               *) echo "::error::required job failed: $j"; exit 1 ;;

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,10 +1,12 @@
 name: CodeQL
 
-# CodeQL static analysis for JavaScript/TypeScript.
+# CodeQL static analysis for JavaScript/TypeScript and GitHub Actions workflows.
 # Runs on push / PR against master / develop, plus a weekly schedule
 # (cron は UTC で 21:00 月曜 = JST 火曜 06:00)。
-# branch protection の required check には登録しない (run time が PR feedback
-# loop に乗らない / queue 競合で発見が遅れることへの許容)。
+# branch protection の required check には `Analyze (actions)` のみ登録 (JS/TS
+# 側は run time が PR feedback loop に乗らないため required から外している)。
+# matrix から `actions` を抜くと "Expected — Waiting for status to be reported"
+# で全 PR が pending するので、language は両方を維持する。
 on:
   push:
     branches: [master, develop]
@@ -37,7 +39,12 @@ jobs:
       matrix:
         # JS と TS は同一の analyzer (`javascript-typescript`) で解析する。
         # 旧 `javascript` / `typescript` 個別指定は deprecated で、統合 ID 推奨。
-        language: [javascript-typescript]
+        # `actions` は GitHub Actions workflow / composite action の static
+        # analysis (script injection / over-privileged token / 未 pin の action
+        # など)。branch protection の required check `Analyze (actions)` が
+        # 既に登録されているため、matrix から外すと "Expected — Waiting for
+        # status to be reported" で全 PR が永久 pending する。
+        language: [javascript-typescript, actions]
 
     steps:
       - name: Harden runner


### PR DESCRIPTION
## Summary
- Add a `changes` detection job (dorny/paths-filter) that flags whether a PR touches docker-relevant files: Dockerfiles, deps (`pnpm-lock.yaml` / `package.json`), Prisma `schema.prisma` / `migrations/**` / `sql/**`, or CI config (`.github/workflows/ci.yml`, `.github/actions/setup-civicship/**`).
- Skip the entire `trivy` job and the docker `buildx` ×2 + smoke-test steps in `build` when no docker-relevant file changed. Expected savings on typical code-only PRs: **~5 min (trivy) + ~2 min (build docker steps)**.
- `push` to `master` is unaffected: the filter step is skipped on non-PR events, and the `changes` output falls back to `docker=true`, preserving the full pre-deploy gate.

## Safety
- The aggregator (`ci` job) already treats `skipped` as success (`case "$j" in success|skipped) ;;`), so the required status check on branch protection is not broken.
- `tsc` / typecheck / generated-files check in `build` still runs on every PR — only the runtime image validation is gated.
- Workflow / composite-action edits force `docker=true` via the path filter, so any CI-touching PR runs the full pipeline.

## Test plan
- [ ] Open this PR (no docker-relevant changes): verify `trivy` shows `skipped` and `build` skips the buildx / smoke-test steps, while aggregator `ci` reports success.
- [ ] Open a follow-up PR that touches `Dockerfile` (or `pnpm-lock.yaml` / `schema.prisma`): verify `trivy` runs and `build` runs the docker steps.
- [ ] Merge to `develop` / `master`: verify `push` events still run trivy + docker build unconditionally.

https://claude.ai/code/session_013FiqFgeH41F3CyZRve8G2M

---
_Generated by [Claude Code](https://claude.ai/code/session_013FiqFgeH41F3CyZRve8G2M)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI を最適化しました。Docker 関連の変更がない PR では Docker ビルドとセキュリティスキャンをスキップし、実行効率を向上させます。
* **Documentation / Tools**
  * 静的解析の対象を拡張し、ワークフロー定義も解析対象に追加しました。解析フローの挙動説明を追記しています。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hopin-inc/civicship-api/pull/1159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->