### PR TITLE
perf(analytics): lazily resolve analyticsCommunity payload fields

### DIFF
--- a/src/application/domain/analytics/community/controller/resolver.ts
+++ b/src/application/domain/analytics/community/controller/resolver.ts
@@ -1,6 +1,8 @@
 import { inject, injectable } from "tsyringe";
 import { IContext } from "@/types/server";
-import AnalyticsCommunityUseCase from "@/application/domain/analytics/community/usecase";
+import AnalyticsCommunityUseCase, {
+  AnalyticsCommunityRoot,
+} from "@/application/domain/analytics/community/usecase";
 import { GqlQueryAnalyticsCommunityArgs } from "@/types/graphql";
 
 @injectable()
@@ -15,5 +17,32 @@ export default class AnalyticsCommunityResolver {
       args: GqlQueryAnalyticsCommunityArgs,
       ctx: IContext,
     ) => this.useCase.getCommunity(args, ctx),
+  };
+
+  // Field resolvers run lazily per the client's selection set. The
+  // scalar fields (communityId, communityName, asOf, windowMonths) live
+  // directly on the root the Query resolver returns, so GraphQL's
+  // default resolver serves them without a field resolver here.
+  AnalyticsCommunityPayload = {
+    summary: (parent: AnalyticsCommunityRoot, _: unknown, ctx: IContext) =>
+      this.useCase.summary(parent, ctx),
+    stages: (parent: AnalyticsCommunityRoot) => this.useCase.stages(parent),
+    monthlyActivityTrend: (parent: AnalyticsCommunityRoot) =>
+      this.useCase.monthlyActivityTrend(parent),
+    retentionTrend: (parent: AnalyticsCommunityRoot, _: unknown, ctx: IContext) =>
+      this.useCase.retentionTrend(parent, ctx),
+    cohortRetention: (parent: AnalyticsCommunityRoot, _: unknown, ctx: IContext) =>
+      this.useCase.cohortRetention(parent, ctx),
+    memberList: (parent: AnalyticsCommunityRoot) => this.useCase.memberList(parent),
+    alerts: (parent: AnalyticsCommunityRoot, _: unknown, ctx: IContext) =>
+      this.useCase.alerts(parent, ctx),
+    dormantCount: (parent: AnalyticsCommunityRoot) => this.useCase.dormantCount(parent),
+    chainDepthDistribution: (parent: AnalyticsCommunityRoot, _: unknown, ctx: IContext) =>
+      this.useCase.chainDepthDistribution(parent, ctx),
+    cohortFunnel: (parent: AnalyticsCommunityRoot) => this.useCase.cohortFunnel(parent),
+    hubMemberCount: (parent: AnalyticsCommunityRoot, _: unknown, ctx: IContext) =>
+      this.useCase.hubMemberCount(parent, ctx),
+    tenureDistribution: (parent: AnalyticsCommunityRoot) =>
+      this.useCase.tenureDistribution(parent),
   };
 }

