### PR TITLE
feat(scripts): add IDENTUS_JWT VC re-issuance backfill

### DIFF
--- a/scripts/backfill-resign-identus-vcs.ts
+++ b/scripts/backfill-resign-identus-vcs.ts
@@ -1,0 +1,241 @@
+#!/usr/bin/env -S node --experimental-strip-types
+/**
+ * Re-issue legacy `IDENTUS_JWT` VCs as `INTERNAL_JWT` signed by the
+ * production `KmsJwtSigner` (prd IDENTUS 撤去 backfill).
+ *
+ * Background
+ * ----------
+ * Before the DID/VC internalization (`docs/report/did-vc-internalization.md`)
+ * VCs were issued through an external Identus agent and persisted with
+ * `vc_format = 'IDENTUS_JWT'`. Phase 4 撤去 で Identus を廃止するにあたり、
+ * 失効していない既存 IDENTUS VC を自前の KMS (Ed25519) 署名による
+ * `INTERNAL_JWT` に再発行し直す必要がある。
+ *
+ * This is distinct from `resign-stub-vcs.ts`: that script targets Phase 1
+ * `INTERNAL_JWT` rows whose signature segment is the `STUB_SIGNATURE`
+ * marker. `IDENTUS_JWT` rows never carry that marker, so they are out of
+ * scope there and need this dedicated backfill.
+ *
+ * What this script does
+ * ---------------------
+ *   1. `vc_format = 'IDENTUS_JWT'` AND `revoked_at IS NULL` の行を全件抽出。
+ *   2. `vc_jwt` が NULL/空 の行（Identus 側で発行が完了しなかった行）は
+ *      SKIP してログ出力する — 復元すべき発行済み VC が存在しないため。
+ *   3. 残る行について:
+ *        - subject DID  = `buildUserDid(userId)`
+ *                         (`did:web:api.civicship.app:users:<userId>`)
+ *          ※ User DID backfill が完了している前提。
+ *        - claims       = `claims` JSON カラムをそのまま使用
+ *          (legacy `VCIssuanceRequestConverter` が `EvaluationCredential`
+ *           形で書き込んだ値が source of truth)。
+ *        - issuanceDate = `completedAt ?? requestedAt ?? createdAt`
+ *          (原本の発行時刻を保持し、再発行の瞬間で上書きしない)。
+ *      を元に `buildVcPayload()` で W3C VC payload を組み立て、
+ *      `KmsJwtSigner` で実 Ed25519 署名した JWT を生成する。
+ *   4. 同一 row を in-place 更新する: `vc_format -> 'INTERNAL_JWT'`,
+ *      `vc_jwt -> <new>`。`updated_at` は Prisma `@updatedAt` が自動更新。
+ *      `revoked_at` は触らない（revoke ではなく置換）。
+ *
+ * Why in-place update (and not "revoke old + insert new")
+ * -------------------------------------------------------
+ * `t_vc_issuance_requests.evaluation_id` は `@unique`(NOT NULL) のため、
+ * 同じ evaluation に対する 2 行目を INSERT できない。よって元 row を
+ * revoke して新 row を作る方式は採れず、`resign-stub-vcs.ts` と同じく
+ * 既存 row を直接書き換える。`credentialStatus`(StatusList) は付与しない
+ * — `buildVcPayload` の replay/legacy パス（`credentialStatus` 省略可）
+ * に合わせ、IDENTUS row が持つ statusList 関連カラムはそのまま残す。
+ *
+ * `--confirm` 無しは dry-run（対象件数・SKIP 件数のみ表示、KMS 署名や
+ * DB 書き込みは行わない）。
+ *
+ * 設計参照:
+ *   docs/report/did-vc-internalization.md §16     (Phase 2 KMS swap)
+ *   docs/report/did-vc-internalization.md §5.2.2  (VC issuance / JWT shape)
+ *   docs/report/did-vc-internalization.md §B      (issuer / subject DID)
+ *
+ * 実行例 (dev):
+ *   pnpm exec dotenvx run -f .env.dev -- pnpm exec tsx scripts/backfill-resign-identus-vcs.ts
+ *   pnpm exec dotenvx run -f .env.dev -- pnpm exec tsx scripts/backfill-resign-identus-vcs.ts --confirm
+ *
+ * Exit codes: 0 = OK (dry-run or all rows resigned), 1 = error.
+ */
+
+import "reflect-metadata";
+import "@/application/provider";
+
+import { container } from "tsyringe";
+import { VcFormat } from "@prisma/client";
+
+import { prismaClient } from "@/infrastructure/prisma/client";
+import type { JwtSigner } from "@/application/domain/credential/shared/jwtSigner";
+import { CIVICSHIP_ISSUER_DID } from "@/application/domain/credential/shared/constants";
+import { buildVcPayload } from "@/application/domain/credential/vcIssuance/service";
+import { buildUserDid } from "@/infrastructure/libs/did/userDidBuilder";
+
+interface Flags {
+  confirm: boolean;
+  limit?: number;
+}
+
+function parseFlags(argv: string[]): Flags {
+  const flags: Flags = { confirm: false };
+  for (const arg of argv) {
+    if (arg === "--confirm") {
+      flags.confirm = true;
+      continue;
+    }
+    const limitMatch = /^--limit=(\d+)$/.exec(arg);
+    if (limitMatch) {
+      flags.limit = Number.parseInt(limitMatch[1], 10);
+      continue;
+    }
+    throw new Error(`Unknown flag: ${arg}`);
+  }
+  return flags;
+}
+
+function base64urlEncodeJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
+}
+
+/**
+ * The legacy `VCIssuanceRequestConverter` always writes `claims` as a JSON
+ * object, but defend against NULL / array / scalar rows so a single corrupt
+ * row fails loudly for that id instead of producing a malformed VC payload.
+ */
+function asClaimsObject(claims: unknown): Record<string, unknown> {
+  if (claims === null || typeof claims !== "object" || Array.isArray(claims)) {
+    throw new Error(`claims is not a JSON object (got ${claims === null ? "null" : Array.isArray(claims) ? "array" : typeof claims})`);
+  }
+  return claims as Record<string, unknown>;
+}
+
+/** Build the new INTERNAL_JWT (header.payload.signature) for one row. */
+async function buildInternalJwt(
+  row: {
+    userId: string;
+    claims: unknown;
+    issuedAt: Date;
+  },
+  signer: JwtSigner,
+): Promise<string> {
+  const subjectDid = buildUserDid(row.userId);
+  const payload = buildVcPayload({
+    issuer: CIVICSHIP_ISSUER_DID,
+    subject: subjectDid,
+    claims: asClaimsObject(row.claims),
+    issuedAt: row.issuedAt,
+  });
+
+  // Mirror `VcIssuanceService.issueVc`: refresh the signer snapshot, then
+  // read `alg` / `kid` synchronously for the header before signing.
+  await signer.prepare();
+  const headerB64u = base64urlEncodeJson({
+    alg: signer.alg,
+    typ: "JWT",
+    kid: signer.kid,
+  });
+  const payloadB64u = base64urlEncodeJson(payload);
+  const signingInput = `${headerB64u}.${payloadB64u}`;
+  const signature = await signer.sign(signingInput);
+  return `${signingInput}.${signature}`;
+}
+
+async function main(): Promise<number> {
+  const flags = parseFlags(process.argv.slice(2));
+  process.stdout.write("Re-issue IDENTUS_JWT VCs as KMS-signed INTERNAL_JWT\n\n");
+  process.stdout.write(`mode: ${flags.confirm ? "EXECUTE" : "DRY-RUN"}\n`);
+  if (flags.limit !== undefined) process.stdout.write(`limit: ${flags.limit}\n`);
+  process.stdout.write("\n");
+
+  const candidates = await prismaClient.vcIssuanceRequest.findMany({
+    where: {
+      vcFormat: VcFormat.IDENTUS_JWT,
+      revokedAt: null,
+    },
+    select: {
+      id: true,
+      userId: true,
+      claims: true,
+      vcJwt: true,
+      createdAt: true,
+      requestedAt: true,
+      completedAt: true,
+    },
+    orderBy: { createdAt: "asc" },
+    take: flags.limit,
+  });
+
+  process.stdout.write(
+    `Found ${candidates.length} IDENTUS_JWT VC row(s) with revokedAt IS NULL\n\n`,
+  );
+  if (candidates.length === 0) {
+    return 0;
+  }
+
+  // Sanity-check the signer once before iterating so a misconfigured KMS /
+  // missing active-key row fails loudly before touching any row. `prepare()`
+  // only resolves the active key (a cheap DB lookup) — no KMS sign call.
+  const signer = container.resolve<JwtSigner>("VcJwtSigner");
+  await signer.prepare();
+  process.stdout.write(`signer: alg=${signer.alg}, kid=${signer.kid}\n\n`);
+
+  let resigned = 0;
+  let skipped = 0;
+  let failed = 0;
+  for (const row of candidates) {
+    try {
+      if (!row.vcJwt || row.vcJwt.length === 0) {
+        // Identus 側で発行が完了しなかった行 — 復元すべき発行済み VC が
+        // 無いので対象外。revoke もしない（既存挙動を変えない）。
+        skipped += 1;
+        process.stdout.write(`SKIP  ${row.id}: vcJwt is empty (IDENTUS issuance never completed)\n`);
+        continue;
+      }
+
+      const issuedAt = row.completedAt ?? row.requestedAt ?? row.createdAt;
+      const subjectDid = buildUserDid(row.userId);
+
+      if (flags.confirm) {
+        const newJwt = await buildInternalJwt({ userId: row.userId, claims: row.claims, issuedAt }, signer);
+        await prismaClient.vcIssuanceRequest.update({
+          where: { id: row.id },
+          data: {
+            vcFormat: VcFormat.INTERNAL_JWT,
+            vcJwt: newJwt,
+          },
+        });
+        resigned += 1;
+        process.stdout.write(`OK    ${row.id}: reissued INTERNAL_JWT (subject=${subjectDid}, new len=${newJwt.length})\n`);
+      } else {
+        // dry-run: 件数のみ。KMS 署名・DB 書き込みは行わない。subject DID
+        // と claims 形状の検証だけ実施し、不正な行は failed として顕在化。
+        asClaimsObject(row.claims);
+        resigned += 1;
+        process.stdout.write(`DRY   ${row.id}: would reissue INTERNAL_JWT (subject=${subjectDid})\n`);
+      }
+    } catch (err) {
+      failed += 1;
+      process.stderr.write(
+        `FAIL  ${row.id}: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+
+  process.stdout.write(
+    `\n${flags.confirm ? "reissued" : "would-reissue"}: ${resigned}, skipped (empty vcJwt): ${skipped}, failed: ${failed}\n`,
+  );
+  if (!flags.confirm) {
+    process.stdout.write("\nRe-run with `--confirm` to apply.\n");
+  }
+  return failed === 0 ? 0 : 1;
+}
+
+main()
+  .then((code) => {
+    prismaClient.$disconnect().finally(() => process.exit(code));
+  })
+  .catch((err: unknown) => {
+    process.stderr.write(`ERROR: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`);
+    prismaClient.$disconnect().finally(() => process.exit(1));
+  });

--- a/scripts/backfill-resign-identus-vcs.ts
+++ b/scripts/backfill-resign-identus-vcs.ts
@@ -130,7 +130,7 @@ async function main(): Promise<number> {
       requestedAt: true,
       completedAt: true,
     },
-    orderBy: { createdAt: "asc" },
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
     take: flags.limit,
   });
 
@@ -162,25 +162,36 @@ async function main(): Promise<number> {
       }
 
       const issuedAt = row.completedAt ?? row.requestedAt ?? row.createdAt;
-      const subjectDid = buildUserDid(row.userId);
 
       if (flags.confirm) {
         const newJwt = await buildInternalJwt({ userId: row.userId, claims: row.claims, issuedAt }, signer);
-        await prismaClient.vcIssuanceRequest.update({
-          where: { id: row.id },
+        // Re-apply the original selection filter on write: a row that was
+        // revoked or already converted between the read and here must NOT
+        // be clobbered. `count !== 1` means the row changed under us.
+        const result = await prismaClient.vcIssuanceRequest.updateMany({
+          where: {
+            id: row.id,
+            vcFormat: VcFormat.IDENTUS_JWT,
+            revokedAt: null,
+          },
           data: {
             vcFormat: VcFormat.INTERNAL_JWT,
             vcJwt: newJwt,
           },
         });
+        if (result.count !== 1) {
+          throw new Error("row no longer matches IDENTUS_JWT / revokedAt=null (changed after read)");
+        }
         resigned += 1;
-        process.stdout.write(`OK    ${row.id}: reissued INTERNAL_JWT (subject=${subjectDid}, new len=${newJwt.length})\n`);
+        process.stdout.write(`OK    ${row.id}: reissued INTERNAL_JWT (new len=${newJwt.length})\n`);
       } else {
         // dry-run: 件数のみ。KMS 署名・DB 書き込みは行わない。subject DID
-        // と claims 形状の検証だけ実施し、不正な行は failed として顕在化。
+        // 導出と claims 形状の検証だけ実施し、不正な行は failed として顕在化。
+        // subject DID(userId を含む) はログに出さない。
+        buildUserDid(row.userId);
         asClaimsObject(row.claims);
         resigned += 1;
-        process.stdout.write(`DRY   ${row.id}: would reissue INTERNAL_JWT (subject=${subjectDid})\n`);
+        process.stdout.write(`DRY   ${row.id}: would reissue INTERNAL_JWT\n`);
       }
     } catch (err) {
       failed += 1;

--- a/scripts/backfill-resign-identus-vcs.ts
+++ b/scripts/backfill-resign-identus-vcs.ts
@@ -14,7 +14,9 @@
  * This is distinct from `resign-stub-vcs.ts`: that script targets Phase 1
  * `INTERNAL_JWT` rows whose signature segment is the `STUB_SIGNATURE`
  * marker. `IDENTUS_JWT` rows never carry that marker, so they are out of
- * scope there and need this dedicated backfill.
+ * scope there and need this dedicated backfill. The shared CLI plumbing
+ * (`--confirm` / `--limit`, JWT signing, teardown) lives in
+ * `scripts/lib/resignVcCli.ts`.
  *
  * What this script does
  * ---------------------
@@ -71,32 +73,12 @@ import type { JwtSigner } from "@/application/domain/credential/shared/jwtSigner
 import { CIVICSHIP_ISSUER_DID } from "@/application/domain/credential/shared/constants";
 import { buildVcPayload } from "@/application/domain/credential/vcIssuance/service";
 import { buildUserDid } from "@/infrastructure/libs/did/userDidBuilder";
-
-interface Flags {
-  confirm: boolean;
-  limit?: number;
-}
-
-function parseFlags(argv: string[]): Flags {
-  const flags: Flags = { confirm: false };
-  for (const arg of argv) {
-    if (arg === "--confirm") {
-      flags.confirm = true;
-      continue;
-    }
-    const limitMatch = /^--limit=(\d+)$/.exec(arg);
-    if (limitMatch) {
-      flags.limit = Number.parseInt(limitMatch[1], 10);
-      continue;
-    }
-    throw new Error(`Unknown flag: ${arg}`);
-  }
-  return flags;
-}
-
-function base64urlEncodeJson(value: unknown): string {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
-}
+import {
+  base64urlEncodeJson,
+  parseResignCliFlags,
+  runResignScript,
+  signJwt,
+} from "./lib/resignVcCli.ts";
 
 /**
  * The legacy `VCIssuanceRequestConverter` always writes `claims` as a JSON
@@ -105,44 +87,30 @@ function base64urlEncodeJson(value: unknown): string {
  */
 function asClaimsObject(claims: unknown): Record<string, unknown> {
   if (claims === null || typeof claims !== "object" || Array.isArray(claims)) {
-    throw new Error(`claims is not a JSON object (got ${claims === null ? "null" : Array.isArray(claims) ? "array" : typeof claims})`);
+    const kind = claims === null ? "null" : Array.isArray(claims) ? "array" : typeof claims;
+    throw new Error(`claims is not a JSON object (got ${kind})`);
   }
   return claims as Record<string, unknown>;
 }
 
-/** Build the new INTERNAL_JWT (header.payload.signature) for one row. */
+/** Build the new KMS-signed INTERNAL_JWT (header.payload.signature) for one row. */
 async function buildInternalJwt(
-  row: {
-    userId: string;
-    claims: unknown;
-    issuedAt: Date;
-  },
+  row: { userId: string; claims: unknown; issuedAt: Date },
   signer: JwtSigner,
 ): Promise<string> {
-  const subjectDid = buildUserDid(row.userId);
+  // Mirror `VcIssuanceService.issueVc` payload shape; `credentialStatus` is
+  // intentionally omitted (replay/legacy path — no new StatusList slot).
   const payload = buildVcPayload({
     issuer: CIVICSHIP_ISSUER_DID,
-    subject: subjectDid,
+    subject: buildUserDid(row.userId),
     claims: asClaimsObject(row.claims),
     issuedAt: row.issuedAt,
   });
-
-  // Mirror `VcIssuanceService.issueVc`: refresh the signer snapshot, then
-  // read `alg` / `kid` synchronously for the header before signing.
-  await signer.prepare();
-  const headerB64u = base64urlEncodeJson({
-    alg: signer.alg,
-    typ: "JWT",
-    kid: signer.kid,
-  });
-  const payloadB64u = base64urlEncodeJson(payload);
-  const signingInput = `${headerB64u}.${payloadB64u}`;
-  const signature = await signer.sign(signingInput);
-  return `${signingInput}.${signature}`;
+  return signJwt(signer, base64urlEncodeJson(payload));
 }
 
 async function main(): Promise<number> {
-  const flags = parseFlags(process.argv.slice(2));
+  const flags = parseResignCliFlags(process.argv.slice(2));
   process.stdout.write("Re-issue IDENTUS_JWT VCs as KMS-signed INTERNAL_JWT\n\n");
   process.stdout.write(`mode: ${flags.confirm ? "EXECUTE" : "DRY-RUN"}\n`);
   if (flags.limit !== undefined) process.stdout.write(`limit: ${flags.limit}\n`);
@@ -231,11 +199,4 @@ async function main(): Promise<number> {
   return failed === 0 ? 0 : 1;
 }
 
-main()
-  .then((code) => {
-    prismaClient.$disconnect().finally(() => process.exit(code));
-  })
-  .catch((err: unknown) => {
-    process.stderr.write(`ERROR: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`);
-    prismaClient.$disconnect().finally(() => process.exit(1));
-  });
+runResignScript(main, () => prismaClient.$disconnect());

--- a/scripts/backfill-resign-identus-vcs.ts
+++ b/scripts/backfill-resign-identus-vcs.ts
@@ -80,6 +80,13 @@ import {
   signJwt,
 } from "./lib/resignVcCli.ts";
 
+/** Human-readable kind of a non-object JSON value, for error messages. */
+function describeJsonKind(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}
+
 /**
  * The legacy `VCIssuanceRequestConverter` always writes `claims` as a JSON
  * object, but defend against NULL / array / scalar rows so a single corrupt
@@ -87,8 +94,7 @@ import {
  */
 function asClaimsObject(claims: unknown): Record<string, unknown> {
   if (claims === null || typeof claims !== "object" || Array.isArray(claims)) {
-    const kind = claims === null ? "null" : Array.isArray(claims) ? "array" : typeof claims;
-    throw new Error(`claims is not a JSON object (got ${kind})`);
+    throw new Error(`claims is not a JSON object (got ${describeJsonKind(claims)})`);
   }
   return claims as Record<string, unknown>;
 }

--- a/scripts/lib/resignVcCli.ts
+++ b/scripts/lib/resignVcCli.ts
@@ -1,0 +1,85 @@
+/**
+ * Shared CLI helpers for the VC re-signing operator scripts.
+ *
+ * `scripts/resign-stub-vcs.ts` (Phase 2 `STUB_SIGNATURE` → KMS swap) and
+ * `scripts/backfill-resign-identus-vcs.ts` (IDENTUS_JWT 撤去 backfill) both
+ * parse the same `--confirm` / `--limit=N` flags, base64url-encode JWT
+ * segments, re-sign a `header.payload` pair via a `JwtSigner`, and tear
+ * down the Prisma connection before exiting. Centralising those here keeps
+ * the two scripts from drifting and removes the cross-file duplication
+ * SonarCloud flags.
+ *
+ * Kept under `scripts/lib/`: these helpers are script-local. The only
+ * non-relative import is the `JwtSigner` *type* (erased at runtime), so —
+ * like `cardanoScriptHelpers.ts` — there is no runtime dependency on the
+ * DI container or Prisma; the Prisma teardown is injected by the caller.
+ */
+
+import type { JwtSigner } from "@/application/domain/credential/shared/jwtSigner";
+
+export interface ResignCliFlags {
+  confirm: boolean;
+  limit?: number;
+}
+
+/** Parse the `--confirm` / `--limit=N` flags shared by the re-sign scripts. */
+export function parseResignCliFlags(argv: string[]): ResignCliFlags {
+  const flags: ResignCliFlags = { confirm: false };
+  for (const arg of argv) {
+    if (arg === "--confirm") {
+      flags.confirm = true;
+      continue;
+    }
+    const limitMatch = /^--limit=(\d+)$/.exec(arg);
+    if (limitMatch) {
+      flags.limit = Number.parseInt(limitMatch[1], 10);
+      continue;
+    }
+    throw new Error(`Unknown flag: ${arg}`);
+  }
+  return flags;
+}
+
+/** Encode a JSON-serialisable value as a base64url JWT segment (RFC 4648 §5). */
+export function base64urlEncodeJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
+}
+
+/**
+ * Re-sign a JWT: rebuild the header from the signer's current `alg` / `kid`,
+ * join it to the supplied (already base64url-encoded) payload segment, and
+ * append a fresh signature. `signer.prepare()` is awaited first so the
+ * synchronous `alg` / `kid` reads land on the same key `sign()` uses.
+ */
+export async function signJwt(signer: JwtSigner, payloadB64u: string): Promise<string> {
+  await signer.prepare();
+  const headerB64u = base64urlEncodeJson({
+    alg: signer.alg,
+    typ: "JWT",
+    kid: signer.kid,
+  });
+  const signingInput = `${headerB64u}.${payloadB64u}`;
+  const signature = await signer.sign(signingInput);
+  return `${signingInput}.${signature}`;
+}
+
+/**
+ * Run a script `main()` that resolves to a process exit code, always
+ * running `cleanup` (typically `prismaClient.$disconnect()`) before exit on
+ * both the success and failure paths.
+ */
+export function runResignScript(
+  main: () => Promise<number>,
+  cleanup: () => Promise<unknown>,
+): void {
+  main()
+    .then((code) => {
+      cleanup().finally(() => process.exit(code));
+    })
+    .catch((err: unknown) => {
+      process.stderr.write(
+        `ERROR: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
+      );
+      cleanup().finally(() => process.exit(1));
+    });
+}

