### PR TITLE
fix: backfill IDENTUS_JWT VCs even when vcJwt is NULL

### DIFF
--- a/scripts/backfill-resign-identus-vcs.ts
+++ b/scripts/backfill-resign-identus-vcs.ts
@@ -21,22 +21,25 @@
  * What this script does
  * ---------------------
  *   1. `vc_format = 'IDENTUS_JWT'` AND `revoked_at IS NULL` の行を全件抽出。
- *   2. `vc_jwt` が NULL/空 の行（Identus 側で発行が完了しなかった行）は
- *      SKIP してログ出力する — 復元すべき発行済み VC が存在しないため。
- *   3. 残る行について:
+ *   2. 各行について (`vc_jwt` が NULL/空 かどうかに依らず):
  *        - subject DID  = `buildUserDid(userId)`
  *                         (`did:web:api.civicship.app:users:<userId>`)
  *          ※ User DID backfill が完了している前提。
  *        - claims       = `claims` JSON カラムをそのまま使用
  *          (legacy `VCIssuanceRequestConverter` が `EvaluationCredential`
- *           形で書き込んだ値が source of truth)。
+ *           形で書き込んだ値が source of truth)。prd の IDENTUS_JWT 行は
+ *           `vc_jwt` が NULL でも `claims` に VC 内容が残っているため、
+ *           `vc_jwt` の有無に関わらず `claims` から復元して再発行する。
  *        - issuanceDate = `completedAt ?? requestedAt ?? createdAt`
  *          (原本の発行時刻を保持し、再発行の瞬間で上書きしない)。
  *      を元に `buildVcPayload()` で W3C VC payload を組み立て、
  *      `KmsJwtSigner` で実 Ed25519 署名した JWT を生成する。
- *   4. 同一 row を in-place 更新する: `vc_format -> 'INTERNAL_JWT'`,
+ *   3. 同一 row を in-place 更新する: `vc_format -> 'INTERNAL_JWT'`,
  *      `vc_jwt -> <new>`。`updated_at` は Prisma `@updatedAt` が自動更新。
  *      `revoked_at` は触らない（revoke ではなく置換）。
+ *
+ *   `claims` が NULL / 非オブジェクト で復元元が無い行は `asClaimsObject`
+ *   が loud に失敗し、`failed` として顕在化する（暗黙 SKIP はしない）。
  *
  * Why in-place update (and not "revoke old + insert new")
  * -------------------------------------------------------
@@ -47,7 +50,7 @@
  * — `buildVcPayload` の replay/legacy パス（`credentialStatus` 省略可）
  * に合わせ、IDENTUS row が持つ statusList 関連カラムはそのまま残す。
  *
- * `--confirm` 無しは dry-run（対象件数・SKIP 件数のみ表示、KMS 署名や
+ * `--confirm` 無しは dry-run（対象件数のみ表示、KMS 署名や
  * DB 書き込みは行わない）。
  *
  * 設計参照:
