### PR TITLE
fix(userDid): thread previousAnchorId so DID version chains link on-chain

### DIFF
--- a/src/__tests__/integration/acceptance/phase-1.5/phase14_did_deactivate_vc_cascade.test.ts
+++ b/src/__tests__/integration/acceptance/phase-1.5/phase14_did_deactivate_vc_cascade.test.ts
@@ -136,6 +136,9 @@ describe("[§14.2] DID DEACTIVATE → cascade-revokes the user's live VCs (§9.7
     //    Both must commit together — splitting them would violate §14.2
     //    line 2123 (no "DID tombstoned but VC still live" window).
     const useCase = container.resolve(UserDidUseCase);
+    // A DID must exist before it can be deactivated — §5.1.6 requires the
+    // DEACTIVATE op to chain from a prior anchor. Establish CREATE first.
+    await useCase.createDidForUser(ctx, userId);
     await useCase.deactivateDid(ctx, userId);
 
     // 4. Both VC rows are revoked.
@@ -172,6 +175,9 @@ describe("[§14.2] DID DEACTIVATE → cascade-revokes the user's live VCs (§9.7
     });
 
     const useCase = container.resolve(UserDidUseCase);
+    // A DID must exist before it can be deactivated — §5.1.6 requires the
+    // DEACTIVATE op to chain from a prior anchor. Establish CREATE first.
+    await useCase.createDidForUser(ctx, userId);
 
     // First DEACTIVATE — revokes the single VC.
     await useCase.deactivateDid(ctx, userId);
@@ -240,6 +246,9 @@ describe("[§14.2] DID DEACTIVATE → cascade-revokes the user's live VCs (§9.7
     });
 
     const useCase = container.resolve(UserDidUseCase);
+    // A DID must exist before it can be deactivated — §5.1.6 requires the
+    // DEACTIVATE op to chain from a prior anchor. Establish CREATE first.
+    await useCase.createDidForUser(ctx, userId);
     await useCase.deactivateDid(ctx, userId);
 
     // Wired VC is revoked; legacy VC remains live (revokedAt stays null).

--- a/src/__tests__/integration/application/domain/account/userDid/repository.test.ts
+++ b/src/__tests__/integration/application/domain/account/userDid/repository.test.ts
@@ -96,6 +96,25 @@ describe("UserDidAnchorRepository (integration)", () => {
       expect(latest!.id).not.toBe(first.id);
       expect(latest!.operation).toBe(DidOperation.UPDATE);
     });