--- a/scripts/resign-stub-vcs.ts
+++ b/scripts/resign-stub-vcs.ts
@@ -35,32 +35,7 @@ import { container } from "tsyringe";
 import { prismaClient } from "@/infrastructure/prisma/client";
 import type { JwtSigner } from "@/application/domain/credential/shared/jwtSigner";
 import { STUB_SIGNATURE } from "@/application/domain/credential/shared/stubJwtSigner";
-
-interface Flags {
-  confirm: boolean;
-  limit?: number;
-}
-
-function parseFlags(argv: string[]): Flags {
-  const flags: Flags = { confirm: false };
-  for (const arg of argv) {
-    if (arg === "--confirm") {
-      flags.confirm = true;
-      continue;
-    }
-    const limitMatch = /^--limit=(\d+)$/.exec(arg);
-    if (limitMatch) {
-      flags.limit = Number.parseInt(limitMatch[1], 10);
-      continue;
-    }
-    throw new Error(`Unknown flag: ${arg}`);
-  }
-  return flags;
-}
-
-function base64urlEncodeJson(value: unknown): string {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
-}
+import { parseResignCliFlags, runResignScript, signJwt } from "./lib/resignVcCli.ts";
 
 function payloadSegmentOf(vcJwt: string): string {
   const segments = vcJwt.split(".");
@@ -76,20 +51,8 @@ function isStubSignature(vcJwt: string): boolean {
     || segments[2] === STUB_SIGNATURE;
 }
 
-async function rebuildJwt(payloadB64u: string, signer: JwtSigner): Promise<string> {
-  await signer.prepare();
-  const headerB64u = base64urlEncodeJson({
-    alg: signer.alg,
-    typ: "JWT",
-    kid: signer.kid,
-  });
-  const signingInput = `${headerB64u}.${payloadB64u}`;
-  const signature = await signer.sign(signingInput);
-  return `${signingInput}.${signature}`;
-}
-
 async function main(): Promise<number> {
-  const flags = parseFlags(process.argv.slice(2));
+  const flags = parseResignCliFlags(process.argv.slice(2));
   process.stdout.write("Re-sign STUB_SIGNATURE VCs with KmsJwtSigner\n\n");
   process.stdout.write(`mode: ${flags.confirm ? "EXECUTE" : "DRY-RUN"}\n`);
   if (flags.limit !== undefined) process.stdout.write(`limit: ${flags.limit}\n`);
@@ -124,7 +87,7 @@ async function main(): Promise<number> {
         continue;
       }
       const payloadB64u = payloadSegmentOf(row.vcJwt);
-      const newJwt = await rebuildJwt(payloadB64u, signer);
+      const newJwt = await signJwt(signer, payloadB64u);
 
       if (flags.confirm) {
         await prismaClient.vcIssuanceRequest.update({
@@ -154,11 +117,4 @@ async function main(): Promise<number> {
   return failed === 0 ? 0 : 1;
 }
 
-main()
-  .then((code) => {
-    prismaClient.$disconnect().finally(() => process.exit(code));
-  })
-  .catch((err: unknown) => {
-    process.stderr.write(`ERROR: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`);
-    prismaClient.$disconnect().finally(() => process.exit(1));
-  });
+runResignScript(main, () => prismaClient.$disconnect());


### PR DESCRIPTION
## 背景

prd の IDENTUS 撤去（Phase 4）にあたり、失効していない既存 `IDENTUS_JWT` VC を自前 KMS（Ed25519）署名の `INTERNAL_JWT` に再発行し直す必要がある。`resign-stub-vcs.ts` は `STUB_SIGNATURE` を含む Phase 1 の `INTERNAL_JWT` 行のみが対象で、`IDENTUS_JWT` は対象外のため、専用 backfill を追加する。

## 確認事項の結果

- **件数**: この環境から prd DB へ接続できないため未確認。`SELECT count(*) FROM t_vc_issuance_requests WHERE vc_format = 'IDENTUS_JWT' AND revoked_at IS NULL;` で要確認。なお `vcFormat` のデフォルトは `IDENTUS_JWT` で、legacy の `createManyInputs` は `vcFormat` を設定しないため、旧 evaluation→VC フローの行はすべて `IDENTUS_JWT`。
- **resign-stub-vcs.ts**: `vcJwt CONTAINS 'stub-not-signed'` で抽出。stub 行は `vcFormat=INTERNAL_JWT`（Phase 1 service が必ず設定）であり、`IDENTUS_JWT` は完全に対象外 — 確認済み。
- **DB からの復元**: `claims` カラム（`EvaluationCredential` 形）に格納済み。subject DID は `userId` から `buildUserDid()` で導出。issuanceDate は `completedAt ?? requestedAt ?? createdAt` で原本の発行時刻を保持。

## 実装

`scripts/backfill-resign-identus-vcs.ts` を追加。

- `vc_format='IDENTUS_JWT'` かつ `revoked_at IS NULL` の行を全件抽出（`--limit=N` で段階実行可）
- `vc_jwt` が NULL/空 の行（Identus 側で発行未完了）は SKIP してログ出力
- `claims` カラム＋`buildUserDid(userId)` の subject DID から `buildVcPayload()` で W3C VC payload を構築し、`KmsJwtSigner` で実 Ed25519 署名
- 同一 row を in-place 更新（`vc_format -> 'INTERNAL_JWT'`, `vc_jwt -> <new>`）。`revoked_at` は触らない
- dry-run デフォルト（`--confirm` 無しは件数表示のみ、KMS 署名・DB 書き込みなし）

## 設計判断: in-place 更新（revoke + 新 row INSERT ではなく）

当初要件は「元 row を revoke + 新 row を INSERT」だが、`t_vc_issuance_requests.evaluation_id` が `@unique`(NOT NULL) のため同一 evaluation に 2 行目を作れない。`resign-stub-vcs.ts` と同じく既存 row を直接書き換える方針を採用（ユーザー確認済み）。`credentialStatus`（StatusList）は付与せず、`buildVcPayload` の replay/legacy パスに合わせている。

## Test plan

- [ ] dev で `pnpm exec dotenvx run -f .env.dev -- pnpm exec tsx scripts/backfill-resign-identus-vcs.ts`（dry-run）を実行し、対象件数・SKIP 件数を確認
- [ ] dev で `--confirm` を実行し、対象 row が `vc_format='INTERNAL_JWT'` / 新 `vc_jwt` に更新されることを確認
- [ ] 再発行後の VC JWT が `/.well-known/did.json` の公開鍵で署名検証できることを確認（`dev-issue-vc.ts` と同じ検証）
- [ ] prd で件数を確認のうえ dry-run → `--confirm` の順で実行

https://claude.ai/code/session_01H3M6tsYAXzoDYbKkUrQMRu

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3M6tsYAXzoDYbKkUrQMRu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 既存の検証証明(VC)をIDENTUS_JWTから内部署名付きJWTへ一括で再発行・置換するバックフィル用スクリプトを追加しました（dry-run対応、確認時のみin-place更新）。
* **Refactor**
  * 再署名処理のCLI解析・JWT署名・実行後処理を共通化し、個別スクリプトの処理を簡潔化しました。
* **New Features**
  * 件数制限、確認フラグ、サブジェクトDIDとクレーム形状検証、失敗集計、確実な切断を伴う安全な実行フローを導入しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hopin-inc/civicship-api/pull/1197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->