### PR TITLE
release: develop → master (izu リッチメニュー「社員権NFT購入」リンク追加)

### DIFF
--- a/src/infrastructure/richmenu/izu/definitions/public-join.ts
+++ b/src/infrastructure/richmenu/izu/definitions/public-join.ts
@@ -1,4 +1,5 @@
 import { RichMenuDefinition } from "../../types";
+import { buyMembershipNftArea } from "./shared";
 
 export const publicJoinMenu: RichMenuDefinition = {
   size: {
@@ -61,19 +62,7 @@ export const publicJoinMenu: RichMenuDefinition = {
         uri: "https://drive.google.com/file/d/1DAZ2IEdApt-X8SolJ2CKAE6mpw6bHxyk/view?usp=sharing",
       },
     },
-    {
-      bounds: {
-        x: 886,
-        y: 1044,
-        width: 1500,
-        height: 576,
-      },
-      action: {
-        type: "uri",
-        label: "社員権NFT購入",
-        uri: "https://dao.izudao.net/",
-      },
-    },
+    buyMembershipNftArea,
   ],
   alias: "public-join",
   imagePath: "images/public_menu_join.png",

--- a/src/infrastructure/richmenu/izu/definitions/public-join.ts
+++ b/src/infrastructure/richmenu/izu/definitions/public-join.ts
@@ -61,6 +61,19 @@ export const publicJoinMenu: RichMenuDefinition = {
         uri: "https://drive.google.com/file/d/1DAZ2IEdApt-X8SolJ2CKAE6mpw6bHxyk/view?usp=sharing",
       },
     },
+    {
+      bounds: {
+        x: 886,
+        y: 1044,
+        width: 1500,
+        height: 576,
+      },
+      action: {
+        type: "uri",
+        label: "社員権NFT購入",
+        uri: "https://dao.izudao.net/",
+      },
+    },
   ],
   alias: "public-join",
   imagePath: "images/public_menu_join.png",

--- a/src/infrastructure/richmenu/izu/definitions/shared.ts
+++ b/src/infrastructure/richmenu/izu/definitions/shared.ts
@@ -1,0 +1,19 @@
+import { RichMenuArea } from "../../types";
+
+/**
+ * 「参加する(Join)」メニュー右下の「社員権NFT購入」ボタン領域。
+ * public-join / user-join で共通利用する。
+ */
+export const buyMembershipNftArea: RichMenuArea = {
+  bounds: {
+    x: 886,
+    y: 1044,
+    width: 1500,
+    height: 576,
+  },
+  action: {
+    type: "uri",
+    label: "社員権NFT購入",
+    uri: "https://dao.izudao.net/",
+  },
+};

--- a/src/infrastructure/richmenu/izu/definitions/user-join.ts
+++ b/src/infrastructure/richmenu/izu/definitions/user-join.ts
@@ -61,6 +61,19 @@ export const userJoinMenu: RichMenuDefinition = {
         uri: "https://drive.google.com/file/d/1DAZ2IEdApt-X8SolJ2CKAE6mpw6bHxyk/view?usp=sharing",
       },
     },
+    {
+      bounds: {
+        x: 886,
+        y: 1044,
+        width: 1500,
+        height: 576,
+      },
+      action: {
+        type: "uri",
+        label: "社員権NFT購入",
+        uri: "https://dao.izudao.net/",
+      },
+    },
   ],
   alias: "user-join",
   imagePath: "images/user_menu_join.png",

--- a/src/infrastructure/richmenu/izu/definitions/user-join.ts
+++ b/src/infrastructure/richmenu/izu/definitions/user-join.ts
@@ -1,4 +1,5 @@
 import { RichMenuDefinition } from "../../types";
+import { buyMembershipNftArea } from "./shared";
 
 export const userJoinMenu: RichMenuDefinition = {
   size: {
@@ -61,19 +62,7 @@ export const userJoinMenu: RichMenuDefinition = {
         uri: "https://drive.google.com/file/d/1DAZ2IEdApt-X8SolJ2CKAE6mpw6bHxyk/view?usp=sharing",
       },
     },
-    {
-      bounds: {
-        x: 886,
-        y: 1044,
-        width: 1500,
-        height: 576,
-      },
-      action: {
-        type: "uri",
-        label: "社員権NFT購入",
-        uri: "https://dao.izudao.net/",
-      },
-    },
+    buyMembershipNftArea,
   ],
   alias: "user-join",
   imagePath: "images/user_menu_join.png",


### PR DESCRIPTION
## 概要

`develop` を `master` に反映するリリースPRです。

## 含まれる主な変更

### fix(richmenu): izu join メニューの「社員権NFT購入」ボタンにリンクを追加 (#1216)

- izu リッチメニュー「参加する(Join)」右下の **「社員権NFT購入 (Buy Membership NFT)」ボタンにタップ領域(URL)が未定義**で、押しても何も起きない状態だったのを修正
- public-join / user-join の両方に `https://dao.izudao.net/` へ遷移する領域を追加
- 重複定義は `definitions/shared.ts` の `buyMembershipNftArea` 共通定数に集約（SonarCloud 重複ゲート対応済み）

## デプロイに関する注意

master マージだけでは LINE 上のリッチメニューには反映されません。リッチメニュー本体の本番反映は別途デプロイが必要です:

```bash
pnpm richmenu:deploy:prd --community=izu
```

※ dev へのデプロイ・実機確認は実施済み。

https://claude.ai/code/session_01VRifKJPqAum7j1xHc43D8S

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRifKJPqAum7j1xHc43D8S)_