### PR TITLE
ci(prd-deploy): gate on CI success and block destructive migrations

### DIFF
--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -127,11 +127,17 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha || '' }}
-          # `block-destructive-migrations` の strict scan が `git diff HEAD^1...HEAD`
-          # で migration の追加分を見るために、merge commit の親 (= 直前の master tip)
-          # まで辿れる履歴が必要。fetch-depth: 2 で十分 (squash/rebase merge を含め、
-          # 直前の master tip は常に HEAD^1 として参照できる)。
-          fetch-depth: 2
+          # `block-destructive-migrations` の strict scan が PR base (= PR が
+          # 派生した時点の master tip) から HEAD までを `git diff` するため、
+          # その範囲をすべて含む完全履歴が必要。fetch-depth: 0 を指定する。
+          #
+          # 旧実装は `HEAD^1` を base にしていたが、rebase merge では PR の
+          # 複数 commit が線形に master に追加されるため `HEAD^1` は最後の
+          # 1 commit しか catch せず、PR 内の先行 commit にある destructive
+          # DDL を見逃す (CodeRabbit #1163 指摘)。`pull_request.base.sha` を
+          # 渡すことで squash / rebase / true-merge いずれの戦略でも PR が
+          # 持ち込んだ変更全体をカバーできる。
+          fetch-depth: 0
 
       # Destructive-migration gate. prd では `block-destructive-migrations: true`
       # を渡してこの step が hits を検出した時点で deploy を fail させる
@@ -147,10 +153,11 @@ jobs:
       - name: Block destructive migrations (strict scan)
         if: ${{ inputs.block-destructive-migrations }}
         env:
-          # PR merge 後の checkout なので HEAD は merge commit。HEAD^1 は merge
-          # 直前の master tip (true merge / squash / rebase いずれの merge
-          # strategy でも parent[0] が base branch 側になる)。
-          MIGRATE_DIFF_BASE_REF: HEAD^1
+          # `pull_request.base.sha` は PR が派生した時点の master tip。
+          # squash/rebase/true-merge いずれの merge 戦略でも、この SHA から
+          # HEAD までの diff が PR の持ち込んだ変更全体になる (HEAD^1 だと
+          # rebase merge で先行 commit を取りこぼす — CodeRabbit #1163 指摘)。
+          MIGRATE_DIFF_BASE_REF: ${{ github.event.pull_request.base.sha }}
           MIGRATE_DIFF_STRICT: 'true'
         run: ./scripts/prisma/migrate-diff.sh --ci
 

--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -54,6 +54,18 @@ on:
         type: string
         required: false
         default: '300'
+      block-destructive-migrations:
+        description: |
+          When true, scan Prisma migrations introduced by this deploy for
+          destructive DDL (DROP TABLE/COLUMN, ALTER TYPE, RENAME, TRUNCATE,
+          non-CONCURRENTLY DROP INDEX, …) and **fail the deploy** before
+          `db:deploy` runs against the target DB. Prd sets this true; dev
+          stays false (the same scan still runs as advisory in `ci.yml`).
+          To merge a known-safe destructive migration to prd, split it into a
+          2-step migration per docs/handbook/DB_MIGRATION.md.
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   deploy:
@@ -115,6 +127,32 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha || '' }}
+          # `block-destructive-migrations` の strict scan が `git diff HEAD^1...HEAD`
+          # で migration の追加分を見るために、merge commit の親 (= 直前の master tip)
+          # まで辿れる履歴が必要。fetch-depth: 2 で十分 (squash/rebase merge を含め、
+          # 直前の master tip は常に HEAD^1 として参照できる)。
+          fetch-depth: 2
+
+      # Destructive-migration gate. prd では `block-destructive-migrations: true`
+      # を渡してこの step が hits を検出した時点で deploy を fail させる
+      # (`db:deploy` がまだ走っていないので prd DB は無傷)。dev では入力 false
+      # で skip。同じ scan は `ci.yml` の build job 内で advisory として PR レビ
+      # ュアに warning を出している (#1059 経緯) が、advisory は admin override
+      # / protection 設定漏れで素通りしうるため、本 step を deploy 入口に置く
+      # ことで「destructive migration は必ず人間が分解してから merge される」
+      # 不変条件を保証する。
+      #
+      # 既知の安全な destructive 変更 (2-step migration の後半など) を流す手順
+      # は docs/handbook/DB_MIGRATION.md を参照。
+      - name: Block destructive migrations (strict scan)
+        if: ${{ inputs.block-destructive-migrations }}
+        env:
+          # PR merge 後の checkout なので HEAD は merge commit。HEAD^1 は merge
+          # 直前の master tip (true merge / squash / rebase いずれの merge
+          # strategy でも parent[0] が base branch 側になる)。
+          MIGRATE_DIFF_BASE_REF: HEAD^1
+          MIGRATE_DIFF_STRICT: 'true'
+        run: ./scripts/prisma/migrate-diff.sh --ci
 
       - name: Authenticate to Google Cloud (Workload Identity Federation)
         uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70 # v2.1.6

