### PR TITLE
refactor(deploy): isolate GITHUB_TOKEN writes per Scorecard

### DIFF
--- a/.github/workflows/_deploy-cloud-run.yml
+++ b/.github/workflows/_deploy-cloud-run.yml
@@ -28,7 +28,11 @@ on:
         required: false
         default: ''
       create-git-tag:
-        description: Whether to create + push a timestamp git tag (prd only).
+        description: |
+          DEPRECATED — the create-tag responsibility was moved to the calling
+          workflow's own `create-tag` job (see `deploy-to-cloud-run-prd.yml`)
+          to keep the deploy job free of `contents: write`. Kept here so old
+          callers don't break; the value is ignored.
         type: boolean
         required: false
         default: false
@@ -74,14 +78,15 @@ jobs:
     timeout-minutes: 30
 
     permissions:
+      # OIDC token for Workload Identity Federation auth to GCP. This is the
+      # ONLY write the deploy job needs — the previous `contents: write` (git
+      # tag) and `security-events: write` (Trivy SARIF upload) were moved to
+      # dedicated downstream jobs in the calling workflows to shrink the
+      # GITHUB_TOKEN's blast radius (Scorecard Token-Permissions findings on
+      # PR #1164). SARIF files are uploaded as an artifact here and the
+      # caller's `upload-sarif` job re-uploads them to the Security tab.
       id-token: write
-      # contents:write は git tag push に必要 (prd only)。GHA の `permissions:` は
-      # 式で動的に切り替えできないため、両 stage で write を付与する
-      # (dev でも実質 read しか使わないので影響なし)。
-      contents: write
-      # security-events:write は Trivy scan 結果 (sarif) を Security タブに
-      # upload するために必要 (codeql-action/upload-sarif)。
-      security-events: write
+      contents: read
 
     env:
       STAGE: ${{ inputs.stage }}
@@ -303,19 +308,26 @@ jobs:
             fi
           done
 
