### PR TITLE
fix(cardano): wire network to CARDANO_NETWORK for mainnet readiness

### DIFF
--- a/src/__tests__/unit/application/domain/account/userDid/service.test.ts
+++ b/src/__tests__/unit/application/domain/account/userDid/service.test.ts
@@ -59,8 +59,8 @@ describe("UserDidService", () => {
       expect(txArg).toBeUndefined();
       expect(input.userId).toBe(VALID_USER_ID);
       expect(input.did).toBe(buildUserDid(VALID_USER_ID));
-      // Default network falls back to mainnet per §4.1.
-      expect(input.network).toBe("CARDANO_MAINNET");
+      // DEFAULT_NETWORK は CARDANO_NETWORK 由来。テストでは env 未設定 → preprod。
+      expect(input.network).toBe("CARDANO_PREPROD");
 
       // documentHash is 64 hex chars (32 bytes) of Blake2b-256 over the
       // CBOR-encoded minimal Document.

--- a/src/__tests__/unit/application/domain/account/userDid/service.test.ts
+++ b/src/__tests__/unit/application/domain/account/userDid/service.test.ts
@@ -22,6 +22,9 @@ import {
 const VALID_USER_ID = "u_xyz_phase1";
 const SAMPLE_NETWORK = "CARDANO_PREPROD" as const;
 
+// Captured before any test mutates process.env; restored in afterAll.
+const ORIGINAL_CARDANO_NETWORK = process.env.CARDANO_NETWORK;
+
 class MockUserDidAnchorRepository {
   findLatestByUserId = jest.fn().mockResolvedValue(null);
   findCreateByUserId = jest.fn().mockResolvedValue(null);
@@ -39,11 +42,24 @@ describe("UserDidService", () => {
     jest.clearAllMocks();
     container.reset();
 
+    // `defaultNetwork()` reads CARDANO_NETWORK at call time and process.env
+    // is shared across the test process — unset it so the default-network
+    // assertions below are deterministic regardless of the CI environment.
+    delete process.env.CARDANO_NETWORK;
+
     mockRepository = new MockUserDidAnchorRepository();
     container.register("UserDidAnchorRepository", { useValue: mockRepository });
     container.register("UserDidService", { useClass: UserDidService });
 
     service = container.resolve(UserDidService);
+  });
+
+  afterAll(() => {
+    if (ORIGINAL_CARDANO_NETWORK === undefined) {
+      delete process.env.CARDANO_NETWORK;
+    } else {
+      process.env.CARDANO_NETWORK = ORIGINAL_CARDANO_NETWORK;
+    }
   });
 
   describe("createDidForUser", () => {
@@ -74,6 +90,16 @@ describe("UserDidService", () => {
       // Hash matches manually-computed Blake2b-256 of the same bytes.
       const recomputed = bytesToHex(blake2b(input.documentCbor as Uint8Array, { dkLen: 32 }));
       expect(input.documentHash).toBe(recomputed);
+    });
+
+    it("defaults the anchor network to CARDANO_MAINNET when CARDANO_NETWORK=mainnet", async () => {
+      process.env.CARDANO_NETWORK = "mainnet";
+      mockRepository.createCreate.mockResolvedValue({ ok: true });
+
+      await service.createDidForUser(mockCtx, VALID_USER_ID);
+
+      const [, input] = mockRepository.createCreate.mock.calls[0];
+      expect(input.network).toBe("CARDANO_MAINNET");
     });
 
     it("forwards the supplied tx to the repository", async () => {

--- a/src/application/domain/account/userDid/service.ts
+++ b/src/application/domain/account/userDid/service.ts
@@ -52,12 +52,15 @@ import {
 const DOCUMENT_HASH_BYTES = 32;
 
 /**
- * Default chain network for new anchors. The design only ships
- * `CARDANO_MAINNET` and `CARDANO_PREPROD` (§4.1 ChainNetwork) — production
- * defaults to mainnet, callers in dev / preview environments must pass
- * `CARDANO_PREPROD` explicitly.
+ * Default chain network for new anchors, derived from the `CARDANO_NETWORK`
+ * environment variable (§4.1 ChainNetwork). Anything other than `mainnet`
+ * — including an unset env — resolves to `CARDANO_PREPROD`, so dev / preview
+ * deployments never mislabel anchors as mainnet and mainnet is never assumed
+ * implicitly. Mirrors the `CARDANO_NETWORK` handling in the Blockfrost DI
+ * factory and `resolvePlatformSignerConfig`.
  */
-const DEFAULT_NETWORK: AnchorNetworkValue = "CARDANO_MAINNET";
+const DEFAULT_NETWORK: AnchorNetworkValue =
+  process.env.CARDANO_NETWORK === "mainnet" ? "CARDANO_MAINNET" : "CARDANO_PREPROD";
 
 /**
  * CBOR-encode a DID Document and return both the bytes and the

--- a/src/application/domain/account/userDid/service.ts
+++ b/src/application/domain/account/userDid/service.ts
@@ -52,15 +52,19 @@ import {
 const DOCUMENT_HASH_BYTES = 32;
 
 /**
- * Default chain network for new anchors, derived from the `CARDANO_NETWORK`
- * environment variable (§4.1 ChainNetwork). Anything other than `mainnet`
- * — including an unset env — resolves to `CARDANO_PREPROD`, so dev / preview
- * deployments never mislabel anchors as mainnet and mainnet is never assumed
- * implicitly. Mirrors the `CARDANO_NETWORK` handling in the Blockfrost DI
- * factory and `resolvePlatformSignerConfig`.
+ * Resolve the default chain network for new anchors from the
+ * `CARDANO_NETWORK` environment variable (§4.1 ChainNetwork). Anything
+ * other than `mainnet` — including an unset env — resolves to
+ * `CARDANO_PREPROD`, so dev / preview deployments never mislabel anchors as
+ * mainnet and mainnet is never assumed implicitly.
+ *
+ * Evaluated on each call (not memoised at module load) so it stays
+ * consistent with `resolvePlatformSignerConfig` and the Blockfrost DI
+ * factory, which also read `CARDANO_NETWORK` at invocation time.
  */
-const DEFAULT_NETWORK: AnchorNetworkValue =
-  process.env.CARDANO_NETWORK === "mainnet" ? "CARDANO_MAINNET" : "CARDANO_PREPROD";
+function defaultNetwork(): AnchorNetworkValue {
+  return process.env.CARDANO_NETWORK === "mainnet" ? "CARDANO_MAINNET" : "CARDANO_PREPROD";
+}
 
 /**
  * CBOR-encode a DID Document and return both the bytes and the
@@ -114,7 +118,7 @@ export default class UserDidService {
     ctx: IContext,
     userId: string,
     tx?: Prisma.TransactionClient,
-    network: AnchorNetworkValue = DEFAULT_NETWORK,
+    network: AnchorNetworkValue = defaultNetwork(),
   ): Promise<UserDidAnchorRow> {
     // Idempotency (§5.2.1): a user has exactly one did:web. If a CREATE
     // anchor already exists, return it instead of enqueueing a duplicate
@@ -164,7 +168,7 @@ export default class UserDidService {
     ctx: IContext,
     userId: string,
     tx?: Prisma.TransactionClient,
-    network: AnchorNetworkValue = DEFAULT_NETWORK,
+    network: AnchorNetworkValue = defaultNetwork(),
   ): Promise<UserDidAnchorRow> {
     const did = buildUserDid(userId);
     const document = buildMinimalDidDocument(userId);
@@ -203,7 +207,7 @@ export default class UserDidService {
     ctx: IContext,
     userId: string,
     tx?: Prisma.TransactionClient,
-    network: AnchorNetworkValue = DEFAULT_NETWORK,
+    network: AnchorNetworkValue = defaultNetwork(),
   ): Promise<UserDidAnchorRow> {
     const did = buildUserDid(userId);
     const tombstone = buildDeactivatedDidDocument(userId);

--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -599,13 +599,22 @@ export function registerProductionDependencies() {
   // BlockfrostClient のコンストラクタは optional 引数 1 つ
   // (`options: BlockfrostClientOptions = {}`) のみで、interface 型を
   // tsyringe が auto-resolve できない (`TypeInfo not known for "Object"`)。
-  // 引数なしで構築すれば env (`BLOCKFROST_PROJECT_ID`) から値を引くため、
+  // network は CARDANO_NETWORK env から導出して明示的に渡す: 省略すると
+  // BlockfrostClient は CARDANO_PREPROD 固定になり、mainnet デプロイで
+  // 誤ったチェーンに anchor してしまう (mainnet キーなら起動時の
+  // assertProjectIdMatchesNetwork で fail-fast する)。projectId は引き続き
+  // env (`BLOCKFROST_PROJECT_ID`) から引く。
   // factory + instanceCachingFactory で singleton 化する。
   //
   // dual-binding: クラス自体 (`@inject(BlockfrostClient)`) と string token
   // (`@inject("BlockfrostClient")`) の両方で同じ singleton インスタンスに
   // 解決させる。precedent は L304-306 の UserDidAnchorRepository。
-  const blockfrostFactory = instanceCachingFactory(() => new BlockfrostClient());
+  const blockfrostFactory = instanceCachingFactory(
+    () =>
+      new BlockfrostClient({
+        network: process.env.CARDANO_NETWORK === "mainnet" ? "CARDANO_MAINNET" : "CARDANO_PREPROD",
+      }),
+  );
   container.register(BlockfrostClient, { useFactory: blockfrostFactory });
   container.register("BlockfrostClient", { useToken: BlockfrostClient });
   container.register<BlockfrostLatestSlotProvider>("BlockfrostLatestSlotProvider", {


### PR DESCRIPTION
## Summary

prd の Cardano **mainnet 切替**に向けた配線修正。現状 `CARDANO_NETWORK=mainnet` にしても一部が **preprod 固定**のままで、そのままでは mainnet で正しく動かないため、コード調査（4観点）で特定した必須コード修正2件を入れる。

## 背景

mainnet 切替可否のコード調査で、`CARDANO_NETWORK` を見ていない箇所が2つ判明:

### 1. `BlockfrostClient` の DI factory が preprod 固定（`provider.ts`）

`new BlockfrostClient()` を**引数なし**で構築しており、`BlockfrostClient` の `network` は `options.network ?? "CARDANO_PREPROD"` で **preprod 固定**。anchor の `submitTx` / `awaitConfirmation` 等を担うメインの client が `CARDANO_NETWORK` を無視していた。

mainnet の Blockfrost キーを入れると、起動時の `assertProjectIdMatchesNetwork`（キー prefix と network の不一致検知）で **fail-fast** する＝アプリが起動できない。

→ `CARDANO_NETWORK` 由来の `network` を `new BlockfrostClient({ network })` で明示的に渡すよう修正。

### 2. `UserDidService.DEFAULT_NETWORK` が mainnet ハードコード（`userDid/service.ts`）

`DEFAULT_NETWORK = "CARDANO_MAINNET"` のハードコードで、`updateDid` / `deactivateDid` 経路の `UserDidAnchor.network` が**環境に関係なく `CARDANO_MAINNET`** とラベルされていた（dev/preprod でも mainnet 扱い）。

→ `CARDANO_NETWORK` 由来に変更。未設定 / 非 `mainnet` は `CARDANO_PREPROD`（mainnet を暗黙に仮定しない安全側）。Blockfrost factory・`resolvePlatformSignerConfig` と同じ `CARDANO_NETWORK` 解釈に統一。

## 変更

- `src/application/provider.ts` — Blockfrost DI factory に `network` を配線
- `src/application/domain/account/userDid/service.ts` — `DEFAULT_NETWORK` を env 由来に
- `src/__tests__/unit/.../userDid/service.test.ts` — env 未設定時の既定が `CARDANO_PREPROD` になったため期待値を更新

## 補足（本 PR では未変更）

`UserDidAnchorRepository.buildCreateData` の `input.network ?? "CARDANO_MAINNET"` fallback は、service が常に `network` を渡すため**到達不能**。かつ `repository.test.ts` がこの fallback を直接検証しているため、本 PR のスコープ外とした。

## 検証

- `pnpm tsc --noEmit` exit 0
- `userDid/service.test.ts` 7/7 green、eslint / prettier クリーン
- 影響テスト調査: `CARDANO_MAINNET` を含む他テストはすべて mock fixture / repository 層テスト（repository 未変更）で無影響

## マージ後のインフラ作業（別途）

3. prd 環境に `CARDANO_NETWORK=mainnet`
4. Secret Manager `PROD_BLOCKFROST_PROJECT_ID` の値を env 名 `BLOCKFROST_PROJECT_ID` に配線
5. mainnet wallet 生成 → `CARDANO_PLATFORM_ADDRESS`（`addr1…`）/ `CARDANO_PLATFORM_PRIVATE_KEY_HEX`
6. mainnet アドレスに実 ADA ≥100 を funding
7. KMS Ed25519 鍵の mainnet 確認

https://claude.ai/code/session_018iAncVNcxmEnH2eZ5wTnhv

---
_Generated by [Claude Code](https://claude.ai/code/session_018iAncVNcxmEnH2eZ5wTnhv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * デフォルトのチェーンネットワーク判断を改善し、環境変数が未設定または mainnet 以外の場合はプリプロダクションを利用するように変更。プロダクション時のクライアント生成でネットワークを明示指定し、誤ったネットワーク選択を防止。

* **Tests**
  * 環境変数の切り替えを考慮したテスト制御を追加。未設定時の挙動と mainnet 指定時の挙動をそれぞれ検証するケースを追加。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hopin-inc/civicship-api/pull/1185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->