### PR TITLE
fix(deploy): grant caller `contents: read` for reusable workflow checkout

### DIFF
--- a/.github/workflows/deploy-to-cloud-run-dev.yml
+++ b/.github/workflows/deploy-to-cloud-run-dev.yml
@@ -21,10 +21,15 @@ permissions:
 
 jobs:
   deploy:
-    # 最小権限: reusable deploy job は WIF auth に必要な OIDC token のみ受け
-    # 取る。security-events:write は upload-sarif job に隔離。詳細は prd 側
+    # 最小権限: reusable deploy job は WIF auth に必要な OIDC token と、
+    # reusable workflow 内 `actions/checkout` 用の `contents: read` のみ受け
+    # 取る。caller の permissions が called workflow の envelope (上限) に
+    # なるため、`contents: read` を caller でも宣言しないと reusable 側の
+    # checkout が暗黙的に `none` にダウングレードされて失敗する。
+    # security-events:write は upload-sarif job に隔離。詳細は prd 側
     # (`deploy-to-cloud-run-prd.yml`) の同コメント参照。
     permissions:
+      contents: read
       id-token: write
     uses: ./.github/workflows/_deploy-cloud-run.yml
     with:

--- a/.github/workflows/deploy-to-cloud-run-prd.yml
+++ b/.github/workflows/deploy-to-cloud-run-prd.yml
@@ -117,11 +117,16 @@ jobs:
     needs: verify-ci
     if: github.event.pull_request.merged == true
     # 最小権限: deploy job (reusable workflow) は WIF auth に必要な OIDC token
-    # だけを受け取る。`security-events: write` (Trivy SARIF upload) と
-    # `contents: write` (git tag) は下流の専用 job (`upload-sarif`,
-    # `create-tag`) に隔離した — 各 job の攻撃面を最小化することで
-    # Scorecard Token-Permissions 0 点を解消する (PR #1164)。
+    # と、reusable workflow 内 `actions/checkout` 用の `contents: read` のみ
+    # 受け取る。caller の permissions が called workflow の envelope (上限)
+    # になるため、`contents: read` を caller でも宣言しないと reusable 側の
+    # checkout が暗黙的に `none` にダウングレードされて失敗する。
+    # `security-events: write` (Trivy SARIF upload) と `contents: write`
+    # (git tag) は下流の専用 job (`upload-sarif`, `create-tag`) に隔離した
+    # — 各 job の攻撃面を最小化することで Scorecard Token-Permissions 0 点
+    # を解消する (PR #1164)。
     permissions:
+      contents: read
       id-token: write
     uses: ./.github/workflows/_deploy-cloud-run.yml
     with:


### PR DESCRIPTION
## 背景

#1170 で deploy job の GITHUB_TOKEN 権限を最小化した際、caller の `permissions` 宣言と reusable workflow の `permissions` 宣言の相互作用を見落としていた。

## 問題

`deploy-to-cloud-run-{dev,prd}.yml` の `deploy` job が caller として渡す permissions が `id-token: write` のみ。

GitHub Actions では **caller が宣言した `permissions` が called workflow の envelope (上限) になり、called workflow 側は downgrade しかできない** ([docs](https://docs.github.com/en/actions/reference/reusable-workflows-reference))。caller で `permissions:` を明示した時点で未指定のキーは暗黙的に `none` になるため、reusable workflow `_deploy-cloud-run.yml` が `contents: read` を宣言しても `none` にダウングレードされ、`actions/checkout` が失敗する。

CodeRabbit も #1170 のレビューで同じ指摘をしている ([dev](https://github.com/Hopin-inc/civicship-api/pull/1170#discussion_r3264207755) / [prd](https://github.com/Hopin-inc/civicship-api/pull/1170#discussion_r3264207764))。

## 修正

dev/prd 両方の caller `deploy` job に `contents: read` を追加。`security-events: write` (Trivy SARIF) と `contents: write` (git tag) は引き続き下流の `upload-sarif` / `create-tag` job に隔離されたまま — 最小権限の方針は維持される。

```diff
   deploy:
     permissions:
+      contents: read
       id-token: write
     uses: ./.github/workflows/_deploy-cloud-run.yml
```

## Test plan

- [ ] develop マージ後、本 PR の変更が #1170 (develop→master) の diff に反映されることを確認
- [ ] master マージ後、prd デプロイで `actions/checkout` が成功すること
- [ ] dev workflow も同様に通ること
- [ ] Trivy SARIF が Security タブに publish されること (upload-sarif job)
- [ ] prd で git tag が打たれること (create-tag job)

ワークフロー変更は master マージ後にしか effective にならないため、コードレビューで正しさを担保する。


---
_Generated by [Claude Code](https://claude.ai/code/session_016gyT6Jxjj7QSWdVcArHtuX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CDワークフローのセキュリティ権限設定を強化しました。デプロイパイプラインにおいて、必要最小限の権限割り当てを実装し、セキュリティ体制を向上させました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hopin-inc/civicship-api/pull/1173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->