### PR TITLE
feat(presentation): serve /.well-known/security.txt

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { createApolloServer } from "@/presentation/graphql/server";
 import logger from "@/infrastructure/logging";
 import { authHandler } from "@/presentation/middleware/auth";
 import lineRouter from "@/presentation/router/line";
+import wellKnownRouter from "@/presentation/router/wellKnown";
 import { batchProcess } from "@/batch";
 import express from "express";
 import { corsHandler } from "@/presentation/middleware/cors";
@@ -75,6 +76,7 @@ async function startServer() {
     authHandler(apolloServer),
   );
   app.use("/line", lineRouter);
+  app.use("/.well-known", wellKnownRouter);
 
   app.get("/health", (req, res) => {
     res.status(200).json({ status: "healthy", service: "internal-api" });

--- a/src/presentation/router/wellKnown.ts
+++ b/src/presentation/router/wellKnown.ts
@@ -1,0 +1,15 @@
+import express from "express";
+
+const router = express();
+
+router.get("/security.txt", (_req, res) => {
+  res.type("text/plain");
+  res.send(
+    `Contact: mailto:info@hopin.co.jp
+Expires: 2027-01-01T00:00:00.000Z
+Preferred-Languages: ja, en
+`,
+  );
+});
+
+export default router;

--- a/src/presentation/router/wellKnown.ts
+++ b/src/presentation/router/wellKnown.ts
@@ -1,6 +1,6 @@
 import express from "express";
 
-const router = express();
+const router = express.Router();
 
 router.get("/security.txt", (_req, res) => {
   res.type("text/plain");


### PR DESCRIPTION
## Summary
- Adds a new Express sub-router at `src/presentation/router/wellKnown.ts` that responds to `GET /.well-known/security.txt` with an RFC 9116–compliant plain-text body (Contact, Expires, Preferred-Languages).
- Mounts the router at `/.well-known` in `src/index.ts` so vulnerability reporters can discover the security contact.

## Test plan
- [ ] `pnpm dev` then `curl -i http://localhost:3000/.well-known/security.txt` returns `200`, `Content-Type: text/plain`, and the expected body.
- [ ] Verify no other `/.well-known/*` paths leak unexpected responses (404 from Express default).

https://claude.ai/code/session_01HuLqbiDVGGNVYbEBL4azmo

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuLqbiDVGGNVYbEBL4azmo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * `.well-known/security.txt` エンドポイントを追加しました。セキュリティ連絡先、対応期限、優先言語をプレーンテキストで取得できます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hopin-inc/civicship-api/pull/1174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->