### PR TITLE
fix(community): default portal rootPath to /users/me

### DIFF
--- a/src/application/domain/account/community/config/portal/service.ts
+++ b/src/application/domain/account/community/config/portal/service.ts
@@ -57,7 +57,7 @@ const PORTAL_CONFIG_CREATE_DEFAULTS: Prisma.CommunityPortalConfigCreateWithoutCo
   squareLogoPath: "",
   ogImagePath: "",
   enableFeatures: DEFAULT_ENABLE_FEATURES,
-  rootPath: "/",
+  rootPath: "/users/me",
   adminRootPath: "/admin",
 };
 


### PR DESCRIPTION
## Summary
- コミュニティ作成時の `CommunityPortalConfig` フォールバックデフォルトのうち `rootPath` を `"/"` → `"/users/me"` に変更
- `faviconPrefix` と `ogImagePath` は空文字のまま据え置き（運用側でアップロードして埋める前提）

## Context
`src/application/domain/account/community/config/portal/service.ts` の `PORTAL_CONFIG_CREATE_DEFAULTS` は、PortalConfig が未登録のコミュニティで初めて upsert される際の NOT NULL 制約を満たすためのフォールバック。これまで `rootPath` が `"/"` で作成され、ポータルのトップ遷移先として意図と合っていなかったため `/users/me` に変更する。

## Test plan
- [ ] 新規コミュニティ作成 → `CommunityPortalConfig.rootPath` が `/users/me` で作成されることを確認
- [ ] 既存コミュニティ（rootPath が `/` 以外で設定済み）の値が変わらないこと（CREATE defaults のみの変更でUPDATEには影響しない）
- [ ] 入力で `rootPath` が指定された場合は入力値が優先されること

https://claude.ai/code/session_01C8F8WEfPxs65iYbAof5Ruw

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8F8WEfPxs65iYbAof5Ruw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

- ポータル設定の初期化時におけるデフォルトパスが更新されました。設定作成時の初期ディレクトリアクセス経路が変更されます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hopin-inc/civicship-api/pull/1168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->