### PR TITLE
test(analytics): cover analyticsCommunity lazy resolution & passthrough presenters

### DIFF
--- a/src/__tests__/unit/analytics/community/presenter.test.ts
+++ b/src/__tests__/unit/analytics/community/presenter.test.ts
@@ -469,4 +469,50 @@ describe("AnalyticsCommunityPresenter", () => {
       expect(out.dormantCount).toBe(1);
     });
   });
+
+  describe("chainDepthDistribution / cohortFunnel — passthrough mapping", () => {
+    it("maps chain-depth rows to the GraphQL bucket shape 1:1", () => {
+      const out = AnalyticsCommunityPresenter.chainDepthDistribution([
+        { depth: 1, count: 5 },
+        { depth: 5, count: 2 },
+      ]);
+      expect(out).toEqual([
+        { depth: 1, count: 5 },
+        { depth: 5, count: 2 },
+      ]);
+    });
+
+    it("returns an empty array for an empty chain-depth input", () => {
+      expect(AnalyticsCommunityPresenter.chainDepthDistribution([])).toEqual([]);
+    });
+
+    it("maps cohort-funnel points 1:1 and passes the cohortMonth Date through untouched", () => {
+      const cohortMonth = new Date("2026-04-01T00:00:00Z");
+      const out = AnalyticsCommunityPresenter.cohortFunnel([
+        {
+          cohortMonth,
+          acquired: 10,
+          activatedD30: 6,
+          repeated: 3,
+          habitual: 1,
+        },
+      ]);
+      expect(out).toEqual([
+        {
+          cohortMonth,
+          acquired: 10,
+          activatedD30: 6,
+          repeated: 3,
+          habitual: 1,
+        },
+      ]);
+      // Date identity is preserved (serialised as Datetime downstream),
+      // not coerced to a string or a new Date instance.
+      expect(out[0].cohortMonth).toBe(cohortMonth);
+    });
+
+    it("returns an empty array for an empty cohort-funnel input", () => {
+      expect(AnalyticsCommunityPresenter.cohortFunnel([])).toEqual([]);
+    });
+  });
 });

--- a/src/__tests__/unit/analytics/community/usecase.test.ts
+++ b/src/__tests__/unit/analytics/community/usecase.test.ts
@@ -1,6 +1,11 @@
 import "reflect-metadata";
 import AnalyticsCommunityUseCase from "@/application/domain/analytics/community/usecase";
 import type AnalyticsCommunityService from "@/application/domain/analytics/community/service";
+import {
+  DEFAULT_HUB_BREADTH_THRESHOLD,
+  DEFAULT_WINDOW_DAYS,
+  DEFAULT_WINDOW_MONTHS,
+} from "@/application/domain/analytics/community/service";
 import { IContext } from "@/types/server";
 import { AuthorizationError } from "@/errors/graphql";
 
