### PR TITLE
fix(transaction): 空文字の toUserId をコミュニティ拠出に分岐させない

### DIFF
--- a/src/application/domain/transaction/usecase.ts
+++ b/src/application/domain/transaction/usecase.ts
@@ -174,7 +174,7 @@ export default class TransactionUseCase {
 
     let transaction: PrismaTransactionDetail;
 
-    if (!toUserId) {
+    if (toUserId == null) {
       // 送付先ユーザーが指定されない場合は、コミュニティ財布への送付
       // (フリマ支払い・DAO への返還等) として扱う。送金元はカレントユーザー、
       // 送金先は communityId のコミュニティ財布 (member → community)。


### PR DESCRIPTION
## 概要

`transactionDonateSelfPoint` の送付先分岐にある空文字判定バグを修正します。PR #1251（develop→master 反映）のレビューで Copilot / CodeRabbit の両方から Major として指摘された内容です。

## 問題

`toUserId` が GraphQL 上で任意化されたため、送付先の分岐に `if (!toUserId)` を使うと `toUserId: ""`（空文字）も「未指定」とみなされてしまいます。その結果、クライアントが誤って空文字を送った場合に、無効な宛先への送付が**意図せずコミュニティ財布への CONTRIBUTION に分岐**します。

```ts
// Before
if (!toUserId) { /* コミュニティ財布への送付 */ }

// After
if (toUserId == null) { /* コミュニティ財布への送付 */ }
```

`null` / `undefined` のみを「未指定」として扱うことで、空文字は通常の member→member 送付分岐に入り、`findMemberWalletOrThrow` で宛先ウォレットが見つからずエラーになります（＝無効な宛先が正しく弾かれる）。

## 変更ファイル

- `src/application/domain/transaction/usecase.ts` — `userDonateSelfPointToAnother` の送付先分岐条件を `!toUserId` → `toUserId == null` に変更

## 補足

このPRを `develop` にマージすると、release PR #1251（develop→master）にも自動的に反映されます。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VV5qEXySUVqBbZT3LkGZ3S)_