### PR TITLE
fix(ci): create trivy-daily label before issue management

### DIFF
--- a/.github/workflows/trivy-daily.yml
+++ b/.github/workflows/trivy-daily.yml
@@ -184,6 +184,30 @@ jobs:
           sarif_file: trivy-external.sarif
           category: trivy-external-critical
 
+      # `gh issue create` / `gh issue edit --add-label` で使う label を先に
+      # 用意する。repo に label が存在しないと
+      # `could not add label: '...' not found` で step が落ちる
+      # (`trivy-daily` は default では存在しない label)。既存 label の
+      # color/description を壊さないよう、欠けている label だけ作成する。
+      - name: Ensure issue labels exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          ensure_label() {
+            local name="$1" color="$2" desc="$3"
+            if gh label list --repo "$REPO" --limit 200 --json name --jq '.[].name' \
+                 | grep -qxF "$name"; then
+              echo "Label '${name}' already exists — leaving as-is."
+            else
+              gh label create "$name" --repo "$REPO" --color "$color" --description "$desc"
+              echo "Created label '${name}'."
+            fi
+          }
+          ensure_label trivy-daily B60205 "Daily Trivy CVE scan tracking issue (managed by trivy-daily.yml)"
+          ensure_label security D93F0B "Security-related issue or vulnerability"
+
       # body 生成 + 既存 issue との CVE-ID set 比較 + upsert/close。
       - name: Manage Trivy tracking issue
         env:


### PR DESCRIPTION
## Summary

The `Daily Trivy CVE scan` workflow (`.github/workflows/trivy-daily.yml`) fails at the **Manage Trivy tracking issue** step:

```
could not add label: 'trivy-daily' not found
##[error]Process completed with exit code 1.
```

The workflow's whole issue-tracking design depends on a `trivy-daily` label (`gh issue list --label trivy-daily`, `gh issue create --label trivy-daily`, `gh issue edit --add-label trivy-daily`), but nothing ever creates that label. With 4 CRITICAL CVEs detected, `gh issue create` aborted because the label didn't exist.

## Fix

Add an **Ensure issue labels exist** step before the issue-management step. It creates only *missing* labels via a check-then-create helper, so:

- `trivy-daily` — created (did not exist).
- `security` — left untouched (already exists in the repo as `セキュリティ`, color `e4e669`); the step does **not** overwrite its color/description.

The helper is idempotent, so every scheduled run is safe.

## Test plan

- [ ] Re-run the `Daily Trivy CVE scan` workflow via `workflow_dispatch`.
- [ ] Confirm the `trivy-daily` label is created on first run.
- [ ] Confirm the tracking issue is created/updated with `trivy-daily` + `security` labels.
- [ ] Confirm the existing `security` label's color/description are unchanged.

https://claude.ai/code/session_015hZjvcXGATumReHZAeD6z9

---
_Generated by [Claude Code](https://claude.ai/code/session_015hZjvcXGATumReHZAeD6z9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * セキュリティワークフローの安定性を向上させるための改善を実施しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hopin-inc/civicship-api/pull/1193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->