### PR TITLE
fix(anchor): persist chainOpIndex when anchoring DID operations

### DIFF
--- a/src/__tests__/integration/application/domain/anchor/anchorBatch/repository.test.ts
+++ b/src/__tests__/integration/application/domain/anchor/anchorBatch/repository.test.ts
@@ -18,12 +18,7 @@
 
 import "reflect-metadata";
 import { container } from "tsyringe";
-import {
-  AnchorStatus,
-  ChainNetwork,
-  CurrentPrefecture,
-  DidOperation,
-} from "@prisma/client";
+import { AnchorStatus, ChainNetwork, CurrentPrefecture, DidOperation } from "@prisma/client";
 import { registerProductionDependencies } from "@/application/provider";
 import TestDataSourceHelper from "@/__tests__/helper/test-data-source-helper";
 import { PrismaClientIssuer, prismaClient } from "@/infrastructure/prisma/client";
@@ -198,6 +193,7 @@ describe("AnchorBatchRepository (integration)", () => {
         transactionAnchorIds: [txId],
         vcAnchorIds: [vcId],
         userDidAnchorIds: [didId],
+        userDidOpIndexes: [{ anchorId: didId, opIndex: 0 }],
       });
 
       const tx = await prismaClient.transactionAnchor.findUnique({ where: { id: txId } });