--- a/src/application/domain/analytics/community/presenter.ts
+++ b/src/application/domain/analytics/community/presenter.ts
@@ -1,5 +1,7 @@
 import { bigintToSafeNumber } from "@/application/domain/report/util";
 import {
+  GqlAnalyticsChainDepthBucket,
+  GqlAnalyticsCohortFunnelPoint,
   GqlAnalyticsCohortRetentionPoint,
   GqlAnalyticsCommunityAlerts,
   GqlAnalyticsCommunitySummaryCard,
@@ -17,6 +19,7 @@ import {
 } from "@/types/graphql";
 import {
   AnalyticsAllTimeTotalsRow,
+  AnalyticsChainDepthBucketRow,
   AnalyticsMemberStatsRow,
   AnalyticsMonthlyActivityRow,
 } from "@/application/domain/analytics/community/data/type";
@@ -31,6 +34,7 @@ import {
   StageBreakdown,
   StageBucketStats,
   StageCounts,
+  AnalyticsCohortFunnelPoint,
   TenureDistribution,
   WeeklyRetentionPoint,
 } from "@/application/domain/analytics/community/aggregations";
@@ -97,6 +101,33 @@ export default class AnalyticsCommunityPresenter {
       // without per-element transformation.
       monthlyHistogram: d.monthlyHistogram,
     };
+  }
+
+  /**
+   * Chain-depth histogram. The bucket shape (depth + count) matches the
+   * GraphQL type 1:1, so this is a passthrough map — its purpose is to
+   * keep payload formatting on the presenter rather than leaking the
+   * Prisma row type out of the usecase.
+   */
+  static chainDepthDistribution(
+    rows: AnalyticsChainDepthBucketRow[],
+  ): GqlAnalyticsChainDepthBucket[] {
+    return rows.map((r) => ({ depth: r.depth, count: r.count }));
+  }
+
+  /**
+   * Per-cohort send-funnel series. Point shape (cohortMonth + 4 stage
+   * counts) matches the GraphQL type 1:1; same passthrough rationale as
+   * `chainDepthDistribution`.
+   */
+  static cohortFunnel(points: AnalyticsCohortFunnelPoint[]): GqlAnalyticsCohortFunnelPoint[] {
+    return points.map((p) => ({
+      cohortMonth: p.cohortMonth,
+      acquired: p.acquired,
+      activatedD30: p.activatedD30,
+      repeated: p.repeated,
+      habitual: p.habitual,
+    }));
   }
 
   // --- L2 ----------------------------------------------------------------

--- a/src/application/domain/analytics/community/presenter.ts
+++ b/src/application/domain/analytics/community/presenter.ts
@@ -2,7 +2,6 @@ import { bigintToSafeNumber } from "@/application/domain/report/util";
 import {
   GqlAnalyticsCohortRetentionPoint,
   GqlAnalyticsCommunityAlerts,
-  GqlAnalyticsCommunityPayload,
   GqlAnalyticsCommunitySummaryCard,
   GqlAnalyticsLatestCohort,
   GqlAnalyticsMemberList,
@@ -18,7 +17,6 @@ import {
 } from "@/types/graphql";
 import {
   AnalyticsAllTimeTotalsRow,
-  AnalyticsChainDepthBucketRow,
   AnalyticsMemberStatsRow,
   AnalyticsMonthlyActivityRow,
 } from "@/application/domain/analytics/community/data/type";
@@ -33,7 +31,6 @@ import {
   StageBreakdown,
   StageBucketStats,
   StageCounts,
-  AnalyticsCohortFunnelPoint,
   TenureDistribution,
   WeeklyRetentionPoint,
 } from "@/application/domain/analytics/community/aggregations";
@@ -249,51 +246,6 @@ export default class AnalyticsCommunityPresenter {
     };
   }
 