--- a/.github/workflows/deploy-to-cloud-run-prd.yml
+++ b/.github/workflows/deploy-to-cloud-run-prd.yml
@@ -15,16 +15,15 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
-# Caller permissions must be a superset of the reusable workflow's permissions
-# (`_deploy-cloud-run.yml`: id-token:write + contents:write + security-events:write).
-# Setting them explicitly here also silences CodeQL's missing-permissions warning.
+# Workflow-level permissions are intentionally minimal (read-only metadata).
+# Each job declares only the writes it actually needs:
+#   - verify-ci: checks:read + actions:read (gh api on check-runs)
+#   - deploy:    id-token:write + contents:write + security-events:write
+#                (must be a superset of the reusable workflow's permissions)
+# Splitting permissions per job (vs. granting workflow-wide write) satisfies
+# Sonar's least-privilege rule and limits the blast radius of any single step.
 permissions:
-  id-token: write
-  contents: write
-  security-events: write
-  # verify-ci ジョブが gh api 経由で check-runs を読むのに必要。
-  checks: read
-  actions: read
+  contents: read
 
 jobs:
   # CI が緑かを deploy 前に必ず確認するゲート。`pull_request: closed` は
@@ -71,7 +70,7 @@ jobs:
           while :; do
             attempt=$((attempt + 1))
             now=$(date +%s)
-            if [ "$now" -ge "$deadline" ]; then
+            if [[ "$now" -ge "$deadline" ]]; then
               echo "::error::Timed out waiting ${POLL_TIMEOUT_SECONDS}s for CI check '${REQUIRED_CHECK}' on ${MERGE_SHA}. Deploy aborted."
               exit 1
             fi
@@ -83,7 +82,7 @@ jobs:
               "repos/${REPO}/commits/${MERGE_SHA}/check-runs?check_name=${REQUIRED_CHECK}&filter=latest")
 
             count=$(echo "$payload" | jq '.total_count')
-            if [ "$count" -eq 0 ]; then
+            if [[ "$count" -eq 0 ]]; then
               echo "[attempt ${attempt}] CI check '${REQUIRED_CHECK}' not yet reported on ${MERGE_SHA}; sleeping ${POLL_INTERVAL_SECONDS}s..."
               sleep "$POLL_INTERVAL_SECONDS"
               continue
@@ -116,6 +115,14 @@ jobs:
   deploy:
     needs: verify-ci
     if: github.event.pull_request.merged == true
+    # Caller permissions must be a superset of the reusable workflow's
+    # permissions (`_deploy-cloud-run.yml` declares: id-token:write +
+    # contents:write + security-events:write at the job level). Declared
+    # here per job (not workflow-wide) so verify-ci stays read-only.
+    permissions:
+      id-token: write
+      contents: write
+      security-events: write
     uses: ./.github/workflows/_deploy-cloud-run.yml
     with:
       stage: prd

