### PR TITLE
release: develop → master

### DIFF
--- a/src/__tests__/unit/analytics/community/presenter.test.ts
+++ b/src/__tests__/unit/analytics/community/presenter.test.ts
@@ -469,4 +469,50 @@ describe("AnalyticsCommunityPresenter", () => {
       expect(out.dormantCount).toBe(1);
     });
   });
+
+  describe("chainDepthDistribution / cohortFunnel — passthrough mapping", () => {
+    it("maps chain-depth rows to the GraphQL bucket shape 1:1", () => {
+      const out = AnalyticsCommunityPresenter.chainDepthDistribution([
+        { depth: 1, count: 5 },
+        { depth: 5, count: 2 },
+      ]);
+      expect(out).toEqual([
+        { depth: 1, count: 5 },
+        { depth: 5, count: 2 },
+      ]);
+    });
+
+    it("returns an empty array for an empty chain-depth input", () => {
+      expect(AnalyticsCommunityPresenter.chainDepthDistribution([])).toEqual([]);
+    });
+
+    it("maps cohort-funnel points 1:1 and passes the cohortMonth Date through untouched", () => {
+      const cohortMonth = new Date("2026-04-01T00:00:00Z");
+      const out = AnalyticsCommunityPresenter.cohortFunnel([
+        {
+          cohortMonth,
+          acquired: 10,
+          activatedD30: 6,
+          repeated: 3,
+          habitual: 1,
+        },
+      ]);
+      expect(out).toEqual([
+        {
+          cohortMonth,
+          acquired: 10,
+          activatedD30: 6,
+          repeated: 3,
+          habitual: 1,
+        },
+      ]);
+      // Date identity is preserved (serialised as Datetime downstream),
+      // not coerced to a string or a new Date instance.
+      expect(out[0].cohortMonth).toBe(cohortMonth);
+    });
+
+    it("returns an empty array for an empty cohort-funnel input", () => {
+      expect(AnalyticsCommunityPresenter.cohortFunnel([])).toEqual([]);
+    });
+  });
 });

--- a/src/__tests__/unit/analytics/community/usecase.test.ts
+++ b/src/__tests__/unit/analytics/community/usecase.test.ts
@@ -1,6 +1,11 @@
 import "reflect-metadata";
 import AnalyticsCommunityUseCase from "@/application/domain/analytics/community/usecase";
 import type AnalyticsCommunityService from "@/application/domain/analytics/community/service";
+import {
+  DEFAULT_HUB_BREADTH_THRESHOLD,
+  DEFAULT_WINDOW_DAYS,
+  DEFAULT_WINDOW_MONTHS,
+} from "@/application/domain/analytics/community/service";
 import { IContext } from "@/types/server";
 import { AuthorizationError } from "@/errors/graphql";
 
