### PR TITLE
fix(ci): scope CT log check to recently-issued certs

### DIFF
--- a/.github/workflows/ct-log-check.yml
+++ b/.github/workflows/ct-log-check.yml
@@ -48,9 +48,16 @@ jobs:
           disable-sudo: true
 
       # crt.sh の Certificate Transparency 検索 API (output=json) で
-      # civicship.app 関連の全証明書の issuer を取得し、Google Trust Services
-      # 以外が混ざっていないか確認する。想定外 CA を 1 つでも検出したら step を
-      # fail させ、GitHub annotation と (後続 step で) Slack に通知する。
+      # civicship.app 関連の証明書を取得し、Google Trust Services 以外の CA が
+      # 混ざっていないか確認する。想定外 CA を 1 つでも検出したら step を fail
+      # させ、GitHub annotation と (後続 step で) Slack に通知する。
+      #
+      # crt.sh は過去の全証明書 (期限切れ含む) を返すため、CAA を pki.goog に
+      # ロックする前の歴史的証明書をそのまま見ると恒久的に誤検知する
+      # (civicship.app は Cloudflare proxied で、旧構成では Cloudflare Universal
+      #  SSL が Cloudflare CA / Sectigo 経由の edge 証明書を発行していた)。
+      # 直近 WINDOW_DAYS 日以内に発行 (not_before) された証明書だけを対象とする
+      # rolling window 方式とし、月次 cron に対し十分なオーバーラップを取る。
       #
       # crt.sh は不安定なため --retry で一時的な 5xx / 接続断を吸収する。
       # python3 の出力は `result=$(...)` で受けず直接パイプに流す: set -e 環境
@@ -63,15 +70,32 @@ jobs:
             "https://crt.sh/?q=civicship.app&output=json" \
             | python3 -c "
           import json, sys
-          data = json.load(sys.stdin)
-          issuers = {cert.get('issuer_name', '') for cert in data}
+          from datetime import datetime, timedelta, timezone
+
+          # 月次 cron に対し 2x のオーバーラップ。run が 1 回飛んでも取りこぼさない。
+          WINDOW_DAYS = 60
+          cutoff = datetime.now(timezone.utc) - timedelta(days=WINDOW_DAYS)
           allowed = ['Google Trust Services']
-          unexpected = sorted(i for i in issuers if not any(a in i for a in allowed))
+
+          def not_before(cert):
+              raw = (cert.get('not_before') or '').strip()
+              if not raw:
+                  return None
+              try:
+                  dt = datetime.fromisoformat(raw)
+              except ValueError:
+                  return None
+              return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+          data = json.load(sys.stdin)
+          recent = [c for c in data if (nb := not_before(c)) and nb >= cutoff]
+          issuers = {c.get('issuer_name', '') for c in recent}
+          unexpected = sorted(i for i in issuers if i and not any(a in i for a in allowed))
           if unexpected:
               for u in unexpected:
-                  print(f'::error::想定外の CA を検出: {u}')
+                  print(f'::error::想定外の CA を検出 (直近 {WINDOW_DAYS} 日以内に発行): {u}')
               sys.exit(1)
-          print(f'OK: 全 {len(issuers)} issuer が Google Trust Services から発行されています')
+          print(f'OK: 直近 {WINDOW_DAYS} 日以内発行の証明書 {len(recent)} 件 / {len(issuers)} issuer はすべて Google Trust Services')
           "
 
       # check 失敗 (想定外 CA 検出 or crt.sh 取得失敗) のときだけ Slack に投げる。


### PR DESCRIPTION
## Summary

`ct-log-check.yml`（CT log 監視ワークフロー）の初回手動実行が **歴史的証明書による誤検知で fail** したため、`not_before` の rolling window フィルタを追加する。

## 背景

ワークフローを手動実行したところ、以下3つの非 Google Trust Services issuer を検出して fail した:

- `CLOUDFLARE, INC.` — Cloudflare TLS Issuing RSA CA 1
- `CLOUDFLARE, INC.` — Cloudflare TLS Issuing ECC CA 1
- `Sectigo Limited` — Sectigo Public Server Authentication CA DV E36

crt.sh の実データで全証明書の発行日を確認した結果:

- **Cloudflare 証明書（5件）**: `not_before` 2025-04〜2025-08、**全て期限切れ**（最新の `not_after` でも 2025-11-22）
- **Sectigo 証明書（6件）**: 最新でも `not_before` 2026-02-27（`not_after` 2026-05-28）、残りは期限切れ
- **2026-02-27 以降に発行された非 GTS 証明書は 0 件** — それ以降は全て Google Trust Services

これらは civicship.app が Cloudflare proxied であることに由来する旧 **Cloudflare Universal SSL の edge 証明書**で、CAA を `pki.goog` にロックする前は Cloudflare CA / Sectigo 経由で発行されていたもの。**現行のセキュリティ問題ではない。**

crt.sh は過去の全証明書（期限切れ含む）を返すため、日付フィルタが無いと歴史的証明書を**恒久的に誤検知**し続ける（PR #1176 でワークフロー追加時にフラグした既知の制約）。

## 変更

`Check CT logs for civicship.app` ステップの判定ロジックを変更:

- **直近 `WINDOW_DAYS`（=60）日以内に発行（`not_before`）された証明書だけ**を対象に
- CAA ロック日のハードコードではなく **rolling window 方式** — 月次 cron に対し 2x のオーバーラップがあり、run が1回飛んでも取りこぼさず、歴史的証明書は窓から自然に外れる。日付メンテ不要で自己完結
- 新規の不正発行は引き続き確実に検出（次回 cron 以内 = 30日 << 60日窓）

## 検証

- `python3` で YAML 構文 OK
- ロジックを synthetic データでテスト:
  - 歴史的 Cloudflare/Sectigo + 直近 GTS → 歴史的分を除外し **OK / exit 0** ✓
  - 直近の非 GTS 証明書 → **`::error::` + exit 1** ✓

https://claude.ai/code/session_018iAncVNcxmEnH2eZ5wTnhv

---
_Generated by [Claude Code](https://claude.ai/code/session_018iAncVNcxmEnH2eZ5wTnhv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * CT証明書チェックワークフローを最適化し、直近60日以内に発行された証明書を対象に検証するように変更
  * エラーメッセージと検証結果のメッセージをより正確な情報に更新
  * タイムゾーン処理の一貫性を向上

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hopin-inc/civicship-api/pull/1183?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->