--- a/.github/workflows/deploy-to-cloud-run-prd.yml
+++ b/.github/workflows/deploy-to-cloud-run-prd.yml
@@ -22,9 +22,99 @@ permissions:
   id-token: write
   contents: write
   security-events: write
+  # verify-ci ジョブが gh api 経由で check-runs を読むのに必要。
+  checks: read
+  actions: read
 
 jobs:
+  # CI が緑かを deploy 前に必ず確認するゲート。`pull_request: closed` は
+  # branch protection の required check 状態を一切参照しないため、protection
+  # 設定漏れ・admin override / repo settings 変更などで未テストコードが prd
+  # に流れる経路を塞ぐ (cf. レビュー指摘 #🔴-1)。本ゲートで CI を strict に
+  # 二重検証する。
+  #
+  # ロジック: merge commit SHA (= master 新 tip) に対する `CI` workflow の
+  # check-run を polling し、`success` を確認するまで待つ。`failure` /
+  # `cancelled` / `timed_out` を見たら即 fail。タイムアウト (デフォ 25min)
+  # 内に決着しなければ fail。
+  verify-ci:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      checks: read
+      actions: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+          disable-sudo: true
+
+      - name: Wait for CI to pass on merge commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          REPO: ${{ github.repository }}
+          # `ci.yml` 内 aggregator job 名 (`ci:`)。CI 全体の合否を要約する
+          # 唯一の required check として運用されているため、これだけ見れば良い。
+          # job 名を変えた場合はここも更新する。
+          REQUIRED_CHECK: ci
+          POLL_INTERVAL_SECONDS: '20'
+          # workflow 全体の timeout-minutes (30) より小さく取り、polling
+          # 自体のタイムアウトをジョブ kill より先に走らせる。
+          POLL_TIMEOUT_SECONDS: '1500'
+        run: |
+          set -euo pipefail
+          deadline=$(( $(date +%s) + POLL_TIMEOUT_SECONDS ))
+          attempt=0
+          while :; do
+            attempt=$((attempt + 1))
+            now=$(date +%s)
+            if [ "$now" -ge "$deadline" ]; then
+              echo "::error::Timed out waiting ${POLL_TIMEOUT_SECONDS}s for CI check '${REQUIRED_CHECK}' on ${MERGE_SHA}. Deploy aborted."
+              exit 1
+            fi
+
+            # check-runs API は同名 check の履歴をすべて返す。最新 (= latest)
+            # の 1 件を採用 (master push で rerun された場合は最後の状態が真)。
+            payload=$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${REPO}/commits/${MERGE_SHA}/check-runs?check_name=${REQUIRED_CHECK}&filter=latest")
+
+            count=$(echo "$payload" | jq '.total_count')
+            if [ "$count" -eq 0 ]; then
+              echo "[attempt ${attempt}] CI check '${REQUIRED_CHECK}' not yet reported on ${MERGE_SHA}; sleeping ${POLL_INTERVAL_SECONDS}s..."
+              sleep "$POLL_INTERVAL_SECONDS"
+              continue
+            fi
+
+            status=$(echo "$payload" | jq -r '.check_runs[0].status')
+            conclusion=$(echo "$payload" | jq -r '.check_runs[0].conclusion')
+            url=$(echo "$payload" | jq -r '.check_runs[0].html_url')
+            echo "[attempt ${attempt}] status=${status} conclusion=${conclusion} url=${url}"
+
+            case "$status" in
+              completed)
+                case "$conclusion" in
+                  success)
+                    echo "✅ CI passed on ${MERGE_SHA}"
+                    exit 0
+                    ;;
+                  *)
+                    echo "::error::CI check '${REQUIRED_CHECK}' on ${MERGE_SHA} concluded '${conclusion}'. Deploy aborted. See ${url}"
+                    exit 1
+                    ;;
+                esac
+                ;;
+              *)
+                sleep "$POLL_INTERVAL_SECONDS"
+                ;;
+            esac
+          done
+
   deploy:
