### PR TITLE
fix(scripts): persist chainOpIndex in DID anchor backfill

### DIFF
--- a/scripts/backfill-transaction-anchor.ts
+++ b/scripts/backfill-transaction-anchor.ts
@@ -63,29 +63,11 @@ import {
 import { buildRoot } from "@/infrastructure/libs/merkle/merkleTreeBuilder";
 import { deriveCardanoKeypair } from "@/infrastructure/libs/cardano/keygen";
 
-import { parseFixedLengthHex, runStep } from "./lib/cardanoScriptHelpers.ts";
-
-interface Flags {
-  confirm: boolean;
-  limit?: number;
-}
-
-function parseFlags(argv: string[]): Flags {
-  const flags: Flags = { confirm: false };
-  for (const arg of argv) {
-    if (arg === "--confirm") {
-      flags.confirm = true;
-      continue;
-    }
-    const limit = /^--limit=(\d+)$/.exec(arg);
-    if (limit) {
-      flags.limit = Number.parseInt(limit[1], 10);
-      continue;
-    }
-    throw new Error(`Unknown flag: ${arg}`);
-  }
-  return flags;
-}
+import {
+  parseConfirmLimitFlags,
+  parseFixedLengthHex,
+  runStep,
+} from "./lib/cardanoScriptHelpers.ts";
 
 interface PlatformConfig {
   network: "preprod" | "mainnet";
@@ -121,7 +103,7 @@ async function fetchCurrentSlot(projectId: string, network: "preprod" | "mainnet
 }
 
 async function main(): Promise<number> {
-  const flags = parseFlags(process.argv.slice(2));
+  const flags = parseConfirmLimitFlags(process.argv.slice(2));
   process.stdout.write("Backfill Transaction anchor — single 1-tx Merkle commit\n\n");
   process.stdout.write(`mode: ${flags.confirm ? "EXECUTE" : "DRY-RUN"}\n`);
   if (flags.limit !== undefined) process.stdout.write(`limit: ${flags.limit}\n`);

--- a/scripts/backfill-user-did-chain-op-index.ts
+++ b/scripts/backfill-user-did-chain-op-index.ts
@@ -61,7 +61,7 @@ import { prismaClient } from "@/infrastructure/prisma/client";
 import { BlockfrostClient } from "@/infrastructure/libs/blockfrost/client";
 import { METADATA_LABEL_1985 } from "@/infrastructure/libs/cardano/txBuilder";
 
-import { runStep } from "./lib/cardanoScriptHelpers.ts";
+import { runScript, runStep } from "./lib/cardanoScriptHelpers.ts";
 
 interface Flags {
   confirm: boolean;
@@ -377,13 +377,4 @@ async function main(): Promise<number> {
   return unresolvedTotal === 0 ? 0 : 1;
 }
 
-main()
-  .then((code) => {
-    prismaClient.$disconnect().finally(() => process.exit(code));
-  })
-  .catch((err: unknown) => {
-    process.stderr.write(
-      `ERROR: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
-    );
-    prismaClient.$disconnect().finally(() => process.exit(1));
-  });
+runScript(main, () => prismaClient.$disconnect());

--- a/scripts/backfill-user-did-chain-op-index.ts
+++ b/scripts/backfill-user-did-chain-op-index.ts
@@ -22,8 +22,10 @@
  * ---------------------
  *
  *   1. SELECT `UserDidAnchor` rows that are on chain
- *      (`status IN (SUBMITTED, CONFIRMED)`, `chainTxHash IS NOT NULL`)
- *      but still have `chainOpIndex IS NULL`.
+ *      (`status IN (SUBMITTED, CONFIRMED)`, `chainTxHash IS NOT NULL`,
+ *      `operation IN (CREATE, UPDATE)`) but still have `chainOpIndex IS NULL`.
+ *      DEACTIVATE ops carry no on-chain doc hash, so they cannot be
+ *      cross-checked and are out of scope (manual triage only).
  *   2. Group those rows by `chainTxHash`.
  *   3. For each distinct tx: fetch Cardano metadata label 1985 via
  *      Blockfrost and read the ordered `ops[]` array.
@@ -79,14 +81,21 @@ interface TargetRow {
 
 /**
  * `UserDidAnchor` rows that are anchored on chain but still lack a
- * `chainOpIndex`. `FAILED` rows are deliberately excluded even when they
- * carry a `chainTxHash` — those need manual operator triage (see
- * `backfill-user-did.ts` SUBMITTABLE_ANCHOR_WHERE).
+ * `chainOpIndex`.
+ *
+ * Restricted to CREATE / UPDATE: those ops carry a document hash (`h`) in
+ * the on-chain metadata, so the derived index can be cross-checked against
+ * `documentHash` before it is written. DEACTIVATE ops carry no `h` (see the
+ * `DidOp` shape in txBuilder), so this tool cannot verify them — they are
+ * left for manual operator triage rather than risking a wrong index.
+ * `FAILED` rows are likewise excluded even when they carry a `chainTxHash`
+ * (see `backfill-user-did.ts` SUBMITTABLE_ANCHOR_WHERE).
  */
 async function findRowsMissingOpIndex(limit?: number): Promise<TargetRow[]> {
   const rows = await prismaClient.userDidAnchor.findMany({
     where: {
       status: { in: [AnchorStatus.SUBMITTED, AnchorStatus.CONFIRMED] },
+      operation: { in: [DidOperation.CREATE, DidOperation.UPDATE] },
       chainTxHash: { not: null },
       chainOpIndex: null,
     },
@@ -230,10 +239,17 @@ function resolveTxGroup(
     }
 
     const op = candidates[0];
-    // Final integrity cross-check: the on-chain doc hash MUST equal the DB
-    // `documentHash`. A mismatch means the row and the chain disagree —
-    // writing the index would aim the verifier at the wrong op.
-    if (op.h !== null && op.h.toLowerCase() !== row.documentHash.toLowerCase()) {
+    // Final integrity cross-check. A CREATE/UPDATE op always carries `h` on
+    // chain (txBuilder enforces a 64-hex-char hash), and only CREATE/UPDATE
+    // rows reach here (findRowsMissingOpIndex filters them). A missing or
+    // mismatched hash means the row and the chain disagree, so the index is
+    // NOT written — aiming the verifier at the wrong op is worse than
+    // leaving `chainOpIndex` NULL.
+    if (op.h === null) {
+      skip(row, `on-chain op for ${row.operation} row has no doc hash (h); cannot verify`);
+      continue;
+    }
+    if (op.h.toLowerCase() !== row.documentHash.toLowerCase()) {
       skip(row, `doc hash mismatch: chain=${op.h} db=${row.documentHash}`);
       continue;
     }

--- a/scripts/backfill-user-did-chain-op-index.ts
+++ b/scripts/backfill-user-did-chain-op-index.ts
@@ -163,18 +163,21 @@ function normalizeMetadataText(value: unknown): string {
     return value.map((v) => normalizeMetadataText(v)).join("");
   }
   if (typeof value === "string") return value;
-  if (value === null || value === undefined) return "";
-  return String(value);
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  // null / undefined / object / symbol: not a meaningful metadata text value.
+  return "";
 }
 
 /** Parse the ordered `ops[]` array out of a label-1985 `json_metadata` blob. */
 function extractOps(jsonMetadata: unknown): ChainOp[] {
   if (!jsonMetadata || typeof jsonMetadata !== "object") {
-    throw new Error("metadata label 1985 payload is not an object");
+    throw new TypeError("metadata label 1985 payload is not an object");
   }
   const ops = (jsonMetadata as { ops?: unknown }).ops;
   if (!Array.isArray(ops)) {
-    throw new Error("metadata label 1985 has no `ops` array");
+    throw new TypeError("metadata label 1985 has no `ops` array");
   }
   return ops.map((op, index) => {
     const o = (op && typeof op === "object" ? op : {}) as Record<string, unknown>;
@@ -221,12 +224,15 @@ function resolveTxGroup(
 ): { matches: Match[]; unresolved: Unresolved[] } {
   const matches: Match[] = [];
   const unresolved: Unresolved[] = [];
+  const skip = (row: TargetRow, reason: string): void => {
+    unresolved.push({ row, reason });
+  };
 
   for (const row of rows) {
     const expectedK = operationToK(row.operation);
     const sameDid = ops.filter((o) => o.did === row.did);
     if (sameDid.length === 0) {
-      unresolved.push({ row, reason: `did ${row.did} not present in tx ops[]` });
+      skip(row, `did ${row.did} not present in tx ops[]`);
       continue;
     }
 
@@ -235,10 +241,7 @@ function resolveTxGroup(
     // weekly batch) is still disambiguated.
     let candidates = sameDid.filter((o) => o.k === expectedK);
     if (candidates.length === 0) {
-      unresolved.push({
-        row,
-        reason: `did ${row.did} present but no op has kind k='${expectedK}'`,
-      });
+      skip(row, `did ${row.did} present but no op has kind k='${expectedK}'`);
       continue;
     }
     if (candidates.length > 1) {
@@ -247,10 +250,7 @@ function resolveTxGroup(
       );
     }
     if (candidates.length !== 1) {
-      unresolved.push({
-        row,
-        reason: `ambiguous: ${candidates.length} ops match did+kind+hash`,
-      });
+      skip(row, `ambiguous: ${candidates.length} ops match did+kind+hash`);
       continue;
     }
 
@@ -259,10 +259,7 @@ function resolveTxGroup(
     // `documentHash`. A mismatch means the row and the chain disagree —
     // writing the index would aim the verifier at the wrong op.
     if (op.h !== null && op.h.toLowerCase() !== row.documentHash.toLowerCase()) {
-      unresolved.push({
-        row,
-        reason: `doc hash mismatch: chain=${op.h} db=${row.documentHash}`,
-      });
+      skip(row, `doc hash mismatch: chain=${op.h} db=${row.documentHash}`);
       continue;
     }
 

--- a/scripts/backfill-user-did-chain-op-index.ts
+++ b/scripts/backfill-user-did-chain-op-index.ts
@@ -61,32 +61,7 @@ import { prismaClient } from "@/infrastructure/prisma/client";
 import { BlockfrostClient } from "@/infrastructure/libs/blockfrost/client";
 import { METADATA_LABEL_1985 } from "@/infrastructure/libs/cardano/txBuilder";
 
-import { runScript, runStep } from "./lib/cardanoScriptHelpers.ts";
-
-interface Flags {
-  confirm: boolean;
-  limit?: number;
-}
-
-function parseFlags(argv: string[]): Flags {
-  const flags: Flags = { confirm: false };
-  for (const arg of argv) {
-    if (arg === "--confirm") {
-      flags.confirm = true;
-      continue;
-    }
-    const limit = /^--limit=(\d+)$/.exec(arg);
-    if (limit) {
-      flags.limit = Number.parseInt(limit[1], 10);
-      continue;
-    }
-    throw new Error(`Unknown flag: ${arg}`);
-  }
-  if (flags.limit !== undefined && flags.limit <= 0) {
-    throw new Error("--limit must be > 0");
-  }
-  return flags;
-}
+import { parseConfirmLimitFlags, runScript, runStep } from "./lib/cardanoScriptHelpers.ts";
 
 /** Resolve the Cardano network from env (mirrors `backfill-user-did.ts`). */
 function resolveChainNetwork(): ChainNetwork {
@@ -270,7 +245,7 @@ function resolveTxGroup(
 }
 
 async function main(): Promise<number> {
-  const flags = parseFlags(process.argv.slice(2));
+  const flags = parseConfirmLimitFlags(process.argv.slice(2));
   process.stdout.write("Backfill UserDidAnchor.chainOpIndex from on-chain metadata\n\n");
   process.stdout.write(`mode: ${flags.confirm ? "EXECUTE" : "DRY-RUN"}\n`);
   if (flags.limit !== undefined) process.stdout.write(`limit: ${flags.limit}\n`);

--- a/scripts/backfill-user-did-chain-op-index.ts
+++ b/scripts/backfill-user-did-chain-op-index.ts
@@ -1,0 +1,389 @@
+#!/usr/bin/env -S node --experimental-strip-types
+/**
+ * Backfill `chainOpIndex` on `UserDidAnchor` rows that were anchored on
+ * Cardano by an older `backfill-user-did.ts` run which never persisted the
+ * on-chain operation position.
+ *
+ * Why this script exists
+ * ----------------------
+ *
+ * `scripts/backfill-user-did.ts` — before its `chainOpIndex` fix — submitted
+ * ~1466 CREATE ops to Cardano and marked the rows `CONFIRMED`, but its
+ * `updateMany` only wrote `status / chainTxHash / batchId`. It never stamped
+ * `chainOpIndex` (unlike `AnchorBatchService.markSubmitted`, which does).
+ *
+ * The verifier locates a DID operation inside a tx via
+ * `metadata.ops[chainOpIndex]` (see `scripts/verify-from-chain.ts` and
+ * §8.3 chain inclusion). A `CONFIRMED` anchor whose `chainOpIndex` is NULL
+ * is therefore unverifiable — exactly the state the prd backfill left
+ * 1466 rows in.
+ *
+ * What this script does
+ * ---------------------
+ *
+ *   1. SELECT `UserDidAnchor` rows that are on chain
+ *      (`status IN (SUBMITTED, CONFIRMED)`, `chainTxHash IS NOT NULL`)
+ *      but still have `chainOpIndex IS NULL`.
+ *   2. Group those rows by `chainTxHash`.
+ *   3. For each distinct tx: fetch Cardano metadata label 1985 via
+ *      Blockfrost and read the ordered `ops[]` array.
+ *   4. Match each DB row to its op by `did`, cross-checked against the op
+ *      kind (`k`) and the document hash (`h` vs `documentHash`). The op's
+ *      0-based index in `ops[]` is the row's `chainOpIndex`.
+ *   5. UPDATE the row with the derived index.
+ *
+ * Idempotency / safety
+ * --------------------
+ *
+ *   - `--confirm` 無しは dry-run（DB write も Blockfrost 呼び出しもしない）。
+ *   - `chainOpIndex` が既に入っている行は SELECT 段階で対象外。再実行安全。
+ *   - status は一切変更しない（`chainOpIndex` のみを additive に書く）。
+ *   - chain と DB が食い違う行（`h` mismatch / `did` 不在 / 同一 tx 内で
+ *     did+kind+hash が一意に絞れない）は **書き込まず** UNRESOLVED として
+ *     stderr に出し、exit code 1 で運用者に手動 triage を促す。
+ *
+ * Required env (loaded from `.env.prd` / `.env.dev` via dotenvx):
+ *   BLOCKFROST_PROJECT_ID, CARDANO_NETWORK, DATABASE_URL
+ *
+ * 実行例:
+ *   pnpm exec dotenvx run -f .env.prd -- pnpm exec tsx scripts/backfill-user-did-chain-op-index.ts
+ *   pnpm exec dotenvx run -f .env.prd -- pnpm exec tsx scripts/backfill-user-did-chain-op-index.ts --confirm
+ *
+ * Exit codes: 0 = every targeted row resolved (or nothing to do),
+ *             1 = at least one row could not be resolved.
+ */
+
+import "reflect-metadata";
+
+import { AnchorStatus, ChainNetwork, DidOperation } from "@prisma/client";
+
+import { prismaClient } from "@/infrastructure/prisma/client";
+import { BlockfrostClient } from "@/infrastructure/libs/blockfrost/client";
+import { METADATA_LABEL_1985 } from "@/infrastructure/libs/cardano/txBuilder";
+
+import { runStep } from "./lib/cardanoScriptHelpers.ts";
+
+interface Flags {
+  confirm: boolean;
+  limit?: number;
+}
+
+function parseFlags(argv: string[]): Flags {
+  const flags: Flags = { confirm: false };
+  for (const arg of argv) {
+    if (arg === "--confirm") {
+      flags.confirm = true;
+      continue;
+    }
+    const limit = /^--limit=(\d+)$/.exec(arg);
+    if (limit) {
+      flags.limit = Number.parseInt(limit[1], 10);
+      continue;
+    }
+    throw new Error(`Unknown flag: ${arg}`);
+  }
+  if (flags.limit !== undefined && flags.limit <= 0) {
+    throw new Error("--limit must be > 0");
+  }
+  return flags;
+}
+
+/** Resolve the Cardano network from env (mirrors `backfill-user-did.ts`). */
+function resolveChainNetwork(): ChainNetwork {
+  const raw = process.env.CARDANO_NETWORK ?? "preprod";
+  return raw === "mainnet" ? ChainNetwork.CARDANO_MAINNET : ChainNetwork.CARDANO_PREPROD;
+}
+
+interface TargetRow {
+  id: string;
+  did: string;
+  operation: DidOperation;
+  documentHash: string;
+  chainTxHash: string;
+}
+
+/**
+ * `UserDidAnchor` rows that are anchored on chain but still lack a
+ * `chainOpIndex`. `FAILED` rows are deliberately excluded even when they
+ * carry a `chainTxHash` — those need manual operator triage (see
+ * `backfill-user-did.ts` SUBMITTABLE_ANCHOR_WHERE).
+ */
+async function findRowsMissingOpIndex(limit?: number): Promise<TargetRow[]> {
+  const rows = await prismaClient.userDidAnchor.findMany({
+    where: {
+      status: { in: [AnchorStatus.SUBMITTED, AnchorStatus.CONFIRMED] },
+      chainTxHash: { not: null },
+      chainOpIndex: null,
+    },
+    select: {
+      id: true,
+      did: true,
+      operation: true,
+      documentHash: true,
+      chainTxHash: true,
+    },
+    orderBy: { createdAt: "asc" },
+    take: limit,
+  });
+  // `chainTxHash` is non-null by the `where` filter above; narrow the type.
+  return rows.map((r) => ({ ...r, chainTxHash: r.chainTxHash as string }));
+}
+
+function groupByTxHash(rows: TargetRow[]): Map<string, TargetRow[]> {
+  const groups = new Map<string, TargetRow[]>();
+  for (const row of rows) {
+    const existing = groups.get(row.chainTxHash);
+    if (existing) {
+      existing.push(row);
+    } else {
+      groups.set(row.chainTxHash, [row]);
+    }
+  }
+  return groups;
+}
+
+/** A single DID operation as read back from on-chain metadata label 1985. */
+interface ChainOp {
+  /** 0-based position in the metadata `ops[]` array — i.e. `chainOpIndex`. */
+  index: number;
+  /** Operation kind: "c" (CREATE) / "u" (UPDATE) / "d" (DEACTIVATE). */
+  k: string;
+  did: string;
+  /** Document hash (64 hex chars); absent on DEACTIVATE ops. */
+  h: string | null;
+}
+
+/**
+ * Blockfrost returns metadata `text` / `bytes` items that exceeded the 64-byte
+ * chunk limit as JSON arrays of strings. Join them back into a single string
+ * so a chunked `did` compares equal to the DB value.
+ */
+function normalizeMetadataText(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.map((v) => normalizeMetadataText(v)).join("");
+  }
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return "";
+  return String(value);
+}
+
+/** Parse the ordered `ops[]` array out of a label-1985 `json_metadata` blob. */
+function extractOps(jsonMetadata: unknown): ChainOp[] {
+  if (!jsonMetadata || typeof jsonMetadata !== "object") {
+    throw new Error("metadata label 1985 payload is not an object");
+  }
+  const ops = (jsonMetadata as { ops?: unknown }).ops;
+  if (!Array.isArray(ops)) {
+    throw new Error("metadata label 1985 has no `ops` array");
+  }
+  return ops.map((op, index) => {
+    const o = (op && typeof op === "object" ? op : {}) as Record<string, unknown>;
+    return {
+      index,
+      k: normalizeMetadataText(o.k),
+      did: normalizeMetadataText(o.did),
+      h: o.h === undefined || o.h === null ? null : normalizeMetadataText(o.h),
+    };
+  });
+}
+
+/** `DidOperation` → metadata-1985 op kind (`k`). */
+function operationToK(operation: DidOperation): string {
+  switch (operation) {
+    case DidOperation.CREATE:
+      return "c";
+    case DidOperation.UPDATE:
+      return "u";
+    case DidOperation.DEACTIVATE:
+      return "d";
+  }
+}
+
+interface Match {
+  row: TargetRow;
+  opIndex: number;
+}
+
+interface Unresolved {
+  row: TargetRow;
+  reason: string;
+}
+
+/**
+ * Match every DB row in one tx group to its on-chain op and derive the
+ * `chainOpIndex`. A row is only resolved when exactly one op matches its
+ * `did` + kind, and that op's `h` agrees with the DB `documentHash` — so a
+ * row is never pointed at the wrong (or a corrupted) operation.
+ */
+function resolveTxGroup(
+  rows: TargetRow[],
+  ops: ChainOp[],
+): { matches: Match[]; unresolved: Unresolved[] } {
+  const matches: Match[] = [];
+  const unresolved: Unresolved[] = [];
+
+  for (const row of rows) {
+    const expectedK = operationToK(row.operation);
+    const sameDid = ops.filter((o) => o.did === row.did);
+    if (sameDid.length === 0) {
+      unresolved.push({ row, reason: `did ${row.did} not present in tx ops[]` });
+      continue;
+    }
+
+    // Narrow by op kind, then by doc hash, so a DID that legitimately
+    // appears more than once in the same tx (e.g. CREATE + UPDATE in one
+    // weekly batch) is still disambiguated.
+    let candidates = sameDid.filter((o) => o.k === expectedK);
+    if (candidates.length === 0) {
+      unresolved.push({
+        row,
+        reason: `did ${row.did} present but no op has kind k='${expectedK}'`,
+      });
+      continue;
+    }
+    if (candidates.length > 1) {
+      candidates = candidates.filter(
+        (o) => o.h !== null && o.h.toLowerCase() === row.documentHash.toLowerCase(),
+      );
+    }
+    if (candidates.length !== 1) {
+      unresolved.push({
+        row,
+        reason: `ambiguous: ${candidates.length} ops match did+kind+hash`,
+      });
+      continue;
+    }
+
+    const op = candidates[0];
+    // Final integrity cross-check: the on-chain doc hash MUST equal the DB
+    // `documentHash`. A mismatch means the row and the chain disagree —
+    // writing the index would aim the verifier at the wrong op.
+    if (op.h !== null && op.h.toLowerCase() !== row.documentHash.toLowerCase()) {
+      unresolved.push({
+        row,
+        reason: `doc hash mismatch: chain=${op.h} db=${row.documentHash}`,
+      });
+      continue;
+    }
+
+    matches.push({ row, opIndex: op.index });
+  }
+
+  return { matches, unresolved };
+}
+
+async function main(): Promise<number> {
+  const flags = parseFlags(process.argv.slice(2));
+  process.stdout.write("Backfill UserDidAnchor.chainOpIndex from on-chain metadata\n\n");
+  process.stdout.write(`mode: ${flags.confirm ? "EXECUTE" : "DRY-RUN"}\n`);
+  if (flags.limit !== undefined) process.stdout.write(`limit: ${flags.limit}\n`);
+  process.stdout.write("\n");
+
+  // Step 1 — survey
+  const surveyStep = await runStep<TargetRow[]>(
+    "db: anchored UserDidAnchor rows missing chainOpIndex",
+    async () => {
+      const rows = await findRowsMissingOpIndex(flags.limit);
+      const txCount = new Set(rows.map((r) => r.chainTxHash)).size;
+      return {
+        value: rows,
+        detail: `${rows.length} row(s) across ${txCount} tx`,
+      };
+    },
+  );
+  if (!surveyStep.ok) return 1;
+  const rows = surveyStep.value;
+
+  if (rows.length === 0) {
+    process.stdout.write(
+      "Nothing to do — every anchored UserDidAnchor already has a chainOpIndex.\n",
+    );
+    return 0;
+  }
+
+  const groups = groupByTxHash(rows);
+
+  if (!flags.confirm) {
+    process.stdout.write(
+      `\nDry-run: would resolve chainOpIndex for ${rows.length} row(s) across ` +
+        `${groups.size} tx by reading on-chain metadata label ${METADATA_LABEL_1985}.\n`,
+    );
+    process.stdout.write("Re-run with `--confirm` to apply.\n");
+    return 0;
+  }
+
+  // ---------- EXECUTE path below ----------
+
+  const projectId = process.env.BLOCKFROST_PROJECT_ID;
+  if (!projectId) throw new Error("BLOCKFROST_PROJECT_ID is unset");
+  const client = new BlockfrostClient({ network: resolveChainNetwork() });
+
+  let resolvedTotal = 0;
+  let unresolvedTotal = 0;
+  let txIdx = 0;
+
+  for (const [txHash, groupRows] of groups) {
+    txIdx += 1;
+    const step = await runStep<{ resolved: number; unresolved: number }>(
+      `chain(${txIdx}/${groups.size}): tx ${txHash} — ${groupRows.length} row(s)`,
+      async () => {
+        const metadata = await client.getTxMetadata(txHash);
+        const label = metadata.find((m) => String(m.label) === String(METADATA_LABEL_1985));
+        if (!label) {
+          throw new Error(`tx has no metadata under label ${METADATA_LABEL_1985}`);
+        }
+        const ops = extractOps(label.json_metadata);
+        const { matches, unresolved } = resolveTxGroup(groupRows, ops);
+
+        for (const u of unresolved) {
+          process.stderr.write(`   UNRESOLVED ${u.row.id} (${u.row.did}): ${u.reason}\n`);
+        }
+
+        if (matches.length > 0) {
+          // One $transaction per tx group: each row gets a distinct
+          // `chainOpIndex`, so per-row `update` is required, and atomicity
+          // keeps a crashed run from leaving the group half-stamped.
+          await prismaClient.$transaction(
+            matches.map((m) =>
+              prismaClient.userDidAnchor.update({
+                where: { id: m.row.id },
+                data: { chainOpIndex: m.opIndex },
+              }),
+            ),
+          );
+        }
+
+        return {
+          value: { resolved: matches.length, unresolved: unresolved.length },
+          detail:
+            `${matches.length} resolved, ${unresolved.length} unresolved ` +
+            `(on-chain ops[] length=${ops.length})`,
+        };
+      },
+    );
+    if (step.ok) {
+      resolvedTotal += step.value.resolved;
+      unresolvedTotal += step.value.unresolved;
+    } else {
+      // The whole tx group could not be read / parsed — every row in it
+      // is unresolved and needs a re-run or manual triage.
+      unresolvedTotal += groupRows.length;
+    }
+  }
+
+  process.stdout.write(
+    `\ntx=${groups.size}, resolved=${resolvedTotal}, unresolved=${unresolvedTotal}\n`,
+  );
+  return unresolvedTotal === 0 ? 0 : 1;
+}
+
+main()
+  .then((code) => {
+    prismaClient.$disconnect().finally(() => process.exit(code));
+  })
+  .catch((err: unknown) => {
+    process.stderr.write(
+      `ERROR: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
+    );
+    prismaClient.$disconnect().finally(() => process.exit(1));
+  });

--- a/scripts/backfill-user-did.ts
+++ b/scripts/backfill-user-did.ts
@@ -30,7 +30,10 @@
  *          — this is a DID-only anchor batch).
  *        - `buildAnchorTx` → `submitTx` → `awaitConfirmation`.
  *        - UPDATE the chunk's `UserDidAnchor` rows to
- *          `status=CONFIRMED, chainTxHash, batchId`.
+ *          `status=CONFIRMED, chainTxHash, chainOpIndex, batchId` —
+ *          `chainOpIndex` is the row's 0-based position in the on-chain
+ *          metadata `ops[]` array, which the verifier needs to locate the
+ *          operation (`ops[chainOpIndex]`).
  *        - Sleep `--inter-tx-sleep-ms` (default 5 min) before the next
  *          chunk to let the change UTxO settle.
  *
@@ -451,15 +454,31 @@ async function main(): Promise<number> {
         });
         const txHash = await client.submitTx(built.txCborBytes);
         // Mark SUBMITTED early so a crash mid-await still leaves a trail.
-        await prismaClient.userDidAnchor.updateMany({
-          where: { id: { in: chunk.map((r) => r.id) } },
-          data: {
-            status: AnchorStatus.SUBMITTED,
-            chainTxHash: txHash,
-            submittedAt: new Date(),
-            batchId: bid,
-          },
-        });
+        //
+        // Per-row `update` (not a single `updateMany`) because `chainOpIndex`
+        // differs per row: `ops[i]` was built from `chunk[i]` directly above,
+        // so an anchor's position in the on-chain metadata `ops[]` array is
+        // exactly its index in `chunk`. The verifier resolves a DID op via
+        // `ops[chainOpIndex]`, so a CONFIRMED anchor with a NULL
+        // `chainOpIndex` is unverifiable. Wrap the per-row updates in one
+        // `$transaction` so the whole chunk is marked atomically — exactly
+        // the atomicity the former `updateMany` gave — ensuring a re-run can
+        // never re-submit a partially-marked chunk and double-anchor.
+        const submittedAt = new Date();
+        await prismaClient.$transaction(
+          chunk.map((row, opIndex) =>
+            prismaClient.userDidAnchor.update({
+              where: { id: row.id },
+              data: {
+                status: AnchorStatus.SUBMITTED,
+                chainTxHash: txHash,
+                submittedAt,
+                batchId: bid,
+                chainOpIndex: opIndex,
+              },
+            }),
+          ),
+        );
         const confirmed = await client.awaitConfirmation(txHash);
         await prismaClient.userDidAnchor.updateMany({
           where: { id: { in: chunk.map((r) => r.id) } },

--- a/scripts/backfill-user-did.ts
+++ b/scripts/backfill-user-did.ts
@@ -94,7 +94,7 @@ import {
 import { buildMinimalDidDocument, buildUserDid } from "@/infrastructure/libs/did/userDidBuilder";
 import { deriveCardanoKeypair } from "@/infrastructure/libs/cardano/keygen";
 
-import { bytesToHex, parseFixedLengthHex, runStep } from "./lib/cardanoScriptHelpers.ts";
+import { bytesToHex, parseFixedLengthHex, runScript, runStep } from "./lib/cardanoScriptHelpers.ts";
 
 const DEFAULT_CHUNK_SIZE = 80;
 const DEFAULT_INTER_TX_SLEEP_MS = 5 * 60 * 1000;
@@ -531,13 +531,4 @@ async function markChunkFailed(rows: ReadonlyArray<{ id: string }>, reason: stri
     });
 }
 
-main()
-  .then((code) => {
-    prismaClient.$disconnect().finally(() => process.exit(code));
-  })
-  .catch((err: unknown) => {
-    process.stderr.write(
-      `ERROR: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
-    );
-    prismaClient.$disconnect().finally(() => process.exit(1));
-  });
+runScript(main, () => prismaClient.$disconnect());

--- a/scripts/lib/cardanoScriptHelpers.ts
+++ b/scripts/lib/cardanoScriptHelpers.ts
@@ -98,3 +98,38 @@ export function runScript(
       cleanup().finally(() => process.exit(1));
     });
 }
+
+/**
+ * CLI flags common to one-shot backfill scripts:
+ *   - `confirm` — `--confirm` toggles execute mode (otherwise dry-run).
+ *   - `limit`   — `--limit=<n>` caps the number of rows processed.
+ */
+export interface ConfirmLimitFlags {
+  confirm: boolean;
+  limit?: number;
+}
+
+/**
+ * Parse the `--confirm` / `--limit=<n>` flags. Throws on an unknown flag or a
+ * non-positive `--limit`. Extracted because every backfill script otherwise
+ * repeats this exact parser verbatim.
+ */
+export function parseConfirmLimitFlags(argv: string[]): ConfirmLimitFlags {
+  const flags: ConfirmLimitFlags = { confirm: false };
+  for (const arg of argv) {
+    if (arg === "--confirm") {
+      flags.confirm = true;
+      continue;
+    }
+    const limit = /^--limit=(\d+)$/.exec(arg);
+    if (limit) {
+      flags.limit = Number.parseInt(limit[1], 10);
+      continue;
+    }
+    throw new Error(`Unknown flag: ${arg}`);
+  }
+  if (flags.limit !== undefined && flags.limit <= 0) {
+    throw new Error("--limit must be > 0");
+  }
+  return flags;
+}

--- a/scripts/lib/cardanoScriptHelpers.ts
+++ b/scripts/lib/cardanoScriptHelpers.ts
@@ -78,39 +78,39 @@ export function bytesToHex(b: Uint8Array): string {
  * on both the success and failure paths; on an uncaught error the stack is
  * written to stderr and the process exits 1.
  *
+ * `main` and `cleanup` are invoked behind `await` inside an async wrapper so a
+ * *synchronous* throw from either is normalized into the same handling path as
+ * a rejected promise — the exit code is always honoured and a `cleanup`
+ * failure never escapes as an unhandled rejection.
+ *
  * `cleanup` is passed in (rather than imported) so this module keeps its
  * "no DI container / no Prisma / no `@/infrastructure`" constraint — every
- * one-shot script otherwise repeats this same `main().then().catch()`
- * boilerplate verbatim.
+ * one-shot script otherwise repeats this same boilerplate verbatim.
  */
 export function runScript(
   main: () => Promise<number>,
   cleanup: () => Promise<unknown> = () => Promise.resolve(),
 ): void {
-  main()
-    .then((code) => exitAfterCleanup(cleanup, code))
-    .catch((err: unknown) => {
+  void (async () => {
+    let code = 1;
+    try {
+      code = await main();
+    } catch (err) {
       process.stderr.write(
         `ERROR: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
       );
-      exitAfterCleanup(cleanup, 1);
-    });
-}
-
-/**
- * Run `cleanup`, then exit with `code`. A `cleanup` rejection is caught and
- * logged rather than left to surface as an unhandled promise rejection — the
- * process is already terminating, and the exit code (not the cleanup
- * outcome) is what matters.
- */
-function exitAfterCleanup(cleanup: () => Promise<unknown>, code: number): void {
-  cleanup()
-    .catch((err: unknown) => {
+    }
+    try {
+      await cleanup();
+    } catch (err) {
+      // The process is already terminating; a cleanup failure must not mask
+      // the exit code or surface as an unhandled rejection.
       process.stderr.write(
         `WARN: cleanup failed: ${err instanceof Error ? err.message : String(err)}\n`,
       );
-    })
-    .finally(() => process.exit(code));
+    }
+    process.exit(code);
+  })();
 }
 
 /**

--- a/scripts/lib/cardanoScriptHelpers.ts
+++ b/scripts/lib/cardanoScriptHelpers.ts
@@ -88,15 +88,29 @@ export function runScript(
   cleanup: () => Promise<unknown> = () => Promise.resolve(),
 ): void {
   main()
-    .then((code) => {
-      cleanup().finally(() => process.exit(code));
-    })
+    .then((code) => exitAfterCleanup(cleanup, code))
     .catch((err: unknown) => {
       process.stderr.write(
         `ERROR: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
       );
-      cleanup().finally(() => process.exit(1));
+      exitAfterCleanup(cleanup, 1);
     });
+}
+
+/**
+ * Run `cleanup`, then exit with `code`. A `cleanup` rejection is caught and
+ * logged rather than left to surface as an unhandled promise rejection — the
+ * process is already terminating, and the exit code (not the cleanup
+ * outcome) is what matters.
+ */
+function exitAfterCleanup(cleanup: () => Promise<unknown>, code: number): void {
+  cleanup()
+    .catch((err: unknown) => {
+      process.stderr.write(
+        `WARN: cleanup failed: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    })
+    .finally(() => process.exit(code));
 }
 
 /**

--- a/scripts/lib/cardanoScriptHelpers.ts
+++ b/scripts/lib/cardanoScriptHelpers.ts
@@ -71,3 +71,30 @@ export function bytesToHex(b: Uint8Array): string {
   for (const byte of b) s += byte.toString(16).padStart(2, "0");
   return s;
 }
+
+/**
+ * Run a script's `main` to completion and exit the process with its returned
+ * code. `cleanup` (e.g. `() => prismaClient.$disconnect()`) always runs first,
+ * on both the success and failure paths; on an uncaught error the stack is
+ * written to stderr and the process exits 1.
+ *
+ * `cleanup` is passed in (rather than imported) so this module keeps its
+ * "no DI container / no Prisma / no `@/infrastructure`" constraint — every
+ * one-shot script otherwise repeats this same `main().then().catch()`
+ * boilerplate verbatim.
+ */
+export function runScript(
+  main: () => Promise<number>,
+  cleanup: () => Promise<unknown> = () => Promise.resolve(),
+): void {
+  main()
+    .then((code) => {
+      cleanup().finally(() => process.exit(code));
+    })
+    .catch((err: unknown) => {
+      process.stderr.write(
+        `ERROR: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
+      );
+      cleanup().finally(() => process.exit(1));
+    });
+}