@@ -208,6 +204,10 @@ describe("AnchorBatchRepository (integration)", () => {
       expect(did!.status).toBe(AnchorStatus.SUBMITTED);
       expect(tx!.chainTxHash).toBe("deadbeef".repeat(8));
       expect(tx!.submittedAt).not.toBeNull();
+      // The DID anchor's metadata `ops[]` position is persisted so the
+      // verifier can locate it via `ops[chainOpIndex]` (chain inclusion).
+      expect(did!.chainTxHash).toBe("deadbeef".repeat(8));
+      expect(did!.chainOpIndex).toBe(0);
     });
 
     it("markConfirmed advances to CONFIRMED with confirmedAt + blockHeight", async () => {

--- a/src/__tests__/unit/application/domain/anchor/anchorBatch/service.test.ts
+++ b/src/__tests__/unit/application/domain/anchor/anchorBatch/service.test.ts
@@ -432,6 +432,36 @@ describe("AnchorBatchService", () => {
       expect(submittedArgs.userDidOpIndexes).toHaveLength(2);
     });
 
+    it("breaks opIndex ties by anchor id when two anchors share a did", async () => {
+      // A user that does createDid then updateDid within one week has two
+      // PENDING anchors with the *same* `did`. The op order — and therefore
+      // chainOpIndex — must be deterministic regardless of DB row order, so
+      // the comparator tie-breaks on `id` (cuid, creation-time ordered).
+      const higherId = {
+        ...PENDING_DID,
+        id: "did_anchor_zzz",
+        did: "did:web:api.civicship.app:users:u_same",
+      };
+      const lowerId = {
+        ...PENDING_DID,
+        id: "did_anchor_aaa",
+        did: "did:web:api.civicship.app:users:u_same",
+      };
+      // Fed in reverse-id order — the comparator must still sort by id.
+      setupPending({ userDidAnchors: [higherId, lowerId] });
+
+      const service = container.resolve(AnchorBatchService);
+      await service.runWeeklyBatch(ctx, { weeklyKey: "2026-W19" });
+
+      const submittedArgs = mockRepository.markSubmitted.mock.calls[0][1];
+      expect(submittedArgs.userDidOpIndexes).toEqual(
+        expect.arrayContaining([
+          { anchorId: "did_anchor_aaa", opIndex: 0 },
+          { anchorId: "did_anchor_zzz", opIndex: 1 },
+        ]),
+      );
+    });
+
     it("marks anchors FAILED when awaitConfirmation throws", async () => {
       setupPending({ transactionAnchors: [PENDING_TX] });
       mockBlockfrost.awaitConfirmation.mockRejectedValue(
@@ -575,7 +605,7 @@ describe("AnchorBatchService", () => {
         0x62, 0x3a, 0x63,
       ]);
       setupPending({
-        userDidAnchors: [{ ...PENDING_DID, documentCbor: cborBytes as unknown as null }],
+        userDidAnchors: [{ ...PENDING_DID, documentCbor: cborBytes }],
       });
 
       const service = container.resolve(AnchorBatchService);
@@ -608,7 +638,7 @@ describe("AnchorBatchService", () => {
 
     it("treats empty Uint8Array documentCbor as absent (defensive)", async () => {
       setupPending({
-        userDidAnchors: [{ ...PENDING_DID, documentCbor: new Uint8Array(0) as unknown as null }],
+        userDidAnchors: [{ ...PENDING_DID, documentCbor: new Uint8Array(0) }],
       });
 
       const service = container.resolve(AnchorBatchService);
@@ -625,7 +655,7 @@ describe("AnchorBatchService", () => {
           {
             ...PENDING_DID,
             operation: DidOperation.DEACTIVATE,
-            documentCbor: new Uint8Array([0xa0]) as unknown as null,
+            documentCbor: new Uint8Array([0xa0]),
             previousAnchorId: null,
           },
         ],

--- a/src/__tests__/unit/application/domain/anchor/anchorBatch/service.test.ts
+++ b/src/__tests__/unit/application/domain/anchor/anchorBatch/service.test.ts
@@ -401,6 +401,37 @@ describe("AnchorBatchService", () => {
       expect(mockRepository.markFailed).not.toHaveBeenCalled();
     });
 
+    it("passes per-anchor chainOpIndex to markSubmitted (sorted-by-did ops[] position)", async () => {
+      // Two DID anchors fed in non-sorted order. The metadata `ops[]` array
+      // is sorted by `did` asc, so the lexicographically smaller did takes
+      // op index 0 — and that index must reach markSubmitted so the
+      // repository can stamp `chainOpIndex` (chain inclusion proof).
+      const didB = {
+        ...PENDING_DID,
+        id: "did_anchor_b",
+        did: "did:web:api.civicship.app:users:u_bbb",
+      };
+      const didA = {
+        ...PENDING_DID,
+        id: "did_anchor_a",
+        did: "did:web:api.civicship.app:users:u_aaa",
+      };
+      setupPending({ userDidAnchors: [didB, didA] });
+
+      const service = container.resolve(AnchorBatchService);
+      await service.runWeeklyBatch(ctx, { weeklyKey: "2026-W19" });
+
+      expect(mockRepository.markSubmitted).toHaveBeenCalledTimes(1);
+      const submittedArgs = mockRepository.markSubmitted.mock.calls[0][1];
+      expect(submittedArgs.userDidOpIndexes).toEqual(
+        expect.arrayContaining([
+          { anchorId: "did_anchor_a", opIndex: 0 },
+          { anchorId: "did_anchor_b", opIndex: 1 },
+        ]),
+      );
+      expect(submittedArgs.userDidOpIndexes).toHaveLength(2);
+    });
+
     it("marks anchors FAILED when awaitConfirmation throws", async () => {
       setupPending({ transactionAnchors: [PENDING_TX] });
       mockBlockfrost.awaitConfirmation.mockRejectedValue(
@@ -577,9 +608,7 @@ describe("AnchorBatchService", () => {
 
     it("treats empty Uint8Array documentCbor as absent (defensive)", async () => {
       setupPending({
-        userDidAnchors: [
-          { ...PENDING_DID, documentCbor: new Uint8Array(0) as unknown as null },
-        ],
+        userDidAnchors: [{ ...PENDING_DID, documentCbor: new Uint8Array(0) as unknown as null }],
       });
 
       const service = container.resolve(AnchorBatchService);

--- a/src/application/domain/anchor/anchorBatch/data/interface.ts
+++ b/src/application/domain/anchor/anchorBatch/data/interface.ts
@@ -14,6 +14,7 @@ import {
   PendingUserDidAnchor,
   PendingVcAnchor,
   PreviousAnchorChainTx,
+  UserDidOpIndex,
   VcJwtLeaf,
 } from "@/application/domain/anchor/anchorBatch/data/type";
 
@@ -71,7 +72,12 @@ export interface IAnchorBatchRepository {
     userDidAnchors: number;
   }>;
 
-  /** 全 anchor 行を SUBMITTED 状態に遷移し、chainTxHash を埋める。 */
+  /**
+   * 全 anchor 行を SUBMITTED 状態に遷移し、chainTxHash を埋める。
+   *
+   * `userDidOpIndexes` は各 UserDidAnchor の tx metadata `ops[]` 内位置で、
+   * `chainOpIndex` 列へ行ごとに書き戻す（chain inclusion proof の特定に必須）。
+   */
   markSubmitted(
     ctx: IContext,
     args: {
@@ -80,6 +86,7 @@ export interface IAnchorBatchRepository {
       transactionAnchorIds: string[];
       vcAnchorIds: string[];
       userDidAnchorIds: string[];
+      userDidOpIndexes: UserDidOpIndex[];
     },
   ): Promise<void>;
 

--- a/src/application/domain/anchor/anchorBatch/data/repository.ts
+++ b/src/application/domain/anchor/anchorBatch/data/repository.ts
@@ -17,6 +17,7 @@ import {
   PendingUserDidAnchor,
   PendingVcAnchor,
   PreviousAnchorChainTx,
+  UserDidOpIndex,
   VcJwtLeaf,
 } from "@/application/domain/anchor/anchorBatch/data/type";
 
@@ -206,13 +207,41 @@ export default class AnchorBatchRepository implements IAnchorBatchRepository {
       transactionAnchorIds: string[];
       vcAnchorIds: string[];
       userDidAnchorIds: string[];
+      userDidOpIndexes: UserDidOpIndex[];
     },
   ): Promise<void> {
     const submittedAt = new Date();
-    await this.applyToAllAnchors(ctx, args, {
-      txData: { status: AnchorStatus.SUBMITTED, chainTxHash: args.chainTxHash, submittedAt },
-      vcData: { status: AnchorStatus.SUBMITTED, chainTxHash: args.chainTxHash, submittedAt },
-      didData: { status: AnchorStatus.SUBMITTED, chainTxHash: args.chainTxHash, submittedAt },
+    const opIndexByAnchorId = new Map(args.userDidOpIndexes.map((e) => [e.anchorId, e.opIndex]));
+    const issuer = ctx.issuer ?? this.getIssuer();
+    await issuer.internal(async (tx) => {
+      await Promise.all([
+        args.transactionAnchorIds.length
+          ? tx.transactionAnchor.updateMany({
+              where: { id: { in: args.transactionAnchorIds } },
+              data: { status: AnchorStatus.SUBMITTED, chainTxHash: args.chainTxHash, submittedAt },
+            })
+          : Promise.resolve(),
+        args.vcAnchorIds.length
+          ? tx.vcAnchor.updateMany({
+              where: { id: { in: args.vcAnchorIds } },
+              data: { status: AnchorStatus.SUBMITTED, chainTxHash: args.chainTxHash, submittedAt },
+            })
+          : Promise.resolve(),
+      ]);
+      // userDidAnchor は `chainOpIndex` が行ごとに異なるため、`data` を一律に
+      // 適用する `updateMany` では書けない。status 遷移と同一トランザクション内で
+      // 1 行ずつ update し、chain inclusion proof の index を確実に永続化する。
+      for (const id of args.userDidAnchorIds) {
+        await tx.userDidAnchor.update({
+          where: { id },
+          data: {
+            status: AnchorStatus.SUBMITTED,
+            chainTxHash: args.chainTxHash,
+            submittedAt,
+            chainOpIndex: opIndexByAnchorId.get(id) ?? null,
+          },
+        });
+      }
     });
   }
 

--- a/src/application/domain/anchor/anchorBatch/data/repository.ts
+++ b/src/application/domain/anchor/anchorBatch/data/repository.ts
@@ -232,13 +232,21 @@ export default class AnchorBatchRepository implements IAnchorBatchRepository {
       // 適用する `updateMany` では書けない。status 遷移と同一トランザクション内で
       // 1 行ずつ update し、chain inclusion proof の index を確実に永続化する。
       for (const id of args.userDidAnchorIds) {
+        const opIndex = opIndexByAnchorId.get(id);
+        if (opIndex === undefined) {
+          // 不変条件: claim した全 UserDidAnchor は op index を持つ。欠落を
+          // `null` で握り潰すと SUBMITTED なのに chainOpIndex 欠落の行が
+          // 再発する（= この書き戻し経路が防ぐはずのバグそのもの）。例外を
+          // 投げてトランザクションごと中断させる。
+          throw new Error(`markSubmitted: missing chainOpIndex for userDidAnchor ${id}`);
+        }
         await tx.userDidAnchor.update({
           where: { id },
           data: {
             status: AnchorStatus.SUBMITTED,
             chainTxHash: args.chainTxHash,
             submittedAt,
-            chainOpIndex: opIndexByAnchorId.get(id) ?? null,
+            chainOpIndex: opIndex,
           },
         });
       }

--- a/src/application/domain/anchor/anchorBatch/data/type.ts
+++ b/src/application/domain/anchor/anchorBatch/data/type.ts
@@ -73,6 +73,19 @@ export interface PreviousAnchorChainTx {
   chainTxHash: string | null;
 }
 
+/**
+ * UserDidAnchor の `chainOpIndex` 書き戻し用エントリ。
+ *
+ * `opIndex` は tx metadata の DID `ops[]` 配列内での 0-origin 位置で、
+ * verifier が `ops[chainOpIndex]` で対象 DID 操作を特定するために使う。
+ */
+export interface UserDidOpIndex {
+  /** UserDidAnchor.id。 */
+  anchorId: string;
+  /** tx metadata の DID `ops[]` 配列内での 0-origin index。 */
+  opIndex: number;
+}
+
 export interface AnchorBatchPendingSet {
   transactionAnchors: PendingTransactionAnchor[];
   vcAnchors: PendingVcAnchor[];

--- a/src/application/domain/anchor/anchorBatch/service.ts
+++ b/src/application/domain/anchor/anchorBatch/service.ts
@@ -369,8 +369,15 @@ export class AnchorBatchService {
     userDidAnchors: PendingUserDidAnchor[],
   ): Promise<{ ops: DidOp[]; opIndexByAnchorId: Map<string, number> }> {
     if (userDidAnchors.length === 0) return { ops: [], opIndexByAnchorId: new Map() };
-    // 「sorted by did asc」で決定論的出力にする（§5.3.1 の bid + 順序）
-    const sorted = [...userDidAnchors].sort((a, b) => (a.did < b.did ? -1 : a.did > b.did ? 1 : 0));
+    // 「sorted by did asc」で決定論的出力にする（§5.3.1 の bid + 順序）。
+    // 同一週内に同一ユーザーの CREATE と UPDATE が両方 PENDING で入る場合、
+    // `did` は同一になるため `id`（cuid, 生成時刻順）を第 2 キーにして
+    // 並びを完全に決定論化する（さもなくば opIndex が入力順依存になる）。
+    const sorted = [...userDidAnchors].sort((a, b) => {
+      if (a.did < b.did) return -1;
+      if (a.did > b.did) return 1;
+      return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+    });
     const prevIds = sorted
       .map((a) => a.previousAnchorId)
       .filter((id): id is string => typeof id === "string");

--- a/src/application/domain/anchor/anchorBatch/service.ts
+++ b/src/application/domain/anchor/anchorBatch/service.ts
@@ -275,7 +275,7 @@ export class AnchorBatchService {
     // 4. Merkle root 計算 + ops 構築
     const txRoot = buildTxRoot(pending.transactionAnchors);
     const vcRoot = await this.buildVcRoot(ctx, pending.vcAnchors);
-    const rawOps = await this.buildDidOps(ctx, pending.userDidAnchors);
+    const { ops: rawOps, opIndexByAnchorId } = await this.buildDidOps(ctx, pending.userDidAnchors);
 
     // 5. AuxiliaryData を組み立てる（§8.4 size budget — documentCbor を含めると
     //    16 KB を超える場合は末尾の op から順次 docCbor を脱落させる）
@@ -321,6 +321,13 @@ export class AnchorBatchService {
     await this.repository.markSubmitted(ctx, {
       batchId: weeklyKey,
       chainTxHash: txHash,
+      // Per-anchor DID op position so the persistence layer can stamp
+      // `chainOpIndex` — the verifier locates the operation via
+      // `ops[chainOpIndex]` and a confirmed anchor is unverifiable without it.
+      userDidOpIndexes: [...opIndexByAnchorId].map(([anchorId, opIndex]) => ({
+        anchorId,
+        opIndex,
+      })),
       ...ids,
     });
 
@@ -360,8 +367,8 @@ export class AnchorBatchService {
   private async buildDidOps(
     ctx: IContext,
     userDidAnchors: PendingUserDidAnchor[],
-  ): Promise<DidOp[]> {
-    if (userDidAnchors.length === 0) return [];
+  ): Promise<{ ops: DidOp[]; opIndexByAnchorId: Map<string, number> }> {
+    if (userDidAnchors.length === 0) return { ops: [], opIndexByAnchorId: new Map() };
     // 「sorted by did asc」で決定論的出力にする（§5.3.1 の bid + 順序）
     const sorted = [...userDidAnchors].sort((a, b) => (a.did < b.did ? -1 : a.did > b.did ? 1 : 0));
     const prevIds = sorted
@@ -372,7 +379,14 @@ export class AnchorBatchService {
       : [];
     const prevByAnchorId = new Map(prevs.map((p) => [p.id, p.chainTxHash]));
 
-    return sorted.map((a) => buildOp(a, prevByAnchorId));
+    // `chainOpIndex` は、この anchor が tx metadata の DID `ops[]` 配列の
+    // 何番目かを指す。ここで sort 済の位置を採番し、submit 時に各
+    // UserDidAnchor 行へ書き戻す（§8.3 chain inclusion）。後続の
+    // `trimDocCborForSizeBudget` は docCbor を落とすだけで配列順を変えない
+    // ため、ここで確定した index は最終 metadata の op 位置と一致する。
+    const opIndexByAnchorId = new Map(sorted.map((a, i) => [a.id, i]));
+
+    return { ops: sorted.map((a) => buildOp(a, prevByAnchorId)), opIndexByAnchorId };
   }
 
   /**


### PR DESCRIPTION
## Summary

One of three release-blocking bugs found in the blockchain functional-parity audit of the DID/VC internalization. This bug breaks third-party verifiability of **DID operations** — a regression vs the old `did:prism` system and a violation of design-doc §1.3 success criterion #3.

### Root cause — who can't do what

A third party **cannot** verify an anchored DID Document against the chain, because `UserDidAnchor.chainOpIndex` is never written.

- `AnchorBatchService.buildDidOps` sorts `UserDidAnchor` rows by `did` into the tx metadata `ops[]` array, but discards each anchor's position.
- `AnchorBatchRepository.markSubmitted` / `markConfirmed` flip `status` / `chainTxHash` via a uniform `updateMany` and never touch `chainOpIndex`.
- The schema column and the read side both exist: `didDocumentResolver.ts` reads `opIndexInTx: anchor.chainOpIndex` and `verify-from-chain.ts` looks up `meta.ops[proof.opIndexInTx]`. With `chainOpIndex` null, a CONFIRMED DID still serves `opIndexInTx: null` and the verifier fails with *"missing anchorTxHash / opIndexInTx despite confirmed status"*.

The structural cause: schema column + read side implemented, write side never wired.

## Changes

- `buildDidOps` now returns `{ ops, opIndexByAnchorId }` — the op index is the anchor's position in the deterministic `did`-sorted array (unchanged by the later `trimDocCborForSizeBudget`, which only drops `docCbor`).
- `markSubmitted` accepts `userDidOpIndexes` and stamps `chainOpIndex` per `UserDidAnchor` row inside the **same transaction** as the SUBMITTED status flip (`updateMany` cannot vary `data` per row, so the DID rows are updated individually).
- New `UserDidOpIndex` type; `IAnchorBatchRepository.markSubmitted` signature extended.

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `anchorBatch/service.test.ts` (21 tests) — incl. new case asserting `markSubmitted` receives the correct sorted-by-`did` op-index mapping
- [x] Updated `anchorBatch/repository.test.ts` integration case to assert `chainOpIndex` is persisted (requires DB — not run in this environment)

https://claude.ai/code/session_018iAncVNcxmEnH2eZ5wTnhv

---
_Generated by [Claude Code](https://claude.ai/code/session_018iAncVNcxmEnH2eZ5wTnhv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * DIDアンカー関連のテストを拡充・改良し、アンカーのチェーン関連メタデータ（トランザクションおよび順序情報）の永続化が期待通りに行われることを検証

* **Refactor**
  * DIDアンカーのメタデータ書き戻し処理を改良し、チェーン上のトランザクション情報と各アンカーの順序情報の一貫性と決定論的動作を向上

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hopin-inc/civicship-api/pull/1189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->