+    needs: verify-ci
     if: github.event.pull_request.merged == true
     uses: ./.github/workflows/_deploy-cloud-run.yml
     with:
@@ -37,4 +127,10 @@ jobs:
       # 失敗時は前 revision に traffic を戻す。dev 側は `enable-canary: false`
       # で従来通り即 100%。詳細は `_deploy-cloud-run.yml` 参照。
       enable-canary: true
+      # destructive DDL (DROP TABLE/COLUMN, ALTER TYPE, RENAME, TRUNCATE,
+      # non-CONCURRENTLY DROP INDEX, …) を含む migration を deploy 入口で
+      # 検出して fail させる (db:deploy 実行前)。CI の同 scan は advisory
+      # なので、prd への fail-closed gate として本入力を true にする。
+      # 2-step migration の正規手順は docs/handbook/DB_MIGRATION.md 参照。
+      block-destructive-migrations: true
     secrets: inherit

--- a/scripts/prisma/migrate-diff.sh
+++ b/scripts/prisma/migrate-diff.sh
@@ -18,8 +18,13 @@
 #    stdout. Exit code is always 0 — this check informs reviewers, it does
 #    not block merge.
 #
-# The two modes are mutually exclusive. If the first argument is `--ci` or no
-# argument is supplied, CI mode runs; otherwise developer mode runs.
+# 3. Strict CI scan mode (`--strict` or MIGRATE_DIFF_STRICT=true):
+#      pnpm db:migrate-diff --strict
+#    Same scan as CI mode, but hits are emitted as `::error::` and the script
+#    exits 1 on any hit. Used at the prd deploy entry point to **block**
+#    destructive migrations from reaching production unreviewed. The pre-merge
+#    PR check stays advisory (mode 2) so reviewers see warnings; the deploy
+#    gate (mode 3) is the actual fail-closed guard.
 
 # `set -e` を加える: pipeline 直外の単独コマンドが失敗した時点で即停止し、
 # 後続を中途半端に走らせない。grep の "no match" は exit 1 を返すが、明示的に
