### PR TITLE
fix: address PR #1178 review feedback (userDid + deps)

### DIFF
--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -1125,6 +1125,7 @@ CARDANO_PREPROD CARDANO_PREPROD
     DateTime submitted_at "❓"
     DateTime confirmed_at "❓"
     String batch_id "❓"
+    String last_error "❓"
     Int version 
     String user_id 
     DateTime created_at 

--- a/docs/schema.dbml
+++ b/docs/schema.dbml
@@ -964,6 +964,7 @@ Table t_user_did_anchors {
   submittedAt DateTime
   confirmedAt DateTime
   batchId String
+  lastError String
   version Int [not null, default: 0]
   userId String [not null]
   user t_users [not null]

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
       "ajv": "^6.12.6",
       "axios": ">=1.15.2",
       "bn.js": ">=4.12.3",
+      "brace-expansion": ">=5.0.6",
       "diff": ">=4.0.4",
       "fast-xml-parser": "^4.5.4",
       "follow-redirects": "^1.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   ajv: ^6.12.6
   axios: '>=1.15.2'
   bn.js: '>=4.12.3'
+  brace-expansion: '>=5.0.6'
   diff: '>=4.0.4'
   fast-xml-parser: ^4.5.4
   follow-redirects: ^1.16.0
@@ -4216,8 +4217,8 @@ packages:
     resolution: {integrity: sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==}
     engines: {node: '>=14.16'}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -14447,7 +14448,7 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -17532,11 +17533,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@9.0.6:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimist@1.2.8: {}
 

--- a/scripts/backfill-user-did.ts
+++ b/scripts/backfill-user-did.ts
@@ -84,13 +84,10 @@ import {
   metadataByteSize,
   MAX_METADATA_TX_BYTES,
 } from "@/infrastructure/libs/cardano/txBuilder";
-import {
-  buildMinimalDidDocument,
-  buildUserDid,
-} from "@/infrastructure/libs/did/userDidBuilder";
+import { buildMinimalDidDocument, buildUserDid } from "@/infrastructure/libs/did/userDidBuilder";
 import { deriveCardanoKeypair } from "@/infrastructure/libs/cardano/keygen";
 
-import { parseFixedLengthHex, runStep } from "./lib/cardanoScriptHelpers.ts";
+import { bytesToHex, parseFixedLengthHex, runStep } from "./lib/cardanoScriptHelpers.ts";
 
 const DEFAULT_CHUNK_SIZE = 80;
 const DEFAULT_INTER_TX_SLEEP_MS = 5 * 60 * 1000;
@@ -163,9 +160,7 @@ function encodeAndHashUserDoc(userId: string): { cbor: Uint8Array; hashHex: stri
   const raw = cborEncode(doc);
   const cbor = raw instanceof Uint8Array ? raw : new Uint8Array(raw);
   const hash = blake2b(cbor, { dkLen: 32 });
-  let s = "";
-  for (const b of hash) s += b.toString(16).padStart(2, "0");
-  return { cbor, hashHex: s };
+  return { cbor, hashHex: bytesToHex(hash) };
 }
 
 function sleep(ms: number): Promise<void> {
@@ -191,7 +186,10 @@ async function findUsersWithoutInternal(limit?: number): Promise<{ id: string }[
   });
 }
 
