### PR TITLE
fix(richmenu): izu join メニューの「社員権NFT購入」ボタンにリンクを追加

### DIFF
--- a/src/infrastructure/richmenu/izu/definitions/public-join.ts
+++ b/src/infrastructure/richmenu/izu/definitions/public-join.ts
@@ -1,4 +1,5 @@
 import { RichMenuDefinition } from "../../types";
+import { buyMembershipNftArea } from "./shared";
 
 export const publicJoinMenu: RichMenuDefinition = {
   size: {
@@ -61,19 +62,7 @@ export const publicJoinMenu: RichMenuDefinition = {
         uri: "https://drive.google.com/file/d/1DAZ2IEdApt-X8SolJ2CKAE6mpw6bHxyk/view?usp=sharing",
       },
     },
-    {
-      bounds: {
-        x: 886,
-        y: 1044,
-        width: 1500,
-        height: 576,
-      },
-      action: {
-        type: "uri",
-        label: "社員権NFT購入",
-        uri: "https://dao.izudao.net/",
-      },
-    },
+    buyMembershipNftArea,
   ],
   alias: "public-join",
   imagePath: "images/public_menu_join.png",

--- a/src/infrastructure/richmenu/izu/definitions/public-join.ts
+++ b/src/infrastructure/richmenu/izu/definitions/public-join.ts
@@ -61,6 +61,19 @@ export const publicJoinMenu: RichMenuDefinition = {
         uri: "https://drive.google.com/file/d/1DAZ2IEdApt-X8SolJ2CKAE6mpw6bHxyk/view?usp=sharing",
       },
     },
+    {
+      bounds: {
+        x: 886,
+        y: 1044,
+        width: 1500,
+        height: 576,
+      },
+      action: {
+        type: "uri",
+        label: "社員権NFT購入",
+        uri: "https://dao.izudao.net/",
+      },
+    },
   ],
   alias: "public-join",
   imagePath: "images/public_menu_join.png",

--- a/src/infrastructure/richmenu/izu/definitions/shared.ts
+++ b/src/infrastructure/richmenu/izu/definitions/shared.ts
@@ -1,0 +1,19 @@
+import { RichMenuArea } from "../../types";
+
+/**
+ * 「参加する(Join)」メニュー右下の「社員権NFT購入」ボタン領域。
+ * public-join / user-join で共通利用する。
+ */
+export const buyMembershipNftArea: RichMenuArea = {
+  bounds: {
+    x: 886,
+    y: 1044,
+    width: 1500,
+    height: 576,
+  },
+  action: {
+    type: "uri",
+    label: "社員権NFT購入",
+    uri: "https://dao.izudao.net/",
+  },
+};

--- a/src/infrastructure/richmenu/izu/definitions/user-join.ts
+++ b/src/infrastructure/richmenu/izu/definitions/user-join.ts
@@ -61,6 +61,19 @@ export const userJoinMenu: RichMenuDefinition = {
         uri: "https://drive.google.com/file/d/1DAZ2IEdApt-X8SolJ2CKAE6mpw6bHxyk/view?usp=sharing",
       },
     },
+    {
+      bounds: {
+        x: 886,
+        y: 1044,
+        width: 1500,
+        height: 576,
+      },
+      action: {
+        type: "uri",
+        label: "社員権NFT購入",
+        uri: "https://dao.izudao.net/",
+      },
+    },
   ],
   alias: "user-join",
   imagePath: "images/user_menu_join.png",

--- a/src/infrastructure/richmenu/izu/definitions/user-join.ts
+++ b/src/infrastructure/richmenu/izu/definitions/user-join.ts
@@ -1,4 +1,5 @@
 import { RichMenuDefinition } from "../../types";
+import { buyMembershipNftArea } from "./shared";
 
 export const userJoinMenu: RichMenuDefinition = {
   size: {
@@ -61,19 +62,7 @@ export const userJoinMenu: RichMenuDefinition = {
         uri: "https://drive.google.com/file/d/1DAZ2IEdApt-X8SolJ2CKAE6mpw6bHxyk/view?usp=sharing",
       },
     },
-    {
-      bounds: {
-        x: 886,
-        y: 1044,
-        width: 1500,
-        height: 576,
-      },
-      action: {
-        type: "uri",
-        label: "社員権NFT購入",
-        uri: "https://dao.izudao.net/",
-      },
-    },
+    buyMembershipNftArea,
   ],
   alias: "user-join",
   imagePath: "images/user_menu_join.png",


### PR DESCRIPTION
## 概要

izu リッチメニューの「参加する(Join)」メニュー右下にある **「社員権NFT購入 (Buy Membership NFT)」ボタンにタップ領域(URL)が定義されておらず、押しても何も起きない**状態だったのを修正します。

## 原因

`public-join.ts` / `user-join.ts` の `areas` には、上タブ3つと右上の「IZUとDAO」ボタンのみ領域が定義されており、**右下の「社員権NFT購入」ボタンには `area` が1つも存在しなかった**ため、ボタン画像はあるがリンクが効かない状態でした（このリポジトリの履歴上、最初から未設定）。

※ 当初疑われた「URLが切れている」ではなく、**そもそも領域が未定義だった**のが実態です。なお右上「IZUとDAO」ボタンの Google Drive リンクは別ボタンで、今回は変更していません。

## 変更内容

`public-join.ts` / `user-join.ts` の両方（ログイン前/ログイン後の Join メニュー）に、`社員権NFT購入` の uri アクション領域を追加し、`https://dao.izudao.net/` へ遷移するようにしました。

- 座標は上段「IZUとDAO」領域 (`x:886, width:1500`) に揃え、下段 (`y:1044, height:576`) に配置
- 既存領域・メニュー枠 (2500×1686) と重複なし

## 反映方法（注意）

このリポジトリのコード変更だけでは LINE 上のリッチメニューには反映されません。マージ後、担当者が手動でデプロイする必要があります:

```bash
# 事前確認
pnpm richmenu:deploy:dev --community=izu --dry-run
# dev で確認 → 問題なければ本番
pnpm richmenu:deploy:prd --community=izu
```

> ⚠️ デプロイ処理は各メニューを「削除→再作成」する非アトモミックな実装のため、`--community=izu` で対象を絞り、まず dev で確認することを推奨します。

https://claude.ai/code/session_01VRifKJPqAum7j1xHc43D8S

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRifKJPqAum7j1xHc43D8S)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **UI/UX 変更**
  * メニューのラベルを「IZUとDAO」から「社員権NFT購入」に更新しました。
  * DAO関連ページへのリンク先を変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->