### PR TITLE
fix(community): use originalId as Firebase tenant displayName

### DIFF
--- a/src/__tests__/e2e/userJourney.test.ts
+++ b/src/__tests__/e2e/userJourney.test.ts
@@ -158,6 +158,7 @@ describe("End-to-End User Journey Integration Tests", () => {
     const communityResult = await communityUseCase.userCreateCommunityAndJoin(
       {
         input: {
+          originalId: `c-${uniqueId.slice(-10).replace(/[^a-zA-Z0-9-]/g, "")}`,
           name: `Multi User Community ${uniqueId}`,
           pointName: "pts",
         },

--- a/src/__tests__/integration/walletCreation/createCommunity.error.test.ts
+++ b/src/__tests__/integration/walletCreation/createCommunity.error.test.ts
@@ -65,7 +65,7 @@ describe("Community Creation Error Handling Tests", () => {
   ])("should fail with ValidationError when originalId is %s", async (_label, originalId) => {
     const user = await TestDataSourceHelper.createUser({
       name: "Validation Tester",
-      slug: `validation-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      slug: `validation-${crypto.randomUUID().slice(0, 8)}`,
       currentPrefecture: CurrentPrefecture.KAGAWA,
     });
     const ctx = { currentUser: { id: user.id }, issuer } as IContext;

--- a/src/__tests__/integration/walletCreation/createCommunity.error.test.ts
+++ b/src/__tests__/integration/walletCreation/createCommunity.error.test.ts
@@ -39,7 +39,7 @@ describe("Community Creation Error Handling Tests", () => {
 
     await expect(
       useCase.userCreateCommunityAndJoin({
-        input: { name: "Test Community", pointName: "test-points" }
+        input: { originalId: "test-community", name: "Test Community", pointName: "test-points" }
       }, ctx)
     ).rejects.toThrow(/foreign key constraint|user_id_fkey/i);
   });
@@ -49,7 +49,7 @@ describe("Community Creation Error Handling Tests", () => {
 
     await expect(
       useCase.userCreateCommunityAndJoin({
-        input: { name: "Test Community", pointName: "test-points" }
+        input: { originalId: "test-community", name: "Test Community", pointName: "test-points" }
       }, ctx)
     ).rejects.toThrow(/authentication|logged.*in/i);
   });

--- a/src/__tests__/integration/walletCreation/createCommunity.error.test.ts
+++ b/src/__tests__/integration/walletCreation/createCommunity.error.test.ts
@@ -16,6 +16,8 @@ import CommunityUseCase from "@/application/domain/account/community/usecase";
 import { container } from "tsyringe";
 import { registerProductionDependencies } from "@/application/provider";
 import { PrismaClientIssuer } from "@/infrastructure/prisma/client";
+import { ValidationError } from "@/errors/graphql";
+import { CurrentPrefecture } from "@prisma/client";
 
 describe("Community Creation Error Handling Tests", () => {
   let useCase: CommunityUseCase;
@@ -61,12 +63,18 @@ describe("Community Creation Error Handling Tests", () => {
     ["invalid char", "foo_bar"],
     ["too long", "a".repeat(21)],
   ])("should fail with ValidationError when originalId is %s", async (_label, originalId) => {
-    const ctx = { currentUser: { id: "any-user-id" }, issuer } as IContext;
+    const user = await TestDataSourceHelper.createUser({
+      name: "Validation Tester",
+      slug: `validation-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      currentPrefecture: CurrentPrefecture.KAGAWA,
+    });
+    const ctx = { currentUser: { id: user.id }, issuer } as IContext;
 
-    await expect(
-      useCase.userCreateCommunityAndJoin({
-        input: { originalId, name: "Test Community", pointName: "test-points" }
-      }, ctx)
-    ).rejects.toThrow(/originalId/i);
+    const promise = useCase.userCreateCommunityAndJoin({
+      input: { originalId, name: "Test Community", pointName: "test-points" }
+    }, ctx);
+
+    await expect(promise).rejects.toThrow(ValidationError);
+    await expect(promise).rejects.toThrow(/originalId/i);
   });
 });

--- a/src/__tests__/integration/walletCreation/createCommunity.error.test.ts
+++ b/src/__tests__/integration/walletCreation/createCommunity.error.test.ts
@@ -53,4 +53,20 @@ describe("Community Creation Error Handling Tests", () => {
       }, ctx)
     ).rejects.toThrow(/authentication|logged.*in/i);
   });
+
+  it.each([
+    ["empty", ""],
+    ["too short", "abc"],
+    ["leading digit", "1bad"],
+    ["invalid char", "foo_bar"],
+    ["too long", "a".repeat(21)],
+  ])("should fail with ValidationError when originalId is %s", async (_label, originalId) => {
+    const ctx = { currentUser: { id: "any-user-id" }, issuer } as IContext;
+
+    await expect(
+      useCase.userCreateCommunityAndJoin({
+        input: { originalId, name: "Test Community", pointName: "test-points" }
+      }, ctx)
+    ).rejects.toThrow(/originalId/i);
+  });
 });

