### PR TITLE
refactor(cardano): centralize CARDANO_NETWORK interpretation

### DIFF
--- a/src/__tests__/unit/infrastructure/libs/cardano/network.test.ts
+++ b/src/__tests__/unit/infrastructure/libs/cardano/network.test.ts
@@ -1,0 +1,40 @@
+import {
+  resolveCardanoChainNetwork,
+  resolveCardanoNetworkToken,
+} from "@/infrastructure/libs/cardano/network";
+
+describe("cardano network resolution from CARDANO_NETWORK", () => {
+  const original = process.env.CARDANO_NETWORK;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.CARDANO_NETWORK;
+    } else {
+      process.env.CARDANO_NETWORK = original;
+    }
+  });
+
+  it("resolves CARDANO_NETWORK=mainnet to the mainnet forms", () => {
+    process.env.CARDANO_NETWORK = "mainnet";
+    expect(resolveCardanoChainNetwork()).toBe("CARDANO_MAINNET");
+    expect(resolveCardanoNetworkToken()).toBe("mainnet");
+  });
+
+  it("resolves CARDANO_NETWORK=preprod to the preprod forms", () => {
+    process.env.CARDANO_NETWORK = "preprod";
+    expect(resolveCardanoChainNetwork()).toBe("CARDANO_PREPROD");
+    expect(resolveCardanoNetworkToken()).toBe("preprod");
+  });
+
+  it("falls back to preprod when CARDANO_NETWORK is unset", () => {
+    delete process.env.CARDANO_NETWORK;
+    expect(resolveCardanoChainNetwork()).toBe("CARDANO_PREPROD");
+    expect(resolveCardanoNetworkToken()).toBe("preprod");
+  });
+
+  it("falls back to preprod for any non-mainnet value", () => {
+    process.env.CARDANO_NETWORK = "preview";
+    expect(resolveCardanoChainNetwork()).toBe("CARDANO_PREPROD");
+    expect(resolveCardanoNetworkToken()).toBe("preprod");
+  });
+});

--- a/src/application/domain/account/userDid/service.ts
+++ b/src/application/domain/account/userDid/service.ts
@@ -47,24 +47,10 @@ import {
   type DidDocument,
   type TombstoneDocument,
 } from "@/infrastructure/libs/did/userDidBuilder";
+import { resolveCardanoChainNetwork } from "@/infrastructure/libs/cardano/network";
 
 /** Output length of `documentHash`, in bytes (Blake2b-256 → 32 B). */
 const DOCUMENT_HASH_BYTES = 32;