@@ -95,7 +100,7 @@ describe("AnalyticsCommunityUseCase lazy field resolution", () => {
     expect(root.communityId).toBe("kibotcha");
     expect(root.communityName).toBe("きぼっちゃ");
     expect(root.asOf).toBe(asOf);
-    expect(root.windowMonths).toBe(10); // DEFAULT_WINDOW_MONTHS
+    expect(root.windowMonths).toBe(DEFAULT_WINDOW_MONTHS);
     expect(typeof root.loadMembers).toBe("function");
     expect(typeof root.loadMonthlyActivity).toBe("function");
 
@@ -154,7 +159,11 @@ describe("AnalyticsCommunityUseCase lazy field resolution", () => {
     // Empty member set → funnel points exist (one per window month) but
     // with zero counts; the important assertion is the mapped shape.
     const funnel = await usecase.cohortFunnel(root);
-    expect(Array.isArray(funnel)).toBe(true);
+    // computeCohortFunnel emits one zero-filled point per window month
+    // even for an empty member set, so the array is never empty — assert
+    // the length up front so the per-element checks below can't pass
+    // vacuously on an unexpectedly empty result.
+    expect(funnel).toHaveLength(DEFAULT_WINDOW_MONTHS);
     funnel.forEach((p) => {
       expect(p).toEqual(
         expect.objectContaining({
@@ -180,5 +189,16 @@ describe("AnalyticsCommunityUseCase lazy field resolution", () => {
     expect(service.getAlerts).toHaveBeenCalledWith(adminCtx, "kibotcha", asOf);
 
     await expect(usecase.hubMemberCount(root, adminCtx)).resolves.toBe(2);
+    // L2 hub classification uses the fixed 28-day window (matching L1's
+    // default) and the request's clamped hub-breadth threshold, not the
+    // trend-length `windowMonths`. Pin those args so a regression in the
+    // window/threshold wiring is caught.
+    expect(service.getWindowHubMemberCount).toHaveBeenCalledWith(
+      adminCtx,
+      "kibotcha",
+      asOf,
+      DEFAULT_WINDOW_DAYS,
+      DEFAULT_HUB_BREADTH_THRESHOLD,
+    );
   });
 });

--- a/src/__tests__/unit/analytics/community/usecase.test.ts
+++ b/src/__tests__/unit/analytics/community/usecase.test.ts
@@ -1,5 +1,6 @@
 import "reflect-metadata";
 import AnalyticsCommunityUseCase from "@/application/domain/analytics/community/usecase";
+import type AnalyticsCommunityService from "@/application/domain/analytics/community/service";
 import { IContext } from "@/types/server";
 import { AuthorizationError } from "@/errors/graphql";
 
@@ -33,5 +34,151 @@ describe("AnalyticsCommunityUseCase authz scoping", () => {
     await expect(usecase.getCommunity({ input: baseInput }, ctx)).rejects.toThrow(
       AuthorizationError,
     );
+  });
+});
+
+describe("AnalyticsCommunityUseCase lazy field resolution", () => {
+  const asOf = new Date("2026-04-01T00:00:00Z");
+  const baseInput = { communityId: "kibotcha", asOf };
+  // SYS_ADMIN bypasses the input.communityId scope check, so a single
+  // admin ctx exercises the happy path for every community id.
+  const adminCtx = { isAdmin: true } as IContext;
+
+  /**
+   * Fresh jest-mock service double per test. Every DB-facing method the
+   * usecase can reach is stubbed with a benign value so the field
+   * resolvers run end-to-end (through the real aggregations + presenter)
+   * over an empty member set without touching a database.
+   */
+  function buildService() {
+    return {
+      getCommunityById: jest
+        .fn()
+        .mockResolvedValue({ communityId: "kibotcha", communityName: "きぼっちゃ" }),
+      getMemberStats: jest.fn().mockResolvedValue([]),
+      getMonthlyActivity: jest.fn().mockResolvedValue([]),
+      getAllTimeTotals: jest.fn().mockResolvedValue({
+        totalDonationPoints: BigInt(0),
+        maxChainDepth: 0,
+        dataFrom: null,
+        dataTo: null,
+      }),
+      getMonthActivityWithPrev: jest.fn().mockResolvedValue({
+        currentRate: 0,
+        currentSenderCount: 0,
+        currentTotalMembers: 0,
+        growthRateActivity: null,
+      }),
+      getRetentionTrend: jest.fn().mockResolvedValue([]),
+      getCohortRetention: jest.fn().mockResolvedValue([]),
+      getChainDepthDistribution: jest.fn().mockResolvedValue([{ depth: 1, count: 3 }]),
+      getAlerts: jest
+        .fn()
+        .mockResolvedValue({ churnSpike: false, activeDrop: false, noNewMembers: false }),
+      getWindowHubMemberCount: jest.fn().mockResolvedValue(2),
+    };
+  }
+
+  function build() {
+    const service = buildService();
+    const usecase = new AnalyticsCommunityUseCase(
+      service as unknown as AnalyticsCommunityService,
+    );
+    return { service, usecase };
+  }
+
+  it("returns a lazy root carrying the scalar fields and memoised loaders", async () => {
+    const { service, usecase } = build();
+
+    const root = await usecase.getCommunity({ input: baseInput }, adminCtx);
+
+    expect(root.communityId).toBe("kibotcha");
+    expect(root.communityName).toBe("きぼっちゃ");
+    expect(root.asOf).toBe(asOf);
+    expect(root.windowMonths).toBe(10); // DEFAULT_WINDOW_MONTHS
+    expect(typeof root.loadMembers).toBe("function");
+    expect(typeof root.loadMonthlyActivity).toBe("function");
+
+    // getCommunity itself must not eagerly pull any of the heavy
+    // sections — only the community-row lookup runs up front.
+    expect(service.getCommunityById).toHaveBeenCalledTimes(1);
+    expect(service.getMemberStats).not.toHaveBeenCalled();
+    expect(service.getRetentionTrend).not.toHaveBeenCalled();
+    expect(service.getCohortRetention).not.toHaveBeenCalled();
+  });
+
+  it("shares the member-stats query across every member-dependent field (memoised once)", async () => {
+    const { service, usecase } = build();
+    const root = await usecase.getCommunity({ input: baseInput }, adminCtx);
+
+    await Promise.all([
+      usecase.stages(root),
+      usecase.memberList(root),
+      usecase.dormantCount(root),
+      usecase.tenureDistribution(root),
+      usecase.cohortFunnel(root),
+      usecase.summary(root, adminCtx),
+    ]);
+
+    expect(service.getMemberStats).toHaveBeenCalledTimes(1);
+    expect(service.getMemberStats).toHaveBeenCalledWith(adminCtx, "kibotcha", asOf);
+  });
+
+  it("shares the monthly-activity query across monthlyActivityTrend and summary", async () => {
+    const { service, usecase } = build();
+    const root = await usecase.getCommunity({ input: baseInput }, adminCtx);
+
+    await Promise.all([usecase.monthlyActivityTrend(root), usecase.summary(root, adminCtx)]);
+
+    expect(service.getMonthlyActivity).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not run retention/cohort fan-outs when only summary is selected", async () => {
+    const { service, usecase } = build();
+    const root = await usecase.getCommunity({ input: baseInput }, adminCtx);
+
+    await usecase.summary(root, adminCtx);
+
+    expect(service.getRetentionTrend).not.toHaveBeenCalled();
+    expect(service.getCohortRetention).not.toHaveBeenCalled();
+  });
+
+  it("routes chainDepthDistribution / cohortFunnel through the presenter (Gql shape)", async () => {
+    const { service, usecase } = build();
+    const root = await usecase.getCommunity({ input: baseInput }, adminCtx);
+
+    const chain = await usecase.chainDepthDistribution(root, adminCtx);
+    expect(service.getChainDepthDistribution).toHaveBeenCalledWith(adminCtx, "kibotcha", asOf);
+    expect(chain).toEqual([{ depth: 1, count: 3 }]);
+
+    // Empty member set → funnel points exist (one per window month) but
+    // with zero counts; the important assertion is the mapped shape.
+    const funnel = await usecase.cohortFunnel(root);
+    expect(Array.isArray(funnel)).toBe(true);
+    funnel.forEach((p) => {
+      expect(p).toEqual(
+        expect.objectContaining({
+          cohortMonth: expect.any(Date),
+          acquired: expect.any(Number),
+          activatedD30: expect.any(Number),
+          repeated: expect.any(Number),
+          habitual: expect.any(Number),
+        }),
+      );
+    });
+  });
+
+  it("delegates alerts and hubMemberCount to the matching service methods", async () => {
+    const { service, usecase } = build();
+    const root = await usecase.getCommunity({ input: baseInput }, adminCtx);
+
+    await expect(usecase.alerts(root, adminCtx)).resolves.toEqual({
+      churnSpike: false,
+      activeDrop: false,
+      noNewMembers: false,
+    });
+    expect(service.getAlerts).toHaveBeenCalledWith(adminCtx, "kibotcha", asOf);
+
+    await expect(usecase.hubMemberCount(root, adminCtx)).resolves.toBe(2);
   });
 });


### PR DESCRIPTION
## 概要

#1236（`analyticsCommunity` の遅延フィールド解決リファクタ）のリグレッションテストを追加する follow-up PR。#1238（develop→master リリース）のレビューで Copilot から指摘されたテスト不足に対応。**プロダクションコードの変更なし・テスト追加のみ。**

## 背景

#1236 で `analyticsCommunity` を遅延フィールド解決 + `once` メモ化に変更したが、既存の `usecase.test.ts` は認可ガードのみを検証しており、lazy root / メモ化 / フィールド委譲のリグレッションを検知できなかった。また新規追加した presenter passthrough メソッドもテストがなかった。

## 変更内容

### `usecase.test.ts`
- `getCommunity` が lazy root（scalar フィールド + メモ化ローダ）を返し、**重いセクションを事前計算しない**こと。
- **リクエストスコープのメモ化**：`stages`/`memberList`/`dormantCount`/`tenureDistribution`/`cohortFunnel`/`summary` を並行に呼んでも `getMemberStats` は1回、`monthlyActivityTrend`+`summary` で `getMonthlyActivity` は1回。
- **サマリーのみ選択時**に retention/cohort のファンアウト（`getRetentionTrend`/`getCohortRetention`）が走らないこと。
- `chainDepthDistribution`/`cohortFunnel` が presenter 経由で Gql 形状を返すこと、`alerts`/`hubMemberCount` が対応 service に委譲されること。

### `presenter.test.ts`
- `chainDepthDistribution`/`cohortFunnel` の 1:1 passthrough マッピング（`cohortMonth` の Date 同一性保持、空配列ハンドリング含む）。

## テスト

- `presenter.test.ts` は本サンドボックスで実行し **26件 PASS**（新規4件含む）。
- `usecase.test.ts` はサンドボックスで Prisma クライアント未生成（egress ポリシーでエンジンDL不可）のため実行不可だが、失敗要因は本PRで触っていない `report/service.ts` の `@prisma/client` import に起因する環境制約で、CI 上では生成済みクライアントで実行される。
- 変更2ファイル ESLint clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011MuXNtJe9LAeDZTWas7scL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * コミュニティ分析の出力形式や空データ時の挙動を含むテストを追加し、表示結果の安定性を強化しました。
  * レスポンスの一部項目が期待どおりに変換・保持されることや、不要な処理が増えないことを検証するテストを追加しました。
  * 重要な集計項目の取得が適切に連携されることを確認するテストを拡充しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->