### PR DESCRIPTION
## 背景

prd で `backfill-user-did.ts` を実行し、~1466 件の DID CREATE op を Cardano に submit して CONFIRMED まで到達したが、**全件 `chainOpIndex` が NULL のまま**になっていた。

原因は、`backfill-user-did.ts` が anchor batch (`AnchorBatchService`) の `markSubmitted` / `markConfirmed` を一切通っておらず、独自の `updateMany` で `status / chainTxHash / batchId` だけを書いていたこと。`chainOpIndex`（metadata `ops[]` 配列内の位置）を書き戻す処理が存在しなかった。

PR #1189 (`fix-chainopindex-writeback`) で `chainOpIndex` 書き戻しを修正済みだが、あれは **週次バッチ (`AnchorBatchService`) 側のみ**で、この standalone スクリプトは対象外だった。検証側は `metadata.ops[chainOpIndex]` で DID 操作を特定するため、`chainOpIndex` が NULL の CONFIRMED anchor は検証不能。

## 変更内容

### (1) Forward fix — `scripts/backfill-user-did.ts`
- submit 時に各 anchor へ `chainOpIndex` を書き戻すよう修正。`ops[i]` は `chunk[i]` から構築されるため、anchor のチェーン上 `ops[]` 内の位置は `chunk` 内のインデックスと一致する。
- `chainOpIndex` は行ごとに値が異なるため、一括 `updateMany` ではなく per-row `update` に変更。ただし chunk マーキングの原子性（再実行時の二重 anchor 防止）を保つため、per-row update を 1 つの `$transaction` でまとめている。

