### PR TITLE
ci(posture): harden dig against transient resolver failures

### DIFF
--- a/.github/workflows/tls-dns-posture.yml
+++ b/.github/workflows/tls-dns-posture.yml
@@ -84,21 +84,51 @@ jobs:
       # 親ゾーン (.app) に署名チェーンが繋がらず DNSSEC が事実上 OFF。
       # api.civicship.app は通常 CNAME → apex なので apex 側の DS が引ければ
       # 両方 OK の扱い、ただし matrix で個別に引いて誤設定を可視化する。
+      #
+      # 過去に 1.1.1.1 への UDP/53 が一時的に応答しないことで dig 自体が exit
+      # code 9 (no reply) で落ち、posture 異常ではないのに Slack に false
+      # alarm が飛ぶ事例があった。リゾルバ fallback と短い timeout で dig の
+      # transient 失敗を「DS 不在」と区別する。`set -e` 下でも dig の失敗で
+      # スクリプトが死なないよう、戻り値は `||` 経由で受ける。
       - name: DNSSEC DS record check (${{ matrix.host }})
         run: |
           set -euo pipefail
-          ds=$(dig +short DS ${{ matrix.host }} @1.1.1.1)
+
+          # 複数 resolver を順に試して最初に応答した結果を返す。
+          # 戻り値: 0 = 応答取得 (空文字含む) / 1 = 全 resolver 沈黙
+          query_ds() {
+            local name=$1
+            local resolver out
+            for resolver in 1.1.1.1 8.8.8.8 9.9.9.9; do
+              if out=$(dig +short +tries=3 +time=3 DS "$name" @"$resolver" 2>/dev/null); then
+                printf '%s' "$out"
+                return 0
+              fi
+              echo "::warning::dig DS $name @$resolver failed (transient), trying next resolver" >&2
+            done
+            return 1
+          }
+
+          host="${{ matrix.host }}"
+          if ! ds=$(query_ds "$host"); then
+            echo "::error::All DNS resolvers failed to respond for DS $host (network issue, not a posture failure)"
+            exit 1
+          fi
+
           if [ -z "$ds" ]; then
             # subdomain は親 (apex) の DS でカバーされるケースがある。subdomain
             # 側が空なら apex に fallback して chain の存在を確認する。
-            apex=$(echo "${{ matrix.host }}" | awk -F. '{print $(NF-1)"."$NF}')
-            if [ "${{ matrix.host }}" = "$apex" ]; then
-              echo "::error::DNSSEC DS record missing for ${{ matrix.host }}"
+            apex=$(echo "$host" | awk -F. '{print $(NF-1)"."$NF}')
+            if [ "$host" = "$apex" ]; then
+              echo "::error::DNSSEC DS record missing for $host"
               exit 1
             fi
-            ds_apex=$(dig +short DS "$apex" @1.1.1.1)
+            if ! ds_apex=$(query_ds "$apex"); then
+              echo "::error::All DNS resolvers failed to respond for DS $apex (network issue)"
+              exit 1
+            fi
             if [ -z "$ds_apex" ]; then
-              echo "::error::DNSSEC DS record missing for ${{ matrix.host }} and parent zone $apex"
+              echo "::error::DNSSEC DS record missing for $host and parent zone $apex"
               exit 1
             fi
             echo "DS via parent zone $apex: $ds_apex"
@@ -124,22 +154,44 @@ jobs:
       # してはいけない」を宣言しているか確認。CAA が消える / issuer が
       # 想定外に増えると、任意の CA で証明書発行できてしまう (= TLS MITM の
       # 入口になる)。subdomain の CAA は親ドメインから継承されうるので
-      # 親側も併せて確認。
+      # 親側も併せて確認。DS check と同じく resolver fallback + timeout で
+      # transient な dig 失敗を posture 異常から切り分ける。
       - name: CAA record check (${{ matrix.host }})
         run: |
           set -euo pipefail
-          caa=$(dig CAA ${{ matrix.host }} +short @1.1.1.1)
+
+          query_caa() {
+            local name=$1
+            local resolver out
+            for resolver in 1.1.1.1 8.8.8.8 9.9.9.9; do
+              if out=$(dig +short +tries=3 +time=3 CAA "$name" @"$resolver" 2>/dev/null); then
+                printf '%s' "$out"
+                return 0
+              fi
+              echo "::warning::dig CAA $name @$resolver failed (transient), trying next resolver" >&2
+            done
+            return 1
+          }
+
+          host="${{ matrix.host }}"
+          if ! caa=$(query_caa "$host"); then
+            echo "::error::All DNS resolvers failed to respond for CAA $host (network issue, not a posture failure)"
+            exit 1
+          fi
           if [ -z "$caa" ]; then
-            apex=$(echo "${{ matrix.host }}" | awk -F. '{print $(NF-1)"."$NF}')
-            if [ "${{ matrix.host }}" != "$apex" ]; then
-              caa=$(dig CAA "$apex" +short @1.1.1.1)
+            apex=$(echo "$host" | awk -F. '{print $(NF-1)"."$NF}')
+            if [ "$host" != "$apex" ]; then
+              if ! caa=$(query_caa "$apex"); then
+                echo "::error::All DNS resolvers failed to respond for CAA $apex (network issue)"
+                exit 1
+              fi
               echo "Falling back to parent zone $apex CAA"
             fi
           fi
           echo "CAA records:"
           echo "$caa"
           if ! echo "$caa" | grep -q 'pki.goog'; then