-async function fetchCurrentSlot(projectId: string, network: "preprod" | "mainnet"): Promise<number> {
+async function fetchCurrentSlot(
+  projectId: string,
+  network: "preprod" | "mainnet",
+): Promise<number> {
   const api = new BlockFrostAPI({ projectId, network });
   const latest = (await api.blocksLatest()) as { slot?: number | null };
   if (typeof latest?.slot !== "number") {
@@ -332,13 +330,12 @@ async function main(): Promise<number> {
   let chunkIdx = 0;
   let confirmedTotal = 0;
   let failedTotal = 0;
-  let bailOut = false;
 
   // Drain PENDING anchors one chunk at a time. The outer loop terminates
   // when `findPendingAnchors` returns an empty array (all CONFIRMED) or
-  // when a chunk fails (set `bailOut=true`; operator must reset FAILED rows
-  // back to PENDING before re-running).
-  while (!bailOut) {
+  // when a chunk fails (the failure path `break`s out; operator must reset
+  // FAILED rows back to PENDING before re-running).
+  while (true) {
     const chunk = await findPendingAnchors(flags.chunkSize);
     if (chunk.length === 0) break;
     chunkIdx += 1;
@@ -382,7 +379,6 @@ async function main(): Promise<number> {
         `chunk ${chunkIdx} metadata ${size}B exceeds 16KB ceiling; lower --chunk-size and retry\n`,
       );
       await markChunkFailed(chunk, `metadata oversize (${size}B)`);
-      failedTotal += chunk.length;
       return 1;
     }
 
@@ -436,7 +432,6 @@ async function main(): Promise<number> {
       // Bail out — re-running picks up the FAILED rows once the operator
       // resets them to PENDING (manual). Continuing would keep burning
       // ADA on the same broken state.
-      bailOut = true;
       break;
     }
     confirmedTotal += chunk.length;
@@ -453,15 +448,13 @@ async function main(): Promise<number> {
   return failedTotal === 0 ? 0 : 1;
 }
 
-async function markChunkFailed(
-  rows: ReadonlyArray<{ id: string }>,
-  reason: string,
-): Promise<void> {
+async function markChunkFailed(rows: ReadonlyArray<{ id: string }>, reason: string): Promise<void> {
   await prismaClient.userDidAnchor
     .updateMany({
       where: { id: { in: rows.map((r) => r.id) } },
       data: {
         status: AnchorStatus.FAILED,
+        lastError: reason,
       },
     })
     .catch(() => {

--- a/src/__tests__/unit/infrastructure/libs/did/didDocumentResolver.test.ts
+++ b/src/__tests__/unit/infrastructure/libs/did/didDocumentResolver.test.ts
@@ -56,6 +56,7 @@ function buildAnchor(overrides: Partial<UserDidAnchorRow> = {}): UserDidAnchorRo
     submittedAt: null,
     confirmedAt: new Date("2026-01-15T12:00:00.000Z"),
     batchId: null,
+    lastError: null,
     version: 0,
     userId: "u_alice",
     createdAt: new Date("2026-01-15T11:50:00.000Z"),

--- a/src/application/domain/account/userDid/data/interface.ts
+++ b/src/application/domain/account/userDid/data/interface.ts
@@ -37,6 +37,18 @@ export interface IUserDidAnchorRepository extends UserDidAnchorStore {
    */
   findLatestByUserId(userId: string): Promise<UserDidAnchorRow | null>;
 
+  /**
+   * Return the CREATE-op anchor for `userId` if one exists, else `null`.
+   * `UserDidService.createDidForUser` uses this to stay idempotent — a
+   * user has exactly one did:web (§5.2.1), so a second CREATE op must
+   * never be enqueued (double-submit / client-retry guard).
+   */
+  findCreateByUserId(
+    ctx: IContext,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<UserDidAnchorRow | null>;
+
   createCreate(
     ctx: IContext,
     input: CreateUserDidAnchorInput,

--- a/src/application/domain/account/userDid/data/repository.ts
+++ b/src/application/domain/account/userDid/data/repository.ts
@@ -25,8 +25,6 @@
  *   docs/report/did-vc-internalization.md §5.1.4 (DidDocumentResolver storage)
  */
 
-// TODO(perf): consider @@index([userId, createdAt(sort: Desc)]) on UserDidAnchor (Phase 1.5)
-
 import { inject, injectable } from "tsyringe";
 import { DidOperation, Prisma } from "@prisma/client";
 import { IContext } from "@/types/server";
@@ -61,6 +59,25 @@ export default class UserDidAnchorRepository implements IUserDidAnchorRepository
         where: { userId },
         orderBy: { createdAt: "desc" },
       }),
+    );
+  }
+
+  /**
+   * Return the CREATE-op anchor for `userId` if one exists, else `null`.
+   * `tx`-aware so `UserDidService.createDidForUser` runs the idempotency
+   * check inside its own write transaction.
+   */
+  async findCreateByUserId(
+    ctx: IContext,
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<UserDidAnchorRow | null> {
+    const where = { userId, operation: DidOperation.CREATE };
+    if (tx) {
+      return tx.userDidAnchor.findFirst({ where, orderBy: { createdAt: "asc" } });
+    }
+    return this.issuer.public(ctx, (innerTx) =>
+      innerTx.userDidAnchor.findFirst({ where, orderBy: { createdAt: "asc" } }),
     );
   }
 

--- a/src/application/domain/account/userDid/service.ts
+++ b/src/application/domain/account/userDid/service.ts
@@ -96,6 +96,9 @@ export default class UserDidService {
   /**
    * §5.2.1: enqueue a CREATE-op `UserDidAnchor` for `userId`.
    *
+   * Idempotent: if a CREATE anchor already exists for `userId` the
+   * existing row is returned unchanged (a user has exactly one did:web).
+   *
    * Returns the persisted row so the caller (UseCase) can pass it through
    * its presenter. The row is PENDING — it becomes SUBMITTED / CONFIRMED
    * later via the weekly anchor batch.
@@ -110,6 +113,18 @@ export default class UserDidService {
     tx?: Prisma.TransactionClient,
     network: AnchorNetworkValue = DEFAULT_NETWORK,
   ): Promise<UserDidAnchorRow> {
+    // Idempotency (§5.2.1): a user has exactly one did:web. If a CREATE
+    // anchor already exists, return it instead of enqueueing a duplicate
+    // — guards `createUserDid` against double-submit / client retries.
+    const existing = await this.repository.findCreateByUserId(ctx, userId, tx);
+    if (existing) {
+      logger.debug("[UserDidService] createDidForUser: CREATE anchor exists; returning existing", {
+        userId,
+        anchorId: existing.id,
+      });
+      return existing;
+    }
+
     const did = buildUserDid(userId);
     const document = buildMinimalDidDocument(userId);
     const { cbor, hashHex } = encodeAndHash(document);

--- a/src/application/domain/anchor/anchorBatch/data/repository.ts
+++ b/src/application/domain/anchor/anchorBatch/data/repository.ts
@@ -248,8 +248,7 @@ export default class AnchorBatchRepository implements IAnchorBatchRepository {
     await this.applyToAllAnchors(ctx, args, {
       txData: { status: AnchorStatus.FAILED, lastError: args.failureReason },
       vcData: { status: AnchorStatus.FAILED, lastError: args.failureReason },
-      // userDidAnchor has no lastError column.
-      didData: { status: AnchorStatus.FAILED },
+      didData: { status: AnchorStatus.FAILED, lastError: args.failureReason },
     });
   }
 
@@ -258,7 +257,7 @@ export default class AnchorBatchRepository implements IAnchorBatchRepository {
    * `issuer.internal` transaction. Empty id lists short-circuit to
    * `Promise.resolve()` so we never issue a no-op `updateMany` (and the
    * per-table `data` shape stays explicit for the few schema columns
-   * that diverge — e.g. `userDidAnchor` has no `blockHeight` / `lastError`).
+   * that diverge — e.g. `userDidAnchor` has no `blockHeight` column).
    */
   private async applyToAllAnchors(
     ctx: IContext,

--- a/src/infrastructure/prisma/factories/__generated__/index.ts
+++ b/src/infrastructure/prisma/factories/__generated__/index.ts
@@ -10530,6 +10530,7 @@ type UserDidAnchorFactoryDefineInput = {
     submittedAt?: Date | null;
     confirmedAt?: Date | null;
     batchId?: string | null;
+    lastError?: string | null;
     version?: number;
     createdAt?: Date;
     updatedAt?: Date | null;

--- a/src/infrastructure/prisma/migrations/20260520022914_add_user_did_anchor_last_error/migration.sql
+++ b/src/infrastructure/prisma/migrations/20260520022914_add_user_did_anchor_last_error/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "t_user_did_anchors" ADD COLUMN     "last_error" TEXT;

--- a/src/infrastructure/prisma/schema.prisma
+++ b/src/infrastructure/prisma/schema.prisma
@@ -2199,6 +2199,10 @@ model UserDidAnchor {
   // §5.3.1 idempotency 対応
   batchId String? @map("batch_id")
 
+  // anchor batch / backfill が FAILED 遷移時に失敗理由を残す運用監視用カラム
+  // (TransactionAnchor / VcAnchor の last_error と揃える)
+  lastError String? @map("last_error") @db.Text
+
   // §H 楽観的ロック（@updatedAt は CAS 不可なので明示 version 列）
   version Int @default(0)
 


### PR DESCRIPTION
## Summary

epic landing PR #1178 に寄せられた bot review コメント（github-code-quality / gemini-code-assist）と Snyk 指摘へのフォローアップ。epic 本体は sub-PR で個別レビュー済みのため #1178 には混ぜず、本 PR にまとめた（`epic/replace-identsu` 宛）。

## 変更内容

### nit 修正 — `scripts/backfill-user-did.ts`
- 冗長な `bailOut` フラグを撤去。`while (!bailOut)` は常に true 評価、`bailOut = true` は直後の `break` で無意味だったため `while (true)` + `break` に統一。
- `return 1` 直前の無意味な `failedTotal += chunk.length` を削除（eslint `no-useless-assignment`）。
- 手書き hex 変換ループを `cardanoScriptHelpers.bytesToHex` ヘルパーに置換（import 追加 + `encodeAndHashUserDoc`）。

### `last_error` カラム追加 — `UserDidAnchor`
- `UserDidAnchor` に `lastError String? @db.Text` を追加（`TransactionAnchor` / `VcAnchor` と揃える）。migration `20260520022914_add_user_did_anchor_last_error`。
- **失敗パス配線**: anchor batch の `markFailed`（`didData` に `lastError` を書き込み）と `backfill-user-did.ts` の `markChunkFailed`（`lastError: reason`）で FAILED 遷移時に失敗理由を残すようにした。これまで列が無く理由が捨てられていた（script header コメント L43 の記述と実装の乖離も解消）。

### `createUserDidForUser` 冪等化
- `UserDidService.createDidForUser` を冪等化: 既に CREATE-op anchor が存在する場合は新規 enqueue せず既存行を返す。`createUserDid` mutation の二重送信 / クライアントリトライで CREATE op が重複するのを防ぐ。
- `findCreateByUserId`（tx 対応）を repository / interface に追加し、サービスの書き込み transaction 内で存在チェックする。

### 複合 index
- Gemini 指摘の `(userId, createdAt)` 複合 index は `schema.prisma` に既に存在（`@@index([userId, createdAt(sort: Desc)])`、Phase 1.5 perf #1104）。`repository.ts` の stale な TODO コメントのみ削除。

### 依存: `brace-expansion` CVE
- `brace-expansion` を pnpm override で `>=5.0.6` に固定（CVE-2026-45149 / CVSS 8.7、`@blockfrost/blockfrost-js` 経由）。dependabot #792 は 5.0.5 止まりで本 CVE に未対応。

## 検証

- `pnpm tsc --noEmit` exit 0
- eslint / prettier クリーン（変更ファイル）
- migration はローカル Postgres に適用確認済（`ADD COLUMN "last_error" TEXT` のみ、nullable で安全）

## Test plan

- [ ] `createUserDid` mutation を同一ユーザーで2回呼び、2回目が既存 anchor を返す（CREATE 行が増えない）
- [ ] anchor batch / backfill の FAILED 遷移で `t_user_did_anchors.last_error` に理由が入る
- [ ] `pnpm db:deploy` で migration が cleanly applied
- [ ] Snyk が brace-expansion CVE を解消と判定

https://claude.ai/code/session_018iAncVNcxmEnH2eZ5wTnhv

---
_Generated by [Claude Code](https://claude.ai/code/session_018iAncVNcxmEnH2eZ5wTnhv)_