@@ -131,7 +134,6 @@ async function main(): Promise<number> {
       id: true,
       userId: true,
       claims: true,
-      vcJwt: true,
       createdAt: true,
       requestedAt: true,
       completedAt: true,
@@ -155,18 +157,11 @@ async function main(): Promise<number> {
   process.stdout.write(`signer: alg=${signer.alg}, kid=${signer.kid}\n\n`);
 
   let resigned = 0;
-  let skipped = 0;
   let failed = 0;
   for (const row of candidates) {
     try {
-      if (!row.vcJwt || row.vcJwt.length === 0) {
-        // Identus 側で発行が完了しなかった行 — 復元すべき発行済み VC が
-        // 無いので対象外。revoke もしない（既存挙動を変えない）。
-        skipped += 1;
-        process.stdout.write(`SKIP  ${row.id}: vcJwt is empty (IDENTUS issuance never completed)\n`);
-        continue;
-      }
-
+      // `vc_jwt` の有無は問わない: prd の IDENTUS_JWT 行は `vc_jwt` が NULL
+      // でも `claims` に VC 内容が残っており、再発行元は常に `claims`。
       const issuedAt = row.completedAt ?? row.requestedAt ?? row.createdAt;
 
       if (flags.confirm) {
@@ -208,7 +203,7 @@ async function main(): Promise<number> {
   }
 
   process.stdout.write(
-    `\n${flags.confirm ? "reissued" : "would-reissue"}: ${resigned}, skipped (empty vcJwt): ${skipped}, failed: ${failed}\n`,
+    `\n${flags.confirm ? "reissued" : "would-reissue"}: ${resigned}, failed: ${failed}\n`,
   );
   if (!flags.confirm) {
     process.stdout.write("\nRe-run with `--confirm` to apply.\n");

--- a/scripts/backfill-resign-identus-vcs.ts
+++ b/scripts/backfill-resign-identus-vcs.ts
@@ -20,15 +20,21 @@
  *
  * What this script does
  * ---------------------
- *   1. `vc_format = 'IDENTUS_JWT'` AND `revoked_at IS NULL` の行を全件抽出。
+ *   1. `vc_format = 'IDENTUS_JWT'` AND `status = 'COMPLETED'` AND
+ *      `revoked_at IS NULL` の行を全件抽出。
+ *      `status = 'COMPLETED'` で絞るのは「発行が成功した行」だけを再発行
+ *      対象にするため — prd の IDENTUS_JWT 行は発行成功済みでも `vc_jwt`
+ *      が NULL のまま `claims` のみに VC 内容が残っているケースがある。
+ *      status が PENDING / PROCESSING / FAILED の行は発行が完了して
+ *      おらず復元すべき VC が存在しないため対象外（再発行しない）。
  *   2. 各行について (`vc_jwt` が NULL/空 かどうかに依らず):
  *        - subject DID  = `buildUserDid(userId)`
  *                         (`did:web:api.civicship.app:users:<userId>`)
  *          ※ User DID backfill が完了している前提。
  *        - claims       = `claims` JSON カラムをそのまま使用
  *          (legacy `VCIssuanceRequestConverter` が `EvaluationCredential`
- *           形で書き込んだ値が source of truth)。prd の IDENTUS_JWT 行は
- *           `vc_jwt` が NULL でも `claims` に VC 内容が残っているため、
+ *           形で書き込んだ値が source of truth)。COMPLETED の IDENTUS_JWT
+ *           行は `vc_jwt` が NULL でも `claims` に VC 内容が残っているため、
  *           `vc_jwt` の有無に関わらず `claims` から復元して再発行する。
  *        - issuanceDate = `completedAt ?? requestedAt ?? createdAt`
  *          (原本の発行時刻を保持し、再発行の瞬間で上書きしない)。
@@ -69,7 +75,7 @@ import "reflect-metadata";
 import "@/application/provider";
 
 import { container } from "tsyringe";
-import { VcFormat } from "@prisma/client";
+import { VcFormat, VcIssuanceStatus } from "@prisma/client";
 
 import { prismaClient } from "@/infrastructure/prisma/client";
 import type { JwtSigner } from "@/application/domain/credential/shared/jwtSigner";
@@ -128,6 +134,7 @@ async function main(): Promise<number> {
   const candidates = await prismaClient.vcIssuanceRequest.findMany({
     where: {
       vcFormat: VcFormat.IDENTUS_JWT,
+      status: VcIssuanceStatus.COMPLETED,
       revokedAt: null,
     },
     select: {
@@ -143,7 +150,7 @@ async function main(): Promise<number> {
   });
 
   process.stdout.write(
-    `Found ${candidates.length} IDENTUS_JWT VC row(s) with revokedAt IS NULL\n\n`,
+    `Found ${candidates.length} IDENTUS_JWT VC row(s) with status=COMPLETED, revokedAt IS NULL\n\n`,
   );
   if (candidates.length === 0) {
     return 0;
@@ -173,6 +180,7 @@ async function main(): Promise<number> {
           where: {
             id: row.id,
             vcFormat: VcFormat.IDENTUS_JWT,
+            status: VcIssuanceStatus.COMPLETED,
             revokedAt: null,
           },
           data: {
@@ -181,7 +189,9 @@ async function main(): Promise<number> {
           },
         });
         if (result.count !== 1) {
-          throw new Error("row no longer matches IDENTUS_JWT / revokedAt=null (changed after read)");
+          throw new Error(
+            "row no longer matches IDENTUS_JWT / status=COMPLETED / revokedAt=null (changed after read)",
+          );
         }
         resigned += 1;
         process.stdout.write(`OK    ${row.id}: reissued INTERNAL_JWT (new len=${newJwt.length})\n`);


### PR DESCRIPTION
## 背景 / 問題

`scripts/backfill-resign-identus-vcs.ts` は legacy `IDENTUS_JWT` VC を KMS 署名の `INTERNAL_JWT` に再発行する backfill スクリプト。

これまでは `vc_jwt` が NULL/空 の行を「Identus 側で発行が完了しなかった行」とみなして SKIP していた。

しかし prd の `IDENTUS_JWT` VC は発行成功済み（`status = COMPLETED`）でも `vc_jwt IS NULL` であり、`claims` カラムに VC の内容（`EvaluationCredential` 形式）が残っている。SKIP すると、これらの発行済み VC が再発行されないまま失われる。

## 変更内容

- 再発行対象を `vc_format = IDENTUS_JWT` AND `status = COMPLETED` AND `revoked_at IS NULL` の行に変更（`findMany` / `updateMany` 双方の `where`）。
  - `vc_jwt` が NULL/空 かどうかでは分岐しない。再発行元はもともと `claims` カラム（`buildVcPayload` に渡す source of truth）であり `vc_jwt` の値は一切使っていなかったため。
  - `status = COMPLETED` で絞ることで、発行が完了していない `PENDING` / `PROCESSING` / `FAILED` の行は対象外になる（復元すべき VC が存在しないため）。
- 各行の再発行内容:
  - subject DID = `buildUserDid(userId)`
  - claims = `claims` JSON カラム
  - issuanceDate = `completedAt ?? requestedAt ?? createdAt`
- 不要になった `vcJwt` SELECT・`vc_jwt IS NULL` SKIP ブロック・`skipped` カウンタを削除。
- `claims` が NULL / 非オブジェクト で復元元が無い行は従来どおり `asClaimsObject` が loud に失敗し `failed` として顕在化する（暗黙 SKIP はしない）。
- ヘッダコメント / dry-run 説明 / サマリ出力を更新。

挙動の安全性（書き込み時の selection filter 再適用、`revoked_at` 非更新、`--confirm` 無しは dry-run）は変更なし。

## Test plan

- [ ] `--confirm` 無しで dry-run し、`vc_jwt IS NULL` かつ `status = COMPLETED` の prd 行が `DRY ... would reissue` と表示されること（従来は `SKIP`）
- [ ] `status` が `PENDING` / `PROCESSING` / `FAILED` の IDENTUS_JWT 行は対象に含まれないこと
- [ ] `--confirm` で実行し、対象行の `vc_format -> INTERNAL_JWT` / `vc_jwt` が新 JWT で更新されること
- [ ] `claims` が NULL / 非オブジェクト の行は `FAIL` として報告され exit code 1 になること

https://claude.ai/code/session_01TBzYZJMTCiKb8SQFpNqzWP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 再発行バッチの挙動を「クレームを信頼源」に統一し、空のVCを暗黙でスキップしない処理に変更。
  * ドライラン時は署名・書き込みを行わず、対象の識別子とクレーム形式の検証のみ実施して集計。
  * 結果表示を簡略化し、再発行（実行/想定）と失敗のみを報告するよう更新。
  * 実行前説明と出力文言をそれに合わせて明確化。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hopin-inc/civicship-api/pull/1200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->