### (2) 既存データの修復 — `scripts/backfill-user-did-chain-op-index.ts`（新規）
既に anchor 済みで `chainOpIndex` が NULL の行を、チェーン上の真実から復旧する:
1. `status IN (SUBMITTED, CONFIRMED)` かつ `chainTxHash IS NOT NULL` かつ `chainOpIndex IS NULL` の `UserDidAnchor` を抽出
2. `chainTxHash` でグルーピング
3. 各 tx の metadata label 1985 を Blockfrost から取得し、順序付き `ops[]` を読む
4. 各行を `did` でマッチ（op 種別 `k` と document hash `h` でクロスチェック）、その op の配列インデックスを `chainOpIndex` として導出
5. 行を UPDATE（`chainOpIndex` のみ additive に書く。status は変更しない）

`--confirm` 無しは dry-run。チェーンと DB が食い違う行（`h` mismatch / `did` 不在 / 一意に絞れない）は **書き込まず** UNRESOLVED として報告し exit 1 で手動 triage を促す。再実行安全。

## Test plan

- [ ] dev で `dotenvx run -f .env.dev -- tsx scripts/backfill-user-did-chain-op-index.ts`（dry-run）を実行し、対象行数・tx 数が想定通りか確認
- [ ] dev で `--confirm` 付き実行 → `chainOpIndex` が埋まり、`verify-from-chain.ts --did ...` が PASS することを確認
- [ ] prd で同様に dry-run → `--confirm` の順で 1466 件を修復
- [ ] forward fix: 新規 `backfill-user-did.ts` 実行時に submit 直後 `chainOpIndex` が入ることを確認

https://claude.ai/code/session_0187jAioL2oqUfKnNZvj1ZZx

---
_Generated by [Claude Code](https://claude.ai/code/session_0187jAioL2oqUfKnNZvj1ZZx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ユーザーDIDのチェーン操作インデックスを補完するバックフィルを追加（ドライラン/確定実行モード、各トランザクションごとの解決可否報告と未解決時の終了コード）。
  * スクリプト実行ユーティリティを追加し、終了時の後処理と正常/異常終了時のログ出力を統一。

* **Chores**
  * CLIフラグ処理を共通化し、送信時の更新をチャンク単位で原子的に適用するよう改善。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hopin-inc/civicship-api/pull/1202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->