-      - name: Upload Trivy CRITICAL results to Security tab
+      # Trivy SARIF を artifact として upload する。`security-events: write` を
+      # 持つ caller 側の `upload-sarif` job がこの artifact を download して
+      # Security タブに publish する責務を担う (Scorecard PR #1164: deploy
+      # job からの write 権限切り出し)。
+      #
+      # `if: always()` で deploy 失敗時にも CRITICAL/HIGH の sarif を残し、
+      # 後続 upload job が Security タブに上げられるようにする (旧 inline
+      # upload と同じ挙動)。`if-no-files-found: warn` で scan step がそもそも
+      # 走らず sarif が無い場合でも artifact upload を fail させない (deploy
+      # job が build phase で死んだケース等)。
+      - name: Upload Trivy SARIF artifacts (consumed by caller's upload-sarif job)
         if: always()
-        uses: github/codeql-action/upload-sarif@4f3212b61783c3c68e8309a0f18a699764811cda # v3.27.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          sarif_file: trivy-critical.sarif
-          category: trivy-critical
-
-      - name: Upload Trivy HIGH results to Security tab
-        if: always()
-        uses: github/codeql-action/upload-sarif@4f3212b61783c3c68e8309a0f18a699764811cda # v3.27.1
-        with:
-          sarif_file: trivy-high.sarif
-          category: trivy-high
+          name: trivy-sarif-${{ inputs.stage }}
+          path: |
+            trivy-critical.sarif
+            trivy-high.sarif
+          retention-days: 5
+          if-no-files-found: warn
 
       # --- Non-canary deploy (dev / 既存挙動) ---------------------------------
       # `enable-canary: false` の場合は従来通り即 100% で切り替える。
@@ -584,19 +596,9 @@ jobs:
           export PATH="$HOME/.rover/bin:$PATH"
           rover graph publish "civicship-api-jq1988@${{ inputs.apollo-variant }}" --schema ./docs/schema.graphql
 
-      - name: Create Git tag
-        # TZ env でプロセス単位に JST を効かせる。tzdata の system-wide install
-        # は不要 (#986) — apt 経由のネット I/O / sudo が消えるので、harden-runner
-        # で `disable-sudo: true` を有効化できる。
-        if: ${{ inputs.create-git-tag }}
-        env:
-          TZ: Asia/Tokyo
-        run: |
-          TAG_NAME=$(date +"%Y%m%d%H%M%S")
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git tag "$TAG_NAME"
-          git push origin "$TAG_NAME"
+      # NOTE: Git tag 作成は caller の `create-tag` job に移動した (PR #1164,
+      # Scorecard Token-Permissions findings — deploy job から `contents: write`
+      # を外すため)。`deploy-to-cloud-run-prd.yml` の `create-tag` job 参照。
 
       - name: Cleanup SSH Key
         if: always()

--- a/.github/workflows/deploy-to-cloud-run-dev.yml
+++ b/.github/workflows/deploy-to-cloud-run-dev.yml
@@ -11,16 +11,21 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
-# Caller permissions must be a superset of the reusable workflow's permissions
-# (`_deploy-cloud-run.yml`: id-token:write + contents:write + security-events:write).
-# Setting them explicitly here also silences CodeQL's missing-permissions warning.
+# Workflow-level permissions are intentionally read-only. Each job declares
+# only the writes it actually needs (PR #1164 / Scorecard Token-Permissions
+# 対応): deploy job は WIF の OIDC のみ、upload-sarif job だけが
+# `security-events: write` を持つ。dev は git tag を打たないので
+# `contents: write` を持つ job は存在しない。
 permissions:
-  id-token: write
-  contents: write
-  security-events: write
+  contents: read
 
 jobs:
   deploy:
+    # 最小権限: reusable deploy job は WIF auth に必要な OIDC token のみ受け
+    # 取る。security-events:write は upload-sarif job に隔離。詳細は prd 側
+    # (`deploy-to-cloud-run-prd.yml`) の同コメント参照。
+    permissions:
+      id-token: write
     uses: ./.github/workflows/_deploy-cloud-run.yml
     with:
       stage: dev
@@ -29,8 +34,47 @@ jobs:
       node-env: development
       extra-env-vars: |
         ENV=dev
-      create-git-tag: false
       # dev は canary を skip し従来通り即 100% で切り替える (ループバック検証
       # を高速化するため)。canary rollout 自体の有効化は prd のみ。
       enable-canary: false
     secrets: inherit
+
+  # Trivy CRITICAL/HIGH の SARIF を Security タブに publish する。prd 側と
+  # 同じ構造 — deploy job が upload した `trivy-sarif-dev` artifact を
+  # download → codeql-action/upload-sarif で再 upload する。本 job だけが
+  # `security-events: write` を持つことで deploy job 本体から書き込み権限を
+  # 取り除いて Scorecard Token-Permissions の指摘を解消する (PR #1164)。
+  upload-sarif:
+    needs: deploy
+    if: ${{ always() && needs.deploy.result != 'cancelled' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      security-events: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+          disable-sudo: true
+
+      - name: Download Trivy SARIF artifacts
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          name: trivy-sarif-dev
+
+      - name: Upload Trivy CRITICAL results to Security tab
+        if: ${{ steps.download.outcome == 'success' && hashFiles('trivy-critical.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@4f3212b61783c3c68e8309a0f18a699764811cda # v3.27.1
+        with:
+          sarif_file: trivy-critical.sarif
+          category: trivy-critical
+
+      - name: Upload Trivy HIGH results to Security tab
+        if: ${{ steps.download.outcome == 'success' && hashFiles('trivy-high.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@4f3212b61783c3c68e8309a0f18a699764811cda # v3.27.1
+        with:
+          sarif_file: trivy-high.sarif
+          category: trivy-high

--- a/.github/workflows/deploy-to-cloud-run-prd.yml
+++ b/.github/workflows/deploy-to-cloud-run-prd.yml
@@ -15,13 +15,14 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
-# Workflow-level permissions are intentionally minimal (read-only metadata).
-# Each job declares only the writes it actually needs:
-#   - verify-ci: checks:read + actions:read (gh api on check-runs)
-#   - deploy:    id-token:write + contents:write + security-events:write
-#                (must be a superset of the reusable workflow's permissions)
-# Splitting permissions per job (vs. granting workflow-wide write) satisfies
-# Sonar's least-privilege rule and limits the blast radius of any single step.
+# Workflow-level permissions are intentionally read-only. Each job declares
+# only the writes it actually needs (Scorecard Token-Permissions: PR #1164):
+#   - verify-ci:    checks:read + actions:read (gh api on check-runs)
+#   - deploy:       id-token:write (WIF auth only — no contents/security-events)
+#   - upload-sarif: security-events:write (Trivy SARIF → Security tab)
+#   - create-tag:   contents:write (git tag push, prd only)
+# Each write is scoped to a single small downstream job (≤5 steps each),
+# limiting the blast radius if any individual step is compromised.
 permissions:
   contents: read
 
@@ -115,21 +116,19 @@ jobs:
   deploy:
     needs: verify-ci
     if: github.event.pull_request.merged == true
-    # Caller permissions must be a superset of the reusable workflow's
-    # permissions (`_deploy-cloud-run.yml` declares: id-token:write +
-    # contents:write + security-events:write at the job level). Declared
-    # here per job (not workflow-wide) so verify-ci stays read-only.
+    # 最小権限: deploy job (reusable workflow) は WIF auth に必要な OIDC token
+    # だけを受け取る。`security-events: write` (Trivy SARIF upload) と
+    # `contents: write` (git tag) は下流の専用 job (`upload-sarif`,
+    # `create-tag`) に隔離した — 各 job の攻撃面を最小化することで
+    # Scorecard Token-Permissions 0 点を解消する (PR #1164)。
     permissions:
       id-token: write
-      contents: write
-      security-events: write
     uses: ./.github/workflows/_deploy-cloud-run.yml
     with:
       stage: prd
       environment: co-creation-dao-prod
       apollo-variant: prod
       node-env: production
-      create-git-tag: true
       # prd は canary rollout (10% → bake → 5xx チェック → 100%) を強制。
       # 失敗時は前 revision に traffic を戻す。dev 側は `enable-canary: false`
       # で従来通り即 100%。詳細は `_deploy-cloud-run.yml` 参照。
@@ -141,3 +140,85 @@ jobs:
       # 2-step migration の正規手順は docs/handbook/DB_MIGRATION.md 参照。
       block-destructive-migrations: true
     secrets: inherit
+
+  # Trivy CRITICAL/HIGH の SARIF を Security タブに publish する。reusable
+  # deploy job が同名 artifact (`trivy-sarif-prd`) を upload するので、ここで
+  # download → codeql-action/upload-sarif で再 upload する。本 job だけが
+  # `security-events: write` を持つことで deploy job 本体 (build/push/deploy
+  # を含む大きな job) から書き込み権限を取り除ける (Scorecard 対応)。
+  #
+  # `if: always() && needs.deploy.result != 'cancelled'` で deploy が
+  # CRITICAL CVE 検出 (`exit-code: '1'`) や smoke 失敗で fail した場合でも
+  # SARIF を publish できるようにする (旧 inline upload と同じ挙動)。
+  upload-sarif:
+    needs: deploy
+    if: ${{ always() && needs.deploy.result != 'cancelled' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      security-events: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+          disable-sudo: true
+
+      - name: Download Trivy SARIF artifacts
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          name: trivy-sarif-prd
+
+      - name: Upload Trivy CRITICAL results to Security tab
+        if: ${{ steps.download.outcome == 'success' && hashFiles('trivy-critical.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@4f3212b61783c3c68e8309a0f18a699764811cda # v3.27.1
+        with:
+          sarif_file: trivy-critical.sarif
+          category: trivy-critical
+
+      - name: Upload Trivy HIGH results to Security tab
+        if: ${{ steps.download.outcome == 'success' && hashFiles('trivy-high.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@4f3212b61783c3c68e8309a0f18a699764811cda # v3.27.1
+        with:
+          sarif_file: trivy-high.sarif
+          category: trivy-high
+
+  # 本番 deploy 成功時に JST タイムスタンプ tag を打って push する。`contents:
+  # write` を持つのは本 job だけ (PR #1164: deploy job から git tag 責務を
+  # 切り出して攻撃面を縮小)。`if: success()` でレールに乗らなかった (deploy
+  # 失敗) PR では tag が打たれないことを保証する。
+  create-tag:
+    needs: deploy
+    if: ${{ success() && github.event.pull_request.merged == true }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+          disable-sudo: true
+
+      - name: Checkout merge commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Create and push timestamp tag
+        # TZ env でプロセス単位に JST を効かせる。tzdata の system-wide install
+        # は不要 (#986) — apt 経由のネット I/O / sudo が消えるので、harden-runner
+        # で `disable-sudo: true` を有効化できる。
+        env:
+          TZ: Asia/Tokyo
+        run: |
+          set -euo pipefail
+          TAG_NAME=$(date +"%Y%m%d%H%M%S")
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git tag "$TAG_NAME"
+          git push origin "$TAG_NAME"
+          echo "Created tag: $TAG_NAME"


### PR DESCRIPTION
## Summary

Scorecard Token-Permissions が PR #1164 で flag した 2 件 (`contents: write` / `security-events: write` on the deploy job) を構造的に解消する。**マージされると PR #1164 の diff にも反映され、release PR の Scorecard findings が解消される**。

## 背景

`_deploy-cloud-run.yml` の deploy job は以下のために write 権限を持っていた:
- `contents: write` → `Create Git tag` step (prd のみ)
- `security-events: write` → Trivy SARIF を Security タブに publish

deploy job は build / push / scan / Cloud Run deploy / canary / batch update / schema publish と数十 step・多数のサードパーティ action を抱える「最大の攻撃面」。ここに広範な write を付与するのは GITHUB_TOKEN の blast radius を不必要に広げていた。

## 変更内容

**`_deploy-cloud-run.yml` (reusable):**
- deploy job permissions を `id-token: write` のみに縮小 (+ `contents: read` for checkout)
- Trivy SARIF の Security タブへの inline upload を artifact upload (`trivy-sarif-<stage>`) に置き換え
- `Create Git tag` step を削除 (caller の専用 job に移管)
- `create-git-tag` input は deprecated として残置 (後方互換)

**`deploy-to-cloud-run-prd.yml` (caller):**
- deploy job permissions: `id-token: write` のみ
- 新 job `upload-sarif` (5 steps, `security-events: write`): SARIF artifact を download → Security タブに publish。`if: always() && needs.deploy.result != 'cancelled'` で deploy 失敗時にも CVE を surface
- 新 job `create-tag` (3 steps, `contents: write`): 成功時のみ JST timestamp tag を push

**`deploy-to-cloud-run-dev.yml` (caller):**
- 同様に prd と並行構造 (create-tag は dev 不要なので無し)
- workflow-level の write 権限を全て撤廃 → job-level に集約
- dev は `contents: write` を持つ job が存在しなくなる (Scorecard score 改善)

## Net effect

| Job | Steps | Permissions |
|---|---|---|
| deploy (reusable) | 多数 (build/push/deploy/canary 等) | `id-token: write` のみ |
| upload-sarif | ≤5 | `security-events: write` のみ |
| create-tag (prd) | ≤3 | `contents: write` のみ |
| verify-ci (prd) | 2 | `checks: read` + `actions: read` |

write 権限を持つ全ての job が ≤5 steps + 単一責務になり、攻撃面が大幅に縮小。

## Test plan

- [x] `actionlint` clean (全 workflow)
- [x] reusable workflow の input `create-git-tag` は deprecated default false で後方互換維持
- [x] SARIF artifact 名は stage 別 (`trivy-sarif-prd` / `trivy-sarif-dev`) で衝突なし
- [ ] **dev deploy で実環境動作確認** — develop に merge 後、最初の push が走った時に:
  - deploy job が completed
  - upload-sarif job が SARIF を Security タブに publish
  - Trivy CRITICAL 検出時に deploy が fail し、upload-sarif は `if: always()` で SARIF を publish できる
- [ ] **prd deploy で実環境動作確認** — develop→master merge 時に:
  - verify-ci → deploy → upload-sarif + create-tag (並列) → 全て success
  - JST タグが master tip に push される (旧挙動と同一)

## リスク

deploy 経路の中規模リファクタなので壊れた場合の影響が大きい。万一バグがあった場合:
- `git tag` が打たれない → 旧 tag は残るので影響軽微、ホットフィックスで戻せる
- `SARIF` が Security タブに上がらない → 視認性問題のみ、Trivy scan 自体は deploy job で blocking で動く
- `deploy` が動かない → revert PR を即出す

https://claude.ai/code/session_01SC8DWWX4K4Ze5cdgVM16Ca

---
_Generated by [Claude Code](https://claude.ai/code/session_01SC8DWWX4K4Ze5cdgVM16Ca)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

**Chores**
- GitHub Actions デプロイワークフローの権限設定を最適化し、セキュリティ態勢を強化しました
- デプロイパイプラインのジョブ構成を整理し、責務を明確に分離しました
- セキュリティスキャン結果の処理フローを再構成しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hopin-inc/civicship-api/pull/1165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->