@@ -95,7 +100,7 @@ describe("AnalyticsCommunityUseCase lazy field resolution", () => {
     expect(root.communityId).toBe("kibotcha");
     expect(root.communityName).toBe("きぼっちゃ");
     expect(root.asOf).toBe(asOf);
-    expect(root.windowMonths).toBe(10); // DEFAULT_WINDOW_MONTHS
+    expect(root.windowMonths).toBe(DEFAULT_WINDOW_MONTHS);
     expect(typeof root.loadMembers).toBe("function");
     expect(typeof root.loadMonthlyActivity).toBe("function");
 
@@ -154,7 +159,11 @@ describe("AnalyticsCommunityUseCase lazy field resolution", () => {
     // Empty member set → funnel points exist (one per window month) but
     // with zero counts; the important assertion is the mapped shape.
     const funnel = await usecase.cohortFunnel(root);
-    expect(Array.isArray(funnel)).toBe(true);
+    // computeCohortFunnel emits one zero-filled point per window month
+    // even for an empty member set, so the array is never empty — assert
+    // the length up front so the per-element checks below can't pass
+    // vacuously on an unexpectedly empty result.
+    expect(funnel).toHaveLength(DEFAULT_WINDOW_MONTHS);
     funnel.forEach((p) => {
       expect(p).toEqual(
         expect.objectContaining({
@@ -180,5 +189,16 @@ describe("AnalyticsCommunityUseCase lazy field resolution", () => {
     expect(service.getAlerts).toHaveBeenCalledWith(adminCtx, "kibotcha", asOf);
 
     await expect(usecase.hubMemberCount(root, adminCtx)).resolves.toBe(2);
+    // L2 hub classification uses the fixed 28-day window (matching L1's
+    // default) and the request's clamped hub-breadth threshold, not the
+    // trend-length `windowMonths`. Pin those args so a regression in the
+    // window/threshold wiring is caught.
+    expect(service.getWindowHubMemberCount).toHaveBeenCalledWith(
+      adminCtx,
+      "kibotcha",
+      asOf,
+      DEFAULT_WINDOW_DAYS,
+      DEFAULT_HUB_BREADTH_THRESHOLD,
+    );
   });
 });

--- a/src/__tests__/unit/analytics/community/usecase.test.ts
+++ b/src/__tests__/unit/analytics/community/usecase.test.ts
@@ -1,5 +1,6 @@
 import "reflect-metadata";
 import AnalyticsCommunityUseCase from "@/application/domain/analytics/community/usecase";
+import type AnalyticsCommunityService from "@/application/domain/analytics/community/service";
 import { IContext } from "@/types/server";
 import { AuthorizationError } from "@/errors/graphql";
 
@@ -33,5 +34,151 @@ describe("AnalyticsCommunityUseCase authz scoping", () => {
     await expect(usecase.getCommunity({ input: baseInput }, ctx)).rejects.toThrow(
       AuthorizationError,
     );
+  });
+});
+
+describe("AnalyticsCommunityUseCase lazy field resolution", () => {
+  const asOf = new Date("2026-04-01T00:00:00Z");
+  const baseInput = { communityId: "kibotcha", asOf };
+  // SYS_ADMIN bypasses the input.communityId scope check, so a single
+  // admin ctx exercises the happy path for every community id.
+  const adminCtx = { isAdmin: true } as IContext;
+
+  /**
+   * Fresh jest-mock service double per test. Every DB-facing method the
+   * usecase can reach is stubbed with a benign value so the field
+   * resolvers run end-to-end (through the real aggregations + presenter)
+   * over an empty member set without touching a database.
+   */
+  function buildService() {
+    return {
+      getCommunityById: jest
+        .fn()
+        .mockResolvedValue({ communityId: "kibotcha", communityName: "きぼっちゃ" }),
+      getMemberStats: jest.fn().mockResolvedValue([]),
+      getMonthlyActivity: jest.fn().mockResolvedValue([]),
+      getAllTimeTotals: jest.fn().mockResolvedValue({
+        totalDonationPoints: BigInt(0),
+        maxChainDepth: 0,
+        dataFrom: null,
+        dataTo: null,
+      }),
+      getMonthActivityWithPrev: jest.fn().mockResolvedValue({
+        currentRate: 0,
+        currentSenderCount: 0,
+        currentTotalMembers: 0,
+        growthRateActivity: null,
+      }),
+      getRetentionTrend: jest.fn().mockResolvedValue([]),
+      getCohortRetention: jest.fn().mockResolvedValue([]),
+      getChainDepthDistribution: jest.fn().mockResolvedValue([{ depth: 1, count: 3 }]),
+      getAlerts: jest
+        .fn()
+        .mockResolvedValue({ churnSpike: false, activeDrop: false, noNewMembers: false }),
+      getWindowHubMemberCount: jest.fn().mockResolvedValue(2),
+    };
+  }
+
+  function build() {
+    const service = buildService();
+    const usecase = new AnalyticsCommunityUseCase(
+      service as unknown as AnalyticsCommunityService,
+    );
+    return { service, usecase };
+  }
+
+  it("returns a lazy root carrying the scalar fields and memoised loaders", async () => {
+    const { service, usecase } = build();
+
+    const root = await usecase.getCommunity({ input: baseInput }, adminCtx);
+
+    expect(root.communityId).toBe("kibotcha");
+    expect(root.communityName).toBe("きぼっちゃ");
+    expect(root.asOf).toBe(asOf);
+    expect(root.windowMonths).toBe(10); // DEFAULT_WINDOW_MONTHS
+    expect(typeof root.loadMembers).toBe("function");
+    expect(typeof root.loadMonthlyActivity).toBe("function");
+
+    // getCommunity itself must not eagerly pull any of the heavy
+    // sections — only the community-row lookup runs up front.
+    expect(service.getCommunityById).toHaveBeenCalledTimes(1);
+    expect(service.getMemberStats).not.toHaveBeenCalled();
+    expect(service.getRetentionTrend).not.toHaveBeenCalled();
+    expect(service.getCohortRetention).not.toHaveBeenCalled();
+  });
+
+  it("shares the member-stats query across every member-dependent field (memoised once)", async () => {
+    const { service, usecase } = build();
+    const root = await usecase.getCommunity({ input: baseInput }, adminCtx);
+
+    await Promise.all([
+      usecase.stages(root),
+      usecase.memberList(root),
+      usecase.dormantCount(root),
+      usecase.tenureDistribution(root),
+      usecase.cohortFunnel(root),
+      usecase.summary(root, adminCtx),
+    ]);
+
+    expect(service.getMemberStats).toHaveBeenCalledTimes(1);
+    expect(service.getMemberStats).toHaveBeenCalledWith(adminCtx, "kibotcha", asOf);
+  });
+
+  it("shares the monthly-activity query across monthlyActivityTrend and summary", async () => {
+    const { service, usecase } = build();
+    const root = await usecase.getCommunity({ input: baseInput }, adminCtx);
+
+    await Promise.all([usecase.monthlyActivityTrend(root), usecase.summary(root, adminCtx)]);
+
+    expect(service.getMonthlyActivity).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not run retention/cohort fan-outs when only summary is selected", async () => {
+    const { service, usecase } = build();
+    const root = await usecase.getCommunity({ input: baseInput }, adminCtx);
+
+    await usecase.summary(root, adminCtx);
+
+    expect(service.getRetentionTrend).not.toHaveBeenCalled();
+    expect(service.getCohortRetention).not.toHaveBeenCalled();
+  });
+
+  it("routes chainDepthDistribution / cohortFunnel through the presenter (Gql shape)", async () => {
+    const { service, usecase } = build();
+    const root = await usecase.getCommunity({ input: baseInput }, adminCtx);
+
+    const chain = await usecase.chainDepthDistribution(root, adminCtx);
+    expect(service.getChainDepthDistribution).toHaveBeenCalledWith(adminCtx, "kibotcha", asOf);
+    expect(chain).toEqual([{ depth: 1, count: 3 }]);
+
+    // Empty member set → funnel points exist (one per window month) but
+    // with zero counts; the important assertion is the mapped shape.
+    const funnel = await usecase.cohortFunnel(root);
+    expect(Array.isArray(funnel)).toBe(true);
+    funnel.forEach((p) => {
+      expect(p).toEqual(
+        expect.objectContaining({
+          cohortMonth: expect.any(Date),
+          acquired: expect.any(Number),
+          activatedD30: expect.any(Number),
+          repeated: expect.any(Number),
+          habitual: expect.any(Number),
+        }),
+      );
+    });
+  });
+
+  it("delegates alerts and hubMemberCount to the matching service methods", async () => {
+    const { service, usecase } = build();
+    const root = await usecase.getCommunity({ input: baseInput }, adminCtx);
+
+    await expect(usecase.alerts(root, adminCtx)).resolves.toEqual({
+      churnSpike: false,
+      activeDrop: false,
+      noNewMembers: false,
+    });
+    expect(service.getAlerts).toHaveBeenCalledWith(adminCtx, "kibotcha", asOf);
+
+    await expect(usecase.hubMemberCount(root, adminCtx)).resolves.toBe(2);
   });
 });

--- a/src/application/domain/analytics/community/controller/resolver.ts
+++ b/src/application/domain/analytics/community/controller/resolver.ts
@@ -1,6 +1,8 @@
 import { inject, injectable } from "tsyringe";
 import { IContext } from "@/types/server";
-import AnalyticsCommunityUseCase from "@/application/domain/analytics/community/usecase";
+import AnalyticsCommunityUseCase, {
+  AnalyticsCommunityRoot,
+} from "@/application/domain/analytics/community/usecase";
 import { GqlQueryAnalyticsCommunityArgs } from "@/types/graphql";
 
 @injectable()
@@ -15,5 +17,32 @@ export default class AnalyticsCommunityResolver {
       args: GqlQueryAnalyticsCommunityArgs,
       ctx: IContext,
     ) => this.useCase.getCommunity(args, ctx),
+  };
+
+  // Field resolvers run lazily per the client's selection set. The
+  // scalar fields (communityId, communityName, asOf, windowMonths) live
+  // directly on the root the Query resolver returns, so GraphQL's
+  // default resolver serves them without a field resolver here.
+  AnalyticsCommunityPayload = {
+    summary: (parent: AnalyticsCommunityRoot, _: unknown, ctx: IContext) =>
+      this.useCase.summary(parent, ctx),
+    stages: (parent: AnalyticsCommunityRoot) => this.useCase.stages(parent),
+    monthlyActivityTrend: (parent: AnalyticsCommunityRoot) =>
+      this.useCase.monthlyActivityTrend(parent),
+    retentionTrend: (parent: AnalyticsCommunityRoot, _: unknown, ctx: IContext) =>
+      this.useCase.retentionTrend(parent, ctx),
+    cohortRetention: (parent: AnalyticsCommunityRoot, _: unknown, ctx: IContext) =>
+      this.useCase.cohortRetention(parent, ctx),
+    memberList: (parent: AnalyticsCommunityRoot) => this.useCase.memberList(parent),
+    alerts: (parent: AnalyticsCommunityRoot, _: unknown, ctx: IContext) =>
+      this.useCase.alerts(parent, ctx),
+    dormantCount: (parent: AnalyticsCommunityRoot) => this.useCase.dormantCount(parent),
+    chainDepthDistribution: (parent: AnalyticsCommunityRoot, _: unknown, ctx: IContext) =>
+      this.useCase.chainDepthDistribution(parent, ctx),
+    cohortFunnel: (parent: AnalyticsCommunityRoot) => this.useCase.cohortFunnel(parent),
+    hubMemberCount: (parent: AnalyticsCommunityRoot, _: unknown, ctx: IContext) =>
+      this.useCase.hubMemberCount(parent, ctx),
+    tenureDistribution: (parent: AnalyticsCommunityRoot) =>
+      this.useCase.tenureDistribution(parent),
   };
 }

--- a/src/application/domain/analytics/community/presenter.ts
+++ b/src/application/domain/analytics/community/presenter.ts
@@ -1,8 +1,9 @@
 import { bigintToSafeNumber } from "@/application/domain/report/util";
 import {
+  GqlAnalyticsChainDepthBucket,
+  GqlAnalyticsCohortFunnelPoint,
   GqlAnalyticsCohortRetentionPoint,
   GqlAnalyticsCommunityAlerts,
-  GqlAnalyticsCommunityPayload,
   GqlAnalyticsCommunitySummaryCard,
   GqlAnalyticsLatestCohort,
   GqlAnalyticsMemberList,
@@ -100,6 +101,33 @@ export default class AnalyticsCommunityPresenter {
       // without per-element transformation.
       monthlyHistogram: d.monthlyHistogram,
     };
+  }
+
+  /**
+   * Chain-depth histogram. The bucket shape (depth + count) matches the
+   * GraphQL type 1:1, so this is a passthrough map — its purpose is to
+   * keep payload formatting on the presenter rather than leaking the
+   * Prisma row type out of the usecase.
+   */
+  static chainDepthDistribution(
+    rows: AnalyticsChainDepthBucketRow[],
+  ): GqlAnalyticsChainDepthBucket[] {
+    return rows.map((r) => ({ depth: r.depth, count: r.count }));
+  }
+
+  /**
+   * Per-cohort send-funnel series. Point shape (cohortMonth + 4 stage
+   * counts) matches the GraphQL type 1:1; same passthrough rationale as
+   * `chainDepthDistribution`.
+   */
+  static cohortFunnel(points: AnalyticsCohortFunnelPoint[]): GqlAnalyticsCohortFunnelPoint[] {
+    return points.map((p) => ({
+      cohortMonth: p.cohortMonth,
+      acquired: p.acquired,
+      activatedD30: p.activatedD30,
+      repeated: p.repeated,
+      habitual: p.habitual,
+    }));
   }
 
   // --- L2 ----------------------------------------------------------------
@@ -249,51 +277,6 @@ export default class AnalyticsCommunityPresenter {
     };
   }
 
-  static communityDetail(params: {
-    communityId: string;
-    communityName: string;
-    asOf: Date;
-    windowMonths: number;
-    summary: GqlAnalyticsCommunitySummaryCard;
-    stages: GqlAnalyticsStageDistribution;
-    monthlyActivityTrend: GqlAnalyticsMonthlyActivityPoint[];
-    retentionTrend: GqlAnalyticsRetentionTrendPoint[];
-    cohortRetention: GqlAnalyticsCohortRetentionPoint[];
-    memberList: GqlAnalyticsMemberList;
-    alerts: GqlAnalyticsCommunityAlerts;
-    dormantCount: number;
-    chainDepthDistribution: AnalyticsChainDepthBucketRow[];
-    cohortFunnel: AnalyticsCohortFunnelPoint[];
-    hubMemberCount: number;
-    tenureDistribution: TenureDistribution;
-  }): GqlAnalyticsCommunityPayload {
-    return {
-      communityId: params.communityId,
-      communityName: params.communityName,
-      asOf: params.asOf,
-      windowMonths: params.windowMonths,
-      summary: params.summary,
-      stages: params.stages,
-      monthlyActivityTrend: params.monthlyActivityTrend,
-      retentionTrend: params.retentionTrend,
-      cohortRetention: params.cohortRetention,
-      memberList: params.memberList,
-      alerts: params.alerts,
-      dormantCount: params.dormantCount,
-      // Chain-depth bucket shape (depth + count) matches the
-      // GraphQL type 1:1 so the array passes through without
-      // per-element transformation.
-      chainDepthDistribution: params.chainDepthDistribution,
-      // Same passthrough pattern: the cohort funnel point shape
-      // (cohortMonth + 4 stage counts) matches the GraphQL type
-      // 1:1.
-      cohortFunnel: params.cohortFunnel,
-      hubMemberCount: params.hubMemberCount,
-      tenureDistribution: AnalyticsCommunityPresenter.tenureDistribution(
-        params.tenureDistribution,
-      ),
-    };
-  }
 }
 
 /**

--- a/src/application/domain/analytics/community/usecase.ts
+++ b/src/application/domain/analytics/community/usecase.ts
@@ -3,7 +3,16 @@ import { IContext } from "@/types/server";
 import { AuthorizationError, NotFoundError } from "@/errors/graphql";
 import {
   GqlQueryAnalyticsCommunityArgs,
-  GqlAnalyticsCommunityPayload,
+  GqlAnalyticsChainDepthBucket,
+  GqlAnalyticsCohortFunnelPoint,
+  GqlAnalyticsCohortRetentionPoint,
+  GqlAnalyticsCommunityAlerts,
+  GqlAnalyticsCommunitySummaryCard,
+  GqlAnalyticsMemberList,
+  GqlAnalyticsMonthlyActivityPoint,
+  GqlAnalyticsRetentionTrendPoint,
+  GqlAnalyticsStageDistribution,
+  GqlAnalyticsTenureDistribution,
 } from "@/types/graphql";
 import AnalyticsCommunityService, {
   DEFAULT_WINDOW_DAYS,
@@ -18,10 +27,63 @@ import {
   computeStageCounts,
   computeTenureDistribution,
 } from "@/application/domain/analytics/community/aggregations";
-import { MAX_LIMIT, paginateMembers } from "@/application/domain/analytics/community/pagination";
+import {
+  MAX_LIMIT,
+  MemberListParams,
+  paginateMembers,
+} from "@/application/domain/analytics/community/pagination";
+import {
+  AnalyticsMemberStatsRow,
+  AnalyticsMonthlyActivityRow,
+} from "@/application/domain/analytics/community/data/type";
 import AnalyticsCommunityPresenter from "@/application/domain/analytics/community/presenter";
 import AnalyticsCommunityConverter from "@/application/domain/analytics/community/data/converter";
 import AnalyticsConverter from "@/application/domain/analytics/data/converter";
+
+type SegmentThresholds = ReturnType<typeof AnalyticsConverter.resolveThresholds>;
+
+/**
+ * Lazily-resolved root for `analyticsCommunity`. The Query resolver
+ * returns this immediately (after the cheap auth + 404 + community-row
+ * checks); each expensive section becomes a field resolver on
+ * `AnalyticsCommunityPayload` that runs ONLY when the client selects
+ * that field.
+ *
+ * Before this split the usecase eagerly `Promise.all`-ed all ~9
+ * sections on every call — including the retention-trend
+ * (~windowMonths×4.3 weeks × 2 queries) and cohort-retention
+ * (~windowMonths × 4 queries) fan-outs — even when the caller asked
+ * only for `summary`. Mobile clients that render the summary card
+ * first now skip those ~120 SQL round-trips entirely.
+ *
+ * `loadMembers` / `loadMonthlyActivity` are request-scoped memoised
+ * loaders: several fields (summary, stages, memberList, dormantCount,
+ * cohortFunnel, tenureDistribution all read `members`) share the same
+ * underlying query, so the memo keeps a multi-field selection set from
+ * re-running the member-stats / monthly-activity SQL per field.
+ */
+export interface AnalyticsCommunityRoot {
+  communityId: string;
+  communityName: string;
+  asOf: Date;
+  windowMonths: number;
+  thresholds: SegmentThresholds;
+  dormantThresholdDays: number;
+  hubBreadthThreshold: number;
+  memberListParams: MemberListParams;
+  loadMembers: () => Promise<AnalyticsMemberStatsRow[]>;
+  loadMonthlyActivity: () => Promise<AnalyticsMonthlyActivityRow[]>;
+}
+
+/**
+ * Memoise a zero-arg async thunk so repeated calls within one request
+ * share a single in-flight promise. Inlined rather than reaching for a
+ * library — the analytics root is the only caller.
+ */
+function once<T>(fn: () => Promise<T>): () => Promise<T> {
+  let cached: Promise<T> | undefined;
+  return () => (cached ??= fn());
+}
 
 @injectable()
 export default class AnalyticsCommunityUseCase {
@@ -31,14 +93,16 @@ export default class AnalyticsCommunityUseCase {
   constructor(@inject("AnalyticsCommunityService") private readonly service: AnalyticsCommunityService) {}
 
   /**
-   * L2 detail: summary card + stage breakdown + trailing-window trends
-   * + cohort retention + paginated member list + alerts for one
-   * community.
+   * L2 detail entry point. Resolves only the cheap, always-needed bits
+   * eagerly (authorization scope check, 404, community name) and returns
+   * a lazy root. The expensive sections are computed by the
+   * `AnalyticsCommunityPayload` field resolvers below, driven by the
+   * client's selection set.
    */
   async getCommunity(
     { input }: GqlQueryAnalyticsCommunityArgs,
     ctx: IContext,
-  ): Promise<GqlAnalyticsCommunityPayload> {
+  ): Promise<AnalyticsCommunityRoot> {
     // IsCommunityOwner verifies the caller owns `ctx.communityId` but
     // does not bind `input.communityId` to it — without this check an
     // owner of community A could read community B's analytics by
@@ -73,51 +137,8 @@ export default class AnalyticsCommunityUseCase {
       throw new NotFoundError("Community", { id: input.communityId });
     }
 
-    const [
-      members,
-      monthlyActivity,
-      allTimeTotals,
-      currentMonthActivity,
-      retentionTrend,
-      cohortRetention,
-      chainDepthDistribution,
-      alerts,
-      hubMemberCount,
-    ] = await Promise.all([
-      this.service.getMemberStats(ctx, community.communityId, asOf),
-      this.service.getMonthlyActivity(
-        ctx,
-        community.communityId,
-        asOf,
-        windowMonths,
-        hubBreadthThreshold,
-      ),
-      this.service.getAllTimeTotals(ctx, community.communityId, asOf),
-      this.service.getMonthActivityWithPrev(ctx, community.communityId, asOf),
-      this.service.getRetentionTrend(ctx, community.communityId, asOf, windowMonths),
-      this.service.getCohortRetention(ctx, community.communityId, asOf, windowMonths),
-      this.service.getChainDepthDistribution(ctx, community.communityId, asOf),
-      this.service.getAlerts(ctx, community.communityId, asOf),
-      // Fixed 28-day window matches L1's default `windowDays` so the
-      // L2 `hubMemberCount` reads directly comparable to L1 for the
-      // same community + `hubBreadthThreshold`. L2's `windowMonths`
-      // input drives trend-array length only, not hub classification.
-      this.service.getWindowHubMemberCount(
-        ctx,
-        community.communityId,
-        asOf,
-        DEFAULT_WINDOW_DAYS,
-        hubBreadthThreshold,
-      ),
-    ]);
-
-    const stageCounts = computeStageCounts(members, thresholds);
-    const stageBreakdown = computeStageBreakdown(members, thresholds);
-    const dormantCount = computeDormantCount(members, asOf, dormantThresholdDays);
-    const cohortFunnel = computeCohortFunnel(members, asOf, windowMonths, thresholds);
-    const tenureDistribution = computeTenureDistribution(members);
-
-    const memberList = paginateMembers(members, {
+    const communityId = community.communityId;
+    const memberListParams: MemberListParams = {
       minSendRate: input.userFilter?.minSendRate ?? 0.7,
       maxSendRate: input.userFilter?.maxSendRate ?? null,
       minMonthsIn: input.userFilter?.minMonthsIn ?? null,
@@ -128,11 +149,58 @@ export default class AnalyticsCommunityUseCase {
       // Decode at the converter boundary so service operates on a
       // numeric offset only — no wire-format leakage.
       cursor: AnalyticsCommunityConverter.parseMemberListCursor(input.cursor),
-    });
+    };
 
-    const summary = AnalyticsCommunityPresenter.summaryCard({
-      communityId: community.communityId,
+    return {
+      communityId,
       communityName: community.communityName,
+      asOf,
+      windowMonths,
+      thresholds,
+      dormantThresholdDays,
+      hubBreadthThreshold,
+      memberListParams,
+      // ctx is the same instance for every field resolver of this
+      // query, so binding it into the memoised loaders here is safe.
+      loadMembers: once(() => this.service.getMemberStats(ctx, communityId, asOf)),
+      loadMonthlyActivity: once(() =>
+        this.service.getMonthlyActivity(
+          ctx,
+          communityId,
+          asOf,
+          windowMonths,
+          hubBreadthThreshold,
+        ),
+      ),
+    };
+  }
+
+  // ==========================================================================
+  // Field resolvers for AnalyticsCommunityPayload — each runs only when
+  // the client selects the matching field. Shared reads (members,
+  // monthly activity) go through the root's memoised loaders so a
+  // multi-field selection issues each underlying query at most once.
+  // ==========================================================================
+
+  /**
+   * Summary card. Reads the shared member + monthly-activity loaders and
+   * fires the two summary-only queries (all-time totals, month-over-month
+   * activity) in parallel.
+   */
+  async summary(
+    root: AnalyticsCommunityRoot,
+    ctx: IContext,
+  ): Promise<GqlAnalyticsCommunitySummaryCard> {
+    const [members, monthlyActivity, allTimeTotals, currentMonthActivity] = await Promise.all([
+      root.loadMembers(),
+      root.loadMonthlyActivity(),
+      this.service.getAllTimeTotals(ctx, root.communityId, root.asOf),
+      this.service.getMonthActivityWithPrev(ctx, root.communityId, root.asOf),
+    ]);
+    const stageCounts = computeStageCounts(members, root.thresholds);
+    return AnalyticsCommunityPresenter.summaryCard({
+      communityId: root.communityId,
+      communityName: root.communityName,
       totalMembers: stageCounts.total,
       communityActivityRate: currentMonthActivity.currentRate,
       communityActivityRate3mAvg: computeActivityRate3mAvg(monthlyActivity),
@@ -140,25 +208,109 @@ export default class AnalyticsCommunityUseCase {
       tier2Count: stageCounts.tier2Count,
       allTimeTotals,
     });
+  }
 
-    return AnalyticsCommunityPresenter.communityDetail({
-      communityId: community.communityId,
-      communityName: community.communityName,
-      asOf,
-      windowMonths,
-      summary,
-      stages: AnalyticsCommunityPresenter.stages(stageBreakdown),
-      monthlyActivityTrend: monthlyActivity.map(AnalyticsCommunityPresenter.monthlyActivityPoint),
-      retentionTrend: retentionTrend.map(AnalyticsCommunityPresenter.retentionTrendPoint),
-      cohortRetention: cohortRetention.map(AnalyticsCommunityPresenter.cohortPoint),
-      memberList: AnalyticsCommunityPresenter.memberList(memberList),
-      alerts: AnalyticsCommunityPresenter.alerts(alerts),
-      dormantCount,
-      chainDepthDistribution,
-      cohortFunnel,
-      hubMemberCount,
-      tenureDistribution,
-    });
+  async stages(root: AnalyticsCommunityRoot): Promise<GqlAnalyticsStageDistribution> {
+    const members = await root.loadMembers();
+    return AnalyticsCommunityPresenter.stages(computeStageBreakdown(members, root.thresholds));
+  }
+
+  async monthlyActivityTrend(
+    root: AnalyticsCommunityRoot,
+  ): Promise<GqlAnalyticsMonthlyActivityPoint[]> {
+    const monthlyActivity = await root.loadMonthlyActivity();
+    return monthlyActivity.map(AnalyticsCommunityPresenter.monthlyActivityPoint);
+  }
+
+  /**
+   * Trailing-window weekly retention. The heaviest section: fans out
+   * ~windowMonths×4.3 weeks × 2 SQL statements. Only runs when selected.
+   */
+  async retentionTrend(
+    root: AnalyticsCommunityRoot,
+    ctx: IContext,
+  ): Promise<GqlAnalyticsRetentionTrendPoint[]> {
+    const trend = await this.service.getRetentionTrend(
+      ctx,
+      root.communityId,
+      root.asOf,
+      root.windowMonths,
+    );
+    return trend.map(AnalyticsCommunityPresenter.retentionTrendPoint);
+  }
+
+  /**
+   * Monthly cohort retention. Fans out ~windowMonths × 4 SQL
+   * statements. Only runs when selected.
+   */
+  async cohortRetention(
+    root: AnalyticsCommunityRoot,
+    ctx: IContext,
+  ): Promise<GqlAnalyticsCohortRetentionPoint[]> {
+    const cohorts = await this.service.getCohortRetention(
+      ctx,
+      root.communityId,
+      root.asOf,
+      root.windowMonths,
+    );
+    return cohorts.map(AnalyticsCommunityPresenter.cohortPoint);
+  }
+
+  async memberList(root: AnalyticsCommunityRoot): Promise<GqlAnalyticsMemberList> {
+    const members = await root.loadMembers();
+    return AnalyticsCommunityPresenter.memberList(
+      paginateMembers(members, root.memberListParams),
+    );
+  }
+
+  async alerts(
+    root: AnalyticsCommunityRoot,
+    ctx: IContext,
+  ): Promise<GqlAnalyticsCommunityAlerts> {
+    return AnalyticsCommunityPresenter.alerts(
+      await this.service.getAlerts(ctx, root.communityId, root.asOf),
+    );
+  }
+
+  async dormantCount(root: AnalyticsCommunityRoot): Promise<number> {
+    const members = await root.loadMembers();
+    return computeDormantCount(members, root.asOf, root.dormantThresholdDays);
+  }
+
+  async chainDepthDistribution(
+    root: AnalyticsCommunityRoot,
+    ctx: IContext,
+  ): Promise<GqlAnalyticsChainDepthBucket[]> {
+    const rows = await this.service.getChainDepthDistribution(ctx, root.communityId, root.asOf);
+    return AnalyticsCommunityPresenter.chainDepthDistribution(rows);
+  }
+
+  async cohortFunnel(root: AnalyticsCommunityRoot): Promise<GqlAnalyticsCohortFunnelPoint[]> {
+    const members = await root.loadMembers();
+    return AnalyticsCommunityPresenter.cohortFunnel(
+      computeCohortFunnel(members, root.asOf, root.windowMonths, root.thresholds),
+    );
+  }
+
+  async hubMemberCount(root: AnalyticsCommunityRoot, ctx: IContext): Promise<number> {
+    // Fixed 28-day window matches L1's default `windowDays` so the L2
+    // `hubMemberCount` reads directly comparable to L1 for the same
+    // community + `hubBreadthThreshold`. L2's `windowMonths` input
+    // drives trend-array length only, not hub classification.
+    return this.service.getWindowHubMemberCount(
+      ctx,
+      root.communityId,
+      root.asOf,
+      DEFAULT_WINDOW_DAYS,
+      root.hubBreadthThreshold,
+    );
+  }
+
+  async tenureDistribution(
+    root: AnalyticsCommunityRoot,
+  ): Promise<GqlAnalyticsTenureDistribution> {
+    const members = await root.loadMembers();
+    return AnalyticsCommunityPresenter.tenureDistribution(computeTenureDistribution(members));
   }
 }
 

--- a/src/presentation/graphql/resolver.ts
+++ b/src/presentation/graphql/resolver.ts
@@ -176,6 +176,9 @@ const resolvers = {
   ReportTemplate: report.ReportTemplate,
   AdminReportSummaryRow: report.AdminReportSummaryRow,
   ReportFeedback: reportFeedback.ReportFeedback,
+
+  AnalyticsCommunityPayload: analyticsCommunity.AnalyticsCommunityPayload,
+
   GenerateReportPayload: report.GenerateReportPayload,
   UpdateReportTemplatePayload: report.UpdateReportTemplatePayload,
   ApproveReportPayload: report.ApproveReportPayload,


### PR DESCRIPTION
## 概要

`develop` を `master` に反映するリリースPR。

## 含まれる変更（master に未反映のコミット: 1件）

### perf(analytics): lazily resolve analyticsCommunity payload fields (#1236)

携帯から重かった `analyticsCommunity`（L2 コミュニティ詳細）クエリを、**GraphQL のセレクションに応じた遅延フィールド解決**に変更。

- 従来は9セクション全部を毎回 `Promise.all` で計算（retention/cohort のファンアウト ~120 SQL を含む）していたのを、`AnalyticsCommunityPayload` のフィールドリゾルバ化。**選択されたフィールドだけ計算**するようにした。
- サマリー中心の携帯画面は、重い retention/cohort のファンアウトを丸ごとスキップ。
- 共有データ（メンバー統計・月次アクティビティ）はリクエストスコープでメモ化し、複数フィールド選択時も各クエリ最大1回。
- `chainDepthDistribution` / `cohortFunnel` は passthrough presenter 経由に整理し、usecase → presenter の境界を統一。

返却データは従来と同一（フルペイロード時の挙動不変）。認可・404 は引き続き即時評価。

## 補足

- 差分は #1236 のみ（`origin/master..origin/develop` = 1 commit）。
- #1236 は develop 上で CI グリーン・SonarQube 通過・レビュー対応済みでマージ済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011MuXNtJe9LAeDZTWas7scL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * コミュニティ分析の各指標を、必要な分だけ取得する形に対応しました。
  * メンバー一覧、活動トレンド、定着率、コホート分析、アラート、分布系の情報が個別に表示されるようになりました。
* **改善**
  * 分析データの取得を遅延実行に切り替え、表示内容に応じて処理されるようになりました。
  * 同じデータの重複取得を抑え、表示の安定性と応答性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->