--- a/src/__tests__/integration/walletCreation/createCommunity.test.ts
+++ b/src/__tests__/integration/walletCreation/createCommunity.test.ts
@@ -67,6 +67,7 @@ describe("Community Integration Tests", () => {
       const pointName = `${communityName}-point`;
 
       const createCommunityInput: GqlCommunityCreateInput = {
+        originalId: communityName,
         name: communityName,
         pointName: pointName,
         image: undefined,

--- a/src/application/domain/account/community/service.ts
+++ b/src/application/domain/account/community/service.ts
@@ -6,7 +6,7 @@ import {
 import CommunityConverter from "@/application/domain/account/community/data/converter";
 import { Prisma } from "@prisma/client";
 import { IContext } from "@/types/server";
-import { NotFoundError } from "@/errors/graphql";
+import { NotFoundError, ValidationError } from "@/errors/graphql";
 import ImageService from "@/application/domain/content/image/service";
 import { inject, injectable } from "tsyringe";
 import ICommunityRepository from "@/application/domain/account/community/data/interface";
@@ -42,7 +42,13 @@ export default class CommunityService {
     return community;
   }
 
-  async createFirebaseTenant(displayName: string): Promise<string> {
+  async createFirebaseTenant(displayName: string | null | undefined): Promise<string> {
+    if (!displayName || !/^[a-zA-Z][a-zA-Z0-9-]{3,19}$/.test(displayName)) {
+      throw new ValidationError(
+        "originalId must start with a letter and consist of letters, digits and hyphens (4-20 characters)",
+        ["originalId"],
+      );
+    }
     const tenant = await auth.tenantManager().createTenant({ displayName });
     return tenant.tenantId;
   }

--- a/src/application/domain/account/community/usecase.ts
+++ b/src/application/domain/account/community/usecase.ts
@@ -58,7 +58,7 @@ export default class CommunityUseCase {
     { input }: GqlMutationCommunityCreateArgs,
     ctx: IContext,
   ): Promise<GqlCommunityCreatePayload> {
-    const tenantId = await this.communityService.createFirebaseTenant(input.name);
+    const tenantId = await this.communityService.createFirebaseTenant(input.originalId);
 
     try {
       return await ctx.issuer.public(ctx, async (tx) => {


### PR DESCRIPTION
## Summary

- `communityCreate` was passing `input.name` to Firebase `tenantManager.createTenant` as `displayName`. Firebase enforces a strict regex (letters/digits/hyphens, 4-20 chars, must start with a letter), so non-conforming community names — including any Japanese name like `さんりくDAO` — caused the mutation to fail with `INTERNAL_SERVER_ERROR`.
- Switch the source of the Firebase `displayName` from `input.name` to `input.originalId`. The `/sysAdmin/create` form already constrains this field to a URL-safe shape, and it’s what end users naturally type as an ASCII identifier (e.g. `sanriku`).
- Add an explicit regex check in `CommunityService.createFirebaseTenant`. If `originalId` is missing or doesn’t match `^[a-zA-Z][a-zA-Z0-9-]{3,19}$`, the resolver now returns a `ValidationError` (400) with a clear message rather than bubbling up an opaque 500 from Firebase.
- As a side benefit, the Firebase tenant `displayName` now matches the community’s logical id, which makes the tenant easy to identify in the Firebase Console when registering the LINE OIDC provider.

## Test plan

- [ ] `pnpm test src/__tests__/integration/walletCreation/createCommunity.test.ts`
- [ ] `pnpm test src/__tests__/integration/walletCreation/createCommunity.error.test.ts`
- [ ] `pnpm test src/__tests__/e2e/userJourney.test.ts`
- [ ] Manual: create a community via `/sysAdmin/create` with `name: さんりくDAO`, `originalId: sanriku` — expect success
- [ ] Manual: create a community with `originalId: ab` (too short) — expect 400 `ValidationError`, not 500
- [ ] Manual: create a community with `originalId: ` empty — expect 400 `ValidationError`

https://claude.ai/code/session_01WhiGgTiTRotzNU98zWymQ4

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhiGgTiTRotzNU98zWymQ4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * コミュニティ作成で利用する識別子（originalId）を導入・自動生成し、英数字とハイフンのみの形式かつ末尾10文字相当を抽出する仕様で形式検証を追加しました。無効な識別子は検証エラーになり、作成フロー内で識別子が一貫して使用されます。
* **Tests**
  * コミュニティ作成フローの単体／統合テストを更新し、新識別子の正常系・異常系（空文字・短すぎ・先頭数字・不正文字・長すぎ等）およびユーザー未存在・未認証時の失敗ケースを検証するケースを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hopin-inc/civicship-api/pull/1167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->