-  static communityDetail(params: {
-    communityId: string;
-    communityName: string;
-    asOf: Date;
-    windowMonths: number;
-    summary: GqlAnalyticsCommunitySummaryCard;
-    stages: GqlAnalyticsStageDistribution;
-    monthlyActivityTrend: GqlAnalyticsMonthlyActivityPoint[];
-    retentionTrend: GqlAnalyticsRetentionTrendPoint[];
-    cohortRetention: GqlAnalyticsCohortRetentionPoint[];
-    memberList: GqlAnalyticsMemberList;
-    alerts: GqlAnalyticsCommunityAlerts;
-    dormantCount: number;
-    chainDepthDistribution: AnalyticsChainDepthBucketRow[];
-    cohortFunnel: AnalyticsCohortFunnelPoint[];
-    hubMemberCount: number;
-    tenureDistribution: TenureDistribution;
-  }): GqlAnalyticsCommunityPayload {
-    return {
-      communityId: params.communityId,
-      communityName: params.communityName,
-      asOf: params.asOf,
-      windowMonths: params.windowMonths,
-      summary: params.summary,
-      stages: params.stages,
-      monthlyActivityTrend: params.monthlyActivityTrend,
-      retentionTrend: params.retentionTrend,
-      cohortRetention: params.cohortRetention,
-      memberList: params.memberList,
-      alerts: params.alerts,
-      dormantCount: params.dormantCount,
-      // Chain-depth bucket shape (depth + count) matches the
-      // GraphQL type 1:1 so the array passes through without
-      // per-element transformation.
-      chainDepthDistribution: params.chainDepthDistribution,
-      // Same passthrough pattern: the cohort funnel point shape
-      // (cohortMonth + 4 stage counts) matches the GraphQL type
-      // 1:1.
-      cohortFunnel: params.cohortFunnel,
-      hubMemberCount: params.hubMemberCount,
-      tenureDistribution: AnalyticsCommunityPresenter.tenureDistribution(
-        params.tenureDistribution,
-      ),
-    };
-  }
 }
 
 /**

--- a/src/application/domain/analytics/community/usecase.ts
+++ b/src/application/domain/analytics/community/usecase.ts
@@ -3,7 +3,14 @@ import { IContext } from "@/types/server";
 import { AuthorizationError, NotFoundError } from "@/errors/graphql";
 import {
   GqlQueryAnalyticsCommunityArgs,
-  GqlAnalyticsCommunityPayload,
+  GqlAnalyticsCohortRetentionPoint,
+  GqlAnalyticsCommunityAlerts,
+  GqlAnalyticsCommunitySummaryCard,
+  GqlAnalyticsMemberList,
+  GqlAnalyticsMonthlyActivityPoint,
+  GqlAnalyticsRetentionTrendPoint,
+  GqlAnalyticsStageDistribution,
+  GqlAnalyticsTenureDistribution,
 } from "@/types/graphql";
 import AnalyticsCommunityService, {
   DEFAULT_WINDOW_DAYS,
@@ -17,11 +24,66 @@ import {
   computeStageBreakdown,
   computeStageCounts,
   computeTenureDistribution,
+  AnalyticsCohortFunnelPoint,
 } from "@/application/domain/analytics/community/aggregations";
-import { MAX_LIMIT, paginateMembers } from "@/application/domain/analytics/community/pagination";
+import {
+  MAX_LIMIT,
+  MemberListParams,
+  paginateMembers,
+} from "@/application/domain/analytics/community/pagination";
+import {
+  AnalyticsChainDepthBucketRow,
+  AnalyticsMemberStatsRow,
+  AnalyticsMonthlyActivityRow,
+} from "@/application/domain/analytics/community/data/type";
 import AnalyticsCommunityPresenter from "@/application/domain/analytics/community/presenter";
 import AnalyticsCommunityConverter from "@/application/domain/analytics/community/data/converter";
 import AnalyticsConverter from "@/application/domain/analytics/data/converter";
+
+type SegmentThresholds = ReturnType<typeof AnalyticsConverter.resolveThresholds>;
+
+/**
+ * Lazily-resolved root for `analyticsCommunity`. The Query resolver
+ * returns this immediately (after the cheap auth + 404 + community-row
+ * checks); each expensive section becomes a field resolver on
+ * `AnalyticsCommunityPayload` that runs ONLY when the client selects
+ * that field.
+ *
+ * Before this split the usecase eagerly `Promise.all`-ed all ~9
+ * sections on every call — including the retention-trend
+ * (~windowMonths×4.3 weeks × 2 queries) and cohort-retention
+ * (~windowMonths × 4 queries) fan-outs — even when the caller asked
+ * only for `summary`. Mobile clients that render the summary card
+ * first now skip those ~120 SQL round-trips entirely.
+ *
+ * `loadMembers` / `loadMonthlyActivity` are request-scoped memoised
+ * loaders: several fields (summary, stages, memberList, dormantCount,
+ * cohortFunnel, tenureDistribution all read `members`) share the same
+ * underlying query, so the memo keeps a multi-field selection set from
+ * re-running the member-stats / monthly-activity SQL per field.
+ */
+export interface AnalyticsCommunityRoot {
+  communityId: string;
+  communityName: string;
+  asOf: Date;
+  windowMonths: number;
+  thresholds: SegmentThresholds;
+  dormantThresholdDays: number;
+  hubBreadthThreshold: number;
+  memberListParams: MemberListParams;
+  loadMembers: () => Promise<AnalyticsMemberStatsRow[]>;
+  loadMonthlyActivity: () => Promise<AnalyticsMonthlyActivityRow[]>;
+}
+
+/**
+ * Memoise a zero-arg async thunk so repeated calls within one request
+ * share a single in-flight promise. Inlined rather than reaching for a
+ * library — the analytics root is the only caller.
+ */
+function once<T>(fn: () => Promise<T>): () => Promise<T> {
+  let cached: Promise<T> | undefined;
+  return () => (cached ??= fn());
+}
 
 @injectable()
 export default class AnalyticsCommunityUseCase {
@@ -31,14 +93,16 @@ export default class AnalyticsCommunityUseCase {
   constructor(@inject("AnalyticsCommunityService") private readonly service: AnalyticsCommunityService) {}
 
   /**
-   * L2 detail: summary card + stage breakdown + trailing-window trends
-   * + cohort retention + paginated member list + alerts for one
-   * community.
+   * L2 detail entry point. Resolves only the cheap, always-needed bits
+   * eagerly (authorization scope check, 404, community name) and returns
+   * a lazy root. The expensive sections are computed by the
+   * `AnalyticsCommunityPayload` field resolvers below, driven by the
+   * client's selection set.
    */
   async getCommunity(
     { input }: GqlQueryAnalyticsCommunityArgs,
     ctx: IContext,
-  ): Promise<GqlAnalyticsCommunityPayload> {
+  ): Promise<AnalyticsCommunityRoot> {
     // IsCommunityOwner verifies the caller owns `ctx.communityId` but
     // does not bind `input.communityId` to it — without this check an
     // owner of community A could read community B's analytics by
@@ -73,51 +137,8 @@ export default class AnalyticsCommunityUseCase {
       throw new NotFoundError("Community", { id: input.communityId });
     }
 
-    const [
-      members,
-      monthlyActivity,
-      allTimeTotals,
-      currentMonthActivity,
-      retentionTrend,
-      cohortRetention,
-      chainDepthDistribution,
-      alerts,
-      hubMemberCount,
-    ] = await Promise.all([
-      this.service.getMemberStats(ctx, community.communityId, asOf),
-      this.service.getMonthlyActivity(
-        ctx,
-        community.communityId,
-        asOf,
-        windowMonths,
-        hubBreadthThreshold,
-      ),
-      this.service.getAllTimeTotals(ctx, community.communityId, asOf),
-      this.service.getMonthActivityWithPrev(ctx, community.communityId, asOf),
-      this.service.getRetentionTrend(ctx, community.communityId, asOf, windowMonths),
-      this.service.getCohortRetention(ctx, community.communityId, asOf, windowMonths),
-      this.service.getChainDepthDistribution(ctx, community.communityId, asOf),
-      this.service.getAlerts(ctx, community.communityId, asOf),
-      // Fixed 28-day window matches L1's default `windowDays` so the
-      // L2 `hubMemberCount` reads directly comparable to L1 for the
-      // same community + `hubBreadthThreshold`. L2's `windowMonths`
-      // input drives trend-array length only, not hub classification.
-      this.service.getWindowHubMemberCount(
-        ctx,
-        community.communityId,
-        asOf,
-        DEFAULT_WINDOW_DAYS,
-        hubBreadthThreshold,
-      ),
-    ]);
-
-    const stageCounts = computeStageCounts(members, thresholds);
-    const stageBreakdown = computeStageBreakdown(members, thresholds);
-    const dormantCount = computeDormantCount(members, asOf, dormantThresholdDays);
-    const cohortFunnel = computeCohortFunnel(members, asOf, windowMonths, thresholds);
-    const tenureDistribution = computeTenureDistribution(members);
-
-    const memberList = paginateMembers(members, {
+    const communityId = community.communityId;
+    const memberListParams: MemberListParams = {
       minSendRate: input.userFilter?.minSendRate ?? 0.7,
       maxSendRate: input.userFilter?.maxSendRate ?? null,
       minMonthsIn: input.userFilter?.minMonthsIn ?? null,
@@ -128,11 +149,58 @@ export default class AnalyticsCommunityUseCase {
       // Decode at the converter boundary so service operates on a
       // numeric offset only — no wire-format leakage.
       cursor: AnalyticsCommunityConverter.parseMemberListCursor(input.cursor),
-    });
+    };
 
-    const summary = AnalyticsCommunityPresenter.summaryCard({
-      communityId: community.communityId,
+    return {
+      communityId,
       communityName: community.communityName,
+      asOf,
+      windowMonths,
+      thresholds,
+      dormantThresholdDays,
+      hubBreadthThreshold,
+      memberListParams,
+      // ctx is the same instance for every field resolver of this
+      // query, so binding it into the memoised loaders here is safe.
+      loadMembers: once(() => this.service.getMemberStats(ctx, communityId, asOf)),
+      loadMonthlyActivity: once(() =>
+        this.service.getMonthlyActivity(
+          ctx,
+          communityId,
+          asOf,
+          windowMonths,
+          hubBreadthThreshold,
+        ),
+      ),
+    };
+  }
+
+  // ==========================================================================
+  // Field resolvers for AnalyticsCommunityPayload — each runs only when
+  // the client selects the matching field. Shared reads (members,
+  // monthly activity) go through the root's memoised loaders so a
+  // multi-field selection issues each underlying query at most once.
+  // ==========================================================================
+
+  /**
+   * Summary card. Reads the shared member + monthly-activity loaders and
+   * fires the two summary-only queries (all-time totals, month-over-month
+   * activity) in parallel.
+   */
+  async summary(
+    root: AnalyticsCommunityRoot,
+    ctx: IContext,
+  ): Promise<GqlAnalyticsCommunitySummaryCard> {
+    const [members, monthlyActivity, allTimeTotals, currentMonthActivity] = await Promise.all([
+      root.loadMembers(),
+      root.loadMonthlyActivity(),
+      this.service.getAllTimeTotals(ctx, root.communityId, root.asOf),
+      this.service.getMonthActivityWithPrev(ctx, root.communityId, root.asOf),
+    ]);
+    const stageCounts = computeStageCounts(members, root.thresholds);
+    return AnalyticsCommunityPresenter.summaryCard({
+      communityId: root.communityId,
+      communityName: root.communityName,
       totalMembers: stageCounts.total,
       communityActivityRate: currentMonthActivity.currentRate,
       communityActivityRate3mAvg: computeActivityRate3mAvg(monthlyActivity),
@@ -140,25 +208,110 @@ export default class AnalyticsCommunityUseCase {
       tier2Count: stageCounts.tier2Count,
       allTimeTotals,
     });
+  }
 
-    return AnalyticsCommunityPresenter.communityDetail({
-      communityId: community.communityId,
-      communityName: community.communityName,
-      asOf,
-      windowMonths,
-      summary,
-      stages: AnalyticsCommunityPresenter.stages(stageBreakdown),
-      monthlyActivityTrend: monthlyActivity.map(AnalyticsCommunityPresenter.monthlyActivityPoint),
-      retentionTrend: retentionTrend.map(AnalyticsCommunityPresenter.retentionTrendPoint),
-      cohortRetention: cohortRetention.map(AnalyticsCommunityPresenter.cohortPoint),
-      memberList: AnalyticsCommunityPresenter.memberList(memberList),
-      alerts: AnalyticsCommunityPresenter.alerts(alerts),
-      dormantCount,
-      chainDepthDistribution,
-      cohortFunnel,
-      hubMemberCount,
-      tenureDistribution,
-    });
+  async stages(root: AnalyticsCommunityRoot): Promise<GqlAnalyticsStageDistribution> {
+    const members = await root.loadMembers();
+    return AnalyticsCommunityPresenter.stages(computeStageBreakdown(members, root.thresholds));
+  }
+
+  async monthlyActivityTrend(
+    root: AnalyticsCommunityRoot,
+  ): Promise<GqlAnalyticsMonthlyActivityPoint[]> {
+    const monthlyActivity = await root.loadMonthlyActivity();
+    return monthlyActivity.map(AnalyticsCommunityPresenter.monthlyActivityPoint);
+  }
+
+  /**
+   * Trailing-window weekly retention. The heaviest section: fans out
+   * ~windowMonths×4.3 weeks × 2 SQL statements. Only runs when selected.
+   */
+  async retentionTrend(
+    root: AnalyticsCommunityRoot,
+    ctx: IContext,
+  ): Promise<GqlAnalyticsRetentionTrendPoint[]> {
+    const trend = await this.service.getRetentionTrend(
+      ctx,
+      root.communityId,
+      root.asOf,
+      root.windowMonths,
+    );
+    return trend.map(AnalyticsCommunityPresenter.retentionTrendPoint);
+  }
+
+  /**
+   * Monthly cohort retention. Fans out ~windowMonths × 4 SQL
+   * statements. Only runs when selected.
+   */
+  async cohortRetention(
+    root: AnalyticsCommunityRoot,
+    ctx: IContext,
+  ): Promise<GqlAnalyticsCohortRetentionPoint[]> {
+    const cohorts = await this.service.getCohortRetention(
+      ctx,
+      root.communityId,
+      root.asOf,
+      root.windowMonths,
+    );
+    return cohorts.map(AnalyticsCommunityPresenter.cohortPoint);
+  }
+
+  async memberList(root: AnalyticsCommunityRoot): Promise<GqlAnalyticsMemberList> {
+    const members = await root.loadMembers();
+    return AnalyticsCommunityPresenter.memberList(
+      paginateMembers(members, root.memberListParams),
+    );
+  }
+
+  async alerts(
+    root: AnalyticsCommunityRoot,
+    ctx: IContext,
+  ): Promise<GqlAnalyticsCommunityAlerts> {
+    return AnalyticsCommunityPresenter.alerts(
+      await this.service.getAlerts(ctx, root.communityId, root.asOf),
+    );
+  }
+
+  async dormantCount(root: AnalyticsCommunityRoot): Promise<number> {
+    const members = await root.loadMembers();
+    return computeDormantCount(members, root.asOf, root.dormantThresholdDays);
+  }
+
+  async chainDepthDistribution(
+    root: AnalyticsCommunityRoot,
+    ctx: IContext,
+  ): Promise<AnalyticsChainDepthBucketRow[]> {
+    // Bucket shape (depth + count) matches the GraphQL type 1:1, so the
+    // rows pass through without a presenter transform.
+    return this.service.getChainDepthDistribution(ctx, root.communityId, root.asOf);
+  }
+
+  async cohortFunnel(root: AnalyticsCommunityRoot): Promise<AnalyticsCohortFunnelPoint[]> {
+    const members = await root.loadMembers();
+    // Funnel point shape (cohortMonth + 4 stage counts) matches the
+    // GraphQL type 1:1.
+    return computeCohortFunnel(members, root.asOf, root.windowMonths, root.thresholds);
+  }
+
+  async hubMemberCount(root: AnalyticsCommunityRoot, ctx: IContext): Promise<number> {
+    // Fixed 28-day window matches L1's default `windowDays` so the L2
+    // `hubMemberCount` reads directly comparable to L1 for the same
+    // community + `hubBreadthThreshold`. L2's `windowMonths` input
+    // drives trend-array length only, not hub classification.
+    return this.service.getWindowHubMemberCount(
+      ctx,
+      root.communityId,
+      root.asOf,
+      DEFAULT_WINDOW_DAYS,
+      root.hubBreadthThreshold,
+    );
+  }
+
+  async tenureDistribution(
+    root: AnalyticsCommunityRoot,
+  ): Promise<GqlAnalyticsTenureDistribution> {
+    const members = await root.loadMembers();
+    return AnalyticsCommunityPresenter.tenureDistribution(computeTenureDistribution(members));
   }
 }
 

--- a/src/application/domain/analytics/community/usecase.ts
+++ b/src/application/domain/analytics/community/usecase.ts
@@ -3,6 +3,8 @@ import { IContext } from "@/types/server";
 import { AuthorizationError, NotFoundError } from "@/errors/graphql";
 import {
   GqlQueryAnalyticsCommunityArgs,
+  GqlAnalyticsChainDepthBucket,
+  GqlAnalyticsCohortFunnelPoint,
   GqlAnalyticsCohortRetentionPoint,
   GqlAnalyticsCommunityAlerts,
   GqlAnalyticsCommunitySummaryCard,
@@ -24,7 +26,6 @@ import {
   computeStageBreakdown,
   computeStageCounts,
   computeTenureDistribution,
-  AnalyticsCohortFunnelPoint,
 } from "@/application/domain/analytics/community/aggregations";
 import {
   MAX_LIMIT,
@@ -32,7 +33,6 @@ import {
   paginateMembers,
 } from "@/application/domain/analytics/community/pagination";
 import {
-  AnalyticsChainDepthBucketRow,
   AnalyticsMemberStatsRow,
   AnalyticsMonthlyActivityRow,
 } from "@/application/domain/analytics/community/data/type";
@@ -280,17 +280,16 @@ export default class AnalyticsCommunityUseCase {
   async chainDepthDistribution(
     root: AnalyticsCommunityRoot,
     ctx: IContext,
-  ): Promise<AnalyticsChainDepthBucketRow[]> {
-    // Bucket shape (depth + count) matches the GraphQL type 1:1, so the
-    // rows pass through without a presenter transform.
-    return this.service.getChainDepthDistribution(ctx, root.communityId, root.asOf);
+  ): Promise<GqlAnalyticsChainDepthBucket[]> {
+    const rows = await this.service.getChainDepthDistribution(ctx, root.communityId, root.asOf);
+    return AnalyticsCommunityPresenter.chainDepthDistribution(rows);
   }
 
-  async cohortFunnel(root: AnalyticsCommunityRoot): Promise<AnalyticsCohortFunnelPoint[]> {
+  async cohortFunnel(root: AnalyticsCommunityRoot): Promise<GqlAnalyticsCohortFunnelPoint[]> {
     const members = await root.loadMembers();
-    // Funnel point shape (cohortMonth + 4 stage counts) matches the
-    // GraphQL type 1:1.
-    return computeCohortFunnel(members, root.asOf, root.windowMonths, root.thresholds);
+    return AnalyticsCommunityPresenter.cohortFunnel(
+      computeCohortFunnel(members, root.asOf, root.windowMonths, root.thresholds),
+    );
   }
 
   async hubMemberCount(root: AnalyticsCommunityRoot, ctx: IContext): Promise<number> {

--- a/src/presentation/graphql/resolver.ts
+++ b/src/presentation/graphql/resolver.ts
@@ -176,6 +176,9 @@ const resolvers = {
   ReportTemplate: report.ReportTemplate,
   AdminReportSummaryRow: report.AdminReportSummaryRow,
   ReportFeedback: reportFeedback.ReportFeedback,
+
+  AnalyticsCommunityPayload: analyticsCommunity.AnalyticsCommunityPayload,
+
   GenerateReportPayload: report.GenerateReportPayload,
   UpdateReportTemplatePayload: report.UpdateReportTemplatePayload,
   ApproveReportPayload: report.ApproveReportPayload,


### PR DESCRIPTION
## 背景 / 問題

携帯から `analyticsCommunity`（L2 コミュニティ詳細）を叩くと非常に重い、という報告から調査。

`analyticsCommunity` の usecase は、クライアントが GraphQL でどのフィールドを選択していても、**毎回 ~9 セクション全部を `Promise.all` で計算**していた。特に重いのが2つのファンアウト：

- `getRetentionTrend`: `windowMonths`（デフォルト10）で約43週 × 2 SQL ≈ **86クエリ**
- `getCohortRetention`: ~10コホート × 4 SQL ≈ **40クエリ**

合計 **100以上の小さな SQL ラウンドトリップ**を毎リクエスト発行。さらに `getMemberStats` は集計のため全メンバーをフルスキャン。サマリーカードしか表示しない携帯の画面でも、リテンション/コホートの全ファンアウトのコストを払っていた。

`AnalyticsCommunityPayload` にフィールドリゾルバが無く、resolver が usecase の戻り値（完全materialize済みオブジェクト）をそのまま返していたため、GraphQL のセレクションが計算量に反映されていなかった。

## 変更内容

ペイロードをフィールド単位の遅延リゾルバに分割し、**GraphQL のセレクションセットで計算範囲が決まる**ようにした。

- `getCommunity` は、常に必要な軽い処理だけ即時実行（認可スコープチェック・404・コミュニティ名解決）し、遅延 root を返す。
- 各重いセクションを `AnalyticsCommunityPayload` のフィールドリゾルバ化。**選択されたときだけ実行**される。サマリーのみのクエリは retention/cohort のファンアウトに一切触れない。
- 複数フィールドが共有する読み取り（メンバー統計 `loadMembers`・月次アクティビティ `loadMonthlyActivity`）はリクエストスコープのメモ化ローダー経由にし、複数フィールドを選択しても各クエリは**最大1回**しか発行しないようにした。
- 不要になった presenter の `communityDetail`（一括組み立て）メソッドと、それだけが使っていた import を削除。

### 効果

- サマリー中心の携帯画面：4クエリ（members / monthlyActivity / allTimeTotals / monthActivity）のみで応答。~120クエリのファンアウトを丸ごとスキップ。
- フルペイロードのクエリ：挙動・結果は不変（メモ化により重複クエリは増えない）。
- 認可・404 は引き続き即時評価のまま。

## テスト

- `presenter` / `pagination` / `aggregations` のユニットテスト **59件 PASS**（presenter の編集と純粋ロジックを確認）。
- `usecase.test.ts`（認可スコープのガードのみ検証）は、本サンドボックスで Prisma クライアントを生成できない（egress ポリシーがエンジンバイナリのダウンロードをブロック）ため実行不可。失敗箇所は本PRで触っていない `report/service.ts` の `@prisma/client` import に起因し、未変更のコードでも同様に失敗する環境制約。
- 変更4ファイルすべて ESLint clean。
- 認可ガードと 404 は `getCommunity` 内に温存しているため、`usecase.test.ts` のスコープ検証ロジックは変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011MuXNtJe9LAeDZTWas7scL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * コミュニティ分析レポートで、必要な項目だけを個別に取得・表示できるようになりました。
  * サマリー、推移、リテンション、メンバー一覧、アラート、休眠数、ファネル、分布などの詳細指標に対応しました。

* **改善**
  * レポート表示時のデータ取得を遅延化し、表示内容に応じて処理するよう最適化しました。
  * 関連データの重複読み込みを抑え、応答性の向上が期待できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->