-            echo "::error::CAA record does not include expected issuer pki.goog for ${{ matrix.host }}"
+            echo "::error::CAA record does not include expected issuer pki.goog for $host"
             exit 1
           fi
 

--- a/.github/workflows/tls-dns-posture.yml
+++ b/.github/workflows/tls-dns-posture.yml
@@ -94,18 +94,33 @@ jobs:
         run: |
           set -euo pipefail
 
-          # 複数 resolver を順に試して最初に応答した結果を返す。
-          # 戻り値: 0 = 応答取得 (空文字含む) / 1 = 全 resolver 沈黙
+          # 複数 resolver を順に試して結果を返す。
+          # dig +short は SERVFAIL でも exit 0 を返し出力が空になるため、
+          # 「exit 0 かつ空」は「真にレコード無し」とは断定できない。空応答時
+          # は次 resolver も試し、全 resolver が応答かつ全て空のときのみ
+          # 「レコード無し」(空文字) として 0 を返す。
+          # 戻り値: 0 = いずれかの resolver から応答取得 (空文字 = 真に無し)
+          #         1 = 全 resolver が無応答 (network issue)
           query_ds() {
             local name=$1
-            local resolver out
+            local resolver out got_response=0
             for resolver in 1.1.1.1 8.8.8.8 9.9.9.9; do
               if out=$(dig +short +tries=3 +time=3 DS "$name" @"$resolver" 2>/dev/null); then
-                printf '%s' "$out"
-                return 0
+                got_response=1
+                if [ -n "$out" ]; then
+                  printf '%s' "$out"
+                  return 0
+                fi
+                # 空: SERVFAIL の可能性を排除するため次 resolver も試す
+              else
+                echo "::warning::dig DS $name @$resolver no reply, trying next resolver" >&2
               fi
-              echo "::warning::dig DS $name @$resolver failed (transient), trying next resolver" >&2
             done
+            if [ "$got_response" = "1" ]; then
+              # 全 resolver が応答 & 全部空 → 真にレコード無し
+              printf ''
+              return 0
+            fi
             return 1
           }
 
@@ -160,16 +175,27 @@ jobs:
         run: |
           set -euo pipefail
 
+          # DS と同様、SERVFAIL を「レコード無し」と誤判定しないよう
+          # 空応答時は次 resolver も試し、全 resolver が応答 & 全部空のときのみ
+          # 「レコード無し」として 0 を返す。
           query_caa() {
             local name=$1
-            local resolver out
+            local resolver out got_response=0
             for resolver in 1.1.1.1 8.8.8.8 9.9.9.9; do
               if out=$(dig +short +tries=3 +time=3 CAA "$name" @"$resolver" 2>/dev/null); then
-                printf '%s' "$out"
-                return 0
+                got_response=1
+                if [ -n "$out" ]; then
+                  printf '%s' "$out"
+                  return 0
+                fi
+              else
+                echo "::warning::dig CAA $name @$resolver no reply, trying next resolver" >&2
               fi
-              echo "::warning::dig CAA $name @$resolver failed (transient), trying next resolver" >&2
             done
+            if [ "$got_response" = "1" ]; then
+              printf ''
+              return 0
+            fi
             return 1
           }
 


### PR DESCRIPTION
## Summary

Daily `tls-dns-posture` workflow was hitting `dig` exit code 9 (no reply from server) on transient 1.1.1.1 hiccups, exiting the step before fallback logic could run and firing Slack false alarms even though DNSSEC/CAA settings were intact (confirmed via `8.8.8.8` / `9.9.9.9` / `+tcp`).

This change distinguishes "network failure" from "record missing":

- Adds a `query_ds` / `query_caa` helper that walks resolvers `1.1.1.1 → 8.8.8.8 → 9.9.9.9` with `+tries=3 +time=3`
- Captures the helper return code via `if !` so a `dig` failure no longer kills the step under `set -e`
- Only errors out when **all** resolvers stay silent (real network issue) or when a resolver actually returns empty (real posture regression)

Applied to both the DS check and the CAA check; the `delv` chain-validation step already wraps its output and is unaffected. Trigger, intent, and Slack notify behaviour are unchanged — this is purely a robustness fix for the existing daily monitor.

## Test plan

- [ ] Manual `workflow_dispatch` run on both matrix hosts (`civicship.app`, `api.civicship.app`) passes
- [ ] Confirm Slack notify still fires when the workflow as a whole fails (e.g. by temporarily breaking the HSTS step in a scratch branch)
- [ ] Observe a week of scheduled runs to confirm transient `dig` blips no longer page

https://claude.ai/code/session_01B3KvpMDQ3n2e39DoeB65Y6

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3KvpMDQ3n2e39DoeB65Y6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * TLS/DNS信頼性チェックワークフローを強化。複数のパブリックDNSリゾルバを順次試行して一時的なネットワーク障害による誤検知を削減します。
  * DS/CAAの応答が得られない場合は親ドメインへフォールバックしてチェーンを再確認します。
  * CAA検証に期待する発行者の存在確認を追加し、不一致時は失敗扱いとします。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hopin-inc/civicship-api/pull/1208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->