### PR TITLE
fix(ci): harden CT log check against crt.sh flakiness

### DIFF
--- a/.github/workflows/ct-log-check.yml
+++ b/.github/workflows/ct-log-check.yml
@@ -35,7 +35,7 @@ concurrency:
 jobs:
   check-ct-logs:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     permissions:
       contents: read
 
@@ -59,16 +59,37 @@ jobs:
       # 直近 WINDOW_DAYS 日以内に発行 (not_before) された証明書だけを対象とする
       # rolling window 方式とし、月次 cron に対し十分なオーバーラップを取る。
       #
-      # crt.sh は不安定なため --retry で一時的な 5xx / 接続断を吸収する。
-      # python3 の出力は `result=$(...)` で受けず直接パイプに流す: set -e 環境
-      # では代入が fail した時点で停止し echo 前に抜けるため、`result=$(...)`
-      # だと検出した CA 名がログに残らない。
+      # crt.sh は過負荷時に HTTP 200 のまま空ボディ / HTML を返すことがあり、
+      # curl の --retry は status が成功なら弾けない。有効な JSON が取れるまで
+      # bash 側でリトライし、全試行が失敗したら crt.sh のインフラ不調
+      # (セキュリティ事象ではない) として `::warning::` 止まりにする — job は
+      # 緑のまま、Slack も鳴らさない。月次なので次回 cron で再試行される。
       - name: Check CT logs for civicship.app
         run: |
-          set -euo pipefail
-          curl -sS --max-time 60 --retry 3 --retry-delay 15 --retry-all-errors \
-            "https://crt.sh/?q=civicship.app&output=json" \
-            | python3 -c "
+          set -uo pipefail
+
+          # 有効な JSON が取れるまでリトライ。空 200 / HTML 応答も失敗扱い。
+          attempts=5
+          body=""
+          for i in $(seq 1 "$attempts"); do
+            resp=$(curl -sS --max-time 45 "https://crt.sh/?q=civicship.app&output=json" || true)
+            if printf '%s' "$resp" | python3 -c "import json,sys; json.load(sys.stdin)" >/dev/null 2>&1; then
+              body="$resp"
+              echo "crt.sh: 有効な JSON を取得 (試行 ${i}/${attempts})"
+              break
+            fi
+            echo "crt.sh: 非 JSON 応答 (試行 ${i}/${attempts})"
+            [ "$i" -lt "$attempts" ] && sleep 20
+          done
+
+          if [ -z "$body" ]; then
+            # crt.sh のインフラ不調。セキュリティ事象ではないので job は赤に
+            # せず warning 止まりにする (月次なので次回 cron で再試行される)。
+            echo "::warning::crt.sh が有効な JSON を返しませんでした (${attempts} 回試行)。今回の CT log チェックはスキップします。"
+            exit 0
+          fi
+
+          printf '%s' "$body" | python3 -c "
           import json, sys
           from datetime import datetime, timedelta, timezone
 
@@ -98,7 +119,8 @@ jobs:
           print(f'OK: 直近 {WINDOW_DAYS} 日以内発行の証明書 {len(recent)} 件 / {len(issuers)} issuer はすべて Google Trust Services')
           "
 
-      # check 失敗 (想定外 CA 検出 or crt.sh 取得失敗) のときだけ Slack に投げる。
+      # 想定外の CA を検出して step が fail したときだけ Slack に投げる
+      # (crt.sh 取得失敗は前 step が warning + exit 0 で吸収するため鳴らない)。
       # SLACK_WEBHOOK_INFRA secret 未登録の repo でも step が無声に skip する
       # ように `if` で webhook の有無を確認する。tls-dns-posture.yml と同じ
       # secret / 同じ通知パターン。
@@ -117,7 +139,7 @@ jobs:
             exit 0
           fi
           payload=$(cat <<EOF
-          {"text":":rotating_light: civicship.app CT log check failed — 想定外の CA 発行 もしくは crt.sh 取得失敗。see ${RUN_URL}"}
+          {"text":":rotating_light: civicship.app CT log check failed — 想定外の CA を検出。see ${RUN_URL}"}
           EOF
           )
           curl -sS -X POST "$SLACK_WEBHOOK_INFRA" \


### PR DESCRIPTION
## Summary

`ct-log-check.yml` の手動実行が **crt.sh の不安定さ**で fail したため、crt.sh flakiness に耐性を持たせる。

## 背景

CT log ワークフローを再実行したところ、`Check CT logs` ステップが以下で fail:

```
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

crt.sh は過負荷時に **HTTP 200 のまま空ボディ / HTML を返す**ことがある。`curl --retry` は HTTP status が成功なら（ボディが空でも）リトライしないため、空応答がそのまま `python3 json.load` に渡って例外 → exit 1 → ジョブ赤 → **crt.sh のインフラ不調なのに「想定外の CA 発行」扱いの Slack アラートが飛ぶ**状態だった。

これは CA 検出（セキュリティ事象）ではなく、crt.sh 側のインフラ不調。

## 変更

`Check CT logs for civicship.app` ステップ:

- **有効な JSON が取れるまで bash 側でリトライ**（最大5回）。空 200 / HTML 応答も「失敗」として扱う（`curl --retry` では弾けないため）。
- 全試行が失敗した場合は crt.sh のインフラ不調として **`::warning::` + `exit 0`** — ジョブは緑のまま、Slack も鳴らさない。月次 cron なので次回再試行される。
- **「想定外の CA を検出」は従来どおり `::error::` + exit 1 + Slack 通知**。インフラ不調と本物のセキュリティ検出を明確に分離。
- リトライ余地のため job timeout を 5 → 10 分に拡大。

### 設計判断

crt.sh 不調時を「赤 + Slack」ではなく「緑 + warning」にしたのは、月次のセキュリティ監視で外部依存（crt.sh）の不調ごとに偽アラートを出すとアラート疲れを招くため。`::warning::` は Actions UI に残るので無声ではない。「crt.sh 不調も赤にしたい」方針であれば変更可能です。

## 検証

- `python3` で YAML 構文 OK
- リトライループを mock でテスト:
  - crt.sh down（空応答）→ リトライ後 `::warning::` + exit 0（ジョブ緑）✓
  - 有効 JSON → 即 break して CA チェックへ ✓
- CA 判定ロジック自体は #1183 から不変

https://claude.ai/code/session_018iAncVNcxmEnH2eZ5wTnhv

---
_Generated by [Claude Code](https://claude.ai/code/session_018iAncVNcxmEnH2eZ5wTnhv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * CT log 監視プロセスの信頼性を向上。インフラの一時的な問題によるの誤検知を削減し、リトライメカニズムを追加。
  * セキュリティ関連の通知を精密化。重大な問題検出時のみアラートを発火するよう改善。
  * 監視タイムアウト時間を延長し、安定性を強化。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hopin-inc/civicship-api/pull/1184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->