### PR TITLE
fix(vcIssuanceRequest): enforce self-or-admin authz on VC issuance request queries

### DIFF
--- a/src/__tests__/unit/application/domain/experience/evaluation/vcIssuanceRequest/usecase.test.ts
+++ b/src/__tests__/unit/application/domain/experience/evaluation/vcIssuanceRequest/usecase.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Unit tests for `VCIssuanceRequestUseCase` authorization.
+ *
+ * The `vcIssuanceRequests` / `vcIssuanceRequest` queries previously shipped
+ * with NO `@authz` directive and no ownership check, so any caller could
+ * enumerate every user's VC issuance requests (broken object-level
+ * authorization / IDOR). The schema now gates on `IsUser`; these tests lock
+ * in the usecase-layer "self-or-admin" enforcement that binds the request
+ * rows to the caller — mirroring the sibling `credential/vcIssuance` usecase.
+ */
+
+import "reflect-metadata";
+import { container } from "tsyringe";
+import VCIssuanceRequestUseCase from "@/application/domain/experience/evaluation/vcIssuanceRequest/usecase";
+import { VCIssuanceRequestService } from "@/application/domain/experience/evaluation/vcIssuanceRequest/service";
+import { AuthenticationError } from "@/errors/graphql";
+import type { IContext } from "@/types/server";
+import type { PrismaVCIssuanceRequestDetail } from "@/application/domain/experience/evaluation/vcIssuanceRequest/data/type";
+
+const SELF_USER_ID = "user-self";
+const OTHER_USER_ID = "user-other";
+
+function makeRow(
+  overrides: Partial<PrismaVCIssuanceRequestDetail> = {},
+): PrismaVCIssuanceRequestDetail {
+  return {
+    id: "vcr-1",
+    status: "COMPLETED",
+    completedAt: null,
+    evaluationId: "eval-1",
+    userId: SELF_USER_ID,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  } as PrismaVCIssuanceRequestDetail;
+}
+
+function makeCtx(overrides: Partial<IContext> = {}): IContext {
+  return {
+    issuer: {} as never,
+    loaders: {} as never,
+    communityId: "community-1",
+    currentUser: { id: SELF_USER_ID } as never,
+    isAdmin: false,
+    ...overrides,
+  } as IContext;
+}
+
+describe("VCIssuanceRequestUseCase (authz hardening)", () => {
+  let mockService: jest.Mocked<
+    Pick<VCIssuanceRequestService, "fetchVcIssuanceRequests" | "findVcIssuanceRequest">
+  >;
+  let usecase: VCIssuanceRequestUseCase;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    container.reset();
+
+    mockService = {
+      fetchVcIssuanceRequests: jest.fn(),
+      findVcIssuanceRequest: jest.fn(),
+    };
+
+    container.register("VCIssuanceRequestService", { useValue: mockService });
+    container.register("VCIssuanceRequestUseCase", { useClass: VCIssuanceRequestUseCase });
+
+    usecase = container.resolve(VCIssuanceRequestUseCase);
+  });
+
+  describe("visitorBrowseVcIssuanceRequests (list scoping)", () => {
+    it("forces a non-admin caller's userIds filter to their own id", async () => {
+      mockService.fetchVcIssuanceRequests.mockResolvedValueOnce([]);
+      const ctx = makeCtx();
+
+      await usecase.visitorBrowseVcIssuanceRequests(ctx, {
+        // A malicious client trying to read another user's requests.
+        filter: { userIds: [OTHER_USER_ID] },
+      });
+
+      expect(mockService.fetchVcIssuanceRequests).toHaveBeenCalledTimes(1);
+      const [, args] = mockService.fetchVcIssuanceRequests.mock.calls[0];
+      expect(args.filter?.userIds).toEqual([SELF_USER_ID]);
+    });
+
+    it("injects the caller's userIds filter even when none was supplied", async () => {
+      mockService.fetchVcIssuanceRequests.mockResolvedValueOnce([]);
+      const ctx = makeCtx();
+
+      await usecase.visitorBrowseVcIssuanceRequests(ctx, {});
+
+      const [, args] = mockService.fetchVcIssuanceRequests.mock.calls[0];
+      expect(args.filter?.userIds).toEqual([SELF_USER_ID]);
+    });
+
+    it("leaves the filter untouched for admins (cross-user view)", async () => {
+      mockService.fetchVcIssuanceRequests.mockResolvedValueOnce([]);
+      const ctx = makeCtx({ isAdmin: true, currentUser: { id: "admin-1" } as never });
+
+      await usecase.visitorBrowseVcIssuanceRequests(ctx, {
+        filter: { userIds: [OTHER_USER_ID] },
+      });
+
+      const [, args] = mockService.fetchVcIssuanceRequests.mock.calls[0];
+      expect(args.filter?.userIds).toEqual([OTHER_USER_ID]);
+    });
+
+    it("throws for an anonymous caller (defence-in-depth behind IsUser)", async () => {
+      const ctx = makeCtx({ currentUser: undefined, isAdmin: false });
+
+      await expect(usecase.visitorBrowseVcIssuanceRequests(ctx, {})).rejects.toBeInstanceOf(
+        AuthenticationError,
+      );
+      expect(mockService.fetchVcIssuanceRequests).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("visitorViewVcIssuanceRequest (single ownership check)", () => {
+    it("returns null when the request is owned by another user", async () => {
+      mockService.findVcIssuanceRequest.mockResolvedValueOnce(makeRow({ userId: OTHER_USER_ID }));
+      const ctx = makeCtx();
+
+      const result = await usecase.visitorViewVcIssuanceRequest(ctx, { id: "vcr-1" });
+
+      expect(result).toBeNull();
+    });
+
+    it("returns the presented request when the caller owns it", async () => {
+      mockService.findVcIssuanceRequest.mockResolvedValueOnce(makeRow({ userId: SELF_USER_ID }));
+      const ctx = makeCtx();
+
+      const result = await usecase.visitorViewVcIssuanceRequest(ctx, { id: "vcr-1" });
+
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe("vcr-1");
+    });
+
+    it("lets admins read any user's request", async () => {
+      mockService.findVcIssuanceRequest.mockResolvedValueOnce(makeRow({ userId: OTHER_USER_ID }));
+      const ctx = makeCtx({ isAdmin: true, currentUser: { id: "admin-1" } as never });
+
+      const result = await usecase.visitorViewVcIssuanceRequest(ctx, { id: "vcr-1" });
+
+      expect(result).not.toBeNull();
+    });
+
+    it("returns null when no request matches the id", async () => {
+      mockService.findVcIssuanceRequest.mockResolvedValueOnce(null);
+      const ctx = makeCtx();
+
+      const result = await usecase.visitorViewVcIssuanceRequest(ctx, { id: "missing" });
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/__tests__/unit/application/domain/experience/evaluation/vcIssuanceRequest/usecase.test.ts
+++ b/src/__tests__/unit/application/domain/experience/evaluation/vcIssuanceRequest/usecase.test.ts
@@ -151,5 +151,23 @@ describe("VCIssuanceRequestUseCase (authz hardening)", () => {
 
       expect(result).toBeNull();
     });
+
+    it("denies a non-admin caller a request with no owner (null userId)", async () => {
+      mockService.findVcIssuanceRequest.mockResolvedValueOnce(makeRow({ userId: null as never }));
+      const ctx = makeCtx();
+
+      const result = await usecase.visitorViewVcIssuanceRequest(ctx, { id: "vcr-1" });
+
+      expect(result).toBeNull();
+    });
+
+    it("lets an admin read a request with no owner (null userId)", async () => {
+      mockService.findVcIssuanceRequest.mockResolvedValueOnce(makeRow({ userId: null as never }));
+      const ctx = makeCtx({ isAdmin: true, currentUser: { id: "admin-1" } as never });
+
+      const result = await usecase.visitorViewVcIssuanceRequest(ctx, { id: "vcr-1" });
+
+      expect(result).not.toBeNull();
+    });
   });
 });

--- a/src/application/domain/experience/evaluation/vcIssuanceRequest/controller/resolver.ts
+++ b/src/application/domain/experience/evaluation/vcIssuanceRequest/controller/resolver.ts
@@ -14,7 +14,6 @@ export default class VCIssuanceRequestResolver {
   Query = {
     vcIssuanceRequests: (_: unknown, args: GqlQueryVcIssuanceRequestsArgs, ctx: IContext) => {
       return this.usecase.visitorBrowseVcIssuanceRequests(ctx, args);
-      return this.usecase.visitorBrowseVcIssuanceRequests(ctx, args);
     },
 
     vcIssuanceRequest: (_: unknown, args: GqlQueryVcIssuanceRequestArgs, ctx: IContext) => {

--- a/src/application/domain/experience/evaluation/vcIssuanceRequest/schema/query.graphql
+++ b/src/application/domain/experience/evaluation/vcIssuanceRequest/schema/query.graphql
@@ -2,40 +2,40 @@
 # VcIssuanceRequest Query Definitions
 # ------------------------------
 extend type Query {
-    vcIssuanceRequests(
-        filter: VcIssuanceRequestFilterInput
-        sort: VcIssuanceRequestSortInput
-        cursor: String
-        first: Int
-    ): VcIssuanceRequestsConnection!
+  vcIssuanceRequests(
+    filter: VcIssuanceRequestFilterInput
+    sort: VcIssuanceRequestSortInput
+    cursor: String
+    first: Int
+  ): VcIssuanceRequestsConnection! @authz(rules: [IsUser])
 
-    vcIssuanceRequest(id: ID!): VcIssuanceRequest
+  vcIssuanceRequest(id: ID!): VcIssuanceRequest @authz(rules: [IsUser])
 }
 
 # ------------------------------
 # VcIssuanceRequest Connection Type
 # ------------------------------
 type VcIssuanceRequestsConnection {
-    edges: [VcIssuanceRequestEdge!]!
-    pageInfo: PageInfo!
-    totalCount: Int!
+  edges: [VcIssuanceRequestEdge!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
 }
 
 type VcIssuanceRequestEdge implements Edge {
-    cursor: String!
-    node: VcIssuanceRequest
+  cursor: String!
+  node: VcIssuanceRequest
 }
 
 # ------------------------------
 # VcIssuanceRequest Query Inputs
 # ------------------------------
 input VcIssuanceRequestFilterInput {
-    status: VcIssuanceStatus
-    userIds: [ID!]
-    evaluationId: ID
+  status: VcIssuanceStatus
+  userIds: [ID!]
+  evaluationId: ID
 }
 
 input VcIssuanceRequestSortInput {
-    createdAt: SortDirection
-    updatedAt: SortDirection
+  createdAt: SortDirection
+  updatedAt: SortDirection
 }

--- a/src/application/domain/experience/evaluation/vcIssuanceRequest/usecase.ts
+++ b/src/application/domain/experience/evaluation/vcIssuanceRequest/usecase.ts
@@ -9,6 +9,20 @@ import { injectable, inject } from "tsyringe";
 import { clampFirst } from "@/application/domain/utils";
 import { VCIssuanceRequestService } from "@/application/domain/experience/evaluation/vcIssuanceRequest/service";
 import VCIssuanceRequestPresenter from "@/application/domain/experience/evaluation/vcIssuanceRequest/presenter";
+import { AuthenticationError } from "@/errors/graphql";
+
+/**
+ * True when the caller is the target user, or when the caller is an admin.
+ * Mirrors the ownership predicate in the sibling `credential/vcIssuance`
+ * usecase — both VC-surface read paths must apply the same "self-or-admin"
+ * gate. Kept local (a 3-line predicate isn't worth a shared module) and
+ * returns `false` for anonymous callers as defence-in-depth behind the
+ * schema's `IsUser` rule.
+ */
+function isSelfOrAdmin(ctx: IContext, userId: string): boolean {
+  if (ctx.isAdmin) return true;
+  return ctx.currentUser?.id === userId;
+}
 
 @injectable()
 export default class VCIssuanceRequestUseCase {
@@ -17,14 +31,30 @@ export default class VCIssuanceRequestUseCase {
     private readonly service: VCIssuanceRequestService,
   ) {}
 
+  /**
+   * `Query.vcIssuanceRequests`. The schema gates on `IsUser` (authenticated
+   * OR admin), but that rule does not bind the `filter.userIds` argument to
+   * the caller: without the guard below any logged-in user could enumerate
+   * every user's VC issuance requests by passing arbitrary `userIds`
+   * (and, before the `@authz` directive was added, so could an anonymous
+   * caller).
+   *
+   * We therefore scope non-admin callers to their own rows — the effective
+   * `userIds` filter is forced to `[currentUser.id]` regardless of what the
+   * client sent. Admins keep the unrestricted cross-user view the
+   * management surface needs. This mirrors the ownership enforcement in
+   * `credential/vcIssuance` (`viewVcIssuancesByUser`).
+   */
   async visitorBrowseVcIssuanceRequests(
     ctx: IContext,
     { cursor, filter, sort, first }: GqlQueryVcIssuanceRequestsArgs,
   ): Promise<GqlVcIssuanceRequestsConnection> {
+    const scopedFilter = this.scopeFilterToCaller(ctx, filter);
+
     const take = clampFirst(first);
     const requests = await this.service.fetchVcIssuanceRequests(
       ctx,
-      { cursor, filter, sort },
+      { cursor, filter: scopedFilter, sort },
       take,
     );
 
@@ -33,11 +63,38 @@ export default class VCIssuanceRequestUseCase {
     return VCIssuanceRequestPresenter.query(data, hasNextPage);
   }
 
+  /**
+   * `Query.vcIssuanceRequest(id)`. Loads the row, then returns `null` unless
+   * the caller owns it or is an admin — matching the "no such id" path so we
+   * do not leak the existence of another user's request. Same pattern as
+   * `credential/vcIssuance` `viewVcIssuance`.
+   */
   async visitorViewVcIssuanceRequest(
     ctx: IContext,
     { id }: GqlQueryVcIssuanceRequestArgs,
   ): Promise<GqlVcIssuanceRequest | null> {
     const request = await this.service.findVcIssuanceRequest(ctx, id);
-    return request ? VCIssuanceRequestPresenter.get(request) : null;
+    if (!request) return null;
+    if (!request.userId || !isSelfOrAdmin(ctx, request.userId)) return null;
+    return VCIssuanceRequestPresenter.get(request);
+  }
+
+  /**
+   * Restrict a non-admin caller's list filter to their own `userId`,
+   * ignoring any `userIds` they supplied. Admins pass through untouched.
+   * Throws for anonymous callers as defence-in-depth — the schema's
+   * `IsUser` rule should already have rejected them.
+   */
+  private scopeFilterToCaller(
+    ctx: IContext,
+    filter: GqlQueryVcIssuanceRequestsArgs["filter"],
+  ): GqlQueryVcIssuanceRequestsArgs["filter"] {
+    if (ctx.isAdmin) return filter;
+
+    const callerId = ctx.currentUser?.id;
+    if (!callerId) {
+      throw new AuthenticationError("User must be logged in");
+    }
+    return { ...(filter ?? {}), userIds: [callerId] };
   }
 }

--- a/src/application/domain/experience/evaluation/vcIssuanceRequest/usecase.ts
+++ b/src/application/domain/experience/evaluation/vcIssuanceRequest/usecase.ts
@@ -15,13 +15,16 @@ import { AuthenticationError } from "@/errors/graphql";
  * True when the caller is the target user, or when the caller is an admin.
  * Mirrors the ownership predicate in the sibling `credential/vcIssuance`
  * usecase — both VC-surface read paths must apply the same "self-or-admin"
- * gate. Kept local (a 3-line predicate isn't worth a shared module) and
- * returns `false` for anonymous callers as defence-in-depth behind the
- * schema's `IsUser` rule.
+ * gate. Kept local (a 3-line predicate isn't worth a shared module).
+ *
+ * `userId` is nullable so callers can pass a row's FK directly: an admin
+ * still gets access even for a `userId`-less row, while a non-admin (or an
+ * anonymous caller) is denied — the `!!userId` guard makes a missing owner
+ * never match. Defence-in-depth behind the schema's `IsUser` rule.
  */
-function isSelfOrAdmin(ctx: IContext, userId: string): boolean {
+function isSelfOrAdmin(ctx: IContext, userId: string | null | undefined): boolean {
   if (ctx.isAdmin) return true;
-  return ctx.currentUser?.id === userId;
+  return !!userId && ctx.currentUser?.id === userId;
 }
 
 @injectable()
@@ -75,7 +78,7 @@ export default class VCIssuanceRequestUseCase {
   ): Promise<GqlVcIssuanceRequest | null> {
     const request = await this.service.findVcIssuanceRequest(ctx, id);
     if (!request) return null;
-    if (!request.userId || !isSelfOrAdmin(ctx, request.userId)) return null;
+    if (!isSelfOrAdmin(ctx, request.userId)) return null;
     return VCIssuanceRequestPresenter.get(request);
   }
 


### PR DESCRIPTION
## Summary

Closes an authorization gap (broken object-level authorization / IDOR) on the VC issuance **read** surface, found while auditing the credential-revocation flow after an external report (issue #1243).

The `vcIssuanceRequests` and `vcIssuanceRequest(id)` GraphQL queries shipped with:
- **no `@authz` directive** at all (the sibling `vcIssuance` / `vcIssuancesByUser` queries carry `@authz(rules: [IsUser])`), and
- **no ownership check** in the usecase,

while their repository reads run through `ctx.issuer.public(...)`, which **bypasses RLS** (only `onlyBelongingCommunity` applies row-level scoping). Because the auth middleware lets anonymous requests through with `currentUser` unset, **any caller — including an unauthenticated one — could enumerate every user's VC issuance requests** by passing arbitrary `filter.userIds`, and traverse to the linked `user` / `evaluation` objects via the field resolvers. Raw `claims` are not exposed on the type, but cross-user correlation of who requested which credential, its status, and timestamps was fully readable across communities.

Note: the revocation / DID-deactivation / VC state-change paths themselves (`revokeUserVc` → `IsAdmin`, `deactivateUserDid` → `IsSelf` + usecase `isSelfOrAdmin` + userId-scoped cascade) were audited and found correctly guarded — this PR addresses the adjacent read gap.

## Changes

- **Schema** (`vcIssuanceRequest/schema/query.graphql`): gate both queries on `@authz(rules: [IsUser])`.
- **UseCase** (`vcIssuanceRequest/usecase.ts`):
  - Scope non-admin list callers to their own `userId` — the effective `filter.userIds` is forced to `[currentUser.id]` regardless of client input; admins keep the unrestricted cross-user view.
  - Return `null` from the single-item query unless the caller owns the row or is an admin, matching the "no such id" path so existence isn't leaked. Mirrors `credential/vcIssuance`'s `viewVcIssuance` / `viewVcIssuancesByUser`.
  - Throw `AuthenticationError` for anonymous list callers as defence-in-depth behind the `IsUser` rule.
- **Resolver** (`vcIssuanceRequest/controller/resolver.ts`): remove an unreachable duplicate `return`.
- **Tests**: new unit suite covering list scoping (self / admin / anonymous) and the single-item ownership check.

## Verification

- `tsc --noEmit`: no new type errors in the changed files (pre-existing unrelated errors only).
- `eslint` / `prettier`: clean on changed files.
- New unit tests: **8 passed**.
- No codegen changes needed — `schema-ast` does not render field-level `@authz` in `docs/schema.graphql`, and directives don't affect generated TS types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtiRwekowgtzV85C9eAcfo

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtiRwekowgtzV85C9eAcfo)_