### PR TITLE
fix(scripts): 登録確認スクリプトをDI/Prisma依存から切り離す

### DIFF
--- a/scripts/emergency/checkRegistration/index.ts
+++ b/scripts/emergency/checkRegistration/index.ts
@@ -1,5 +1,3 @@
-import "reflect-metadata";
-import "@/application/provider";
 import * as process from "node:process";
 import * as path from "path";
 import logger from "@/infrastructure/logging";


### PR DESCRIPTION
## 背景

#1229 で追加した登録確認スクリプト（`scripts/emergency/checkRegistration/`）を実際に本番で動かそうとしたところ、`@prisma/client` の `NftChain` export 不整合（ローカルの Prisma クライアントが古い状態）でクラッシュした。

原因は `index.ts` 冒頭の不要な import：

```ts
import "reflect-metadata";
import "@/application/provider";
```

これは `nftMint` スクリプトの定型をそのまま流用したものだが、この確認スクリプトは **tsyringe コンテナを一切使っていない**（Firebase Auth への問い合わせと CSV 読み込みだけ）。にもかかわらず `@/application/provider` がアプリの DI コンテナ＝Prisma 一式を巻き込むため、Prisma クライアントが古いと「確認するだけ」のスクリプトまで道連れで落ちていた。

## 変更内容

不要な2行の import を削除。これにより本スクリプトは **Firasebase とファイル読みだけで完結**し、ローカル DB / 生成済み Prisma クライアントの状態に一切依存しなくなる（`db:generate` も不要）。

## 確認

- インポートグラフから `@prisma/client` / `application/provider` / `tsyringe` 参照が消えていることを確認（firebase lib・logger・CSV helpers いずれも Prisma 非依存）
- `tsc` / `prettier` クリーン
- 機能ロジック（CSVパース・E.164集約・登録判定）は無変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016DUmRXccB2wERidyTASj75)_