@@ -70,8 +75,19 @@ run_developer_mode() {
 }
 
 run_ci_mode() {
+  local STRICT="${MIGRATE_DIFF_STRICT:-false}"
   local BASE_REF="${MIGRATE_DIFF_BASE_REF:-origin/develop}"
   local MIGRATIONS_PATH="src/infrastructure/prisma/migrations"
+
+  # In strict mode, hits become GHA `::error::` annotations and the script
+  # exits 1. Used at the prd deploy entry point to block destructive
+  # migrations. Non-strict mode (default) keeps annotations as `::warning::`
+  # and always exits 0 (advisory, pre-merge PR check).
+  local ANNOTATION_LEVEL="warning"
+  if [ "$STRICT" = "true" ]; then
+    ANNOTATION_LEVEL="error"
+    echo "🚨 strict mode: destructive DDL will fail the job"
+  fi
 
   echo "🔍 Scanning Prisma migrations added vs ${BASE_REF} for destructive DDL..."
 
@@ -150,8 +166,8 @@ run_ci_mode() {
           local content="${match_line#*:}"
           # Trim leading whitespace using bash builtin regex.
           [[ "$content" =~ ^[[:space:]]*(.*) ]] && content="${BASH_REMATCH[1]}"
-          printf '::warning file=%s,line=%s::Destructive DDL detected (%s): %s\n' \
-            "$file" "$lineno" "$label" "$content"
+          printf '::%s file=%s,line=%s::Destructive DDL detected (%s): %s\n' \
+            "$ANNOTATION_LEVEL" "$file" "$lineno" "$label" "$content"
           file_hits=$((file_hits + 1))
         done <<< "$matches"
       fi
@@ -173,8 +189,8 @@ run_ci_mode() {
         local lineno="${match_line%%:*}"
         local content="${match_line#*:}"
         [[ "$content" =~ ^[[:space:]]*(.*) ]] && content="${BASH_REMATCH[1]}"
-        printf '::warning file=%s,line=%s::Destructive DDL detected (DROP INDEX without CONCURRENTLY locks readers): %s\n' \
-          "$file" "$lineno" "$content"
+        printf '::%s file=%s,line=%s::Destructive DDL detected (DROP INDEX without CONCURRENTLY locks readers): %s\n' \
+          "$ANNOTATION_LEVEL" "$file" "$lineno" "$content"
         file_hits=$((file_hits + 1))
       done <<< "$drop_index_matches"
     fi
@@ -187,16 +203,23 @@ run_ci_mode() {
 
   if [ "$TOTAL_HITS" -eq 0 ]; then
     echo "✅ No destructive DDL patterns detected in changed migrations."
-  else
-    echo ""
-    echo "::warning::Detected ${TOTAL_HITS} destructive DDL pattern(s) across changed migrations. See docs/handbook/DB_MIGRATION.md for the safe-migration playbook (2-step migrations, backfill, view-based replacement)."
+    exit 0
   fi
 
-  # Always succeed — this check informs reviewers, it does not block merge.
+  echo ""
+  if [ "$STRICT" = "true" ]; then
+    echo "::error::Detected ${TOTAL_HITS} destructive DDL pattern(s) across changed migrations. Deploy blocked. See docs/handbook/DB_MIGRATION.md for the safe-migration playbook (2-step migrations, backfill, view-based replacement)."
+    exit 1
+  fi
+
+  echo "::warning::Detected ${TOTAL_HITS} destructive DDL pattern(s) across changed migrations. See docs/handbook/DB_MIGRATION.md for the safe-migration playbook (2-step migrations, backfill, view-based replacement)."
   exit 0
 }
 
-if [ "$MODE" = "--ci" ] || [ -z "$MODE" ]; then
+if [ "$MODE" = "--strict" ]; then
+  MIGRATE_DIFF_STRICT=true
+  run_ci_mode
+elif [ "$MODE" = "--ci" ] || [ -z "$MODE" ]; then
   run_ci_mode
 else
   run_developer_mode "$MODE"

--- a/scripts/prisma/migrate-diff.sh
+++ b/scripts/prisma/migrate-diff.sh
@@ -75,7 +75,7 @@ run_developer_mode() {
 }
 
 run_ci_mode() {
-  local STRICT="${MIGRATE_DIFF_STRICT:-false}"
+  local strict="${MIGRATE_DIFF_STRICT:-false}"
   local BASE_REF="${MIGRATE_DIFF_BASE_REF:-origin/develop}"
   local MIGRATIONS_PATH="src/infrastructure/prisma/migrations"
 
@@ -83,23 +83,28 @@ run_ci_mode() {
   # exits 1. Used at the prd deploy entry point to block destructive
   # migrations. Non-strict mode (default) keeps annotations as `::warning::`
   # and always exits 0 (advisory, pre-merge PR check).
-  local ANNOTATION_LEVEL="warning"
-  if [ "$STRICT" = "true" ]; then
-    ANNOTATION_LEVEL="error"
+  local annotation_level="warning"
+  if [[ "$strict" == "true" ]]; then
+    annotation_level="error"
     echo "🚨 strict mode: destructive DDL will fail the job"
   fi
 
   echo "🔍 Scanning Prisma migrations added vs ${BASE_REF} for destructive DDL..."
 
   # Resolve the merge-base so we look only at commits introduced by this PR.
-  # If BASE_REF is unavailable (e.g. shallow clone without develop fetched),
-  # fall back to comparing the working tree against HEAD's parent.
+  # If BASE_REF is unavailable (e.g. shallow clone without the target branch
+  # fetched), strict mode fails closed (cannot verify → block deploy);
+  # non-strict mode skips with a warning (advisory PR check, not load-bearing).
   local MERGE_BASE=""
   if git rev-parse --verify --quiet "$BASE_REF" >/dev/null; then
     MERGE_BASE=$(git merge-base "$BASE_REF" HEAD 2>/dev/null || true)
   fi
 
-  if [ -z "$MERGE_BASE" ]; then
+  if [[ -z "$MERGE_BASE" ]]; then
+    if [[ "$strict" == "true" ]]; then
+      echo "::error::base ref '${BASE_REF}' not found locally; cannot run destructive-migration scan in strict mode. Ensure the checkout has enough history (fetch-depth: 0) and that '${BASE_REF}' is reachable." >&2
+      exit 1
+    fi
     echo "::warning::base ref '${BASE_REF}' not found locally; skipping destructive-migration scan"
     exit 0
   fi
@@ -167,7 +172,7 @@ run_ci_mode() {
           # Trim leading whitespace using bash builtin regex.
           [[ "$content" =~ ^[[:space:]]*(.*) ]] && content="${BASH_REMATCH[1]}"
           printf '::%s file=%s,line=%s::Destructive DDL detected (%s): %s\n' \
-            "$ANNOTATION_LEVEL" "$file" "$lineno" "$label" "$content"
+            "$annotation_level" "$file" "$lineno" "$label" "$content"
           file_hits=$((file_hits + 1))
         done <<< "$matches"
       fi
@@ -190,7 +195,7 @@ run_ci_mode() {
         local content="${match_line#*:}"
         [[ "$content" =~ ^[[:space:]]*(.*) ]] && content="${BASH_REMATCH[1]}"
         printf '::%s file=%s,line=%s::Destructive DDL detected (DROP INDEX without CONCURRENTLY locks readers): %s\n' \
-          "$ANNOTATION_LEVEL" "$file" "$lineno" "$content"
+          "$annotation_level" "$file" "$lineno" "$content"
         file_hits=$((file_hits + 1))
       done <<< "$drop_index_matches"
     fi
@@ -207,8 +212,8 @@ run_ci_mode() {
   fi
 
   echo ""
-  if [ "$STRICT" = "true" ]; then
-    echo "::error::Detected ${TOTAL_HITS} destructive DDL pattern(s) across changed migrations. Deploy blocked. See docs/handbook/DB_MIGRATION.md for the safe-migration playbook (2-step migrations, backfill, view-based replacement)."
+  if [[ "$strict" == "true" ]]; then
+    echo "::error::Detected ${TOTAL_HITS} destructive DDL pattern(s) across changed migrations. Deploy blocked. See docs/handbook/DB_MIGRATION.md for the safe-migration playbook (2-step migrations, backfill, view-based replacement)." >&2
     exit 1
   fi
 
@@ -216,10 +221,15 @@ run_ci_mode() {
   exit 0
 }
 
-if [ "$MODE" = "--strict" ]; then
-  MIGRATE_DIFF_STRICT=true
+# `export` is intentional: `run_ci_mode` reads MIGRATE_DIFF_STRICT via
+# `${MIGRATE_DIFF_STRICT:-false}`. A bare assignment would also work for the
+# same shell, but exporting makes the intent explicit and overrides any
+# pre-set env value (e.g. `MIGRATE_DIFF_STRICT=false` in caller env) — Gemini
+# review on this PR flagged the ambiguity, fix it once and forget it.
+if [[ "$MODE" == "--strict" ]]; then
+  export MIGRATE_DIFF_STRICT=true
   run_ci_mode
-elif [ "$MODE" = "--ci" ] || [ -z "$MODE" ]; then
+elif [[ "$MODE" == "--ci" || -z "$MODE" ]]; then
   run_ci_mode
 else
   run_developer_mode "$MODE"


### PR DESCRIPTION
## Summary

CI/CD レビュー (`ci/cdは完璧か？`) で挙げた 🔴 Critical 2 件のうち、本番に直接効くゲート不在を塞ぐ。

### 🔴 #1 prd deploy が CI 完走を確認せず起動する問題

`deploy-to-cloud-run-prd.yml` は `pull_request: closed && merged == true` のみで trigger され、`needs: [ci]` も `if:` ゲートもなかった。CI を required にするかは **branch protection 設定だけが担保**しており、protection 設定漏れ・admin override・bypass などで未テストコードが prd に到達しうる経路があった。

→ `verify-ci` ジョブを追加。GitHub check-runs API を polling し、merge commit SHA に対する `ci` aggregator が **明示的に `success`** になるまで待つ。`deploy` job は `needs: verify-ci` で依存させ、CI 不通過なら deploy が走らない。

- timeout: 25 min (poll 20 s 間隔)
- `failure` / `cancelled` / `timed_out` を見たら即 fail
- check 名は `ci`（`ci.yml` の aggregator job）。job 名変更時は env を更新

### 🔴 #2 prd で destructive migration が無条件適用される問題

`ci.yml:256-260` の `db:migrate-diff` は **advisory (non-blocking)** のため、`DROP TABLE` / `DROP COLUMN` / `ALTER TYPE` / `RENAME` / non-CONCURRENTLY `DROP INDEX` を含む PR でも警告だけで通過し、`_deploy-cloud-run.yml:141-146` の `db:deploy` がそのまま prd DB に適用していた。

→ 3 段で対応:

1. `scripts/prisma/migrate-diff.sh` に `--strict` モード (or `MIGRATE_DIFF_STRICT=true` env) を追加。hits を `::error::` 化して exit 1。
2. `_deploy-cloud-run.yml` に `block-destructive-migrations` input (default `false`) を追加。true のとき checkout 直後に strict scan を走らせ、`db:deploy` 前に deploy を fail させる。
3. prd caller (`deploy-to-cloud-run-prd.yml`) で `block-destructive-migrations: true` を渡す。dev は従来通り advisory。

既知の安全な destructive 変更を流したい場合は `docs/handbook/DB_MIGRATION.md` の 2-step migration 手順に従って分解する。

## 補足: 併せて推奨する手動設定

コード変更では塞げない部分として、GitHub Web UI で以下を設定すると belt-and-suspenders になる:

- `co-creation-dao-prod` Environment に **required reviewers** を設定（destructive 以外の高インパクト変更にも人間ゲートが入る）
- `dev` Environment にも reviewers を設定し、`epic/**` / `hotfix/**` ブランチ push での即 100% deploy を抑止（レビュー 🔴 #3 対応）

## Test plan

- [x] `actionlint` でワークフロー syntax を検証（全 workflow clean）
- [x] `scripts/prisma/migrate-diff.sh` 3 モードを fixture で動作確認
  - non-strict + destructive hit → `::warning::` / exit 0（CI 既存挙動を破壊していない）
  - strict + destructive hit → `::error::` / exit 1
  - strict + no migration changes → exit 0
- [ ] PR merge 後、verify-ci が check-runs API を 1 回叩いて CI 完走を確認できることを実環境で確認
- [ ] 既存 PR (destructive なし) が deploy パイプラインを通過することを確認
- [ ] 意図的に destructive migration を含む test PR で deploy が `Block destructive migrations` step で fail することを確認

https://claude.ai/code/session_01SC8DWWX4K4Ze5cdgVM16Ca

---
_Generated by [Claude Code](https://claude.ai/code/session_01SC8DWWX4K4Ze5cdgVM16Ca)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 本番デプロイ時に破壊的なデータベース変更を自動検出し、検出時はデプロイを停止する仕組みを導入しました（開発環境ではオプトアウト可能）。
* **Bug Fixes**
  * 検出結果に応じてCI上で警告／エラーを明示的に出力するようになり、問題発見時の可視性と失敗挙動が改善されました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hopin-inc/civicship-api/pull/1163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->