+
+    it("reads inside a supplied transaction (tx-aware branch)", async () => {
+      const ctx = buildCtx();
+      const created = await repo.createCreate(ctx, {
+        userId,
+        did: `did:web:api.civicship.app:users:${userId}`,
+        documentHash: "a".repeat(64),
+        documentCbor: new Uint8Array([1, 2, 3]),
+        network: "CARDANO_PREPROD",
+      });
+
+      // The UPDATE / DEACTIVATE lifecycle resolves the prior anchor inside
+      // its own write transaction — exercise that `tx`-aware code path.
+      const seen = await prismaClient.$transaction((tx) =>
+        repo.findLatestByUserId(userId, tx),
+      );
+      expect(seen).not.toBeNull();
+      expect(seen!.id).toBe(created.id);
+    });
   });
 
   describe("createCreate / createUpdate / createDeactivate", () => {
@@ -143,11 +162,21 @@ describe("UserDidAnchorRepository (integration)", () => {
 
     it("persists DEACTIVATE with documentCbor = null (§E tombstone)", async () => {
       const ctx = buildCtx();
+      // DEACTIVATE requires a prior anchor (§5.1.6 — `prev` is mandatory),
+      // so seed a CREATE to chain from.
+      const create = await repo.createCreate(ctx, {
+        userId,
+        did: `did:web:api.civicship.app:users:${userId}`,
+        documentHash: "a".repeat(64),
+        documentCbor: new Uint8Array([1, 2, 3]),
+        network: "CARDANO_PREPROD",
+      });
       const persisted = await repo.createDeactivate(ctx, {
         userId,
         did: `did:web:api.civicship.app:users:${userId}`,
         documentHash: "e".repeat(64),
         network: "CARDANO_PREPROD",
+        previousAnchorId: create.id,
       });
 
       expect(persisted.operation).toBe(DidOperation.DEACTIVATE);

--- a/src/__tests__/integration/application/domain/account/userDid/repository.test.ts
+++ b/src/__tests__/integration/application/domain/account/userDid/repository.test.ts
@@ -13,9 +13,8 @@
  *      operation marker and the documentCbor / documentHash fields.
  *   3. DEACTIVATE rows persist `documentCbor = null` (§E).
  *   4. `network` is honoured per-row (CARDANO_PREPROD vs CARDANO_MAINNET).
- *   5. The schema-level `previousAnchorId` column defaults to `null` for
- *      every row created by the current repository surface (chain wiring
- *      lands in a follow-up phase, this test pins the current contract).
+ *   5. UPDATE / DEACTIVATE rows persist the `previousAnchorId` hash-chain
+ *      link to the prior anchor (§5.1.6); CREATE (genesis) leaves it `null`.
  *
  * Design references:
  *   docs/report/did-vc-internalization.md §5.2.1
@@ -159,6 +158,45 @@ describe("UserDidAnchorRepository (integration)", () => {
       expect(row).not.toBeNull();
       // §E: tombstones do not persist CBOR; the resolver reconstructs.
       expect(row!.documentCbor).toBeNull();
+    });
+
+    it("persists the previousAnchor hash-chain link for UPDATE / DEACTIVATE (§5.1.6)", async () => {
+      const ctx = buildCtx();
+      const cbor = new Uint8Array([1, 2, 3]);
+      const did = `did:web:api.civicship.app:users:${userId}`;
+
+      const create = await repo.createCreate(ctx, {
+        userId,
+        did,
+        documentHash: "a".repeat(64),
+        documentCbor: cbor,
+        network: "CARDANO_PREPROD",
+      });
+      const update = await repo.createUpdate(ctx, {
+        userId,
+        did,
+        documentHash: "b".repeat(64),
+        documentCbor: cbor,
+        network: "CARDANO_PREPROD",
+        previousAnchorId: create.id,
+      });
+      const deactivate = await repo.createDeactivate(ctx, {
+        userId,
+        did,
+        documentHash: "c".repeat(64),
+        network: "CARDANO_PREPROD",
+        previousAnchorId: update.id,
+      });
+
+      const updateRow = await prismaClient.userDidAnchor.findUnique({
+        where: { id: update.id },
+      });
+      const deactivateRow = await prismaClient.userDidAnchor.findUnique({
+        where: { id: deactivate.id },
+      });
+      // The version chain walks DEACTIVATE → UPDATE → CREATE (genesis).
+      expect(updateRow!.previousAnchorId).toBe(create.id);
+      expect(deactivateRow!.previousAnchorId).toBe(update.id);
     });
   });
 

--- a/src/__tests__/unit/application/domain/account/userDid/service.test.ts
+++ b/src/__tests__/unit/application/domain/account/userDid/service.test.ts
@@ -142,7 +142,12 @@ describe("UserDidService", () => {
   });
 
   describe("updateDid", () => {
+    // updateDid now requires an existing, non-deactivated anchor to chain
+    // from (§5.1.6). Happy-path tests seed one.
+    const PRIOR_CREATE = { id: "uda_prev_create", operation: "CREATE" };
+
     it("re-anchors the minimal Document via createUpdate", async () => {
+      mockRepository.findLatestByUserId.mockResolvedValueOnce(PRIOR_CREATE);
       mockRepository.createUpdate.mockResolvedValue({ ok: true });
 
       await service.updateDid(mockCtx, VALID_USER_ID);
@@ -160,29 +165,52 @@ describe("UserDidService", () => {
     });
 
     it("links previousAnchorId to the user's latest anchor (§5.1.6 hash chain)", async () => {
-      mockRepository.findLatestByUserId.mockResolvedValueOnce({ id: "uda_prev_create" });
+      mockRepository.findLatestByUserId.mockResolvedValueOnce(PRIOR_CREATE);
       mockRepository.createUpdate.mockResolvedValue({ ok: true });
 
       await service.updateDid(mockCtx, VALID_USER_ID);
 
-      expect(mockRepository.findLatestByUserId).toHaveBeenCalledWith(VALID_USER_ID);
       const [, input] = mockRepository.createUpdate.mock.calls[0];
       expect(input.previousAnchorId).toBe("uda_prev_create");
     });
 
-    it("leaves previousAnchorId undefined when the user has no prior anchor", async () => {
-      mockRepository.findLatestByUserId.mockResolvedValueOnce(null);
+    it("resolves the prior anchor inside the supplied transaction", async () => {
+      mockRepository.findLatestByUserId.mockResolvedValueOnce(PRIOR_CREATE);
       mockRepository.createUpdate.mockResolvedValue({ ok: true });
+      const fakeTx = { sentinel: true } as never;
 
-      await service.updateDid(mockCtx, VALID_USER_ID);
+      await service.updateDid(mockCtx, VALID_USER_ID, fakeTx);
 
-      const [, input] = mockRepository.createUpdate.mock.calls[0];
-      expect(input.previousAnchorId).toBeUndefined();
+      expect(mockRepository.findLatestByUserId).toHaveBeenCalledWith(VALID_USER_ID, fakeTx);
+    });
+
+    it("throws when the user has no existing DID anchor", async () => {
+      mockRepository.findLatestByUserId.mockResolvedValueOnce(null);
+
+      await expect(service.updateDid(mockCtx, VALID_USER_ID)).rejects.toThrow(
+        /no DID anchor to update/,
+      );
+      expect(mockRepository.createUpdate).not.toHaveBeenCalled();
+    });
+
+    it("throws when the DID is already deactivated", async () => {
+      mockRepository.findLatestByUserId.mockResolvedValueOnce({
+        id: "uda_dead",
+        operation: "DEACTIVATE",
+      });
+
+      await expect(service.updateDid(mockCtx, VALID_USER_ID)).rejects.toThrow(
+        /already deactivated/,
+      );
+      expect(mockRepository.createUpdate).not.toHaveBeenCalled();
     });
   });
 
   describe("deactivateDid", () => {
+    const PRIOR_UPDATE = { id: "uda_prev_update", operation: "UPDATE" };
+
     it("hashes the tombstone Document and emits createDeactivate without CBOR", async () => {
+      mockRepository.findLatestByUserId.mockResolvedValueOnce(PRIOR_UPDATE);
       mockRepository.createDeactivate.mockResolvedValue({ ok: true });
 
       await service.deactivateDid(mockCtx, VALID_USER_ID);
@@ -206,14 +234,47 @@ describe("UserDidService", () => {
     });
 
     it("links previousAnchorId to the user's latest anchor (§5.1.6 mandatory prev)", async () => {
-      mockRepository.findLatestByUserId.mockResolvedValueOnce({ id: "uda_prev_update" });
+      mockRepository.findLatestByUserId.mockResolvedValueOnce(PRIOR_UPDATE);
       mockRepository.createDeactivate.mockResolvedValue({ ok: true });
 
       await service.deactivateDid(mockCtx, VALID_USER_ID);
 
-      expect(mockRepository.findLatestByUserId).toHaveBeenCalledWith(VALID_USER_ID);
       const [, input] = mockRepository.createDeactivate.mock.calls[0];
       expect(input.previousAnchorId).toBe("uda_prev_update");
+    });
+
+    it("resolves the prior anchor inside the supplied transaction", async () => {
+      mockRepository.findLatestByUserId.mockResolvedValueOnce(PRIOR_UPDATE);
+      mockRepository.createDeactivate.mockResolvedValue({ ok: true });
+      const fakeTx = { sentinel: true } as never;
+
+      await service.deactivateDid(mockCtx, VALID_USER_ID, fakeTx);
+
+      expect(mockRepository.findLatestByUserId).toHaveBeenCalledWith(VALID_USER_ID, fakeTx);
+    });
+
+    it("throws when the user has no existing DID anchor (§5.1.6 prev is mandatory)", async () => {
+      mockRepository.findLatestByUserId.mockResolvedValueOnce(null);
+
+      await expect(service.deactivateDid(mockCtx, VALID_USER_ID)).rejects.toThrow(
+        /no DID anchor to deactivate/,
+      );
+      expect(mockRepository.createDeactivate).not.toHaveBeenCalled();
+    });
+
+    it("allows re-deactivating an already-deactivated DID (append-only lifecycle)", async () => {
+      mockRepository.findLatestByUserId.mockResolvedValueOnce({
+        id: "uda_dead",
+        operation: "DEACTIVATE",
+      });
+      mockRepository.createDeactivate.mockResolvedValue({ ok: true });
+
+      await service.deactivateDid(mockCtx, VALID_USER_ID);
+
+      // A second DEACTIVATE still chains from the prior DEACTIVATE anchor,
+      // so `prev` stays non-null and §5.1.6 holds.
+      const [, input] = mockRepository.createDeactivate.mock.calls[0];
+      expect(input.previousAnchorId).toBe("uda_dead");
     });
   });
 });

--- a/src/__tests__/unit/application/domain/account/userDid/service.test.ts
+++ b/src/__tests__/unit/application/domain/account/userDid/service.test.ts
@@ -158,6 +158,27 @@ describe("UserDidService", () => {
       const decoded = cborDecode(input.documentCbor as Uint8Array);
       expect(decoded).toEqual(buildMinimalDidDocument(VALID_USER_ID));
     });
+
+    it("links previousAnchorId to the user's latest anchor (§5.1.6 hash chain)", async () => {
+      mockRepository.findLatestByUserId.mockResolvedValueOnce({ id: "uda_prev_create" });
+      mockRepository.createUpdate.mockResolvedValue({ ok: true });
+
+      await service.updateDid(mockCtx, VALID_USER_ID);
+
+      expect(mockRepository.findLatestByUserId).toHaveBeenCalledWith(VALID_USER_ID);
+      const [, input] = mockRepository.createUpdate.mock.calls[0];
+      expect(input.previousAnchorId).toBe("uda_prev_create");
+    });
+
+    it("leaves previousAnchorId undefined when the user has no prior anchor", async () => {
+      mockRepository.findLatestByUserId.mockResolvedValueOnce(null);
+      mockRepository.createUpdate.mockResolvedValue({ ok: true });
+
+      await service.updateDid(mockCtx, VALID_USER_ID);
+
+      const [, input] = mockRepository.createUpdate.mock.calls[0];
+      expect(input.previousAnchorId).toBeUndefined();
+    });
   });
 
   describe("deactivateDid", () => {
@@ -182,6 +203,17 @@ describe("UserDidService", () => {
         tombstoneCbor instanceof Uint8Array ? tombstoneCbor : new Uint8Array(tombstoneCbor);
       const expectedHash = bytesToHex(blake2b(tombstoneBytes, { dkLen: 32 }));
       expect(input.documentHash).toBe(expectedHash);
+    });
+
+    it("links previousAnchorId to the user's latest anchor (§5.1.6 mandatory prev)", async () => {
+      mockRepository.findLatestByUserId.mockResolvedValueOnce({ id: "uda_prev_update" });
+      mockRepository.createDeactivate.mockResolvedValue({ ok: true });
+
+      await service.deactivateDid(mockCtx, VALID_USER_ID);
+
+      expect(mockRepository.findLatestByUserId).toHaveBeenCalledWith(VALID_USER_ID);
+      const [, input] = mockRepository.createDeactivate.mock.calls[0];
+      expect(input.previousAnchorId).toBe("uda_prev_update");
     });
   });
 });

--- a/src/application/domain/account/userDid/data/interface.ts
+++ b/src/application/domain/account/userDid/data/interface.ts
@@ -32,10 +32,15 @@ export interface IUserDidAnchorRepository extends UserDidAnchorStore {
    * Return the most recently-created anchor for `userId`, regardless of
    * status (PENDING included per §F). Returns `null` when no row exists.
    *
-   * Inherited from `UserDidAnchorStore` so the production class can be
-   * reused by `DidDocumentResolver` without an adapter.
+   * Widens the `UserDidAnchorStore` signature with an optional `tx`: the
+   * UPDATE / DEACTIVATE lifecycle resolves the prior anchor inside its
+   * own write transaction, so the read must be able to participate in it
+   * (the no-`tx` form keeps the unauthenticated resolver path working).
    */
-  findLatestByUserId(userId: string): Promise<UserDidAnchorRow | null>;
+  findLatestByUserId(
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<UserDidAnchorRow | null>;
 
   /**
    * Return the CREATE-op anchor for `userId` if one exists, else `null`.

--- a/src/application/domain/account/userDid/data/repository.ts
+++ b/src/application/domain/account/userDid/data/repository.ts
@@ -64,13 +64,19 @@ export default class UserDidAnchorRepository implements IUserDidAnchorRepository
     if (tx) {
       return tx.userDidAnchor.findFirst({
         where: { userId },
-        orderBy: { createdAt: "desc" },
+        // §5.1.6: `id` (cuid) is the deterministic tie-break so the prior
+        // anchor resolved for `previousAnchorId` is stable even when two
+        // rows share `createdAt` — an ambiguous pick would fork the chain.
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
       });
     }
     return this.issuer.internal((innerTx) =>
       innerTx.userDidAnchor.findFirst({
         where: { userId },
-        orderBy: { createdAt: "desc" },
+        // §5.1.6: `id` (cuid) is the deterministic tie-break so the prior
+        // anchor resolved for `previousAnchorId` is stable even when two
+        // rows share `createdAt` — an ambiguous pick would fork the chain.
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
       }),
     );
   }

--- a/src/application/domain/account/userDid/data/repository.ts
+++ b/src/application/domain/account/userDid/data/repository.ts
@@ -138,6 +138,12 @@ export default class UserDidAnchorRepository implements IUserDidAnchorRepository
       network: input.network ?? "CARDANO_MAINNET",
       user: { connect: { id: input.userId } },
     };
+    // §5.1.6 hash chain: UPDATE / DEACTIVATE rows link to the user's prior
+    // anchor via the `DidVersionChain` self-relation. CREATE is the genesis
+    // op and leaves `previousAnchorId` null.
+    if (input.previousAnchorId) {
+      data.previousAnchor = { connect: { id: input.previousAnchorId } };
+    }
     return data;
   }
 }

--- a/src/application/domain/account/userDid/data/repository.ts
+++ b/src/application/domain/account/userDid/data/repository.ts
@@ -46,16 +46,29 @@ export default class UserDidAnchorRepository implements IUserDidAnchorRepository
    * status (PENDING included per §F). Returns `null` when no row exists.
    *
    * Used by both `DidDocumentResolver` (HTTP `/users/:userId/did.json`) and
-   * `UserDidService` (next-version chaining decisions in future phases).
+   * `UserDidService` (UPDATE / DEACTIVATE prior-anchor resolution).
    *
-   * The HTTP route serving did:web is unauthenticated (§5.4) so there is no
-   * request-scoped `IContext` — `internal()` is the appropriate RLS bypass
-   * (a system-level read), and unlike `public(ctx, ...)` it does not depend
-   * on a request context that we cannot honestly construct here.
+   * When `tx` is supplied, the read runs inside the caller's write
+   * transaction so the lookup is transaction-consistent (the
+   * UPDATE / DEACTIVATE lifecycle resolves the prior anchor mid-write).
+   * Without `tx` the HTTP route serving did:web is unauthenticated (§5.4)
+   * so there is no request-scoped `IContext` — `internal()` is the
+   * appropriate RLS bypass (a system-level read), and unlike
+   * `public(ctx, ...)` it does not depend on a request context that we
+   * cannot honestly construct here.
    */
-  async findLatestByUserId(userId: string): Promise<UserDidAnchorRow | null> {
-    return this.issuer.internal((tx) =>
-      tx.userDidAnchor.findFirst({
+  async findLatestByUserId(
+    userId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<UserDidAnchorRow | null> {
+    if (tx) {
+      return tx.userDidAnchor.findFirst({
+        where: { userId },
+        orderBy: { createdAt: "desc" },
+      });
+    }
+    return this.issuer.internal((innerTx) =>
+      innerTx.userDidAnchor.findFirst({
         where: { userId },
         orderBy: { createdAt: "desc" },
       }),

--- a/src/application/domain/account/userDid/data/type.ts
+++ b/src/application/domain/account/userDid/data/type.ts
@@ -84,8 +84,9 @@ export interface DeactivateUserDidAnchorInput {
   network?: AnchorNetworkValue;
   /**
    * Anchor id of the prior DID version. The DEACTIVATE op's on-chain
-   * `prev` is mandatory (§5.1.6), so callers must thread the user's
-   * latest anchor here.
+   * `prev` is mandatory (§5.1.6), so this is **required** — a DID with no
+   * prior anchor cannot be deactivated. `UserDidService.deactivateDid`
+   * resolves it from the user's latest anchor and throws when absent.
    */
-  previousAnchorId?: string;
+  previousAnchorId: string;
 }

--- a/src/application/domain/account/userDid/data/type.ts
+++ b/src/application/domain/account/userDid/data/type.ts
@@ -57,6 +57,12 @@ export interface CreateUserDidAnchorInput {
   documentCbor: Uint8Array;
   /** Defaults to `"CARDANO_MAINNET"` per §5.2.1 example when omitted. */
   network?: AnchorNetworkValue;
+  /**
+   * Anchor id of the prior DID version — links the on-chain hash chain
+   * (§5.1.6). Left undefined for the genesis CREATE op (no predecessor);
+   * UPDATE / DEACTIVATE callers populate it with the user's latest anchor.
+   */
+  previousAnchorId?: string;
 }
 
 /**
@@ -76,4 +82,10 @@ export interface DeactivateUserDidAnchorInput {
   did: string;
   documentHash: string;
   network?: AnchorNetworkValue;
+  /**
+   * Anchor id of the prior DID version. The DEACTIVATE op's on-chain
+   * `prev` is mandatory (§5.1.6), so callers must thread the user's
+   * latest anchor here.
+   */
+  previousAnchorId?: string;
 }

--- a/src/application/domain/account/userDid/service.ts
+++ b/src/application/domain/account/userDid/service.ts
@@ -160,10 +160,17 @@ export default class UserDidService {
     const document = buildMinimalDidDocument(userId);
     const { cbor, hashHex } = encodeAndHash(document);
 
+    // §5.1.6 hash chain: the UPDATE op must reference the user's most
+    // recent anchor so verifiers can walk the DID version history. Without
+    // this link the anchor batch emits `prev: null` and every version
+    // looks like an independent genesis.
+    const previous = await this.repository.findLatestByUserId(userId);
+
     logger.debug("[UserDidService] updateDid", {
       userId,
       did,
       documentHash: hashHex,
+      previousAnchorId: previous?.id ?? null,
       network,
     });
 
@@ -175,6 +182,7 @@ export default class UserDidService {
         documentHash: hashHex,
         documentCbor: cbor,
         network,
+        previousAnchorId: previous?.id,
       },
       tx,
     );
@@ -199,10 +207,16 @@ export default class UserDidService {
     const tombstone = buildDeactivatedDidDocument(userId);
     const { hashHex } = encodeAndHash(tombstone);
 
+    // §5.1.6: the DEACTIVATE op's on-chain `prev` is mandatory — it must
+    // point at the user's most recent anchor so verifiers can confirm the
+    // tombstone terminates a real DID version chain.
+    const previous = await this.repository.findLatestByUserId(userId);
+
     logger.debug("[UserDidService] deactivateDid", {
       userId,
       did,
       documentHash: hashHex,
+      previousAnchorId: previous?.id ?? null,
       network,
     });
 
@@ -213,6 +227,7 @@ export default class UserDidService {
         did,
         documentHash: hashHex,
         network,
+        previousAnchorId: previous?.id,
       },
       tx,
     );

--- a/src/application/domain/account/userDid/service.ts
+++ b/src/application/domain/account/userDid/service.ts
@@ -161,16 +161,27 @@ export default class UserDidService {
     const { cbor, hashHex } = encodeAndHash(document);
 
     // §5.1.6 hash chain: the UPDATE op must reference the user's most
-    // recent anchor so verifiers can walk the DID version history. Without
-    // this link the anchor batch emits `prev: null` and every version
-    // looks like an independent genesis.
-    const previous = await this.repository.findLatestByUserId(userId);
+    // recent anchor so verifiers can walk the DID version history. Resolve
+    // it inside the caller's `tx` (transaction-consistent read), and
+    // refuse to update a DID that was never created or is already
+    // deactivated — both would break the chain.
+    const previous = await this.repository.findLatestByUserId(userId, tx);
+    if (!previous) {
+      throw new Error(
+        `updateDid: user ${userId} has no DID anchor to update — create the DID first`,
+      );
+    }
+    if (previous.operation === "DEACTIVATE") {
+      throw new Error(
+        `updateDid: DID for user ${userId} is already deactivated and cannot be updated`,
+      );
+    }
 
     logger.debug("[UserDidService] updateDid", {
       userId,
       did,
       documentHash: hashHex,
-      previousAnchorId: previous?.id ?? null,
+      previousAnchorId: previous.id,
       network,
     });
 
@@ -182,7 +193,7 @@ export default class UserDidService {
         documentHash: hashHex,
         documentCbor: cbor,
         network,
-        previousAnchorId: previous?.id,
+        previousAnchorId: previous.id,
       },
       tx,
     );
@@ -209,14 +220,23 @@ export default class UserDidService {
 
     // §5.1.6: the DEACTIVATE op's on-chain `prev` is mandatory — it must
     // point at the user's most recent anchor so verifiers can confirm the
-    // tombstone terminates a real DID version chain.
-    const previous = await this.repository.findLatestByUserId(userId);
+    // tombstone terminates a real DID version chain. Resolve it inside the
+    // caller's `tx`, and refuse to deactivate a DID that was never created
+    // (no `prev` to chain from). A repeated DEACTIVATE is intentionally
+    // allowed: the DID lifecycle is append-only, so it simply chains from
+    // the prior DEACTIVATE anchor and `prev` stays non-null.
+    const previous = await this.repository.findLatestByUserId(userId, tx);
+    if (!previous) {
+      throw new Error(
+        `deactivateDid: user ${userId} has no DID anchor to deactivate`,
+      );
+    }
 
     logger.debug("[UserDidService] deactivateDid", {
       userId,
       did,
       documentHash: hashHex,
-      previousAnchorId: previous?.id ?? null,
+      previousAnchorId: previous.id,
       network,
     });
 
@@ -227,7 +247,7 @@ export default class UserDidService {
         did,
         documentHash: hashHex,
         network,
-        previousAnchorId: previous?.id,
+        previousAnchorId: previous.id,
       },
       tx,
     );


### PR DESCRIPTION
## Summary

One of three release-blocking bugs found in the blockchain functional-parity audit of the DID/VC internalization. This bug breaks third-party verifiability of the **DID version hash chain** — a regression vs the old `did:prism` system and a violation of design-doc §1.3 success criterion #3.

### Root cause — who can't do what

A third party **cannot** walk a DID's version history on-chain, and **cannot** confirm a DEACTIVATE terminates a real chain, because `UserDidAnchor.previousAnchorId` is never written.

- `UserDidService.updateDid` and `deactivateDid` build the new anchor and call `repository.createUpdate` / `createDeactivate` without ever looking up the prior anchor.
- `buildCreateData` therefore never sets `previousAnchorId`, so every row is persisted with `previousAnchorId = null`.
- `AnchorBatchService.buildDidOps` reads `a.previousAnchorId` to populate the on-chain op's `prev`; with it always null, every op emits `prev: null` (UPDATE) / `prev: ""` (DEACTIVATE). Per §5.1.6 the DEACTIVATE `prev` is **mandatory** — a revoked DID becomes unverifiable.

The schema column + the `DidVersionChain` self-relation + the anchor-batch read side all exist; only the write side was never wired.

## Changes

- `updateDid` / `deactivateDid` now resolve the user's most recent anchor via `repository.findLatestByUserId` and pass its id as `previousAnchorId`.
- `buildCreateData` connects the `DidVersionChain` self-relation (`previousAnchor`) when `previousAnchorId` is present; CREATE stays the genesis op with no predecessor.
- `CreateUserDidAnchorInput` / `DeactivateUserDidAnchorInput` gain an optional `previousAnchorId` (UPDATE reuses the Create shape).

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `userDid/service.test.ts` (11 tests) — incl. new cases asserting `previousAnchorId` is threaded for UPDATE / DEACTIVATE and left undefined when no prior anchor exists
- [x] Extended `userDid/repository.test.ts` integration suite to assert the `previousAnchor` FK chain (DEACTIVATE → UPDATE → CREATE) — requires DB, not run in this environment

https://claude.ai/code/session_018iAncVNcxmEnH2eZ5wTnhv

---
_Generated by [Claude Code](https://claude.ai/code/session_018iAncVNcxmEnH2eZ5wTnhv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * 更新・無効化での前アンカー受け渡しとトランザクション内読み取りを検証する統合・単体テストを拡充。受け渡し必須ケースやDEACTIVATE時の振る舞いを追加。

* **New Features**
  * 更新／無効化処理で直前アンカーを参照してチェーンを維持する挙動を導入。
  * トランザクション内での最新アンカー取得に対応し一貫性を強化。

* **Behavior**
  * 存在しないまたは既に無効化されたアンカーへの更新を拒否する検証を追加。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hopin-inc/civicship-api/pull/1191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->