### PR TITLE
fix(ci): use lowercase -v for delv version flag

### DIFF
--- a/.github/workflows/tls-dns-posture.yml
+++ b/.github/workflows/tls-dns-posture.yml
@@ -78,7 +78,7 @@ jobs:
             sudo apt-get update -qq
             sudo apt-get install -y -qq bind9-dnsutils
           fi
-          delv -V | head -n1
+          delv -v | head -n1
 
       # 公開 DNS resolver 経由で DNSSEC DS レコードを引く。DS が空になっていると
       # 親ゾーン (.app) に署名チェーンが繋がらず DNSSEC が事実上 OFF。


### PR DESCRIPTION
## Summary

The `Install delv (bind9-dnsutils)` step in `.github/workflows/tls-dns-posture.yml` failed with:

```
Invalid option: -V
Usage:  delv [@server] {q-opt} {d-opt} [domain] [q-type] [q-class]
```

`delv` (from `bind9-dnsutils`) uses the **lowercase** `-v` flag to print its version and exit. The workflow used uppercase `-V`, which is not a valid option, so the command aborted the step under `set -euo pipefail`.

## Change

- `.github/workflows/tls-dns-posture.yml:81` — `delv -V` → `delv -v`

## Test plan

- [ ] Trigger the `TLS / DNS Posture` workflow via `workflow_dispatch` and confirm the `Install delv` step prints the version line and succeeds.

https://claude.ai/code/session_01KAntes48yzEsRgkeL1W4mP

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAntes48yzEsRgkeL1W4mP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI/CDワークフローの小規模な最適化を実施しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hopin-inc/civicship-api/pull/1194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->