### PR TITLE
fix(transaction): DONATION 通知を残高更新後に発火する

### DIFF
--- a/src/application/domain/transaction/usecase.ts
+++ b/src/application/domain/transaction/usecase.ts
@@ -236,8 +236,16 @@ export default class TransactionUseCase {
           );
         },
       );
+    }
 
-      // コミュニティ送付には受取ユーザーが存在しないため、通知はメンバー間送付のみ。
+    await ctx.issuer.internal(async (tx) => {
+      await this.transactionService.refreshCurrentPoint(ctx, tx);
+    });
+
+    // コミュニティ送付には受取ユーザーが存在しないため、通知はメンバー間送付のみ。
+    // 受信者が通知から即座にウォレットを開いても最新残高を見られるよう、
+    // materialized view (refreshCurrentPoint) の更新後に通知を発火する。
+    if (toUserId != null) {
       this.notificationService
         .pushPointDonationReceivedMessage(ctx, transaction.id, toUserId)
         .catch((error) => {
@@ -247,10 +255,6 @@ export default class TransactionUseCase {
           });
         });
     }
-
-    await ctx.issuer.internal(async (tx) => {
-      await this.transactionService.refreshCurrentPoint(ctx, tx);
-    });
 
     return TransactionPresenter.giveUserPoint(transaction);
   }


### PR DESCRIPTION
## 概要

`userDonateSelfPointToAnother` で DONATION の通知が残高更新（`refreshCurrentPoint`）より**前**に発火するリグレッションを修正します。PR #1251（develop→master 反映）のレビューで Copilot が指摘した内容です。

## 問題

#1250 で送付先分岐が追加された際、通知処理 `pushPointDonationReceivedMessage` がメンバー間送付分岐の内側へ移動し、その結果 `refreshCurrentPoint` より前に実行されるようになっていました。

- 通知は `await` していない fire-and-forget
- そのため受信者が通知（LINE）から**即座にウォレット画面を開くと、materialized view (`mv_current_points`) が未更新の残高**を見てしまう可能性がある
- #1250 以前は `refreshCurrentPoint` の後に通知を発火していた

## 修正

通知ブロックを `refreshCurrentPoint` の後ろへ移動し、メンバー間送付のみ（`toUserId != null`）で発火するようガードしました。コミュニティ財布への送付（CONTRIBUTION）には受取ユーザーが存在しないため通知は発火しません。

```ts
await ctx.issuer.internal(async (tx) => {
  await this.transactionService.refreshCurrentPoint(ctx, tx);
});

// 残高更新後に通知を発火（メンバー間送付のみ）
if (toUserId != null) {
  this.notificationService.pushPointDonationReceivedMessage(ctx, transaction.id, toUserId).catch(...);
}
```

## 変更ファイル

- `src/application/domain/transaction/usecase.ts` — 通知発火を `refreshCurrentPoint` の後へ移動し `toUserId != null` でガード

## 補足

- このPRを `develop` にマージすると release PR #1251（develop→master）にも反映されます。
- 同じ Copilot レビューで挙がった `GqlQueryTransactionsArgs` のドメイン層への漏れ（`interface.ts` / `service.ts`）は、`fetchTransactions` 周りの**既存コード**であり本PR（CONTRIBUTION 追加）由来ではないため、本PRのスコープ外としています。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VV5qEXySUVqBbZT3LkGZ3S)_