-
-/**
- * Resolve the default chain network for new anchors from the
- * `CARDANO_NETWORK` environment variable (§4.1 ChainNetwork). Anything
- * other than `mainnet` — including an unset env — resolves to
- * `CARDANO_PREPROD`, so dev / preview deployments never mislabel anchors as
- * mainnet and mainnet is never assumed implicitly.
- *
- * Evaluated on each call (not memoised at module load) so it stays
- * consistent with `resolvePlatformSignerConfig` and the Blockfrost DI
- * factory, which also read `CARDANO_NETWORK` at invocation time.
- */
-function defaultNetwork(): AnchorNetworkValue {
-  return process.env.CARDANO_NETWORK === "mainnet" ? "CARDANO_MAINNET" : "CARDANO_PREPROD";
-}
 
 /**
  * CBOR-encode a DID Document and return both the bytes and the
@@ -118,7 +104,7 @@ export default class UserDidService {
     ctx: IContext,
     userId: string,
     tx?: Prisma.TransactionClient,
-    network: AnchorNetworkValue = defaultNetwork(),
+    network: AnchorNetworkValue = resolveCardanoChainNetwork(),
   ): Promise<UserDidAnchorRow> {
     // Idempotency (§5.2.1): a user has exactly one did:web. If a CREATE
     // anchor already exists, return it instead of enqueueing a duplicate
@@ -168,7 +154,7 @@ export default class UserDidService {
     ctx: IContext,
     userId: string,
     tx?: Prisma.TransactionClient,
-    network: AnchorNetworkValue = defaultNetwork(),
+    network: AnchorNetworkValue = resolveCardanoChainNetwork(),
   ): Promise<UserDidAnchorRow> {
     const did = buildUserDid(userId);
     const document = buildMinimalDidDocument(userId);
@@ -207,7 +193,7 @@ export default class UserDidService {
     ctx: IContext,
     userId: string,
     tx?: Prisma.TransactionClient,
-    network: AnchorNetworkValue = defaultNetwork(),
+    network: AnchorNetworkValue = resolveCardanoChainNetwork(),
   ): Promise<UserDidAnchorRow> {
     const did = buildUserDid(userId);
     const tombstone = buildDeactivatedDidDocument(userId);

--- a/src/application/domain/anchor/anchorBatch/service.ts
+++ b/src/application/domain/anchor/anchorBatch/service.ts
@@ -27,6 +27,7 @@ import {
 } from "@/infrastructure/libs/cardano/txBuilder";
 import { BlockfrostClient } from "@/infrastructure/libs/blockfrost/client";
 import { deriveCardanoKeypair } from "@/infrastructure/libs/cardano/keygen";
+import { resolveCardanoNetworkToken } from "@/infrastructure/libs/cardano/network";
 import { IAnchorBatchRepository } from "@/application/domain/anchor/anchorBatch/data/interface";
 import {
   AnchorBatchPendingSet,
@@ -501,10 +502,10 @@ export function trimDocCborForSizeBudget(
       prev: op.prev ?? null,
     };
     size = measureMetadataSize({ ...base, ops: candidate });
-    logger.warn(
-      "[AnchorBatchService] documentCbor dropped for size budget (§8.4)",
-      { did: op.did, remainingBytes: MAX_METADATA_TX_BYTES - size },
-    );
+    logger.warn("[AnchorBatchService] documentCbor dropped for size budget (§8.4)", {
+      did: op.did,
+      remainingBytes: MAX_METADATA_TX_BYTES - size,
+    });
     if (size <= MAX_METADATA_TX_BYTES) return candidate;
   }
 
@@ -578,8 +579,7 @@ export function computeIsoWeeklyKey(date: Date = new Date()): string {
 
 /** env から platform signer 設定を組み立てる（Phase 1 暖定）。 */
 export function resolvePlatformSignerConfig(): PlatformSignerConfig {
-  const networkRaw = process.env.CARDANO_NETWORK ?? "preprod";
-  const network = networkRaw === "mainnet" ? "mainnet" : "preprod";
+  const network = resolveCardanoNetworkToken();
   const changeAddressBech32 = process.env.CARDANO_PLATFORM_ADDRESS;
   if (!changeAddressBech32) {
     throw new Error(

--- a/src/application/provider.ts
+++ b/src/application/provider.ts
@@ -141,6 +141,10 @@ import {
 } from "@/application/domain/anchor/anchorBatch/service";
 import AnchorBatchUseCase from "@/application/domain/anchor/anchorBatch/usecase";
 import { BlockfrostClient } from "@/infrastructure/libs/blockfrost/client";
+import {
+  resolveCardanoChainNetwork,
+  resolveCardanoNetworkToken,
+} from "@/infrastructure/libs/cardano/network";
 
 // 🪪 User DID (§5.2 internal DID/VC, Phase 1 — Strategy A: stubs replaced
 //   with Prisma-backed repository, plus GraphQL resolver registration)
@@ -599,21 +603,18 @@ export function registerProductionDependencies() {
   // BlockfrostClient のコンストラクタは optional 引数 1 つ
   // (`options: BlockfrostClientOptions = {}`) のみで、interface 型を
   // tsyringe が auto-resolve できない (`TypeInfo not known for "Object"`)。
-  // network は CARDANO_NETWORK env から導出して明示的に渡す: 省略すると
-  // BlockfrostClient は CARDANO_PREPROD 固定になり、mainnet デプロイで
-  // 誤ったチェーンに anchor してしまう (mainnet キーなら起動時の
-  // assertProjectIdMatchesNetwork で fail-fast する)。projectId は引き続き
-  // env (`BLOCKFROST_PROJECT_ID`) から引く。
+  // network は resolveCardanoChainNetwork() で CARDANO_NETWORK から導出して
+  // 明示的に渡す: 省略すると BlockfrostClient は CARDANO_PREPROD 固定になり、
+  // mainnet デプロイで誤ったチェーンに anchor してしまう (mainnet キーなら
+  // 起動時の assertProjectIdMatchesNetwork で fail-fast する)。projectId は
+  // 引き続き env (`BLOCKFROST_PROJECT_ID`) から引く。
   // factory + instanceCachingFactory で singleton 化する。
   //
   // dual-binding: クラス自体 (`@inject(BlockfrostClient)`) と string token
   // (`@inject("BlockfrostClient")`) の両方で同じ singleton インスタンスに
   // 解決させる。precedent は L304-306 の UserDidAnchorRepository。
   const blockfrostFactory = instanceCachingFactory(
-    () =>
-      new BlockfrostClient({
-        network: process.env.CARDANO_NETWORK === "mainnet" ? "CARDANO_MAINNET" : "CARDANO_PREPROD",
-      }),
+    () => new BlockfrostClient({ network: resolveCardanoChainNetwork() }),
   );
   container.register(BlockfrostClient, { useFactory: blockfrostFactory });
   container.register("BlockfrostClient", { useToken: BlockfrostClient });
@@ -636,8 +637,7 @@ function createBlockfrostLatestSlotProvider(): BlockfrostLatestSlotProvider {
       // 動的 import で起動時の dependency 評価を避ける（テスト時に DI を
       // 別 provider に差し替えるためメインのプロセスでは初期化されない）。
       const { BlockFrostAPI } = await import("@blockfrost/blockfrost-js");
-      const networkRaw = process.env.CARDANO_NETWORK ?? "preprod";
-      const network = networkRaw === "mainnet" ? "mainnet" : "preprod";
+      const network = resolveCardanoNetworkToken();
       const projectId = process.env.BLOCKFROST_PROJECT_ID;
       if (!projectId) {
         throw new Error("BlockfrostLatestSlotProvider: BLOCKFROST_PROJECT_ID is not set.");

--- a/src/infrastructure/libs/cardano/network.ts
+++ b/src/infrastructure/libs/cardano/network.ts
@@ -1,0 +1,43 @@
+/**
+ * Single source of truth for interpreting the `CARDANO_NETWORK` environment
+ * variable.
+ *
+ * `CARDANO_NETWORK` is the one switch that decides whether civicship anchors
+ * to Cardano mainnet or preprod. Anything other than the exact string
+ * `mainnet` — including an unset variable — resolves to preprod, so no
+ * deployment can anchor to mainnet implicitly / by accident.
+ *
+ * Read at call time (never memoised at module load) so every caller observes
+ * a consistent value and tests can vary the env without `jest.resetModules`.
+ *
+ * Two encodings of the same decision are exposed because the codebase needs
+ * both: the civicship-internal `ChainNetwork` enum form (DB rows, Blockfrost
+ * client option) and the lowercase token form (`@blockfrost/blockfrost-js`
+ * and CSL key derivation).
+ */
+
+import type { CardanoChainNetwork } from "@/infrastructure/libs/blockfrost/client";
+
+/** Lowercase network token used by `@blockfrost/blockfrost-js` and CSL. */
+export type CardanoNetworkToken = "mainnet" | "preprod";
+
+/** `true` only when `CARDANO_NETWORK` is exactly `"mainnet"`. */
+function isMainnet(): boolean {
+  return process.env.CARDANO_NETWORK === "mainnet";
+}
+
+/**
+ * `CARDANO_NETWORK` as the civicship-internal `ChainNetwork` enum value
+ * (`CARDANO_MAINNET` / `CARDANO_PREPROD`).
+ */
+export function resolveCardanoChainNetwork(): CardanoChainNetwork {
+  return isMainnet() ? "CARDANO_MAINNET" : "CARDANO_PREPROD";
+}
+
+/**
+ * `CARDANO_NETWORK` as the lowercase token (`mainnet` / `preprod`) expected
+ * by `@blockfrost/blockfrost-js` and `deriveCardanoKeypair`.
+ */
+export function resolveCardanoNetworkToken(): CardanoNetworkToken {
+  return isMainnet() ? "mainnet" : "preprod";
+}


### PR DESCRIPTION
## Summary

PR #1185 の Copilot レビュー指摘 #1（フォローアップ）。`CARDANO_NETWORK` 環境変数の解釈ロジック（`mainnet` 以外 → `preprod`）が **4箇所にコピーされていた**ため、共通ヘルパーに集約する。リリース critical な「どのチェーンに anchor するか」の判定が箇所ごとにズレるリスクを解消。

## 変更

### 新規 `src/infrastructure/libs/cardano/network.ts`

`CARDANO_NETWORK` 解釈の single source of truth。2つの表現を提供:

- `resolveCardanoChainNetwork()` → civicship 内部の `ChainNetwork` enum 形式（`CARDANO_MAINNET` / `CARDANO_PREPROD`）。DB 行・Blockfrost client option 用
- `resolveCardanoNetworkToken()` → 小文字トークン形式（`mainnet` / `preprod`）。`@blockfrost/blockfrost-js` ・ CSL 鍵導出用

どちらも**呼び出し時に env を読む**（モジュールロード時に固定しない）ため、全 caller が一貫した値を見て、テストも `jest.resetModules` 不要。`mainnet` 以外（未設定含む）は常に `preprod` ＝ 暗黙の mainnet 接続を防ぐ。

### 既存4箇所を helper 呼び出しに置換（挙動不変）

- `provider.ts` — `BlockfrostClient` factory（`resolveCardanoChainNetwork()`）
- `provider.ts` — `createBlockfrostLatestSlotProvider`（`resolveCardanoNetworkToken()`）
- `userDid/service.ts` — `defaultNetwork()` ローカル関数を撤去し、デフォルト引数で `resolveCardanoChainNetwork()` を直接使用
- `anchorBatch/service.ts` — `resolvePlatformSignerConfig`（`resolveCardanoNetworkToken()`）

いずれも従来と完全に同じ判定（`mainnet` 以外 → `preprod`）。

### テスト

- `network.ts` の unit テスト追加（mainnet / preprod / 未設定 / 非 mainnet 値の4ケース）

## 検証

- `pnpm tsc --noEmit` exit 0
- `network.test.ts` / `userDid/service.test.ts` / `anchorBatch/service.test.ts` — **32件 green**
- eslint / prettier クリーン
- `develop` に rebase 済み（差分は本集約のみ）

https://claude.ai/code/session_018iAncVNcxmEnH2eZ5wTnhv

---
_Generated by [Claude Code](https://claude.ai/code/session_018iAncVNcxmEnH2eZ5wTnhv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * Cardanoネットワーク設定の単体テストを追加

* **Refactor**
  * Cardanoネットワーク解決ロジックを統一し、一貫性を強化

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hopin-inc/civicship-api/pull/1186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->