### PR TITLE
fix(security): bump websocket-driver to >=0.7.5 (CVE-2026-54466)

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,8 @@
       "qs": "^6.14.2",
       "@smithy/config-resolver": ">=4.4.5",
       "validator": ">=13.15.23",
-      "protobufjs": "^7.5.8"
+      "protobufjs": "^7.5.8",
+      "websocket-driver": ">=0.7.5 <1.0.0"
     }
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,7 @@ overrides:
   '@smithy/config-resolver': '>=4.4.5'
   validator: '>=13.15.23'
   protobufjs: ^7.5.8
+  websocket-driver: '>=0.7.5 <1.0.0'
 
 importers:
 
@@ -8823,8 +8824,8 @@ packages:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
 
-  websocket-driver@0.7.4:
-    resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
+  websocket-driver@0.7.5:
+    resolution: {integrity: sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==}
     engines: {node: '>=0.8.0'}
 
   websocket-extensions@0.1.4:
@@ -15906,7 +15907,7 @@ snapshots:
 
   faye-websocket@0.11.4:
     dependencies:
-      websocket-driver: 0.7.4
+      websocket-driver: 0.7.5
 
   fb-watchman@2.0.2:
     dependencies:
@@ -19658,7 +19659,7 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
-  websocket-driver@0.7.4:
+  websocket-driver@0.7.5:
     dependencies:
       http-parser-js: 0.5.10
       safe-buffer: 5.2.1


### PR DESCRIPTION
## 概要

Daily Trivy scan (#1246) で検出された CRITICAL CVE **CVE-2026-54466** を master へ反映します。

すでに #1247 で develop にマージ済みの修正を、本番系 (`master`) へ取り込むための PR です。develop は master より本コミット1件のみ先行しているため、差分はこの CVE 修正に限定されます。

## 詳細

- **対象パッケージ**: `websocket-driver` `0.7.4` → `0.7.5`
- **深刻度**: CRITICAL
- **依存経路**: transitive dependency

```
firebase-admin
  └─ @firebase/database
       └─ faye-websocket
            └─ websocket-driver@0.7.4
```

`package.json` の `pnpm.overrides` に `"websocket-driver": ">=0.7.5 <1.0.0"` を追加し、修正版 `0.7.5` を強制解決します(将来の非互換なメジャーバージョンは除外)。`pnpm-lock.yaml` も併せて更新済みです。

## 変更ファイル

- `package.json` — pnpm override を1行追加
- `pnpm-lock.yaml` — websocket-driver 0.7.4 → 0.7.5 の解決更新

Closes #1246

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01975BNJAkUF9ZAghCb8hmCa)_