### PR TITLE
feat(point-verify): internalize /point/verify via local TransactionAnchor lookup

### DIFF
--- a/src/infrastructure/libs/point-verify/client.ts
+++ b/src/infrastructure/libs/point-verify/client.ts
@@ -1,6 +1,27 @@
-import axios from "axios";
+/**
+ * `PointVerifyClient` — local Cardano-anchor lookup for `/point/verify`.
+ *
+ * 旧 IDENTUS 連携時代は `IDENTUS_API_URL/point/verify` への HTTP call で
+ * Merkle root 検証を行っていたが、内製化 epic (`epic/replace-identsu`)
+ * 以降は Transaction の Merkle root が `t_transaction_anchors` に持たれ
+ * Cardano metadata 1985 に直接 anchor されているため、外部呼び出し無しで
+ * DB lookup だけで verify 状態を返せる。
+ *
+ * 設計参照 (`docs/report/did-vc-internalization.md`):
+ *   §1.3 成功基準 #1 — 「`/point/verify` が外部 HTTP 呼び出しゼロで
+ *     ローカル DB 参照のみで応答」
+ *   §4.1 `TransactionAnchor` schema
+ *   §6.2 GIN index 戦略 (`leaf_ids && $1::text[]`)
+ *   §0-5 spike PR #1091 — GIN index 採用で 17-27× 高速化を実測
+ *
+ * Class 名は legacy 互換 (DI token / 呼出側を温存) のため `PointVerifyClient`
+ * のまま。将来の cleanup PR でリネーム想定。
+ */
+
 import { injectable } from "tsyringe";
