### PR TITLE
fix(userDid): expose only INTERNAL did:web via didIssuanceRequests

### DIFF
--- a/src/__tests__/unit/application/domain/account/identity/didIssuanceRequest/controller/dataloader.test.ts
+++ b/src/__tests__/unit/application/domain/account/identity/didIssuanceRequest/controller/dataloader.test.ts
@@ -1,0 +1,23 @@
+import { DidMethod, type PrismaClient } from "@prisma/client";
+import { createDidIssuanceRequestsByUserIdLoader } from "@/application/domain/account/identity/didIssuanceRequest/controller/dataloader";
+
+/**
+ * `User.didIssuanceRequests` の dataloader は、IDENTUS 時代の did:prism 行を
+ * API に露出させず、自前発行の did:web (INTERNAL) のみを返さねばならない。
+ * その担保が Prisma クエリの `where` に入っていることを確認する。
+ */
+describe("createDidIssuanceRequestsByUserIdLoader", () => {
+  it("queries only didMethod=INTERNAL — legacy IDENTUS did:prism rows are never exposed", async () => {
+    const findMany = jest.fn().mockResolvedValue([]);
+    const prisma = { didIssuanceRequest: { findMany } } as unknown as PrismaClient;
+
+    const loader = createDidIssuanceRequestsByUserIdLoader(prisma);
+    await loader.load("u_alice");
+
+    expect(findMany).toHaveBeenCalledTimes(1);
+    expect(findMany.mock.calls[0][0].where).toEqual({
+      userId: { in: ["u_alice"] },
+      didMethod: DidMethod.INTERNAL,
+    });
+  });
+});

--- a/src/application/domain/account/identity/didIssuanceRequest/controller/dataloader.ts
+++ b/src/application/domain/account/identity/didIssuanceRequest/controller/dataloader.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+import { DidMethod, PrismaClient } from "@prisma/client";
 import { createHasManyLoaderByKey } from "@/presentation/graphql/dataloader/utils";
 import { Prisma } from "@prisma/client";
 import { GqlDidIssuanceRequest } from "@/types/graphql";
@@ -20,7 +20,10 @@ export function createDidIssuanceRequestsByUserIdLoader(prisma: PrismaClient) {
     "userId",
     async (userIds) =>
       prisma.didIssuanceRequest.findMany({
-        where: { userId: { in: [...userIds] } },
+        // IDENTUS 時代の did:prism 行は履歴として DB に残すが、API では
+        // 自前発行の did:web (INTERNAL) のみを返す。レガシー DID を
+        // クライアントに露出させない担保はフロント任せにせずここで行う。
+        where: { userId: { in: [...userIds] }, didMethod: DidMethod.INTERNAL },
         select,
       }),
     (record): GqlDidIssuanceRequest => ({
@@ -33,6 +36,6 @@ export function createDidIssuanceRequestsByUserIdLoader(prisma: PrismaClient) {
       completedAt: record.completedAt ?? null,
       createdAt: record.createdAt,
       updatedAt: record.updatedAt ?? null,
-    })
+    }),
   );
 }


### PR DESCRIPTION
## Summary

`User.didIssuanceRequests` GraphQL フィールドが、IDENTUS 時代の legacy `did:prism` 行と自前発行の `did:web` 行を**両方**返していた。バックエンドで `did:web`（INTERNAL）のみを返すよう担保する。

## 背景

IDENTUS から内製 did:web への移行に伴い、IDENTUS 時代に DID 発行済みのユーザーは `t_did_issuance_requests` に行が2つできる:

- 旧: `didMethod=IDENTUS` / `did:prism:...`（履歴として保持）
- 新: `didMethod=INTERNAL` / `did:web:...`（backfill が追加）

`createDidIssuanceRequestsByUserIdLoader` が `where` を `userId` のみで絞っていたため、`User.didIssuanceRequests` は**両方の行**を返していた。さらに GraphQL の `DidIssuanceRequest` 型に `didMethod` フィールドが無いため、クライアントは `didValue` の prefix でしか判別できず、レガシー DID を出さない担保がフロント任せになっていた。

設計書 L59 は「旧 `did:prism` 行は履歴として残し、INTERNAL 行で**上書き表示**」としており、本 PR はその「上書き表示」をバックエンドで実装する。

## 変更

`createDidIssuanceRequestsByUserIdLoader` の Prisma `where` に `didMethod: DidMethod.INTERNAL` を追加。

→ `User.didIssuanceRequests` は INTERNAL（did:web）の行のみ返す。legacy `did:prism` は DB に履歴として残るが API には一切出ない。

## 変更不要だった経路（確認済み）

- `userDid(userId)` GraphQL query → `t_user_did_anchors`（`UserDidAnchor`）を読む。このテーブルは INTERNAL did:web 専用（IDENTUS は書いていない）→ 元々 did:web のみ
- HTTP `/users/:userId/did.json` → 同上 → 元々 did:web のみ

## 検証

- `pnpm tsc --noEmit` exit 0
- dataloader の `where` に `didMethod: INTERNAL` が入ることの unit テストを追加（1件 green）
- eslint / prettier クリーン

https://claude.ai/code/session_018iAncVNcxmEnH2eZ5wTnhv

---
_Generated by [Claude Code](https://claude.ai/code/session_018iAncVNcxmEnH2eZ5wTnhv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * DID発行リクエスト取得時に、レガシーDIDメソッドがAPI経由で露出されないよう対象範囲を制限しました。

* **テスト**
  * DID発行リクエスト取得機能のユニットテストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hopin-inc/civicship-api/pull/1187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->