### PR TITLE
fix(scripts): resume PENDING DID anchors after backfill restart

### DIFF
--- a/scripts/backfill-user-did.ts
+++ b/scripts/backfill-user-did.ts
@@ -41,6 +41,9 @@
  *   - 既に INTERNAL 行を持つ user は skip（重複 DID Document を生成しない）。
  *   - 既に SUBMITTED / CONFIRMED な UserDidAnchor も skip。
  *   - 失敗時は当該 UserDidAnchor を `status=FAILED` + `lastError` で残す。
+ *   - 中断後の再実行は Step 2(INSERT) と Step 3(Cardano submit) を独立に
+ *     評価する。全 user の INSERT が済んでいても、未送信の PENDING /
+ *     未ブロードキャストの FAILED anchor が残っていれば Step 3 から再開する。
  *
  * Required env (loaded from `.env.dev` via dotenvx):
  *   BLOCKFROST_PROJECT_ID, CARDANO_PLATFORM_PRIVATE_KEY_HEX,
@@ -205,13 +208,29 @@ interface PendingAnchorRow {
   documentCbor: Buffer | null;
 }
 
-async function findPendingAnchors(chunkSize: number): Promise<PendingAnchorRow[]> {
+/**
+ * UserDidAnchor rows that still need a Cardano submission.
+ *
+ *   - `PENDING`            — inserted by Step 2, never attempted on chain.
+ *   - `FAILED` + no txHash — a previous Step 3 run aborted BEFORE the tx was
+ *                            broadcast (metadata-oversize pre-check, or a
+ *                            getUtxos / buildAnchorTx error). No tx exists,
+ *                            so retrying cannot double-anchor or double-spend.
+ *
+ * `FAILED` rows that DO carry a `chainTxHash` are deliberately excluded: a tx
+ * was already broadcast for them, so re-submitting would anchor the same op a
+ * second time. Those require manual operator triage.
+ */
+const SUBMITTABLE_ANCHOR_WHERE = {
+  status: { in: [AnchorStatus.PENDING, AnchorStatus.FAILED] },
+  batchId: null,
+  chainTxHash: null,
+  operation: DidOperation.CREATE,
+} as const;
+
+async function findSubmittableAnchors(chunkSize: number): Promise<PendingAnchorRow[]> {
   return prismaClient.userDidAnchor.findMany({
-    where: {
-      status: AnchorStatus.PENDING,
-      batchId: null,
-      operation: DidOperation.CREATE,
-    },
+    where: SUBMITTABLE_ANCHOR_WHERE,
     select: {
       id: true,
       did: true,
@@ -221,6 +240,10 @@ async function findPendingAnchors(chunkSize: number): Promise<PendingAnchorRow[]
     orderBy: { createdAt: "asc" },
     take: chunkSize,
   });
+}
+
+async function countSubmittableAnchors(): Promise<number> {
+  return prismaClient.userDidAnchor.count({ where: SUBMITTABLE_ANCHOR_WHERE });
 }
 
 async function main(): Promise<number> {
@@ -245,8 +268,28 @@ async function main(): Promise<number> {
   );
   if (!surveyStep.ok) return 1;
   const users = surveyStep.value;
-  if (users.length === 0) {
-    process.stdout.write("Nothing to do — every user already has an INTERNAL did:web.\n");
+
+  // The DB INSERT (Step 2) and the Cardano submit (Step 3) are independent
+  // units of work. A previous run can complete every INSERT and still leave
+  // anchors un-submitted — e.g. it crashed or aborted partway through Step 3
+  // (metadata-oversize). On such a re-run `users` is empty (every user
+  // already has an INTERNAL row) yet the PENDING anchors must still be
+  // drained. Gate "Nothing to do" on BOTH surveys so those anchors are
+  // never stranded.
+  const pendingStep = await runStep<number>(
+    "db: UserDidAnchor rows awaiting Cardano submit",
+    async () => {
+      const count = await countSubmittableAnchors();
+      return { value: count, detail: `${count} anchor(s) awaiting submit` };
+    },
+  );
+  if (!pendingStep.ok) return 1;
+  const pendingAnchorCount = pendingStep.value;
+
+  if (users.length === 0 && pendingAnchorCount === 0) {
+    process.stdout.write(
+      "Nothing to do — every user has an INTERNAL did:web and no anchors are pending.\n",
+    );
     return 0;
   }
 
@@ -336,7 +379,7 @@ async function main(): Promise<number> {
   // when a chunk fails (the failure path `break`s out; operator must reset
   // FAILED rows back to PENDING before re-running).
   while (true) {
-    const chunk = await findPendingAnchors(flags.chunkSize);
+    const chunk = await findSubmittableAnchors(flags.chunkSize);
     if (chunk.length === 0) break;
     chunkIdx += 1;
 
@@ -375,10 +418,14 @@ async function main(): Promise<number> {
     });
     const size = metadataByteSize(aux);
     if (size > MAX_METADATA_TX_BYTES) {
+      // Pre-submission size check: no tx was built or broadcast, so this
+      // chunk's rows are still valid PENDING work. Leave them untouched
+      // (NOT marked FAILED) so a re-run with a smaller --chunk-size picks
+      // them straight back up.
       process.stderr.write(
-        `chunk ${chunkIdx} metadata ${size}B exceeds 16KB ceiling; lower --chunk-size and retry\n`,
+        `chunk ${chunkIdx} metadata ${size}B exceeds 16KB ceiling; ` +
+          `re-run with a smaller --chunk-size (current ${flags.chunkSize})\n`,
       );
-      await markChunkFailed(chunk, `metadata oversize (${size}B)`);
       return 1;
     }
 
@@ -429,9 +476,10 @@ async function main(): Promise<number> {
     if (!submitOk.ok) {
       await markChunkFailed(chunk, submitOk.detail);
       failedTotal += chunk.length;
-      // Bail out — re-running picks up the FAILED rows once the operator
-      // resets them to PENDING (manual). Continuing would keep burning
-      // ADA on the same broken state.
+      // Bail out. A re-run auto-resumes any FAILED row that never reached
+      // the chain (no chainTxHash) via `findSubmittableAnchors`; rows that
+      // WERE broadcast need manual triage. Continuing here would keep
+      // burning ADA on the same broken state.
       break;
     }
     confirmedTotal += chunk.length;

--- a/scripts/backfill-user-did.ts
+++ b/scripts/backfill-user-did.ts
@@ -74,6 +74,7 @@ import {
   DidIssuanceStatus,
   DidMethod,
   DidOperation,
+  Prisma,
 } from "@prisma/client";
 
 import { prismaClient } from "@/infrastructure/prisma/client";
@@ -221,12 +222,12 @@ interface PendingAnchorRow {
  * was already broadcast for them, so re-submitting would anchor the same op a
  * second time. Those require manual operator triage.
  */
-const SUBMITTABLE_ANCHOR_WHERE = {
+const SUBMITTABLE_ANCHOR_WHERE: Prisma.UserDidAnchorWhereInput = {
   status: { in: [AnchorStatus.PENDING, AnchorStatus.FAILED] },
   batchId: null,
   chainTxHash: null,
   operation: DidOperation.CREATE,
-} as const;
+};
 
 async function findSubmittableAnchors(chunkSize: number): Promise<PendingAnchorRow[]> {
   return prismaClient.userDidAnchor.findMany({


### PR DESCRIPTION
## 背景 / 問題

`scripts/backfill-user-did.ts --confirm` を実行すると:

1. Step 2 で全 ~1466 ユーザーの `DidIssuanceRequest(INTERNAL)` + `UserDidAnchor(PENDING)` を INSERT（成功）
2. Step 3 の最初の chunk で metadata 16KB 超過エラー → `return 1` で途中終了

ところが**再実行すると `Nothing to do` で終了し、PENDING の anchor が Cardano に submit されない**。`--chunk-size` を変えても同じ。

### 根本原因

`Nothing to do` の早期 return が **Step 1（INTERNAL 行を持たない user の調査）だけ**を条件にしていた（`backfill-user-did.ts:248`）。Step 2 が全 user の INTERNAL 行を INSERT 済みのため、再実行では survey が 0 件 → **Step 3（chunked Cardano submit）に到達せず終了**。`--chunk-size` は Step 3 専用フラグなので、到達しない以上無意味だった。

加えて metadata 超過時の事前チェックが、まだ tx をブロードキャストしていない chunk を `FAILED` にマークしていたため、再開対象から漏れていた。

## 変更内容

- **`countSubmittableAnchors` で PENDING anchor を独立に調査**し、`Nothing to do` は「user も pending anchor も 0」のときだけ表示。INSERT 済みでも残りの anchor を Step 3 から再開する。
- **metadata 超過の事前チェックは `FAILED` マークをやめた**。tx 未送信なので行は `PENDING` のまま残り、より小さい `--chunk-size` での再実行が拾える。
- **`findSubmittableAnchors` は `chainTxHash` を持たない `FAILED` 行も再開対象に含める**。これらは on-chain に到達していないため二重 anchor / 二重支払いのリスクなく安全に再送できる。`chainTxHash` を持つ `FAILED` 行（ブロードキャスト済み）は引き続き手動トリアージ対象として除外。

## 復旧手順

1. このブランチをデプロイ
2. 安全な chunk-size で再実行（1 op ≒ 248B、16KB ÷ 248 ≒ 65 が上限。余裕をみて 50 推奨）:
   ```
   pnpm exec dotenvx run -f .env.dev -- pnpm exec tsx scripts/backfill-user-did.ts \
     --confirm --chunk-size=50
   ```
   既存の PENDING / 未送信 FAILED 行を Step 3 から再開し、~30 tx に分けて submit する。

## Test plan

- [ ] `--confirm` なしの dry-run で `Nothing to do` ではなく pending anchor 件数が表示されること
- [ ] `--confirm --chunk-size=50` で残り anchor が chunk 分割され Cardano に submit されること
- [ ] 全 anchor が `CONFIRMED` になった後の再実行で `Nothing to do` が表示されること

https://claude.ai/code/session_01UYknEToNz2pDLT83LDXUqJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYknEToNz2pDLT83LDXUqJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * DID/アンカーバックフィルの再実行時における復帰処理を改善しました
  * 未送信アンカーの検出ロジックを強化し、送信待ちがある限り処理を継続します
  * メタデータサイズ超過時の扱いを調整し、適切にリトライ可能にしました
  * 送信失敗時の中断表示を明確化し、壊れた状態での継続送信を防止します

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hopin-inc/civicship-api/pull/1198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->