-import { IDENTUS_API_URL } from "@/consts/utils";
+import { AnchorStatus, type ChainNetwork } from "@prisma/client";
+
+import { prismaClient } from "@/infrastructure/prisma/client";
 import logger from "@/infrastructure/logging";
 
 export interface VerifyRequest {
@@ -12,108 +33,115 @@ export interface VerifyResponse {
   status: "verified" | "not_verified" | "pending" | "error";
   transactionHash: string;
   rootHash: string;
-  label: string | number; // 外部APIが文字列で返す場合があるため
+  label: string | number;
+}
+
+/**
+ * `t_transaction_anchors` 行のうち本 client が必要とする列だけを raw 取得。
+ * `Prisma.transactionAnchorFindMany` ではなく `$queryRaw` を使うのは GIN index
+ * `@@index([leafIds], type: Gin)` を `leaf_ids && $1::text[]` で確実に引かせ
+ * るため (Prisma の `hasSome` operator は型変換に走りがちで planner が GIN
+ * を選ばないことがある、§6.2 / PR #1091 参照)。
+ */
+interface AnchorRow {
+  id: string;
+  leaf_ids: string[];
+  root_hash: string;
+  chain_tx_hash: string | null;
+  metadata_label: number;
+  status: AnchorStatus;
+  network: ChainNetwork;
+}
+
+function mapAnchorStatus(status: AnchorStatus): VerifyResponse["status"] {
+  switch (status) {
+    case AnchorStatus.CONFIRMED:
+      return "verified";
+    case AnchorStatus.SUBMITTED:
+      return "pending";
+    case AnchorStatus.PENDING:
+      return "pending";
+    case AnchorStatus.FAILED:
+      return "error";
+    default:
+      return "error";
+  }
 }
 
 @injectable()
 export class PointVerifyClient {
-  private readonly baseUrl: string;
-
-  constructor() {
-    this.baseUrl = IDENTUS_API_URL;
-
-    // 環境変数が正しく設定されているか検証
-    if (!this.baseUrl || this.baseUrl === "https://kyoso-identus-api.example.com") {
-      const errorMessage = "[PointVerifyClient] IDENTUS_API_URL is not configured.";
-      logger.error(errorMessage);
-      throw new Error(errorMessage);
-    }
-  }
-
   /**
-   * レスポンスアイテムが有効な VerifyResponse 型かどうかを検証するヘルパー関数
+   * 与えられた `Transaction.id` の集合に対し、各 id がどの
+   * `TransactionAnchor` に含まれているかを 1 クエリで lookup し、
+   * verify 状態 / Cardano tx hash / Merkle root / metadata label を返す。
+   *
+   * 入力件数は呼び元 (`TransactionVerificationUseCase`) で 100 件に
+   * cap 済。本実装でも追加の安全策として `Array.from(new Set(...))` で
+   * dedupe する。anchor に含まれない txId は `status="not_verified"`
+   * で `transactionHash` / `rootHash` を空文字、`label` を 1985 (CIP-10
+   * civicship label) で返す。
    */
-  private isValidVerifyResponse(item: unknown): item is VerifyResponse {
-    if (!item || typeof item !== "object") {
-      return false;
-    }
-
-    const response = item as Record<string, unknown>;
-    const validStatuses = ["verified", "not_verified", "pending", "error"];
-
-    return (
-      typeof response.txId === "string" &&
-      typeof response.status === "string" &&
-      validStatuses.includes(response.status) &&
-      typeof response.transactionHash === "string" &&
-      typeof response.rootHash === "string" &&
-      (typeof response.label === "number" || typeof response.label === "string")
-    );
-  }
-
   async verifyTransactions(txIds: string[]): Promise<VerifyResponse[]> {
-    const url = `${this.baseUrl}/point/verify`;
-    const requestBody: VerifyRequest = { txIds };
+    if (txIds.length === 0) return [];
 
-    logger.debug("[PointVerifyClient] Request", { url, body: requestBody });
+    const dedupedIds = Array.from(new Set(txIds));
 
-    try {
-      const response = await axios.post<VerifyResponse[]>(url, requestBody, {
-        headers: { "Content-Type": "application/json" },
-        timeout: 30000,
-      });
+    // GIN index を効かせる overlap 検索。Prisma `$queryRaw` の tagged
+    // template は parameter 化されるので injection safe。
+    const anchors = await prismaClient.$queryRaw<AnchorRow[]>`
+      SELECT id, leaf_ids, root_hash, chain_tx_hash, metadata_label, status, network
+      FROM t_transaction_anchors
+      WHERE leaf_ids && ${dedupedIds}::text[]
+    `;
 
-      const data = response.data;
-
-      // 配列であることを検証
-      if (!Array.isArray(data)) {
-        logger.error("[PointVerifyClient] Invalid response format: data is not an array", {
-          url,
-          status: response.status,
-          data,
-        });
-        throw new Error("PointVerifyClient: Invalid response format (data is not an array)");
-      }
-
-      // 各要素の必須フィールドを検証
-      for (const item of data) {
-        if (!this.isValidVerifyResponse(item)) {
-          logger.error("[PointVerifyClient] Invalid response item format", {
-            url,
-            status: response.status,
-            item,
-          });
-          throw new Error("PointVerifyClient: Invalid response item format");
+    // txId → 最良 anchor のマップ。同 txId が複数 anchor に乗ることは
+    // 設計上発生しない (`TransactionAnchor.leafIds` は履歴の正本) が、
+    // 異常データに備えて `CONFIRMED > SUBMITTED > PENDING > FAILED` の
+    // 優先度で最良の状態を採用する。
+    const anchorByTxId = new Map<string, AnchorRow>();
+    const priority: Record<AnchorStatus, number> = {
+      [AnchorStatus.CONFIRMED]: 3,
+      [AnchorStatus.SUBMITTED]: 2,
+      [AnchorStatus.PENDING]: 1,
+      [AnchorStatus.FAILED]: 0,
+    };
+    for (const a of anchors) {
+      for (const leaf of a.leaf_ids) {
+        if (!dedupedIds.includes(leaf)) continue;
+        const current = anchorByTxId.get(leaf);
+        if (!current || priority[a.status] > priority[current.status]) {
+          anchorByTxId.set(leaf, a);
         }
       }
-
-      logger.debug("[PointVerifyClient] Response", {
-        status: response.status,
-        count: data.length,
-      });
-
-      return data;
-    } catch (error: unknown) {
-      if (axios.isAxiosError(error)) {
-        logger.error("[PointVerifyClient] Axios Error", {
-          url,
-          status: error.response?.status,
-          response: error.response?.data,
-          message: error.message,
-        });
-      } else if (error instanceof Error) {
-        logger.error("[PointVerifyClient] Error", {
-          url,
-          message: error.message,
-        });
-      } else {
-        logger.error("[PointVerifyClient] Unknown Error", { error });
-      }
-
-      // エラーを抽象化してラップしつつ、元のエラーを cause として保持
-      throw new Error("Failed to communicate with the transaction verification service.", {
-        cause: error,
-      });
     }
+
+    logger.debug("[PointVerifyClient] local lookup", {
+      input: txIds.length,
+      deduped: dedupedIds.length,
+      anchors_hit: anchors.length,
+      matched_tx_ids: anchorByTxId.size,
+    });
+
+    // 入力順を保ったまま結果配列を組み立てる (呼出側が input-output の
+    // index 一致を期待しうるため)。
+    return txIds.map((txId) => {
+      const anchor = anchorByTxId.get(txId);
+      if (!anchor) {
+        return {
+          txId,
+          status: "not_verified" as const,
+          transactionHash: "",
+          rootHash: "",
+          label: 1985,
+        };
+      }
+      return {
+        txId,
+        status: mapAnchorStatus(anchor.status),
+        transactionHash: anchor.chain_tx_hash ?? "",
+        rootHash: anchor.root_hash,
+        label: anchor.metadata_label,
+      };
+    });
   }
 }

--- a/src/infrastructure/libs/point-verify/client.ts
+++ b/src/infrastructure/libs/point-verify/client.ts
@@ -84,7 +84,11 @@ export class PointVerifyClient {
   async verifyTransactions(txIds: string[]): Promise<VerifyResponse[]> {
     if (txIds.length === 0) return [];
 
-    const dedupedIds = Array.from(new Set(txIds));
+    // `requestedIds` は O(1) lookup 用 (anchor row × leaf 二重ループの
+    // 内側で利用するため、batch size × leaves_per_anchor の積で O(N²) に
+    // 跳ねないよう Set を使う)。
+    const requestedIds = new Set(txIds);
+    const dedupedIds = Array.from(requestedIds);
 
     // GIN index を効かせる overlap 検索。Prisma `$queryRaw` の tagged
     // template は parameter 化されるので injection safe。
@@ -107,7 +111,7 @@ export class PointVerifyClient {
     };
     for (const a of anchors) {
       for (const leaf of a.leaf_ids) {
-        if (!dedupedIds.includes(leaf)) continue;
+        if (!requestedIds.has(leaf)) continue;
         const current = anchorByTxId.get(leaf);
         if (!current || priority[a.status] > priority[current.status]) {
           anchorByTxId.set(leaf, a);


### PR DESCRIPTION
## Summary

設計書 [§1.3 成功基準 #1](../blob/epic/replace-identsu/docs/report/did-vc-internalization.md) の **最後のピース**。

> 「`/point/verify` が外部 HTTP 呼び出しゼロでローカル DB 参照のみで応答」

これまで `PointVerifyClient` は依然として `IDENTUS_API_URL/point/verify` に HTTP call して いた。内製化 epic で `t_transaction_anchors` が **Merkle root + leafIds + chain_tx_hash** の正本になり、外部呼び出し無しで verify 状態を返せる状態が揃ったため、client の中身を差し替える。

`docs/report/internalization-completion-2026-05.md` (#1171) の **致命残課題 1 件** がこの PR で消化される (→ 成功基準 6/7 → 7/7)。

## 変更内容

- `axios` + `IDENTUS_API_URL` の依存を撤去
- `prismaClient.$queryRaw` で `t_transaction_anchors.leaf_ids && ${ids}::text[]` の overlap 検索 (GIN index 経由)
  - PoC §0-5 spike PR #1091 で 17-27× 高速化を実測済の path
- `AnchorStatus` を `VerifyResponse.status` にマップ
  | DB status | API status |
  |---|---|
  | `CONFIRMED` | `verified` |
  | `SUBMITTED` | `pending` |
  | `PENDING` | `pending` |
  | `FAILED` | `error` |
  | anchor 不在 | `not_verified` |
- 入力 txId に対する **1 クエリの batch lookup**
- **入力順を保った** 結果配列 (caller の index 一致期待を維持)
- 異常データ (同 txId が複数 anchor に乗る) 対策として `CONFIRMED > SUBMITTED > PENDING > FAILED` 優先度で最良を採用

## 互換性

- **Class 名** `PointVerifyClient` 不変
- **Method** `verifyTransactions(txIds)` 不変
- **`VerifyResponse` shape** (`{ txId, status, transactionHash, rootHash, label }`) 不変
- DI 登録 (`provider.ts`) / 呼び出し側 (`TransactionVerificationService` / `TransactionVerificationPresenter`) は touch しない
- **GraphQL response shape (§1.3 成功基準 #7) 変更なし**

## 残置

`IDENTUS_API_URL` の最終撤去は `src/infrastructure/libs/did.ts` (旧 `DIDVCServerClient`、呼び出し元なし) も同時に消す **Phase 4 cleanup PR** で行う。本 PR では point-verify の外部依存だけを切る最小スコープ。

## Test plan

- [ ] PR CI green
- [ ] dev で GraphQL `userVerifyTransactions(txIds: [...])` mutation
  - **既に anchor 済の Transaction.id** (PR #1149 で 1 tx で anchor した `8165572e...` の leafIds) → `status: "verified"`、`transactionHash` / `rootHash` が埋まる
  - **存在しないがランダムな cuid** → `status: "not_verified"`、`transactionHash` / `rootHash` 空文字
- [ ] dev API のレスポンス時間が IDENTUS 経由時より短いことを log で確認

## 関連

- 親 doc: #1171 (completion report)
- 親 epic: `epic/replace-identsu`
- 設計書 §1.3 / §4.1 / §6.2

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_01NR9mGWrwj2CVsXqT2fGuoN)_