### PR TITLE
fix(vc): align inclusion-proof wire format with the third-party verifier

### DIFF
--- a/src/__tests__/integration/acceptance/phase-1.5/phase14_inclusion_proof.test.ts
+++ b/src/__tests__/integration/acceptance/phase-1.5/phase14_inclusion_proof.test.ts
@@ -10,7 +10,7 @@
  *   1. VcIssuanceRequest (vcJwt 持ち) を複数 seed して Merkle leaf 集合を作る
  *   2. canonical sort + buildRoot で root を計算し、CONFIRMED な VcAnchor として seed
  *   3. Express + did router を立てて `GET /vc/:vcId/inclusion-proof` を叩く
- *   4. レスポンスの proofPath を decode し、`verifyProof` でローカル再計算した
+ *   4. レスポンスの siblings を decode し、`verifyProof` でローカル再計算した
  *      root が anchor の rootHash と一致することを確認
  *
  * Mock 方針: 一切なし（route → usecase → service → repository を real DB で通す）。
@@ -22,7 +22,11 @@ import request from "supertest";
 import { AnchorStatus, ChainNetwork } from "@prisma/client";
 import { prismaClient } from "@/infrastructure/prisma/client";
 import didRouter from "@/presentation/router/did";
-import { buildRoot, verifyProof } from "@/infrastructure/libs/merkle/merkleTreeBuilder";
+import {
+  buildRoot,
+  canonicalLeafHash,
+  verifyProof,
+} from "@/infrastructure/libs/merkle/merkleTreeBuilder";
 import {
   fakeVcJwt,
   seedExtraEvaluationForUser,
@@ -62,9 +66,7 @@ describe("[§14.2] VC inclusion proof — GET /vc/:vcId/inclusion-proof returns 
     const rows: { id: string; vcJwt: string }[] = [];
     for (let i = 0; i < count; i += 1) {
       const evaluationId =
-        i === 0
-          ? firstEvaluationId
-          : (await seedExtraEvaluationForUser(userId)).evaluationId;
+        i === 0 ? firstEvaluationId : (await seedExtraEvaluationForUser(userId)).evaluationId;
       // Deterministic salt (no Math.random — fixes Sonar S2245).
       // The index already guarantees uniqueness across rows in this seed call,
       // and `setupAcceptanceTest` wipes the DB before each test, so collision
@@ -87,9 +89,7 @@ describe("[§14.2] VC inclusion proof — GET /vc/:vcId/inclusion-proof returns 
 
     // Replay the canonical (ASCII byte order) leaf sort used in
     // AnchorBatchService.buildVcRoot / VcIssuanceService.generateInclusionProof.
-    const sortedJwts = [...rows.map((r) => r.vcJwt)].sort((a, b) =>
-      a < b ? -1 : a > b ? 1 : 0,
-    );
+    const sortedJwts = [...rows.map((r) => r.vcJwt)].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
     const rootBytes = buildRoot(sortedJwts);
     const rootHex = Buffer.from(rootBytes).toString("hex");
 
@@ -124,12 +124,15 @@ describe("[§14.2] VC inclusion proof — GET /vc/:vcId/inclusion-proof returns 
       vcId: target.id,
       vcJwt: target.vcJwt,
       vcAnchorId: vcAnchor.id,
-      rootHash: rootHex,
+      root: rootHex,
       chainTxHash: "ef".repeat(32),
       blockHeight: 1_111_111,
     });
-    expect(Array.isArray(res.body.proofPath)).toBe(true);
+    expect(Array.isArray(res.body.siblings)).toBe(true);
     expect(typeof res.body.leafIndex).toBe("number");
+    // `leafHash` is the canonical Blake2b-256 of the target VC JWT — the
+    // verifier seeds its proof walk with exactly this value.
+    expect(res.body.leafHash).toBe(Buffer.from(canonicalLeafHash(target.vcJwt)).toString("hex"));
 
     // Local verification: re-compute root from the returned proof and assert
     // it matches the on-chain rootHash. This is exactly the round-trip a
@@ -138,7 +141,7 @@ describe("[§14.2] VC inclusion proof — GET /vc/:vcId/inclusion-proof returns 
     // The §5.1.7 leaf canonicalisation hashes the VC JWT string itself
     // (`canonicalLeafHash(jwt)`); the proof path was computed on
     // `sortedJwts`, so `verifyProof` must receive the JWT at `leafIndex`.
-    const proofBytes = (res.body.proofPath as string[]).map((hex) =>
+    const proofBytes = (res.body.siblings as string[]).map((hex) =>
       Uint8Array.from(Buffer.from(hex, "hex")),
     );
     const ok = verifyProof(

--- a/src/__tests__/unit/application/domain/credential/vcIssuance/service.test.ts
+++ b/src/__tests__/unit/application/domain/credential/vcIssuance/service.test.ts
@@ -27,7 +27,11 @@ import {
   StubJwtSigner,
   STUB_SIGNATURE,
 } from "@/application/domain/credential/shared/stubJwtSigner";
-import { buildRoot, verifyProof } from "@/infrastructure/libs/merkle/merkleTreeBuilder";
+import {
+  buildRoot,
+  canonicalLeafHash,
+  verifyProof,
+} from "@/infrastructure/libs/merkle/merkleTreeBuilder";
 import type {
   VcAnchorRow,
   VcIssuanceRow,
@@ -296,6 +300,9 @@ describe("VcIssuanceService", () => {
       expect(proof!.rootHash).toBe(rootHex);
       expect(proof!.chainTxHash).toBe(anchor.chainTxHash);
       expect(proof!.blockHeight).toBe(anchor.blockHeight);
+      // §5.1.7: the published leaf hash must be Blake2b-256(utf8(vcJwt)) so
+      // the verifier can seed its proof walk without re-deriving it.
+      expect(proof!.leafHash).toBe(Buffer.from(canonicalLeafHash(targetJwt)).toString("hex"));
 
       // Verifier round-trip: rebuild bytes from hex and run verifyProof
       // against the same root the service published.

--- a/src/__tests__/unit/application/domain/credential/vcIssuance/usecase.test.ts
+++ b/src/__tests__/unit/application/domain/credential/vcIssuance/usecase.test.ts
@@ -180,11 +180,12 @@ describe("VcIssuanceUseCase (authz hardening for PR #1101)", () => {
       expect(result).toBeNull();
     });
 
-    it("returns the presented proof when the service yields one", async () => {
+    it("maps the service proof onto the verifier wire shape", async () => {
       const proof = {
         vcId: "vc-1",
         vcJwt: "h.p.s",
         vcAnchorId: "vca-1",
+        leafHash: "9a".repeat(32),
         rootHash: "ab".repeat(32),
         chainTxHash: "cd".repeat(32),
         proofPath: ["ee".repeat(32)],
@@ -195,7 +196,19 @@ describe("VcIssuanceUseCase (authz hardening for PR #1101)", () => {
       const ctx = makeCtx();
 
       const result = await usecase.getInclusionProof(ctx, "vc-1");
-      expect(result).toEqual(proof);
+      // The presenter renames the service's `rootHash`/`proofPath` to the
+      // verifier's `root`/`siblings` and carries `leafHash` through.
+      expect(result).toEqual({
+        vcId: "vc-1",
+        vcJwt: "h.p.s",
+        vcAnchorId: "vca-1",
+        leafHash: "9a".repeat(32),
+        leafIndex: 0,
+        siblings: ["ee".repeat(32)],
+        root: "ab".repeat(32),
+        chainTxHash: "cd".repeat(32),
+        blockHeight: 999,
+      });
     });
   });
 
@@ -205,9 +218,7 @@ describe("VcIssuanceUseCase (authz hardening for PR #1101)", () => {
       const revokedAt = new Date("2026-05-10T12:00:00Z");
       const revokedRow = makeRow({ revokedAt });
 
-      mockService.findVcById
-        .mockResolvedValueOnce(liveRow)
-        .mockResolvedValueOnce(revokedRow);
+      mockService.findVcById.mockResolvedValueOnce(liveRow).mockResolvedValueOnce(revokedRow);
       mockStatusListService.revokeVc.mockResolvedValueOnce(undefined);
 
       const ctx = makeCtx({ isAdmin: true, currentUser: { id: "admin-1" } as never });

--- a/src/__tests__/unit/presentation/router/did.test.ts
+++ b/src/__tests__/unit/presentation/router/did.test.ts
@@ -194,12 +194,8 @@ describe("router/did (§5.4)", () => {
         type: "JsonWebKey2020",
         publicKeyJwk: { kty: "OKP", crv: "Ed25519" },
       });
-      expect(res.body.assertionMethod).toEqual([
-        "did:web:api.civicship.app#key-7",
-      ]);
-      expect(res.body.authentication).toEqual([
-        "did:web:api.civicship.app#key-7",
-      ]);
+      expect(res.body.assertionMethod).toEqual(["did:web:api.civicship.app#key-7"]);
+      expect(res.body.authentication).toEqual(["did:web:api.civicship.app#key-7"]);
       // `service` parity with the single-key Document so verifiers can
       // discover what credential types this issuer publishes regardless
       // of which shape they hit (Gemini review on PR #1124).
@@ -244,9 +240,7 @@ describe("router/did (§5.4)", () => {
     });
 
     it("returns 500 when the use case throws (genuine misconfiguration, no silent fallback)", async () => {
-      const buildDidDocument = jest
-        .fn()
-        .mockRejectedValue(new Error("KMS PERMISSION_DENIED"));
+      const buildDidDocument = jest.fn().mockRejectedValue(new Error("KMS PERMISSION_DENIED"));
       registerIssuerDidUseCaseMock(buildDidDocument);
 
       const res = await request(buildApp()).get("/.well-known/did.json");
@@ -319,10 +313,11 @@ describe("router/did (§5.4)", () => {
         vcId: "vc_123",
         vcJwt: "header.payload.sig",
         vcAnchorId: "vca_abc",
-        rootHash: "ab".repeat(32),
-        chainTxHash: "cd".repeat(32),
-        proofPath: ["ee".repeat(32), "ff".repeat(32)],
+        leafHash: "9a".repeat(32),
         leafIndex: 1,
+        siblings: ["ee".repeat(32), "ff".repeat(32)],
+        root: "ab".repeat(32),
+        chainTxHash: "cd".repeat(32),
         blockHeight: 12345,
       };
     }

--- a/src/application/domain/credential/vcIssuance/presenter.ts
+++ b/src/application/domain/credential/vcIssuance/presenter.ts
@@ -30,19 +30,34 @@ import type { InclusionProof } from "@/application/domain/credential/vcIssuance/
 /**
  * Wire shape for `GET /vc/:vcId/inclusion-proof` (§5.4.6).
  *
- * Mirrors the service-layer `InclusionProof` 1:1 today; declared here
- * separately so HTTP-shape changes (e.g. snake_case rename, additional
- * verification metadata) can land in this file without touching the
- * service contract.
+ * The field names here are the **public contract** consumed by the
+ * third-party verifier `scripts/verify-from-chain.ts` (and the
+ * civicship-portal verifier UI). They deliberately differ from the
+ * service-layer `InclusionProof`:
+ *
+ *   service `rootHash`  → wire `root`
+ *   service `proofPath` → wire `siblings`
+ *
+ * and the wire format additionally carries `leafHash` (the Merkle leaf
+ * the verifier seeds its proof walk with). Keeping the rename in this
+ * presenter is the whole point of the layer — the verifier's expected
+ * shape and the internal service contract evolve independently.
  */
 export interface InclusionProofResponse {
   vcId: string;
   vcJwt: string;
   vcAnchorId: string;
-  rootHash: string;
-  chainTxHash: string;
-  proofPath: string[];
+  /** Hex-encoded Blake2b-256 hash of the VC JWT — the Merkle leaf (§5.1.7). */
+  leafHash: string;
+  /** Index of the leaf in the canonical (ASCII-sorted) leaf set. */
   leafIndex: number;
+  /** Sibling hashes bottom-up, hex-encoded. */
+  siblings: string[];
+  /** Hex-encoded 32-byte Blake2b-256 Merkle root committed on-chain. */
+  root: string;
+  /** Cardano tx hash (hex). */
+  chainTxHash: string;
+  /** Cardano block height; `null` until confirmation stamps one. */
   blockHeight: number | null;
 }
 
@@ -150,10 +165,11 @@ const VcIssuancePresenter = {
       vcId: proof.vcId,
       vcJwt: proof.vcJwt,
       vcAnchorId: proof.vcAnchorId,
-      rootHash: proof.rootHash,
-      chainTxHash: proof.chainTxHash,
-      proofPath: proof.proofPath,
+      leafHash: proof.leafHash,
       leafIndex: proof.leafIndex,
+      siblings: proof.proofPath,
+      root: proof.rootHash,
+      chainTxHash: proof.chainTxHash,
       blockHeight: proof.blockHeight,
     };
   },

--- a/src/application/domain/credential/vcIssuance/service.ts
+++ b/src/application/domain/credential/vcIssuance/service.ts
@@ -70,8 +70,10 @@ export interface InclusionProof {
   vcAnchorId: string;
   /**
    * Hex-encoded Blake2b-256 hash of the VC JWT — i.e. the Merkle *leaf*
-   * (`canonicalLeafHash(vcJwt)`, §5.1.7). The verifier needs this to seed
-   * the proof walk; it must not re-hash the JWT itself.
+   * (`canonicalLeafHash(vcJwt)`, §5.1.7). The verifier seeds its proof
+   * walk with this value; it doesn't need to re-hash the JWT itself
+   * (a verifier MAY still re-derive it from `vcJwt` as an integrity
+   * cross-check — it just isn't a prerequisite).
    */
   leafHash: string;
   /** Hex-encoded 32-byte Blake2b-256 root committed on-chain. */

--- a/src/application/domain/credential/vcIssuance/service.ts
+++ b/src/application/domain/credential/vcIssuance/service.ts
@@ -56,7 +56,7 @@ import StatusListService from "@/application/domain/credential/statusList/servic
 import { CIVICSHIP_ISSUER_DID } from "@/application/domain/credential/shared/constants";
 import type { JwtSigner } from "@/application/domain/credential/shared/jwtSigner";
 import { STUB_SIGNATURE } from "@/application/domain/credential/shared/stubJwtSigner";
-import { buildProof } from "@/infrastructure/libs/merkle/merkleTreeBuilder";
+import { buildProof, canonicalLeafHash } from "@/infrastructure/libs/merkle/merkleTreeBuilder";
 
 /**
  * Inclusion proof DTO for the `/vc/:vcId/inclusion-proof` REST endpoint
@@ -68,6 +68,12 @@ export interface InclusionProof {
   vcId: string;
   vcJwt: string;
   vcAnchorId: string;
+  /**
+   * Hex-encoded Blake2b-256 hash of the VC JWT — i.e. the Merkle *leaf*
+   * (`canonicalLeafHash(vcJwt)`, §5.1.7). The verifier needs this to seed
+   * the proof walk; it must not re-hash the JWT itself.
+   */
+  leafHash: string;
   /** Hex-encoded 32-byte Blake2b-256 root committed on-chain. */
   rootHash: string;
   /** Cardano tx hash (hex). Always populated for CONFIRMED anchors. */
@@ -255,11 +261,7 @@ export default class VcIssuanceService {
       // Out of scope for the cascade-revoke PR (deferred until admin
       // bulk-purge tooling lands; cascade frequency is low enough that
       // the loop is fine for the user-delete trigger).
-      await this.statusListService.revokeVc(
-        ctx,
-        { vcRequestId: vc.id, reason },
-        tx,
-      );
+      await this.statusListService.revokeVc(ctx, { vcRequestId: vc.id, reason }, tx);
       revoked += 1;
     }
 
@@ -519,6 +521,11 @@ export default class VcIssuanceService {
       vcId: vc.id,
       vcJwt: vc.vcJwt,
       vcAnchorId: anchor.id,
+      // §5.1.7: the Merkle leaf is `Blake2b-256(utf8(vcJwt))`. The verifier
+      // seeds its proof walk with this hash, so it must be published
+      // explicitly — re-deriving it from the JWT is the verifier's job
+      // only when it wants to cross-check, not a prerequisite.
+      leafHash: Buffer.from(canonicalLeafHash(vc.vcJwt)).toString("hex"),
       rootHash: anchor.rootHash,
       chainTxHash: anchor.chainTxHash,
       proofPath: proofBytes.map((b) => Buffer.from(b).toString("hex")),


### PR DESCRIPTION
## Summary

One of three release-blocking bugs found in the blockchain functional-parity audit of the DID/VC internalization. This bug breaks third-party verifiability of **VC inclusion proofs** — a regression vs the old `did:prism` system and a violation of design-doc §1.3 success criterion #3.

### Root cause — who can't do what

A third party **cannot** verify a VC against the on-chain Merkle root, because the `/vc/:vcId/inclusion-proof` response and the verifier disagree on the wire format.

| `scripts/verify-from-chain.ts` reads | `VcIssuancePresenter` emitted |
|---|---|
| `root` | `rootHash` |
| `siblings` | `proofPath` |
| `leafHash` | *(absent)* |

The verifier was written against the intended §5.4.6 spec; the presenter drifted. `JSON.parse` yields `undefined` for `proof.root` / `proof.siblings` / `proof.leafHash`, so the verifier fails to decode the proof for every VC.

The structural cause: the verifier (consumer) was correct, the producer was never reconciled with it — no end-to-end verify-from-chain test crossed the boundary.

## Changes

- `VcIssuanceService.generateInclusionProof` now computes the Merkle **leaf hash** — `Blake2b-256(utf8(vcJwt))` via `canonicalLeafHash` (§5.1.7) — and returns it on the service-layer `InclusionProof`. The verifier seeds its proof walk with this value.
- `VcIssuancePresenter.toInclusionProofResponse` maps the internal service contract onto the verifier's public wire shape: `rootHash`→`root`, `proofPath`→`siblings`, plus the new `leafHash`. Keeping the rename in the presenter is exactly its purpose — the wire contract and the internal type evolve independently.
- `scripts/verify-from-chain.ts` is **unchanged** — it already expected the correct shape.

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `vcIssuance/service.test.ts`, `vcIssuance/usecase.test.ts`, `router/did.test.ts` (46 tests) — incl. new assertions on `leafHash` and the renamed wire fields
- [x] Updated `phase14_inclusion_proof.test.ts` acceptance test to assert the verifier-facing shape (`root` / `siblings` / `leafHash`) — requires DB, not run in this environment

https://claude.ai/code/session_018iAncVNcxmEnH2eZ5wTnhv

---
_Generated by [Claude Code](https://claude.ai/code/session_018iAncVNcxmEnH2eZ5wTnhv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * インクルージョン証明レスポンスに検証用フィールド（leafHash、leafIndex）を追加

* **改善**
  * インクルージョン証明のAPIレスポンス形式を更新（proofPath → siblings、rootHash → rootへリネーム）
  * レスポンスのフィールド整合性チェックを強化し、プルーフ検証を詳細化

* **テスト**
  * 新しいレスポンス形状と検証ロジックに合わせてテストを更新

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hopin-inc/civicship-api/pull/1190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->